### PR TITLE
fix(core): DEFAULT_CONTEXT_LIMIT 从 16 改为 32768

### DIFF
--- a/crates/tiangong-core/src/app_state/mod.rs
+++ b/crates/tiangong-core/src/app_state/mod.rs
@@ -62,7 +62,9 @@ pub use self::store::{AgentState, AppStore, ProviderState, RuntimeState, Session
 pub use self::support::{AppPaths, AppServices, ManagementCommand};
 
 const DEFAULT_SESSION_TITLE: &str = "默认会话";
-const DEFAULT_CONTEXT_LIMIT: usize = 16;
+/// 默认上下文窗口大小（token 数）
+/// 大多数模型支持 8K-128K，使用 32K 作为安全默认值
+const DEFAULT_CONTEXT_LIMIT: usize = 32_768;
 const MCP_CAPABILITY_REFRESH_INTERVAL_SECS: u64 = 300;
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
原值 16 导致 TokenBudget 计算 max_prompt_tokens = 11，
所有工具集（37个）都超出预算被裁剪为 7 个基础工具。
改为 32768（32K tokens），与主流模型的上下文窗口匹配。