### PR TITLE
refactor(core): 滚动摘要机制，支持无限对话延伸

### DIFF
--- a/crates/tiangong-core/src/app_state/services/turn/start.rs
+++ b/crates/tiangong-core/src/app_state/services/turn/start.rs
@@ -80,6 +80,27 @@ impl AppTurnService {
             updated_at: now_text(),
         };
 
+        // 在创建 snapshot 前，检查并更新滚动摘要
+        // 摘要持久化到 session，原始 messages 保持完整
+        {
+            let context_limit = state.services.runtime.context_limit;
+            let organizer =
+                crate::context::organizer::ContextOrganizer::new(context_limit)
+                    .with_keep_recent_turns(6);
+            let session = &state.store.session.sessions[active_idx];
+            if organizer.needs_compression_estimated(session) {
+                let client = SingleProviderClient::new(
+                    state.store.provider.models_config.to_chat_provider_config(),
+                );
+                let session_mut = &mut state.store.session.sessions[active_idx];
+                match organizer.maybe_update_summary(session_mut, &client) {
+                    Ok(true) => tracing::info!("滚动摘要已更新"),
+                    Ok(false) => {}
+                    Err(err) => tracing::warn!("滚动摘要更新失败：{err}"),
+                }
+            }
+        }
+
         state.persist_session_and_app(&session_id)?;
 
         let runtime = state.services.runtime.clone();

--- a/crates/tiangong-core/src/context/compressor.rs
+++ b/crates/tiangong-core/src/context/compressor.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 
 use crate::model::{ModelClient, ModelRequest, SingleProviderClient};
-use crate::session::{Message, MessageRole, now_text};
+use crate::session::{Message, MessageRole, Session, now_text};
 
 /// 上下文压缩器
 ///
-/// 当对话历史过长时，对早期消息生成 LLM 摘要，保留最近 N 轮完整对话。
-/// 如果 LLM 摘要失败，回退到滑动窗口截断。
+/// 采用滚动摘要策略：保留最近 N 轮完整对话，对更早的消息（含旧摘要）
+/// 折叠为新摘要。摘要持久化到 Session，支持无限对话延伸。
 pub struct ContextCompressor {
     /// 保留最近的完整对话轮数
     keep_recent_turns: usize,
@@ -25,50 +25,83 @@ impl ContextCompressor {
         Self { keep_recent_turns }
     }
 
-    /// 自动压缩：优先 LLM 摘要，失败回退滑动窗口
-    pub fn compress(
+    /// 更新 session 的滚动摘要
+    ///
+    /// 如果消息数量足够多（超过 keep_recent_turns），将早期消息（含旧摘要）
+    /// 折叠为新摘要，更新 session.context_summary 和 summary_up_to。
+    ///
+    /// 返回 true 表示执行了压缩，false 表示无需压缩。
+    pub fn update_summary(
         &self,
-        messages: &[Message],
-        client: Option<&SingleProviderClient>,
-    ) -> Result<Vec<Message>> {
-        let split_point = self.find_split_point(messages);
+        session: &mut Session,
+        client: &SingleProviderClient,
+    ) -> Result<bool> {
+        let split_point = self.find_split_point(&session.messages);
         if split_point == 0 {
-            return Ok(messages.to_vec());
+            return Ok(false);
         }
 
-        if let Some(client) = client {
-            match self.compress_with_summary(messages, split_point, client) {
-                Ok(result) => return Ok(result),
-                Err(err) => {
-                    tracing::warn!("LLM 摘要压缩失败，回退到滑动窗口：{err}");
-                }
-            }
+        // 已被摘要覆盖的部分不需要重新处理
+        if split_point <= session.summary_up_to {
+            return Ok(false);
         }
 
-        Ok(messages[split_point..].to_vec())
+        // 需要新增摘要的消息范围：从上次摘要覆盖点到新分割点
+        let new_messages_start = session.summary_up_to;
+        let new_messages = &session.messages[new_messages_start..split_point];
+
+        if new_messages.is_empty() {
+            return Ok(false);
+        }
+
+        // 折叠：旧摘要 + 新溢出消息 → 新摘要
+        let summary = self.fold_summary(
+            session.context_summary.as_deref(),
+            new_messages,
+            client,
+        )?;
+
+        tracing::info!(
+            old_summary_up_to = session.summary_up_to,
+            new_summary_up_to = split_point,
+            new_messages_count = new_messages.len(),
+            summary_len = summary.len(),
+            "滚动摘要已更新"
+        );
+
+        session.context_summary = Some(summary);
+        session.summary_up_to = split_point;
+        Ok(true)
     }
 
-    /// 使用 LLM 摘要压缩早期消息
-    fn compress_with_summary(
-        &self,
-        messages: &[Message],
-        split_point: usize,
-        client: &SingleProviderClient,
-    ) -> Result<Vec<Message>> {
-        let early_messages = &messages[..split_point];
-        let recent_messages = &messages[split_point..];
+    /// 构建发送给 LLM 的上下文消息列表
+    ///
+    /// 结构：[摘要系统消息(可选)] + [最近 N 轮完整消息]
+    pub fn build_context(&self, session: &Session) -> Vec<Message> {
+        let split_point = if session.summary_up_to > 0 {
+            // 使用已有摘要覆盖点
+            session.summary_up_to
+        } else {
+            // 没有摘要时返回全部消息
+            0
+        };
 
-        let summary = self.summarize_messages(early_messages, client)?;
+        let recent_messages = &session.messages[split_point..];
+        let mut context = Vec::new();
 
-        let mut result = vec![Message {
-            id: scru128::new().to_string(),
-            role: MessageRole::System,
-            content: format!("[早期对话摘要]\n{summary}"),
-            reasoning_content: String::new(),
-            created_at: now_text(),
-        }];
-        result.extend_from_slice(recent_messages);
-        Ok(result)
+        // 注入摘要
+        if let Some(summary) = &session.context_summary {
+            context.push(Message {
+                id: scru128::new().to_string(),
+                role: MessageRole::System,
+                content: format!("[早期对话摘要]\n{summary}"),
+                reasoning_content: String::new(),
+                created_at: now_text(),
+            });
+        }
+
+        context.extend_from_slice(recent_messages);
+        context
     }
 
     /// 查找分割点：保留最近 N 轮对话（一轮 = 一次 user 消息及其后续消息）
@@ -92,37 +125,44 @@ impl ContextCompressor {
         split_point
     }
 
-    /// 使用 LLM 对消息列表生成摘要
-    fn summarize_messages(
+    /// 将旧摘要 + 新消息折叠为新摘要
+    fn fold_summary(
         &self,
-        messages: &[Message],
+        old_summary: Option<&str>,
+        new_messages: &[Message],
         client: &SingleProviderClient,
     ) -> Result<String> {
-        let mut conversation_text = String::new();
-        for msg in messages {
+        let mut input_text = String::new();
+
+        // 旧摘要作为上文
+        if let Some(summary) = old_summary {
+            input_text.push_str(&format!("[已有摘要]\n{summary}\n\n[新增对话]\n"));
+        }
+
+        // 新消息
+        for msg in new_messages {
             let role_label = match msg.role {
                 MessageRole::User => "用户",
                 MessageRole::Assistant => "助手",
                 MessageRole::System => "系统",
             };
-            // 截断过长的单条消息，避免摘要请求本身超限
             let content = if msg.content.len() > 2000 {
                 format!("{}...(已截断)", &msg.content[..2000])
             } else {
                 msg.content.clone()
             };
-            conversation_text.push_str(&format!("[{role_label}]: {content}\n"));
+            input_text.push_str(&format!("[{role_label}]: {content}\n"));
         }
 
         let prompt = format!(
-            "请将以下对话历史压缩为简洁的摘要。要求：\n\
+            "请将以下内容压缩为简洁的对话摘要。要求：\n\
              1. 保留所有关键信息、决策结论和重要数据\n\
              2. 保留用户的核心需求和偏好\n\
              3. 保留已执行的操作及其结果\n\
-             4. 去除冗余的中间过程和重复内容\n\
-             5. 摘要使用第三人称陈述\n\
+             4. 如果有已有摘要，将其与新增内容合并为统一摘要\n\
+             5. 去除冗余的中间过程和重复内容\n\
              6. 直接输出摘要内容，不要加前缀说明\n\n\
-             对话历史：\n{conversation_text}"
+             {input_text}"
         );
 
         let req = ModelRequest {
@@ -145,22 +185,20 @@ pub fn compress_loop_messages(
     client: &SingleProviderClient,
 ) -> Result<Vec<Message>> {
     // 按 Assistant+System 配对分组为"轮次"
-    let mut rounds: Vec<(usize, usize)> = Vec::new(); // (start, end) indices
+    let mut rounds: Vec<(usize, usize)> = Vec::new();
     let mut i = 0;
     while i < loop_messages.len() {
         let start = i;
-        // Assistant 消息
         if i < loop_messages.len() && loop_messages[i].role == MessageRole::Assistant {
             i += 1;
         }
-        // 后续的 System 消息（工具结果）
         while i < loop_messages.len() && loop_messages[i].role == MessageRole::System {
             i += 1;
         }
         if i > start {
             rounds.push((start, i));
         } else {
-            i += 1; // 跳过意外消息
+            i += 1;
         }
     }
 
@@ -173,7 +211,6 @@ pub fn compress_loop_messages(
     let early_messages = &loop_messages[..compress_end];
     let recent_messages = &loop_messages[compress_end..];
 
-    // 构建摘要文本
     let mut text = String::new();
     for msg in early_messages {
         let label = match msg.role {

--- a/crates/tiangong-core/src/context/organizer.rs
+++ b/crates/tiangong-core/src/context/organizer.rs
@@ -1,6 +1,6 @@
 use crate::context::compressor::ContextCompressor;
 use crate::model::SingleProviderClient;
-use crate::session::{Message, Session};
+use crate::session::{Message, MessageRole, Session};
 
 /// token 估算（仅用于首次调用前的预判，后续应使用 API 返回的精确值）
 ///
@@ -20,8 +20,8 @@ pub fn estimate_tokens(messages: &[Message]) -> usize {
 
 /// 上下文组织器
 ///
-/// 从 Session 消息构建 LLM 请求上下文，
-/// 自动判断是否需要压缩，替代硬编码的滑动窗口。
+/// 管理对话上下文的构建与压缩策略。
+/// 采用滚动摘要机制：摘要持久化到 Session，原始消息保持完整。
 pub struct ContextOrganizer {
     /// 模型上下文限制（token 数）
     context_limit: usize,
@@ -56,8 +56,11 @@ impl ContextOrganizer {
     }
 
     /// 基于估算判断是否需要压缩（首次调用前使用）
-    pub fn needs_compression_estimated(&self, messages: &[Message]) -> bool {
-        estimate_tokens(messages) > self.token_threshold()
+    pub fn needs_compression_estimated(&self, session: &Session) -> bool {
+        // 构建当前会发送给 LLM 的上下文，估算其 token 量
+        let context = self.compressor.build_context(session);
+        let filtered = Self::filter_execution_traces_vec(&context);
+        estimate_tokens(&filtered) > self.token_threshold()
     }
 
     /// 基于 API 返回的精确 prompt_tokens 判断是否需要压缩
@@ -65,63 +68,46 @@ impl ContextOrganizer {
         actual_prompt_tokens > self.token_threshold()
     }
 
-    /// 构建 LLM 请求上下文
+    /// 在 turn 开始前更新会话摘要（如果需要）
     ///
-    /// 过滤执行痕迹，如果估算 token 超过阈值则自动压缩。
-    /// 首次调用使用估算值；后续轮次应使用 `compress_if_needed` 基于精确值触发。
-    pub fn build_context(
+    /// 检查当前上下文是否超过阈值，如果超过则更新 session 的滚动摘要。
+    /// 摘要持久化到 session，后续 turn 不会重复压缩。
+    pub fn maybe_update_summary(
         &self,
-        session: &Session,
-        client: Option<&SingleProviderClient>,
-    ) -> anyhow::Result<Vec<Message>> {
-        let filtered = Self::filter_execution_traces(&session.messages);
-
-        if !self.needs_compression_estimated(&filtered) {
-            return Ok(filtered);
+        session: &mut Session,
+        client: &SingleProviderClient,
+    ) -> anyhow::Result<bool> {
+        if !self.needs_compression_estimated(session) {
+            return Ok(false);
         }
-
-        tracing::info!(
-            estimated_tokens = estimate_tokens(&filtered),
-            context_limit = self.context_limit,
-            threshold = %self.compression_threshold,
-            "上下文超过阈值（估算），执行压缩"
-        );
-
-        self.compressor.compress(&filtered, client)
+        self.compressor.update_summary(session, client)
     }
 
-    /// 基于 API 返回的精确 prompt_tokens 对消息进行压缩
+    /// 构建 LLM 请求上下文
     ///
-    /// 当 `actual_prompt_tokens` 超过阈值时执行压缩，返回 Some(压缩后消息)；
-    /// 未超过阈值返回 None。
-    pub fn compress_if_needed(
-        &self,
-        messages: &[Message],
-        actual_prompt_tokens: usize,
-        client: Option<&SingleProviderClient>,
-    ) -> anyhow::Result<Option<Vec<Message>>> {
-        if !self.needs_compression(actual_prompt_tokens) {
-            return Ok(None);
-        }
-
-        tracing::info!(
-            actual_prompt_tokens,
-            threshold = self.token_threshold(),
-            "上下文超过阈值（精确），执行压缩"
-        );
-
-        self.compressor.compress(messages, client).map(Some)
+    /// 从 session 的摘要 + 最近消息构建，并过滤执行痕迹。
+    pub fn build_context(&self, session: &Session) -> Vec<Message> {
+        let raw = self.compressor.build_context(session);
+        Self::filter_execution_traces_vec(&raw)
     }
 
     /// 过滤执行阶段的 System 消息，保留纯对话
     pub fn filter_execution_traces(messages: &[Message]) -> Vec<Message> {
+        Self::filter_execution_traces_vec(messages)
+    }
+
+    fn filter_execution_traces_vec(messages: &[Message]) -> Vec<Message> {
         messages
             .iter()
             .filter(|msg| {
-                if msg.role != crate::session::MessageRole::System {
+                if msg.role != MessageRole::System {
                     return true;
                 }
                 let c = msg.content.as_str();
+                // 保留摘要消息
+                if c.starts_with("[早期对话摘要]") {
+                    return true;
+                }
                 !(c.starts_with("工具执行")
                     || c.starts_with("LLM 输出")
                     || c.starts_with("Plan 执行总结")

--- a/crates/tiangong-core/src/runtime.rs
+++ b/crates/tiangong-core/src/runtime.rs
@@ -78,7 +78,7 @@ const MAX_REACT_ROUNDS: usize = 20;
 pub struct RuntimeEngine {
     client: SingleProviderClient,
     tool_executor: LocalToolExecutor,
-    context_limit: usize,
+    pub context_limit: usize,
     agent_config: AgentConfig,
     models_config: ModelsConfig,
 }
@@ -144,10 +144,11 @@ impl RuntimeEngine {
 
         let mut accumulated_usage = TokenUsage::default();
 
-        // 构建对话上下文：使用 ContextOrganizer 自动过滤、压缩
+        // 构建对话上下文：摘要 + 最近消息 + 过滤执行痕迹
+        // 压缩（摘要更新）已在 turn 启动前完成并持久化到 session
         let organizer = ContextOrganizer::new(self.context_limit)
             .with_keep_recent_turns(6);
-        let context = organizer.build_context(session, Some(&self.client))?;
+        let context = organizer.build_context(session);
 
         // 准备工具定义
         let (function_tools, mcp_targets) =

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -34,6 +34,16 @@ pub struct Session {
     /// 会话级工作目录，工具执行时以此为根目录
     #[serde(default)]
     pub cwd: String,
+    /// 早期对话的滚动摘要（用于无限上下文压缩）
+    ///
+    /// 当对话历史超过模型上下文阈值时，早期消息被 LLM 压缩为摘要存储在此。
+    /// 构建 prompt 时注入为系统消息，原始 messages 保持完整供 UI 展示。
+    /// 每次压缩会将旧摘要 + 新溢出消息折叠为新摘要，支持无限延伸。
+    #[serde(default)]
+    pub context_summary: Option<String>,
+    /// 摘要覆盖到的消息索引（messages[0..summary_up_to] 已被摘要覆盖）
+    #[serde(default)]
+    pub summary_up_to: usize,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -112,6 +122,8 @@ impl Session {
             task_records: Vec::new(),
             task_plans: Vec::new(),
             cwd,
+            context_summary: None,
+            summary_up_to: 0,
             created_at: now.clone(),
             updated_at: now,
         }


### PR DESCRIPTION
## Summary
- 重构上下文压缩为滚动摘要策略：摘要持久化到 Session 的 `context_summary` + `summary_up_to` 字段
- 原始 messages 保持完整供 UI 展示，摘要仅用于构建 LLM 请求上下文
- 每次压缩将旧摘要与新溢出消息折叠为新摘要，对话可无限延伸
- turn 启动前检查并更新摘要，避免每轮重复调用 LLM

## 后续检索增强（已创建 issue）
- #13 API 嵌入优先方案
- #14 本地嵌入模型方案
- #15 jieba + TF-IDF 轻量回退方案

## Test plan
- [ ] `cargo check --workspace` 通过
- [ ] `cargo clippy --workspace` 无 warning
- [ ] 短对话不触发压缩，行为无变化
- [ ] 长对话触发滚动摘要，session 文件中可见 context_summary 字段
- [ ] 后续 turn 不重复压缩（summary_up_to 未变则跳过）
- [ ] 旧 session 文件兼容（新字段 serde default）