### PR TITLE
refactor(core): SessionStreamEvent 统一流事件 + 用户消息即时推送

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,8 +3366,20 @@ dependencies = [
  "crossterm 0.28.1",
  "ratatui",
  "termimad",
+ "tiangong-config",
  "tiangong-core",
  "tiangong-types",
+]
+
+[[package]]
+name = "tiangong-config"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tiangong-core",
+ "tracing",
 ]
 
 [[package]]
@@ -3383,6 +3404,7 @@ name = "tiangong-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-openai",
  "chrono",
  "diffy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,15 +49,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b465d66478a9bb84abed46695c44a58e34f3e8d0abfb2e958218d420969049"
+checksum = "eb26fbd2a93308b1c1b74ac4e494a11ac10db57c476882240573bdf961463520"
 dependencies = [
  "atomic-waker",
  "futures-core",
@@ -266,7 +266,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
- "tungstenite 0.28.0",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -397,6 +397,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -422,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -434,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -446,15 +457,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -534,6 +545,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1002,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1048,6 +1068,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "forkguard"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61bab9e346d9936120193360409a5ef77c7fb32ad20322aae22ce7994678713c"
 
 [[package]]
 name = "form_urlencoded"
@@ -1217,6 +1243,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1405,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1420,7 +1447,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1433,7 +1459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls 0.23.37",
  "rustls-native-certs",
@@ -1469,12 +1495,12 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1506,12 +1532,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1519,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1532,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1546,15 +1573,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1566,15 +1593,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1639,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1682,15 +1709,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1722,16 +1749,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.90"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1773,9 +1802,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1791,9 +1820,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1889,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -1949,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1964,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2081,15 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "piper"
@@ -2124,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2191,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "9.0.3"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd9713fe2c91c3c85ac388b31b89de339365d2c995146e630b5e0da9d06526a"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap",
@@ -2216,7 +2239,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2225,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -2253,16 +2276,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2298,6 +2321,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -2337,6 +2371,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "ratatui"
@@ -2463,7 +2503,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -2506,7 +2546,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -2541,6 +2581,15 @@ dependencies = [
  "pin-project-lite",
  "reqwest 0.12.28",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "reseeding_rng"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd71575b08040a946d6b0850fd0d3c1d9e0d698ab9cc7da1c5cd8bea4f69a12f"
+dependencies = [
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -2582,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2644,7 +2693,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -2693,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2716,9 +2765,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2731,14 +2780,27 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scru128"
-version = "3.4.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888ebeaa0a24d408f7c47a224ae5a0451ffa0a5829db45f0a952921caffcaeb"
+checksum = "2226922e0612a5fbfadce4cd029714bba33387422fdffa8537040f9a8632b9ef"
 dependencies = [
+ "forkguard",
  "fstr",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "scru128"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14fc795a0b20b3655959416b720c8a15659e5be7be350cbbfa178f47e4c91b49"
+dependencies = [
+ "forkguard",
+ "fstr",
+ "rand 0.10.0",
+ "reseeding_rng",
 ]
 
 [[package]]
@@ -2786,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2933,7 +2995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2985,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "silent"
-version = "2.15.0"
+version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32294bdfea962ca73b3e9fbb7a4490083f37b8df01d2f70adaaf04d4fa555cc7"
+checksum = "0ee50f61628686849f025a30e2fe830fcfd8c1fb5fa72153f2ab7b2b9d26a3ee"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3004,13 +3066,13 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "memchr",
  "mime",
  "mime_guess",
  "once_cell",
- "scru128",
+ "scru128 4.1.0",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -3026,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -3054,12 +3116,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3412,7 +3474,7 @@ dependencies = [
  "http 1.4.0",
  "reqwest 0.12.28",
  "rmcp",
- "scru128",
+ "scru128 3.6.1",
  "serde",
  "serde_json",
  "tiangong-media",
@@ -3444,7 +3506,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "reqwest 0.12.28",
- "scru128",
+ "scru128 3.6.1",
  "serde",
  "serde_json",
  "tiangong-core",
@@ -3488,7 +3550,7 @@ name = "tiangong-types"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "scru128",
+ "scru128 3.6.1",
  "serde",
  "serde_json",
 ]
@@ -3526,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3536,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3551,25 +3613,25 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3802,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "chrono",
  "matchers",
@@ -3851,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3863,7 +3925,6 @@ dependencies = [
  "rand 0.9.2",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -3892,9 +3953,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -3958,9 +4019,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4020,9 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4033,23 +4094,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.63"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4057,9 +4114,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4070,9 +4127,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -4139,9 +4196,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.90"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4540,9 +4597,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -4647,15 +4704,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4664,9 +4721,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4676,18 +4733,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4696,18 +4753,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4723,9 +4780,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4734,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4745,9 +4802,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/tiangong-gateway",
     "crates/tiangong-connector",
     "crates/tiangong-media",
+    "crates/tiangong-config",
 ]
 exclude = ["src-tauri"]
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -112,12 +112,21 @@
 - Phase C：生命周期管理、优雅关闭与持久化恢复
 - Phase D：清理旧代码（TurnRunner / QueryClassifier / ControlSignal）
 
+### Phase 13（CoreConfig 配置注入）— **待启动**
+> RFC：`docs/rfc/0006-core-config-provider.md`
+
+将 TiangongCore 的配置从内部磁盘加载改为外部注入：
+- Phase A：定义 CoreConfig + CoreConfigProvider，修改 TiangongCore 构造函数
+- Phase B：CLI/GUI/Server 适配，使用 CoreConfigProvider 注入配置
+- Phase C：tiangong-config 独立 crate（可选），提供磁盘加载、持久化、文件监听
+
 ## 参考文档
 - 项目说明：`README.md`
 - RFC 0001：`docs/rfc/0001-tiangong-desktop-agent-roadmap.md`
 - RFC 0002：`docs/rfc/0002-cli-agent-roadmap.md`
 - RFC 0003：`docs/rfc/0003-skill-market.md`
 - RFC 0004：`docs/rfc/0004-full-stack-agent-platform.md`（全栈平台架构）
+- RFC 0006：`docs/rfc/0006-core-config-provider.md`（CoreConfig 配置注入）
 - 架构基准：`docs/desktop-agent-technical-architecture.md`
 - 架构差距分析：`docs/architecture-gap-analysis.md`
 - 需求基线：`docs/requirements.md`

--- a/TODO.md
+++ b/TODO.md
@@ -353,7 +353,37 @@
 - [x] CLI 接入 TiangongCore（直接消费 StreamEvent）
 - [x] src-tauri 依赖 tiangong-types
 - [x] 删除旧 LoopHost/ActiveLoops/CliLoopHost（-433 行）
-- [ ] TurnRunner/ControlSignal 待 Worker 迁移后删除
+- [x] TurnRunner/ControlSignal/EventLoopRunner 已删除（并行智能体集成后清理）
 - [ ] src-tauri/types.rs DTO 转换层待前端完全迁移后删除
 - [x] GUI 全链路功能验证通过
-- [ ] CLI 交互优化（类似 codex/claude code 风格，Phase 10-C）
+- [x] CLI 交互优化（类似 codex/claude code 风格）
+- [x] 并行智能体（TaskCoordinator/Worker）集成到 TiangongCore
+- [x] 统一用户输入通道（消除消息重复）
+- [x] CLI 会话持久化
+
+---
+
+## Phase 14：CoreConfig 配置注入 — **当前阶段**
+
+> RFC：`docs/rfc/0006-core-config-provider.md`
+
+### Phase A：CoreConfig + CoreConfigProvider
+
+- [ ] 定义 `CoreConfig` 结构（models/mcp/skills/trust_mode/context_limit）
+- [ ] 实现 `CoreConfigProvider`（ArcSwap + generation 原子计数）
+- [ ] 修改 `TiangongCore` 构造函数接收 `CoreConfigProvider`
+- [ ] 修改 `worker_loop` 使用 generation 检测 + snapshot 重建 engine
+- [ ] 移除 `build_engine()` 中的磁盘加载逻辑
+
+### Phase B：各端适配
+
+- [ ] CLI：创建 CoreConfigProvider，从磁盘加载初始配置
+- [ ] GUI：TiangongApp 持有 CoreConfigProvider，配置变更时 update
+- [ ] Server/Connector：适配 CoreConfigProvider
+
+### Phase C：验证
+
+- [ ] cargo clippy --workspace 通过
+- [ ] cargo nextest run --workspace 通过
+- [ ] GUI 验证：切换模型/MCP/Skill 后下一轮对话生效
+- [ ] CLI 验证：/model 切换后生效

--- a/crates/tiangong-cli/Cargo.toml
+++ b/crates/tiangong-cli/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 tiangong-core = { path = "../tiangong-core" }
+tiangong-config = { path = "../tiangong-config" }
 tiangong-types = { path = "../tiangong-types" }
 anyhow = "1"
 crossterm = "0.28"

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -1,7 +1,7 @@
 //! CLI REPL — 类似 codex/claude code 风格交互
 
 use anyhow::Result;
-use tiangong_config::{CoreConfigProvider, load_core_config};
+use tiangong_config::load_tiangong_config;
 use tiangong_core::app_state::TiangongState;
 use tiangong_core::core::TiangongCore;
 use tiangong_types::StreamEvent;
@@ -15,7 +15,8 @@ use crate::output;
 
 pub fn run() -> Result<()> {
     let mut state = TiangongState::load_or_default();
-    let config = CoreConfigProvider::new(load_core_config());
+    let app_config = load_tiangong_config();
+    let config = app_config.into_core_config_provider();
     let (stream_tx, stream_rx) = mpsc::channel::<StreamEvent>();
     let core = TiangongCore::new(config, stream_tx);
     let mut reader = InputReader::new();

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -1,6 +1,7 @@
 //! CLI REPL — 类似 codex/claude code 风格交互
 
 use anyhow::Result;
+use tiangong_config::{CoreConfigProvider, load_core_config};
 use tiangong_core::app_state::TiangongState;
 use tiangong_core::core::TiangongCore;
 use tiangong_types::StreamEvent;
@@ -14,8 +15,9 @@ use crate::output;
 
 pub fn run() -> Result<()> {
     let mut state = TiangongState::load_or_default();
+    let config = CoreConfigProvider::new(load_core_config());
     let (stream_tx, stream_rx) = mpsc::channel::<StreamEvent>();
-    let core = TiangongCore::new(stream_tx);
+    let core = TiangongCore::new(config, stream_tx);
     let mut reader = InputReader::new();
     let mut draft_new_session = true;
 

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use tiangong_config::load_tiangong_config;
 use tiangong_core::app_state::TiangongState;
 use tiangong_core::core::TiangongCore;
-use tiangong_types::StreamEvent;
+use tiangong_types::{SessionStreamEvent, StreamEvent};
 
 use std::sync::mpsc;
 
@@ -17,7 +17,7 @@ pub fn run() -> Result<()> {
     let mut state = TiangongState::load_or_default();
     let app_config = load_tiangong_config();
     let config = app_config.into_core_config_provider();
-    let (stream_tx, stream_rx) = mpsc::channel::<StreamEvent>();
+    let (stream_tx, stream_rx) = mpsc::channel::<SessionStreamEvent>();
     let core = TiangongCore::new(config, stream_tx);
     let mut reader = InputReader::new();
     let mut draft_new_session = true;
@@ -92,13 +92,13 @@ pub fn run() -> Result<()> {
 }
 
 /// 处理完整的响应流
-fn handle_response(rx: &mpsc::Receiver<StreamEvent>) {
+fn handle_response(rx: &mpsc::Receiver<SessionStreamEvent>) {
     let mut state = ResponseState::new();
 
     loop {
         match rx.recv_timeout(std::time::Duration::from_secs(300)) {
-            Ok(event) => {
-                if state.process(&event) {
+            Ok(session_event) => {
+                if state.process(&session_event.event) {
                     break;
                 }
             }
@@ -132,7 +132,10 @@ impl ResponseState {
     /// 处理单个事件，返回 true 表示本轮结束
     fn process(&mut self, event: &StreamEvent) -> bool {
         match event {
-            StreamEvent::Reasoning { content } => {
+            StreamEvent::UserMessage { .. } => {
+                // CLI 模式下用户消息由 REPL 自己显示，忽略
+            }
+            StreamEvent::Reasoning { content, .. } => {
                 if !self.thinking_shown {
                     output::thinking_start();
                     self.thinking_shown = true;
@@ -140,7 +143,7 @@ impl ResponseState {
                 self.reasoning_buf.push_str(content);
             }
 
-            StreamEvent::Delta { content } => {
+            StreamEvent::Delta { content, .. } => {
                 if !self.has_delta {
                     if self.thinking_shown {
                         output::thinking_clear();

--- a/crates/tiangong-config/Cargo.toml
+++ b/crates/tiangong-config/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tiangong-config"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tiangong-core = { path = "../tiangong-core" }
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"

--- a/crates/tiangong-config/src/config.rs
+++ b/crates/tiangong-config/src/config.rs
@@ -2,9 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 use tiangong_core::agent_config::{McpConfig, SkillsConfig};
-use tiangong_core::core_config::CoreConfig;
+use tiangong_core::core_config::{CoreConfig, LlmConfig, ModelEndpoint};
 use tiangong_core::mcp::McpToolMeta;
-use tiangong_core::models_config::ModelsConfig;
+use tiangong_core::models_config::{ModelCapability, ModelsConfig};
 use tiangong_core::permission::TrustMode;
 
 const DEFAULT_CONTEXT_LIMIT: usize = 32_768;
@@ -103,14 +103,37 @@ impl Default for TiangongConfig {
 
 impl TiangongConfig {
     /// 转换为 CoreConfig（提取 Core 所需的最小子集）
+    ///
+    /// 将 ModelsConfig（3 层）解析为 LlmConfig（扁平端点）
     pub fn to_core_config(&self) -> CoreConfig {
         CoreConfig {
-            models: self.models.clone(),
+            llm: self.resolve_llm_config(),
             mcp: self.mcp.clone(),
             mcp_capabilities: self.mcp_capabilities.clone(),
             skills: self.skills.clone(),
             trust_mode: self.trust_mode,
             context_limit: self.context_limit,
+        }
+    }
+
+    /// 从 ModelsConfig 解析出 LlmConfig
+    fn resolve_llm_config(&self) -> LlmConfig {
+        let resolve = |cap: ModelCapability| -> Option<ModelEndpoint> {
+            let resolved = self.models.resolve_for_capability(cap)?;
+            Some(ModelEndpoint {
+                base_url: resolved.base_url,
+                api_key: resolved.api_key,
+                model: resolved.model,
+                timeout_ms: resolved.timeout_ms,
+            })
+        };
+
+        LlmConfig {
+            chat: resolve(ModelCapability::Chat).unwrap_or_default(),
+            image_generation: resolve(ModelCapability::ImageGeneration),
+            tts: resolve(ModelCapability::Tts),
+            stt: resolve(ModelCapability::Stt),
+            video_generation: resolve(ModelCapability::VideoGeneration),
         }
     }
 

--- a/crates/tiangong-config/src/config.rs
+++ b/crates/tiangong-config/src/config.rs
@@ -1,0 +1,121 @@
+//! TiangongConfig：完整应用配置
+
+use serde::{Deserialize, Serialize};
+use tiangong_core::agent_config::{McpConfig, SkillsConfig};
+use tiangong_core::core_config::CoreConfig;
+use tiangong_core::mcp::McpToolMeta;
+use tiangong_core::models_config::ModelsConfig;
+use tiangong_core::permission::TrustMode;
+
+const DEFAULT_CONTEXT_LIMIT: usize = 32_768;
+
+/// Server 配置
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerConfig {
+    /// 监听地址
+    #[serde(default = "default_host")]
+    pub host: String,
+    /// 监听端口
+    #[serde(default = "default_port")]
+    pub port: u16,
+    /// API 认证 Token
+    #[serde(default)]
+    pub auth_token: Option<String>,
+}
+
+fn default_host() -> String {
+    "127.0.0.1".to_string()
+}
+fn default_port() -> u16 {
+    8080
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: default_host(),
+            port: default_port(),
+            auth_token: None,
+        }
+    }
+}
+
+/// Connector 类型
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub enum ConnectorType {
+    #[default]
+    Webhook,
+    Telegram,
+    Discord,
+    Lark,
+}
+
+/// Connector 配置
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectorConfig {
+    pub name: String,
+    pub connector_type: ConnectorType,
+    pub enabled: bool,
+    pub settings: serde_json::Value,
+}
+
+/// 天工完整应用配置
+///
+/// 包含 Core 所需的配置（models/mcp/skills/trust_mode）
+/// 以及应用层配置（server/connectors）。
+#[derive(Debug, Clone)]
+pub struct TiangongConfig {
+    // ===== Core 所需配置 =====
+    /// LLM 模型配置
+    pub models: ModelsConfig,
+    /// MCP 服务配置
+    pub mcp: McpConfig,
+    /// MCP 能力数据
+    pub mcp_capabilities: Vec<(String, Vec<McpToolMeta>)>,
+    /// Skill 配置
+    pub skills: SkillsConfig,
+    /// 权限信任模式
+    pub trust_mode: TrustMode,
+    /// 上下文窗口大小
+    pub context_limit: usize,
+
+    // ===== 应用层配置 =====
+    /// Server 配置
+    pub server: ServerConfig,
+    /// Connector 配置列表
+    pub connectors: Vec<ConnectorConfig>,
+}
+
+impl Default for TiangongConfig {
+    fn default() -> Self {
+        Self {
+            models: ModelsConfig::default(),
+            mcp: McpConfig::default(),
+            mcp_capabilities: Vec::new(),
+            skills: SkillsConfig::default(),
+            trust_mode: TrustMode::default(),
+            context_limit: DEFAULT_CONTEXT_LIMIT,
+            server: ServerConfig::default(),
+            connectors: Vec::new(),
+        }
+    }
+}
+
+impl TiangongConfig {
+    /// 转换为 CoreConfig（提取 Core 所需的最小子集）
+    pub fn to_core_config(&self) -> CoreConfig {
+        CoreConfig {
+            models: self.models.clone(),
+            mcp: self.mcp.clone(),
+            mcp_capabilities: self.mcp_capabilities.clone(),
+            skills: self.skills.clone(),
+            trust_mode: self.trust_mode,
+            context_limit: self.context_limit,
+        }
+    }
+
+    /// 创建 CoreConfigProvider（用于注入 TiangongCore）
+    pub fn into_core_config_provider(self) -> tiangong_core::core_config::CoreConfigProvider {
+        tiangong_core::core_config::CoreConfigProvider::new(self.to_core_config())
+    }
+}

--- a/crates/tiangong-config/src/lib.rs
+++ b/crates/tiangong-config/src/lib.rs
@@ -1,15 +1,28 @@
-//! tiangong-config：天工配置加载与管理
+//! tiangong-config：天工完整配置管理
 //!
-//! 负责从磁盘读取配置文件，构建 CoreConfig 供 TiangongCore 使用。
-//! CLI/GUI/Server 依赖此 crate 加载配置。
-//! 第三方开发者可以不依赖此 crate，直接构造 CoreConfig。
+//! 定义 `TiangongConfig`（完整应用配置），提供磁盘加载/保存，
+//! 并通过 `to_core_config()` 转换为 TiangongCore 所需的最小配置。
+//!
+//! ```text
+//! TiangongConfig（应用层完整配置）
+//!   ├── models      → CoreConfig.models
+//!   ├── mcp         → CoreConfig.mcp
+//!   ├── skills      → CoreConfig.skills
+//!   ├── trust_mode  → CoreConfig.trust_mode
+//!   ├── server      ← Core 不关心
+//!   └── connectors  ← Core 不关心
+//!              ↓ to_core_config()
+//!          CoreConfig（最小契约）
+//! ```
+//!
+//! CLI/GUI/Server 操作 TiangongConfig，TiangongCore 只接收 CoreConfig。
+//! 第三方开发者可直接构造 CoreConfig，无需依赖此 crate。
 
+mod config;
 mod loader;
 
-pub use loader::{
-    default_tiangong_dir, load_core_config, load_core_config_from_dir,
-    load_core_config_from_env, load_mcp_config, load_models_config, load_skills_config,
-};
+pub use config::{ConnectorConfig, ConnectorType, ServerConfig, TiangongConfig};
+pub use loader::{load_tiangong_config, load_tiangong_config_from_dir};
 
-// re-export core types for convenience
+// re-export core config types for convenience
 pub use tiangong_core::core_config::{CoreConfig, CoreConfigBuilder, CoreConfigProvider};

--- a/crates/tiangong-config/src/lib.rs
+++ b/crates/tiangong-config/src/lib.rs
@@ -1,0 +1,15 @@
+//! tiangong-config：天工配置加载与管理
+//!
+//! 负责从磁盘读取配置文件，构建 CoreConfig 供 TiangongCore 使用。
+//! CLI/GUI/Server 依赖此 crate 加载配置。
+//! 第三方开发者可以不依赖此 crate，直接构造 CoreConfig。
+
+mod loader;
+
+pub use loader::{
+    default_tiangong_dir, load_core_config, load_core_config_from_dir,
+    load_core_config_from_env, load_mcp_config, load_models_config, load_skills_config,
+};
+
+// re-export core types for convenience
+pub use tiangong_core::core_config::{CoreConfig, CoreConfigBuilder, CoreConfigProvider};

--- a/crates/tiangong-config/src/loader.rs
+++ b/crates/tiangong-config/src/loader.rs
@@ -1,0 +1,103 @@
+//! 配置加载器：从磁盘文件构建 CoreConfig
+//!
+//! 默认配置目录：`~/.tiangong/`
+//! 配置文件：
+//! - `models.json` — 模型配置
+//! - `mcp.json` — MCP 服务配置
+//! - `skills.json` — Skill 配置
+//! - `mcp-tools-cache.json` — MCP 能力缓存
+
+use std::path::{Path, PathBuf};
+
+use tiangong_core::agent_config::{McpConfig, SkillsConfig};
+use tiangong_core::core_config::CoreConfig;
+use tiangong_core::model::ModelProviderConfig;
+use tiangong_core::models_config::ModelsConfig;
+
+/// 获取默认配置目录（~/.tiangong/）
+pub fn default_tiangong_dir() -> PathBuf {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(home).join(".tiangong")
+}
+
+/// 从默认目录加载完整配置
+pub fn load_core_config() -> CoreConfig {
+    load_core_config_from_dir(&default_tiangong_dir())
+}
+
+/// 从指定目录加载完整配置
+pub fn load_core_config_from_dir(dir: &Path) -> CoreConfig {
+    let models = load_models_config();
+    let mcp = load_mcp_config(dir).unwrap_or_default();
+    let skills = load_skills_config(dir).unwrap_or_default();
+
+    // MCP 能力缓存加载 + 异步刷新
+    let cache_path = dir.join("mcp-tools-cache.json");
+    let _ = tiangong_core::mcp::load_mcp_capabilities_cache(&cache_path);
+    let mcp_capabilities = tiangong_core::mcp::cached_active_tools();
+    tiangong_core::mcp::refresh_mcp_capabilities_async(mcp.clone());
+
+    CoreConfig {
+        models,
+        mcp,
+        mcp_capabilities,
+        skills,
+        ..Default::default()
+    }
+}
+
+/// 从环境变量加载最小配置（仅 LLM）
+pub fn load_core_config_from_env() -> CoreConfig {
+    CoreConfig {
+        models: load_models_config(),
+        ..Default::default()
+    }
+}
+
+/// 加载模型配置
+///
+/// 优先从 models.json，回退到环境变量
+pub fn load_models_config() -> ModelsConfig {
+    let mut models = ModelsConfig::load();
+    if models.is_empty() {
+        let env_config = ModelProviderConfig::from_env();
+        if !env_config.api_auth_token.is_empty() {
+            models = ModelsConfig::from_legacy(&env_config);
+        }
+    }
+    models
+}
+
+/// 从指定目录加载 MCP 配置
+pub fn load_mcp_config(dir: &Path) -> Option<McpConfig> {
+    let path = dir.join("mcp.json");
+    if !path.exists() {
+        return None;
+    }
+    let content = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<McpConfig>(&content) {
+        Ok(config) => Some(config),
+        Err(err) => {
+            tracing::warn!("解析 mcp.json 失败：{err}");
+            None
+        }
+    }
+}
+
+/// 从指定目录加载 Skills 配置
+pub fn load_skills_config(dir: &Path) -> Option<SkillsConfig> {
+    let path = dir.join("skills.json");
+    if !path.exists() {
+        return None;
+    }
+    let content = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<SkillsConfig>(&content) {
+        Ok(config) => Some(config),
+        Err(err) => {
+            tracing::warn!("解析 skills.json 失败：{err}");
+            None
+        }
+    }
+}

--- a/crates/tiangong-config/src/loader.rs
+++ b/crates/tiangong-config/src/loader.rs
@@ -1,18 +1,28 @@
-//! 配置加载器：从磁盘文件构建 CoreConfig
+//! 配置加载器：从磁盘文件构建 TiangongConfig
 //!
 //! 默认配置目录：`~/.tiangong/`
 //! 配置文件：
 //! - `models.json` — 模型配置
 //! - `mcp.json` — MCP 服务配置
 //! - `skills.json` — Skill 配置
+//! - `server.json` — Server 配置
+//! - `connectors.json` — Connector 配置
 //! - `mcp-tools-cache.json` — MCP 能力缓存
 
 use std::path::{Path, PathBuf};
 
 use tiangong_core::agent_config::{McpConfig, SkillsConfig};
-use tiangong_core::core_config::CoreConfig;
 use tiangong_core::model::ModelProviderConfig;
 use tiangong_core::models_config::ModelsConfig;
+
+use crate::config::{ConnectorConfig, ServerConfig, TiangongConfig};
+
+/// Connector 配置文件结构
+#[derive(serde::Deserialize)]
+struct ConnectorsFile {
+    #[serde(default)]
+    connectors: Vec<ConnectorConfig>,
+}
 
 /// 获取默认配置目录（~/.tiangong/）
 pub fn default_tiangong_dir() -> PathBuf {
@@ -23,15 +33,19 @@ pub fn default_tiangong_dir() -> PathBuf {
 }
 
 /// 从默认目录加载完整配置
-pub fn load_core_config() -> CoreConfig {
-    load_core_config_from_dir(&default_tiangong_dir())
+pub fn load_tiangong_config() -> TiangongConfig {
+    load_tiangong_config_from_dir(&default_tiangong_dir())
 }
 
 /// 从指定目录加载完整配置
-pub fn load_core_config_from_dir(dir: &Path) -> CoreConfig {
+pub fn load_tiangong_config_from_dir(dir: &Path) -> TiangongConfig {
     let models = load_models_config();
-    let mcp = load_mcp_config(dir).unwrap_or_default();
-    let skills = load_skills_config(dir).unwrap_or_default();
+    let mcp = load_json_config::<McpConfig>(dir, "mcp.json").unwrap_or_default();
+    let skills = load_json_config::<SkillsConfig>(dir, "skills.json").unwrap_or_default();
+    let server = load_json_config::<ServerConfig>(dir, "server.json").unwrap_or_default();
+    let connectors = load_json_config::<ConnectorsFile>(dir, "connectors.json")
+        .map(|f| f.connectors)
+        .unwrap_or_default();
 
     // MCP 能力缓存加载 + 异步刷新
     let cache_path = dir.join("mcp-tools-cache.json");
@@ -39,27 +53,19 @@ pub fn load_core_config_from_dir(dir: &Path) -> CoreConfig {
     let mcp_capabilities = tiangong_core::mcp::cached_active_tools();
     tiangong_core::mcp::refresh_mcp_capabilities_async(mcp.clone());
 
-    CoreConfig {
+    TiangongConfig {
         models,
         mcp,
         mcp_capabilities,
         skills,
+        server,
+        connectors,
         ..Default::default()
     }
 }
 
-/// 从环境变量加载最小配置（仅 LLM）
-pub fn load_core_config_from_env() -> CoreConfig {
-    CoreConfig {
-        models: load_models_config(),
-        ..Default::default()
-    }
-}
-
-/// 加载模型配置
-///
-/// 优先从 models.json，回退到环境变量
-pub fn load_models_config() -> ModelsConfig {
+/// 加载模型配置（优先 models.json，回退环境变量）
+fn load_models_config() -> ModelsConfig {
     let mut models = ModelsConfig::load();
     if models.is_empty() {
         let env_config = ModelProviderConfig::from_env();
@@ -70,33 +76,23 @@ pub fn load_models_config() -> ModelsConfig {
     models
 }
 
-/// 从指定目录加载 MCP 配置
-pub fn load_mcp_config(dir: &Path) -> Option<McpConfig> {
-    let path = dir.join("mcp.json");
+/// 通用 JSON 配置文件加载
+fn load_json_config<T: serde::de::DeserializeOwned>(dir: &Path, filename: &str) -> Option<T> {
+    let path = dir.join(filename);
     if !path.exists() {
         return None;
     }
-    let content = std::fs::read_to_string(&path).ok()?;
-    match serde_json::from_str::<McpConfig>(&content) {
-        Ok(config) => Some(config),
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
         Err(err) => {
-            tracing::warn!("解析 mcp.json 失败：{err}");
-            None
+            tracing::warn!("读取 {filename} 失败：{err}");
+            return None;
         }
-    }
-}
-
-/// 从指定目录加载 Skills 配置
-pub fn load_skills_config(dir: &Path) -> Option<SkillsConfig> {
-    let path = dir.join("skills.json");
-    if !path.exists() {
-        return None;
-    }
-    let content = std::fs::read_to_string(&path).ok()?;
-    match serde_json::from_str::<SkillsConfig>(&content) {
+    };
+    match serde_json::from_str::<T>(&content) {
         Ok(config) => Some(config),
         Err(err) => {
-            tracing::warn!("解析 skills.json 失败：{err}");
+            tracing::warn!("解析 {filename} 失败：{err}");
             None
         }
     }

--- a/crates/tiangong-core/Cargo.toml
+++ b/crates/tiangong-core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 tiangong-types = { path = "../tiangong-types" }
 anyhow = "1"
+arc-swap = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 scru128 = "3"
 serde = { version = "1", features = ["derive"] }

--- a/crates/tiangong-core/examples/test_core.rs
+++ b/crates/tiangong-core/examples/test_core.rs
@@ -1,12 +1,12 @@
 use std::sync::mpsc;
-use tiangong_core::app_state::StreamEvent;
+use tiangong_types::{SessionStreamEvent, StreamEvent};
 use tiangong_core::core::TiangongCore;
 use tiangong_core::core_config::{CoreConfig, CoreConfigProvider};
 
 fn main() {
     // 示例：使用默认配置（第三方开发者可直接构造 CoreConfig）
     let config = CoreConfigProvider::new(CoreConfig::default());
-    let (tx, rx) = mpsc::channel::<StreamEvent>();
+    let (tx, rx) = mpsc::channel::<SessionStreamEvent>();
     let core = TiangongCore::new(config, tx);
 
     println!("=== 发送: 你好 ===");
@@ -15,9 +15,10 @@ fn main() {
     let mut got_done = false;
     loop {
         match rx.recv_timeout(std::time::Duration::from_secs(30)) {
-            Ok(event) => match &event {
-                StreamEvent::Delta { content: text } => print!("{text}"),
-                StreamEvent::Reasoning { content: _ } => print!("[R]"),
+            Ok(se) => match &se.event {
+                StreamEvent::UserMessage { content, .. } => println!("[用户] {content}"),
+                StreamEvent::Delta { content: text, .. } => print!("{text}"),
+                StreamEvent::Reasoning { .. } => print!("[R]"),
                 StreamEvent::ToolCalls { names, .. } => println!("\n[调用] {}", names.join(",")),
                 StreamEvent::ToolStart { name, .. } => println!("[开始] {name}"),
                 StreamEvent::ToolResult { name, ok, .. } => println!("[结果] {name} ok={ok}"),
@@ -47,17 +48,19 @@ fn main() {
 
         loop {
             match rx.recv_timeout(std::time::Duration::from_secs(30)) {
-                Ok(StreamEvent::Delta { content: text }) => print!("{text}"),
-                Ok(StreamEvent::Reasoning { content: _ }) => print!("[R]"),
-                Ok(StreamEvent::Done { .. }) => {
-                    println!("\n=== 第二轮 Done ===");
-                    break;
-                }
-                Ok(StreamEvent::Error { message: err }) => {
-                    println!("\n=== 第二轮 Error: {err} ===");
-                    break;
-                }
-                Ok(_) => {}
+                Ok(se) => match &se.event {
+                    StreamEvent::Delta { content: text, .. } => print!("{text}"),
+                    StreamEvent::Reasoning { .. } => print!("[R]"),
+                    StreamEvent::Done { .. } => {
+                        println!("\n=== 第二轮 Done ===");
+                        break;
+                    }
+                    StreamEvent::Error { message: err } => {
+                        println!("\n=== 第二轮 Error: {err} ===");
+                        break;
+                    }
+                    _ => {}
+                },
                 Err(_) => {
                     println!("\n=== 第二轮超时 ===");
                     break;

--- a/crates/tiangong-core/examples/test_core.rs
+++ b/crates/tiangong-core/examples/test_core.rs
@@ -1,10 +1,13 @@
 use std::sync::mpsc;
 use tiangong_core::app_state::StreamEvent;
 use tiangong_core::core::TiangongCore;
+use tiangong_core::core_config::{CoreConfig, CoreConfigProvider};
 
 fn main() {
+    // 示例：使用默认配置（第三方开发者可直接构造 CoreConfig）
+    let config = CoreConfigProvider::new(CoreConfig::default());
     let (tx, rx) = mpsc::channel::<StreamEvent>();
-    let core = TiangongCore::new(tx);
+    let core = TiangongCore::new(config, tx);
 
     println!("=== 发送: 你好 ===");
     core.send_message("你好".into());

--- a/crates/tiangong-core/src/coordinator/task_coordinator.rs
+++ b/crates/tiangong-core/src/coordinator/task_coordinator.rs
@@ -270,12 +270,14 @@ impl TaskCoordinator {
 
             // 流式合成，实时推送
             let tx = stream_tx.clone();
+            let merge_msg_id = scru128::new().to_string();
             match self
                 .engine
                 .client()
                 .complete_stream_with_callback(&req, |delta| {
                     if !delta.content.is_empty() {
                         let _ = tx.send(StreamEvent::Delta {
+                            message_id: merge_msg_id.clone(),
                             content: delta.content.clone(),
                         });
                     }

--- a/crates/tiangong-core/src/coordinator/worker.rs
+++ b/crates/tiangong-core/src/coordinator/worker.rs
@@ -82,7 +82,7 @@ impl Worker {
             while let Ok(event) = inner_rx.recv() {
                 let tagged = if is_multi {
                     match event {
-                        StreamEvent::Delta { content } => StreamEvent::WorkerChunk {
+                        StreamEvent::Delta { content, .. } => StreamEvent::WorkerChunk {
                             worker_id: fwd_worker_id.clone(),
                             worker_label: fwd_worker_label.clone(),
                             content,

--- a/crates/tiangong-core/src/coordinator/worker.rs
+++ b/crates/tiangong-core/src/coordinator/worker.rs
@@ -59,7 +59,7 @@ impl Worker {
             .into_iter()
             .filter(|t| t.name != "mark_step_completed")
             .collect();
-        inject_enhanced_tools(&mut tools, self.engine.models_config(), self.engine.agent_config());
+        inject_enhanced_tools(&mut tools, &self.engine);
 
         // 创建 Worker 内部的 stream channel
         // 如果是多 Worker 模式，拦截事件并加上 worker_id 标记

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -18,7 +18,7 @@ use crate::model::{
 use crate::prompt::PromptAssembler;
 use crate::runtime::{LlmOutputRecord, RuntimeEngine, inject_enhanced_tools, use_stream_mode};
 use crate::session::{Message, MessageRole, Session, now_text};
-use tiangong_types::StreamEvent;
+use tiangong_types::{SessionStreamEvent, StreamEvent};
 
 const MAX_ROUNDS: usize = 20;
 
@@ -48,7 +48,7 @@ pub struct TiangongCore {
 
 impl TiangongCore {
     /// 创建新对话
-    pub fn new(config: CoreConfigProvider, stream_tx: Sender<StreamEvent>) -> Self {
+    pub fn new(config: CoreConfigProvider, stream_tx: Sender<SessionStreamEvent>) -> Self {
         let session = Session::new("新对话");
         Self::with_session(config, session, stream_tx)
     }
@@ -57,7 +57,7 @@ impl TiangongCore {
     pub fn with_session(
         config: CoreConfigProvider,
         session: Session,
-        stream_tx: Sender<StreamEvent>,
+        stream_tx: Sender<SessionStreamEvent>,
     ) -> Self {
         let session_id = session.id.clone();
         let (cmd_tx, cmd_rx) = mpsc::channel::<Command>();
@@ -125,13 +125,32 @@ impl Drop for TiangongCore {
 fn worker_loop(
     config: CoreConfigProvider,
     mut session: Session,
-    stream_tx: Sender<StreamEvent>,
+    external_tx: Sender<SessionStreamEvent>,
     cmd_rx: Receiver<Command>,
 ) -> Session {
+    let session_id = session.id.clone();
     let mut last_cfg_gen = 0u64;
     let mut engine: Option<RuntimeEngine> = None;
     let mut tools: Vec<FunctionToolSpec> = Vec::new();
     let mut mcp_targets: HashMap<String, McpFunctionTarget> = HashMap::new();
+
+    // 内部 StreamEvent 通道 —— 转发线程负责包装 session_id
+    let (stream_tx, stream_rx) = mpsc::channel::<StreamEvent>();
+    let fwd_session_id = session_id.clone();
+    let fwd_tx = external_tx.clone();
+    let forward_handle = thread::spawn(move || {
+        while let Ok(event) = stream_rx.recv() {
+            if fwd_tx
+                .send(SessionStreamEvent {
+                    session_id: fwd_session_id.clone(),
+                    event,
+                })
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
 
     // 设置工作目录
     if !session.cwd.is_empty() {
@@ -163,6 +182,12 @@ fn worker_loop(
             Command::Message(content) => {
                 // 记录用户消息
                 session.append_message(MessageRole::User, content.clone());
+                // 通知消费端：用户消息已记录（携带 session 中的 message_id）
+                let user_msg_id = session.messages.last().map(|m| m.id.clone()).unwrap_or_default();
+                let _ = stream_tx.send(StreamEvent::UserMessage {
+                    message_id: user_msg_id,
+                    content: content.clone(),
+                });
 
                 // 执行对话轮次
                 execute_turn(
@@ -187,6 +212,10 @@ fn worker_loop(
             Command::Shutdown => break,
         }
     }
+
+    // 关闭内部通道，等待转发线程结束
+    drop(stream_tx);
+    let _ = forward_handle.join();
 
     session
 }
@@ -315,20 +344,26 @@ fn execute_turn_inner(
             assembled_system_prompt: Some(system_prompt),
         };
 
+        // 预生成本轮 assistant 消息 ID（Delta/Reasoning 事件先于消息创建）
+        let pending_msg_id = scru128::new().to_string();
+
         // LLM 流式调用
         let tx = stream_tx.clone();
+        let msg_id_for_cb = pending_msg_id.clone();
         let response = match engine.client().complete_with_functions_stream(
             &req,
             tools,
             &mut |delta: &ModelStreamChunk| {
-                // 直接推送 StreamEvent
+                // 直接推送 StreamEvent（携带 message_id）
                 if !delta.content.is_empty() {
                     let _ = tx.send(StreamEvent::Delta {
+                        message_id: msg_id_for_cb.clone(),
                         content: delta.content.clone(),
                     });
                 }
                 if !delta.reasoning_content.is_empty() {
                     let _ = tx.send(StreamEvent::Reasoning {
+                        message_id: msg_id_for_cb.clone(),
                         content: delta.reasoning_content.clone(),
                     });
                 }
@@ -347,8 +382,9 @@ fn execute_turn_inner(
         round += 1;
 
         if response.tool_calls.is_empty() {
-            // 最终回复：记录到 session
-            session.append_message_with_reasoning(
+            // 最终回复：使用预生成的 ID 记录到 session
+            session.append_message_with_id(
+                pending_msg_id,
                 MessageRole::Assistant,
                 response.text.clone(),
                 response.reasoning_content.clone(),
@@ -527,13 +563,18 @@ fn force_final_response(
         assembled_system_prompt: Some(system_prompt),
     };
 
+    // 预生成 message_id
+    let pending_msg_id = scru128::new().to_string();
+
     let tx = stream_tx.clone();
+    let msg_id_for_cb = pending_msg_id.clone();
     let resp = if use_stream_mode() {
         match engine
             .client()
             .complete_stream_with_callback(&req, |delta| {
                 if !delta.content.is_empty() {
                     let _ = tx.send(StreamEvent::Delta {
+                        message_id: msg_id_for_cb.clone(),
                         content: delta.content.clone(),
                     });
                 }
@@ -547,10 +588,12 @@ fn force_final_response(
             }
         }
     } else {
+        let msg_id_non_stream = pending_msg_id.clone();
         match engine.client().complete(&req) {
             Ok(r) => {
                 if !r.text.is_empty() {
                     let _ = stream_tx.send(StreamEvent::Delta {
+                        message_id: msg_id_non_stream,
                         content: r.text.clone(),
                     });
                 }
@@ -565,7 +608,7 @@ fn force_final_response(
         }
     };
 
-    session.append_message(MessageRole::Assistant, resp.text);
+    session.append_message_with_id(pending_msg_id, MessageRole::Assistant, resp.text, String::new());
     let _ = stream_tx.send(StreamEvent::Done {
         usage: Some(tiangong_types::TokenUsage {
             prompt_tokens: resp.usage.prompt_tokens,

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -7,22 +7,19 @@ use std::collections::HashMap;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread::{self, JoinHandle};
 
-use crate::agent_config::AgentConfig;
 use crate::agents::execution_mcp_agent::{McpFunctionTarget, execution_function_tools};
 use crate::app_state::formatting::{format_llm_output_message, format_tool_trace_message};
 use crate::coordinator::types::CoordinatorTask;
 use crate::coordinator::TaskCoordinator;
+use crate::core_config::CoreConfigProvider;
 use crate::model::{
-    FunctionToolSpec, ModelClient, ModelProviderConfig, ModelRequest, ModelStreamChunk,
-    SingleProviderClient, TokenUsage,
+    FunctionToolSpec, ModelClient, ModelRequest, ModelStreamChunk, SingleProviderClient, TokenUsage,
 };
-use crate::models_config::ModelsConfig;
 use crate::prompt::PromptAssembler;
 use crate::runtime::{LlmOutputRecord, RuntimeEngine, inject_enhanced_tools, use_stream_mode};
 use crate::session::{Message, MessageRole, Session, now_text};
 use tiangong_types::StreamEvent;
 
-const DEFAULT_CONTEXT_LIMIT: usize = 32_768;
 const MAX_ROUNDS: usize = 20;
 
 /// 用户命令
@@ -51,17 +48,21 @@ pub struct TiangongCore {
 
 impl TiangongCore {
     /// 创建新对话
-    pub fn new(stream_tx: Sender<StreamEvent>) -> Self {
+    pub fn new(config: CoreConfigProvider, stream_tx: Sender<StreamEvent>) -> Self {
         let session = Session::new("新对话");
-        Self::with_session(session, stream_tx)
+        Self::with_session(config, session, stream_tx)
     }
 
     /// 从已有 session 创建
-    pub fn with_session(session: Session, stream_tx: Sender<StreamEvent>) -> Self {
+    pub fn with_session(
+        config: CoreConfigProvider,
+        session: Session,
+        stream_tx: Sender<StreamEvent>,
+    ) -> Self {
         let session_id = session.id.clone();
         let (cmd_tx, cmd_rx) = mpsc::channel::<Command>();
 
-        let worker = thread::spawn(move || worker_loop(session, stream_tx, cmd_rx));
+        let worker = thread::spawn(move || worker_loop(config, session, stream_tx, cmd_rx));
 
         Self {
             cmd_tx: Some(cmd_tx),
@@ -122,19 +123,15 @@ impl Drop for TiangongCore {
 
 /// 工作线程：接收用户命令，执行 LLM + 工具，推送 StreamEvent
 fn worker_loop(
+    config: CoreConfigProvider,
     mut session: Session,
     stream_tx: Sender<StreamEvent>,
     cmd_rx: Receiver<Command>,
 ) -> Session {
-    let engine = build_engine();
-
-    // 初始化工具
-    let (all_tools, mcp_targets) = execution_function_tools(&engine.agent_config().mcp);
-    let mut tools: Vec<FunctionToolSpec> = all_tools
-        .into_iter()
-        .filter(|t| t.name != "mark_step_completed")
-        .collect();
-    inject_enhanced_tools(&mut tools, engine.models_config(), engine.agent_config());
+    let mut last_cfg_gen = 0u64;
+    let mut engine: Option<RuntimeEngine> = None;
+    let mut tools: Vec<FunctionToolSpec> = Vec::new();
+    let mut mcp_targets: HashMap<String, McpFunctionTarget> = HashMap::new();
 
     // 设置工作目录
     if !session.cwd.is_empty() {
@@ -145,6 +142,22 @@ fn worker_loop(
     }
 
     while let Ok(cmd) = cmd_rx.recv() {
+        // 配置变更检测：仅在 generation 变化时重建 engine 和工具列表
+        let cfg_gen = config.generation();
+        if engine.is_none() || cfg_gen != last_cfg_gen {
+            let cfg = config.snapshot();
+            engine = Some(build_engine_from_config(&cfg));
+            let e = engine.as_ref().unwrap();
+            let (all_tools, new_mcp_targets) = execution_function_tools(&e.agent_config().mcp);
+            let mut new_tools: Vec<FunctionToolSpec> = all_tools
+                .into_iter()
+                .filter(|t| t.name != "mark_step_completed")
+                .collect();
+            inject_enhanced_tools(&mut new_tools, e.models_config(), e.agent_config());
+            tools = new_tools;
+            mcp_targets = new_mcp_targets;
+            last_cfg_gen = cfg_gen;
+        }
 
         match cmd {
             Command::Message(content) => {
@@ -155,7 +168,7 @@ fn worker_loop(
                 execute_turn(
                     &mut session,
                     &content,
-                    &engine,
+                    engine.as_ref().unwrap(),
                     &tools,
                     &mcp_targets,
                     &stream_tx,
@@ -562,55 +575,21 @@ fn force_final_response(
     });
 }
 
-fn build_engine() -> RuntimeEngine {
-    let mut models_config = ModelsConfig::load();
-    if models_config.is_empty() {
-        let env_config = ModelProviderConfig::from_env();
-        if !env_config.api_auth_token.is_empty() {
-            models_config = ModelsConfig::from_legacy(&env_config);
-        }
-    }
-    let model_config = models_config.to_chat_provider_config();
+/// 从 CoreConfig 快照构建 RuntimeEngine
+fn build_engine_from_config(config: &crate::core_config::CoreConfig) -> RuntimeEngine {
+    use crate::agent_config::AgentConfig;
 
-    // 加载 AgentConfig：从 ~/.tiangong/ 读取 MCP/Skill 配置
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .unwrap_or_else(|_| ".".to_string());
-    let tiangong_dir = std::path::PathBuf::from(&home).join(".tiangong");
-
-    let mut agent_config = AgentConfig::default();
-
-    // 加载 MCP 配置
-    let mcp_config_path = tiangong_dir.join("mcp.json");
-    if mcp_config_path.exists()
-        && let Ok(content) = std::fs::read_to_string(&mcp_config_path)
-        && let Ok(mcp_config) =
-            serde_json::from_str::<crate::agent_config::McpConfig>(&content)
-    {
-        agent_config.mcp = mcp_config;
-    }
-
-    // 加载 Skills 配置
-    let skills_config_path = tiangong_dir.join("skills.json");
-    if skills_config_path.exists()
-        && let Ok(content) = std::fs::read_to_string(&skills_config_path)
-        && let Ok(skills_config) =
-            serde_json::from_str::<crate::agent_config::SkillsConfig>(&content)
-    {
-        agent_config.skills = skills_config;
-    }
-
-    // 加载 MCP 能力缓存（使工具注册为 function tools）
-    let mcp_cache_path = tiangong_dir.join("mcp-tools-cache.json");
-    let _ = crate::mcp::load_mcp_capabilities_cache(&mcp_cache_path);
-
-    // 异步刷新 MCP 能力（后台更新，不阻塞启动）
-    crate::mcp::refresh_mcp_capabilities_async(agent_config.mcp.clone());
+    let model_config = config.models.to_chat_provider_config();
+    let agent_config = AgentConfig {
+        mcp: config.mcp.clone(),
+        skills: config.skills.clone(),
+        trust_mode: config.trust_mode,
+    };
 
     RuntimeEngine::new(
         SingleProviderClient::new(model_config),
-        DEFAULT_CONTEXT_LIMIT,
+        config.context_limit,
         agent_config,
     )
-    .with_models_config(models_config)
+    .with_models_config(config.models.clone())
 }

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -571,7 +571,41 @@ fn build_engine() -> RuntimeEngine {
         }
     }
     let model_config = models_config.to_chat_provider_config();
-    let agent_config = AgentConfig::default();
+
+    // 加载 AgentConfig：从 ~/.tiangong/ 读取 MCP/Skill 配置
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_else(|_| ".".to_string());
+    let tiangong_dir = std::path::PathBuf::from(&home).join(".tiangong");
+
+    let mut agent_config = AgentConfig::default();
+
+    // 加载 MCP 配置
+    let mcp_config_path = tiangong_dir.join("mcp.json");
+    if mcp_config_path.exists()
+        && let Ok(content) = std::fs::read_to_string(&mcp_config_path)
+        && let Ok(mcp_config) =
+            serde_json::from_str::<crate::agent_config::McpConfig>(&content)
+    {
+        agent_config.mcp = mcp_config;
+    }
+
+    // 加载 Skills 配置
+    let skills_config_path = tiangong_dir.join("skills.json");
+    if skills_config_path.exists()
+        && let Ok(content) = std::fs::read_to_string(&skills_config_path)
+        && let Ok(skills_config) =
+            serde_json::from_str::<crate::agent_config::SkillsConfig>(&content)
+    {
+        agent_config.skills = skills_config;
+    }
+
+    // 加载 MCP 能力缓存（使工具注册为 function tools）
+    let mcp_cache_path = tiangong_dir.join("mcp-tools-cache.json");
+    let _ = crate::mcp::load_mcp_capabilities_cache(&mcp_cache_path);
+
+    // 异步刷新 MCP 能力（后台更新，不阻塞启动）
+    crate::mcp::refresh_mcp_capabilities_async(agent_config.mcp.clone());
 
     RuntimeEngine::new(
         SingleProviderClient::new(model_config),

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -153,7 +153,7 @@ fn worker_loop(
                 .into_iter()
                 .filter(|t| t.name != "mark_step_completed")
                 .collect();
-            inject_enhanced_tools(&mut new_tools, e.models_config(), e.agent_config());
+            inject_enhanced_tools(&mut new_tools, e);
             tools = new_tools;
             mcp_targets = new_mcp_targets;
             last_cfg_gen = cfg_gen;
@@ -578,8 +578,12 @@ fn force_final_response(
 /// 从 CoreConfig 快照构建 RuntimeEngine
 fn build_engine_from_config(config: &crate::core_config::CoreConfig) -> RuntimeEngine {
     use crate::agent_config::AgentConfig;
+    use crate::models_config::ModelsConfig;
 
-    let model_config = config.models.to_chat_provider_config();
+    // 从 LlmConfig 构建兼容的 ModelsConfig（供 PromptAssembler 等旧代码使用）
+    let models_config = ModelsConfig::from_llm_config(&config.llm);
+    let model_config = models_config.to_chat_provider_config();
+
     let agent_config = AgentConfig {
         mcp: config.mcp.clone(),
         skills: config.skills.clone(),
@@ -591,5 +595,6 @@ fn build_engine_from_config(config: &crate::core_config::CoreConfig) -> RuntimeE
         config.context_limit,
         agent_config,
     )
-    .with_models_config(config.models.clone())
+    .with_models_config(models_config)
+    .with_core_config(config.clone())
 }

--- a/crates/tiangong-core/src/core_config.rs
+++ b/crates/tiangong-core/src/core_config.rs
@@ -1,0 +1,207 @@
+//! CoreConfig：TiangongCore 运行所需的最小配置契约
+//!
+//! 不包含 UI 偏好、session 策略、日志级别等外围配置。
+//! 只关心：用什么模型、有什么工具、什么权限。
+//!
+//! 外部（CLI/GUI/Server/第三方）负责构建和更新配置，
+//! TiangongCore 仅通过 CoreConfigProvider 只读消费。
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+
+use crate::agent_config::{McpConfig, McpServerConfig, SkillsConfig};
+use crate::mcp::McpToolMeta;
+use crate::models_config::ModelsConfig;
+use crate::permission::TrustMode;
+
+const DEFAULT_CONTEXT_LIMIT: usize = 32_768;
+
+/// TiangongCore 运行所需的最小配置
+#[derive(Debug, Clone)]
+pub struct CoreConfig {
+    /// LLM 模型配置（Provider + Model + Routing）
+    pub models: ModelsConfig,
+    /// MCP 服务配置（server 列表）
+    pub mcp: McpConfig,
+    /// MCP 能力数据（预填充，Core 不发起网络请求）
+    pub mcp_capabilities: Vec<(String, Vec<McpToolMeta>)>,
+    /// Skill 配置（已安装的 skill 列表）
+    pub skills: SkillsConfig,
+    /// 权限信任模式
+    pub trust_mode: TrustMode,
+    /// 上下文窗口大小（token 数）
+    pub context_limit: usize,
+}
+
+impl Default for CoreConfig {
+    fn default() -> Self {
+        Self {
+            models: ModelsConfig::default(),
+            mcp: McpConfig::default(),
+            mcp_capabilities: Vec::new(),
+            skills: SkillsConfig::default(),
+            trust_mode: TrustMode::default(),
+            context_limit: DEFAULT_CONTEXT_LIMIT,
+        }
+    }
+}
+
+impl CoreConfig {
+    /// 快捷构建器
+    pub fn builder() -> CoreConfigBuilder {
+        CoreConfigBuilder::default()
+    }
+}
+
+/// CoreConfig 构建器
+#[derive(Debug, Default)]
+pub struct CoreConfigBuilder {
+    config: CoreConfig,
+}
+
+impl CoreConfigBuilder {
+    /// 设置完整的 ModelsConfig
+    pub fn with_models_config(mut self, models: ModelsConfig) -> Self {
+        self.config.models = models;
+        self
+    }
+
+    /// 添加 MCP server
+    pub fn with_mcp_server(mut self, server: McpServerConfig) -> Self {
+        self.config.mcp.servers.push(server);
+        self
+    }
+
+    /// 设置完整的 McpConfig
+    pub fn with_mcp_config(mut self, mcp: McpConfig) -> Self {
+        self.config.mcp = mcp;
+        self
+    }
+
+    /// 设置 Skills 配置
+    pub fn with_skills_config(mut self, skills: SkillsConfig) -> Self {
+        self.config.skills = skills;
+        self
+    }
+
+    /// 设置信任模式
+    pub fn with_trust_mode(mut self, mode: TrustMode) -> Self {
+        self.config.trust_mode = mode;
+        self
+    }
+
+    /// 设置上下文窗口大小
+    pub fn with_context_limit(mut self, limit: usize) -> Self {
+        self.config.context_limit = limit;
+        self
+    }
+
+    /// 构建
+    pub fn build(self) -> CoreConfig {
+        self.config
+    }
+}
+
+/// 配置提供者
+///
+/// 多线程安全：
+/// - 读操作无锁（ArcSwap::load，纳秒级）
+/// - 写操作原子替换（不阻塞读）
+/// - generation 递增用于快速变更检测
+#[derive(Clone)]
+pub struct CoreConfigProvider {
+    inner: Arc<ArcSwap<CoreConfig>>,
+    generation: Arc<AtomicU64>,
+}
+
+impl CoreConfigProvider {
+    /// 创建配置提供者
+    pub fn new(config: CoreConfig) -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(config)),
+            generation: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    /// 获取当前配置快照（无锁读，纳秒级）
+    pub fn snapshot(&self) -> Arc<CoreConfig> {
+        self.inner.load_full()
+    }
+
+    /// 获取配置版本号（原子读，用于变更检测）
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    /// 更新配置（原子替换 + generation 递增）
+    pub fn update(&self, f: impl FnOnce(&mut CoreConfig)) {
+        let mut new_config = (*self.inner.load_full()).clone();
+        f(&mut new_config);
+        self.inner.store(Arc::new(new_config));
+        self.generation.fetch_add(1, Ordering::Release);
+    }
+
+    /// 整体替换配置
+    pub fn replace(&self, config: CoreConfig) {
+        self.inner.store(Arc::new(config));
+        self.generation.fetch_add(1, Ordering::Release);
+    }
+}
+
+impl std::fmt::Debug for CoreConfigProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CoreConfigProvider")
+            .field("generation", &self.generation())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_snapshot_and_generation() {
+        let config = CoreConfig::default();
+        let provider = CoreConfigProvider::new(config);
+
+        assert_eq!(provider.generation(), 1);
+        let snap = provider.snapshot();
+        assert_eq!(snap.context_limit, DEFAULT_CONTEXT_LIMIT);
+    }
+
+    #[test]
+    fn provider_update_increments_generation() {
+        let provider = CoreConfigProvider::new(CoreConfig::default());
+        assert_eq!(provider.generation(), 1);
+
+        provider.update(|c| c.context_limit = 65536);
+        assert_eq!(provider.generation(), 2);
+
+        let snap = provider.snapshot();
+        assert_eq!(snap.context_limit, 65536);
+    }
+
+    #[test]
+    fn provider_clone_shares_state() {
+        let provider = CoreConfigProvider::new(CoreConfig::default());
+        let cloned = provider.clone();
+
+        provider.update(|c| c.context_limit = 16384);
+        assert_eq!(cloned.generation(), 2);
+        assert_eq!(cloned.snapshot().context_limit, 16384);
+    }
+
+    #[test]
+    fn builder_basic() {
+        let config = CoreConfig::builder()
+            .with_trust_mode(TrustMode::FullTrust)
+            .with_context_limit(65536)
+            .build();
+
+        assert_eq!(config.trust_mode, TrustMode::FullTrust);
+        assert_eq!(config.context_limit, 65536);
+    }
+}

--- a/crates/tiangong-core/src/core_config.rs
+++ b/crates/tiangong-core/src/core_config.rs
@@ -11,18 +11,77 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::agent_config::{McpConfig, McpServerConfig, SkillsConfig};
 use crate::mcp::McpToolMeta;
-use crate::models_config::ModelsConfig;
 use crate::permission::TrustMode;
 
 const DEFAULT_CONTEXT_LIMIT: usize = 32_768;
+const DEFAULT_TIMEOUT_MS: u64 = 120_000;
+
+/// 模型端点配置
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelEndpoint {
+    /// API 基础 URL
+    pub base_url: String,
+    /// API 密钥
+    pub api_key: String,
+    /// 模型名称
+    pub model: String,
+    /// 请求超时（毫秒）
+    #[serde(default = "default_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+fn default_timeout_ms() -> u64 {
+    DEFAULT_TIMEOUT_MS
+}
+
+impl Default for ModelEndpoint {
+    fn default() -> Self {
+        Self {
+            base_url: String::new(),
+            api_key: String::new(),
+            model: String::new(),
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+        }
+    }
+}
+
+/// LLM 配置 — TiangongCore 所需的模型端点
+///
+/// 扁平结构，直接描述端点，无需解析 Provider/Model/Routing。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LlmConfig {
+    /// 主 Chat 端点（必须）
+    pub chat: ModelEndpoint,
+    /// 图片生成端点
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_generation: Option<ModelEndpoint>,
+    /// 语音合成端点
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tts: Option<ModelEndpoint>,
+    /// 语音识别端点
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stt: Option<ModelEndpoint>,
+    /// 视频生成端点
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub video_generation: Option<ModelEndpoint>,
+}
+
+impl LlmConfig {
+    /// 检查是否有有效的 Chat 端点
+    pub fn is_valid(&self) -> bool {
+        !self.chat.base_url.is_empty() && !self.chat.api_key.is_empty()
+    }
+}
 
 /// TiangongCore 运行所需的最小配置
 #[derive(Debug, Clone)]
 pub struct CoreConfig {
-    /// LLM 模型配置（Provider + Model + Routing）
-    pub models: ModelsConfig,
+    /// LLM 模型端点配置
+    pub llm: LlmConfig,
     /// MCP 服务配置（server 列表）
     pub mcp: McpConfig,
     /// MCP 能力数据（预填充，Core 不发起网络请求）
@@ -38,7 +97,7 @@ pub struct CoreConfig {
 impl Default for CoreConfig {
     fn default() -> Self {
         Self {
-            models: ModelsConfig::default(),
+            llm: LlmConfig::default(),
             mcp: McpConfig::default(),
             mcp_capabilities: Vec::new(),
             skills: SkillsConfig::default(),
@@ -62,9 +121,20 @@ pub struct CoreConfigBuilder {
 }
 
 impl CoreConfigBuilder {
-    /// 设置完整的 ModelsConfig
-    pub fn with_models_config(mut self, models: ModelsConfig) -> Self {
-        self.config.models = models;
+    /// 设置 Chat 端点（最常用的快捷方式）
+    pub fn with_chat(mut self, base_url: &str, api_key: &str, model: &str) -> Self {
+        self.config.llm.chat = ModelEndpoint {
+            base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
+            model: model.to_string(),
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+        };
+        self
+    }
+
+    /// 设置完整的 LlmConfig
+    pub fn with_llm_config(mut self, llm: LlmConfig) -> Self {
+        self.config.llm = llm;
         self
     }
 
@@ -197,11 +267,30 @@ mod tests {
     #[test]
     fn builder_basic() {
         let config = CoreConfig::builder()
+            .with_chat("https://api.example.com/v1", "sk-test", "gpt-4o")
             .with_trust_mode(TrustMode::FullTrust)
             .with_context_limit(65536)
             .build();
 
+        assert_eq!(config.llm.chat.base_url, "https://api.example.com/v1");
+        assert_eq!(config.llm.chat.model, "gpt-4o");
+        assert!(config.llm.is_valid());
         assert_eq!(config.trust_mode, TrustMode::FullTrust);
         assert_eq!(config.context_limit, 65536);
+    }
+
+    #[test]
+    fn llm_config_capabilities() {
+        let mut llm = LlmConfig::default();
+        assert!(llm.image_generation.is_none());
+        assert!(llm.tts.is_none());
+
+        llm.image_generation = Some(ModelEndpoint {
+            base_url: "https://api.example.com/v1".into(),
+            api_key: "sk-test".into(),
+            model: "dall-e-3".into(),
+            ..Default::default()
+        });
+        assert!(llm.image_generation.is_some());
     }
 }

--- a/crates/tiangong-core/src/lib.rs
+++ b/crates/tiangong-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod app_state;
 pub mod config_watch;
 pub mod context;
 pub mod core;
+pub mod core_config;
 pub mod coordinator;
 pub mod event;
 pub mod execution;

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -314,6 +314,7 @@ impl SingleProviderClient {
                 let mut chunks = 0usize;
                 let mut has_think_output = false;
                 let mut stream_usage = (0usize, 0usize, 0usize); // (prompt, completion, total)
+                let mut think_filter = ThinkTagFilter::new();
 
                 while let Some(item) = stream.next().await {
                     let payload = match item {
@@ -362,19 +363,63 @@ impl SingleProviderClient {
 
                             let content_delta = extract_delta_text(delta, "content");
                             if !content_delta.is_empty() {
-                                push_stream_piece(
-                                    ModelStreamChunk {
-                                        content: content_delta.clone(),
-                                        reasoning_content: String::new(),
-                                    },
-                                    &mut on_delta,
-                                    &mut content,
-                                    &mut reasoning_content,
-                                    &mut chunks,
-                                );
+                                let (filtered_content, filtered_reasoning) =
+                                    think_filter.filter(&content_delta);
+                                if !filtered_reasoning.is_empty() {
+                                    has_think_output = true;
+                                    push_stream_piece(
+                                        ModelStreamChunk {
+                                            content: String::new(),
+                                            reasoning_content: filtered_reasoning,
+                                        },
+                                        &mut on_delta,
+                                        &mut content,
+                                        &mut reasoning_content,
+                                        &mut chunks,
+                                    );
+                                }
+                                if !filtered_content.is_empty() {
+                                    push_stream_piece(
+                                        ModelStreamChunk {
+                                            content: filtered_content,
+                                            reasoning_content: String::new(),
+                                        },
+                                        &mut on_delta,
+                                        &mut content,
+                                        &mut reasoning_content,
+                                        &mut chunks,
+                                    );
+                                }
                             }
                         }
                     }
+                }
+
+                // 刷出 <think> 过滤器缓冲区残留
+                let (flush_content, flush_reasoning) = think_filter.flush();
+                if !flush_reasoning.is_empty() {
+                    push_stream_piece(
+                        ModelStreamChunk {
+                            content: String::new(),
+                            reasoning_content: flush_reasoning,
+                        },
+                        &mut on_delta,
+                        &mut content,
+                        &mut reasoning_content,
+                        &mut chunks,
+                    );
+                }
+                if !flush_content.is_empty() {
+                    push_stream_piece(
+                        ModelStreamChunk {
+                            content: flush_content,
+                            reasoning_content: String::new(),
+                        },
+                        &mut on_delta,
+                        &mut content,
+                        &mut reasoning_content,
+                        &mut chunks,
+                    );
                 }
 
                 Ok::<
@@ -495,6 +540,7 @@ impl SingleProviderClient {
                 let mut tool_calls_map: std::collections::BTreeMap<u64, (String, String, String)> =
                     std::collections::BTreeMap::new();
                 let mut stream_usage = (0usize, 0usize, 0usize);
+                let mut think_filter = ThinkTagFilter::new();
 
                 while let Some(item) = stream.next().await {
                     let payload = match item {
@@ -526,7 +572,7 @@ impl SingleProviderClient {
                         for choice in choices {
                             let delta = choice.get("delta").unwrap_or(&Value::Null);
 
-                            // 流式输出 reasoning_content
+                            // 流式输出 reasoning_content（API 原生字段）
                             let think_delta = extract_delta_text(delta, "reasoning_content");
                             if !think_delta.is_empty() {
                                 reasoning_content.push_str(&think_delta);
@@ -536,14 +582,25 @@ impl SingleProviderClient {
                                 });
                             }
 
-                            // 流式输出 content
+                            // 流式输出 content（经 <think> 标签过滤）
                             let content_delta = extract_delta_text(delta, "content");
                             if !content_delta.is_empty() {
-                                content.push_str(&content_delta);
-                                on_delta(&ModelStreamChunk {
-                                    content: content_delta,
-                                    reasoning_content: String::new(),
-                                });
+                                let (filtered_content, filtered_reasoning) =
+                                    think_filter.filter(&content_delta);
+                                if !filtered_reasoning.is_empty() {
+                                    reasoning_content.push_str(&filtered_reasoning);
+                                    on_delta(&ModelStreamChunk {
+                                        content: String::new(),
+                                        reasoning_content: filtered_reasoning,
+                                    });
+                                }
+                                if !filtered_content.is_empty() {
+                                    content.push_str(&filtered_content);
+                                    on_delta(&ModelStreamChunk {
+                                        content: filtered_content,
+                                        reasoning_content: String::new(),
+                                    });
+                                }
                             }
 
                             // 累积 tool_calls
@@ -574,6 +631,23 @@ impl SingleProviderClient {
                             }
                         }
                     }
+                }
+
+                // 刷出 <think> 过滤器缓冲区残留
+                let (flush_content, flush_reasoning) = think_filter.flush();
+                if !flush_reasoning.is_empty() {
+                    reasoning_content.push_str(&flush_reasoning);
+                    on_delta(&ModelStreamChunk {
+                        content: String::new(),
+                        reasoning_content: flush_reasoning,
+                    });
+                }
+                if !flush_content.is_empty() {
+                    content.push_str(&flush_content);
+                    on_delta(&ModelStreamChunk {
+                        content: flush_content,
+                        reasoning_content: String::new(),
+                    });
                 }
 
                 Ok::<_, async_openai::error::OpenAIError>((
@@ -1176,6 +1250,92 @@ fn push_stream_piece(
     text.push_str(&piece.content);
     reasoning_content.push_str(&piece.reasoning_content);
     *chunks += 1;
+}
+
+/// 流式 `<think>` 标签过滤器
+///
+/// 某些模型不使用 API 级别的 `reasoning_content` 字段，
+/// 而是在 `content` 中输出 `<think>...</think>` 标签。
+/// 此过滤器跨 chunk 追踪状态，将标签内的内容转移到 `reasoning_content`。
+struct ThinkTagFilter {
+    /// 是否处于 `<think>` 块内
+    inside_think: bool,
+    /// 部分匹配缓冲（可能跨 chunk 的标签片段）
+    buf: String,
+}
+
+impl ThinkTagFilter {
+    fn new() -> Self {
+        Self {
+            inside_think: false,
+            buf: String::new(),
+        }
+    }
+
+    /// 过滤输入的 content，返回 (正文内容, 思考内容)
+    fn filter(&mut self, input: &str) -> (String, String) {
+        let mut content = String::new();
+        let mut reasoning = String::new();
+
+        self.buf.push_str(input);
+
+        while !self.buf.is_empty() {
+            if self.inside_think {
+                // 在 <think> 块内，寻找 </think>
+                if let Some(pos) = self.buf.find("</think>") {
+                    reasoning.push_str(&self.buf[..pos]);
+                    self.buf = self.buf[pos + 8..].to_string();
+                    self.inside_think = false;
+                } else if self.buf.len() >= 8 && !self.buf.ends_with('<')
+                    && !self.buf.ends_with("</")
+                    && !self.buf.ends_with("</t")
+                    && !self.buf.ends_with("</th")
+                    && !self.buf.ends_with("</thi")
+                    && !self.buf.ends_with("</thin")
+                    && !self.buf.ends_with("</think")
+                {
+                    // 没有部分匹配前缀，全部输出为 reasoning
+                    reasoning.push_str(&self.buf);
+                    self.buf.clear();
+                } else {
+                    // 可能有部分 </think> 标签，保留缓冲等下一个 chunk
+                    break;
+                }
+            } else {
+                // 在正常内容中，寻找 <think>
+                if let Some(pos) = self.buf.find("<think>") {
+                    content.push_str(&self.buf[..pos]);
+                    self.buf = self.buf[pos + 7..].to_string();
+                    self.inside_think = true;
+                } else if self.buf.len() >= 7 && !self.buf.ends_with('<')
+                    && !self.buf.ends_with("<t")
+                    && !self.buf.ends_with("<th")
+                    && !self.buf.ends_with("<thi")
+                    && !self.buf.ends_with("<thin")
+                    && !self.buf.ends_with("<think")
+                {
+                    // 没有部分匹配前缀，全部输出为 content
+                    content.push_str(&self.buf);
+                    self.buf.clear();
+                } else {
+                    // 可能有部分 <think> 标签，保留缓冲
+                    break;
+                }
+            }
+        }
+
+        (content, reasoning)
+    }
+
+    /// 流结束时刷出缓冲区残留
+    fn flush(&mut self) -> (String, String) {
+        let remaining = std::mem::take(&mut self.buf);
+        if self.inside_think {
+            (String::new(), remaining)
+        } else {
+            (remaining, String::new())
+        }
+    }
 }
 
 fn should_skip_stream_payload(raw: &str) -> bool {

--- a/crates/tiangong-core/src/models_config.rs
+++ b/crates/tiangong-core/src/models_config.rs
@@ -244,6 +244,64 @@ impl ModelsConfig {
         }
     }
 
+    /// 从 LlmConfig 构建兼容的 ModelsConfig
+    ///
+    /// 将扁平的 LlmConfig 端点映射为 Provider + Model + Routing 三层结构，
+    /// 使旧代码（PromptAssembler、系统 prompt 构建等）无需修改。
+    pub fn from_llm_config(llm: &crate::core_config::LlmConfig) -> Self {
+        let mut providers = HashMap::new();
+        let mut models = HashMap::new();
+        let mut routing = HashMap::new();
+
+        // 辅助：注册一个端点为 provider + model + routing
+        let mut register =
+            |name: &str, endpoint: &crate::core_config::ModelEndpoint, cap: ModelCapability| {
+                let provider_key = format!("{name}-provider");
+                providers.insert(
+                    provider_key.clone(),
+                    ProviderConfig {
+                        base_url: endpoint.base_url.clone(),
+                        api_key: endpoint.api_key.clone(),
+                        timeout_ms: endpoint.timeout_ms,
+                    },
+                );
+                let model_key = format!("{name}-model");
+                models.insert(
+                    model_key.clone(),
+                    ModelEntry {
+                        provider: provider_key,
+                        model: endpoint.model.clone(),
+                        capabilities: vec![cap],
+                        options: default_options(),
+                    },
+                );
+                routing.insert(cap, model_key);
+            };
+
+        // Chat（必须）
+        register("chat", &llm.chat, ModelCapability::Chat);
+
+        // 可选能力
+        if let Some(ref ep) = llm.image_generation {
+            register("image", ep, ModelCapability::ImageGeneration);
+        }
+        if let Some(ref ep) = llm.tts {
+            register("tts", ep, ModelCapability::Tts);
+        }
+        if let Some(ref ep) = llm.stt {
+            register("stt", ep, ModelCapability::Stt);
+        }
+        if let Some(ref ep) = llm.video_generation {
+            register("video", ep, ModelCapability::VideoGeneration);
+        }
+
+        Self {
+            providers,
+            models,
+            routing,
+        }
+    }
+
     /// 解析 api_key 中的 ${ENV_VAR} 引用
     pub fn resolve_api_key(raw: &str) -> String {
         if let Some(inner) = raw.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {

--- a/crates/tiangong-core/src/runtime.rs
+++ b/crates/tiangong-core/src/runtime.rs
@@ -67,6 +67,7 @@ pub struct RuntimeEngine {
     pub context_limit: usize,
     agent_config: AgentConfig,
     models_config: ModelsConfig,
+    core_config: Option<crate::core_config::CoreConfig>,
     permission_gate: crate::permission::PermissionGate,
 }
 
@@ -87,6 +88,7 @@ impl RuntimeEngine {
             context_limit,
             agent_config,
             models_config: ModelsConfig::default(),
+            core_config: None,
             permission_gate,
         }
     }
@@ -112,6 +114,7 @@ impl RuntimeEngine {
             context_limit,
             agent_config,
             models_config: ModelsConfig::default(),
+            core_config: None,
             permission_gate,
         }
     }
@@ -119,6 +122,16 @@ impl RuntimeEngine {
     pub fn with_models_config(mut self, config: ModelsConfig) -> Self {
         self.models_config = config;
         self
+    }
+
+    pub fn with_core_config(mut self, config: crate::core_config::CoreConfig) -> Self {
+        self.core_config = Some(config);
+        self
+    }
+
+    /// 获取 LlmConfig 引用（优先从 core_config 取）
+    pub fn llm_config(&self) -> Option<&crate::core_config::LlmConfig> {
+        self.core_config.as_ref().map(|c| &c.llm)
     }
 
     /// 获取模型客户端引用
@@ -1238,14 +1251,40 @@ impl RuntimeEngine {
 /// 注入增强工具定义（多媒体、Skill、后台任务、MCP 管理）
 pub(crate) fn inject_enhanced_tools(
     tools: &mut Vec<FunctionToolSpec>,
-    models_config: &ModelsConfig,
-    agent_config: &AgentConfig,
+    engine: &RuntimeEngine,
 ) {
-    use crate::models_config::ModelCapability;
-    if models_config
-        .resolve_for_capability(ModelCapability::ImageGeneration)
-        .is_some()
-    {
+    let agent_config = engine.agent_config();
+
+    // 多媒体能力判断：优先使用 LlmConfig（新路径），回退 ModelsConfig（旧路径）
+    let has_image_gen = engine
+        .llm_config()
+        .map(|c| c.image_generation.is_some())
+        .unwrap_or_else(|| {
+            engine
+                .models_config()
+                .resolve_for_capability(crate::models_config::ModelCapability::ImageGeneration)
+                .is_some()
+        });
+    let has_tts = engine
+        .llm_config()
+        .map(|c| c.tts.is_some())
+        .unwrap_or_else(|| {
+            engine
+                .models_config()
+                .resolve_for_capability(crate::models_config::ModelCapability::Tts)
+                .is_some()
+        });
+    let has_stt = engine
+        .llm_config()
+        .map(|c| c.stt.is_some())
+        .unwrap_or_else(|| {
+            engine
+                .models_config()
+                .resolve_for_capability(crate::models_config::ModelCapability::Stt)
+                .is_some()
+        });
+
+    if has_image_gen {
         tools.push(FunctionToolSpec {
             name: "generate_image".to_string(),
             description: "根据文字描述生成图片".to_string(),
@@ -1261,10 +1300,7 @@ pub(crate) fn inject_enhanced_tools(
             }),
         });
     }
-    if models_config
-        .resolve_for_capability(ModelCapability::Tts)
-        .is_some()
-    {
+    if has_tts {
         tools.push(FunctionToolSpec {
             name: "text_to_speech".to_string(),
             description: "将文本转换为语音音频文件".to_string(),
@@ -1280,10 +1316,7 @@ pub(crate) fn inject_enhanced_tools(
             }),
         });
     }
-    if models_config
-        .resolve_for_capability(ModelCapability::Stt)
-        .is_some()
-    {
+    if has_stt {
         tools.push(FunctionToolSpec {
             name: "speech_to_text".to_string(),
             description: "将音频文件转录为文本".to_string(),

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -243,6 +243,25 @@ impl Session {
         self.updated_at = now_text();
     }
 
+    /// 使用预生成的 ID 追加消息（流式场景：Delta/Reasoning 事件先于消息创建）
+    pub fn append_message_with_id(
+        &mut self,
+        id: String,
+        role: MessageRole,
+        content: impl Into<String>,
+        reasoning_content: impl Into<String>,
+    ) {
+        self.messages.push(Message {
+            id,
+            role,
+            content: content.into(),
+            reasoning_content: reasoning_content.into(),
+            worker_id: None,
+            created_at: now_text(),
+        });
+        self.updated_at = now_text();
+    }
+
     pub fn append_worker_message(
         &mut self,
         role: MessageRole,

--- a/crates/tiangong-types/src/lib.rs
+++ b/crates/tiangong-types/src/lib.rs
@@ -12,7 +12,7 @@ pub mod token;
 pub use message::{Message, MessageRole, now_text};
 pub use session::Session;
 pub use status::RunStatus;
-pub use stream::StreamEvent;
+pub use stream::{SessionStreamEvent, StreamEvent};
 pub use token::TokenUsage;
 
 #[cfg(test)]

--- a/crates/tiangong-types/src/stream.rs
+++ b/crates/tiangong-types/src/stream.rs
@@ -10,9 +10,17 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum StreamEvent {
     /// 文本增量（assistant 回复内容）
-    Delta { content: String },
+    Delta {
+        /// 所属消息 ID（前端据此组装到正确的消息）
+        message_id: String,
+        content: String,
+    },
     /// 思考过程增量
-    Reasoning { content: String },
+    Reasoning {
+        /// 所属消息 ID
+        message_id: String,
+        content: String,
+    },
     /// 工具开始执行
     ToolStart { name: String, summary: String },
     /// 工具执行结果
@@ -61,4 +69,22 @@ pub enum StreamEvent {
         worker_label: String,
         success: bool,
     },
+    /// 用户消息（Core 收到用户输入后回传，供前端统一渲染）
+    UserMessage {
+        /// 该用户消息在 session 中的 ID
+        message_id: String,
+        content: String,
+    },
+}
+
+/// 带会话标识的流事件
+///
+/// Core 输出的所有事件都携带 session_id，
+/// 消费端（GUI / CLI / Server）可据此路由到正确的会话。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionStreamEvent {
+    /// 产生该事件的会话 ID
+    pub session_id: String,
+    /// 原始流事件
+    pub event: StreamEvent,
 }

--- a/crates/tiangong-types/src/tests.rs
+++ b/crates/tiangong-types/src/tests.rs
@@ -58,11 +58,13 @@ fn run_status_serde() {
 #[test]
 fn stream_event_serde() {
     let event = StreamEvent::Delta {
+        message_id: "msg-1".into(),
         content: "你好".into(),
     };
     let json = serde_json::to_string(&event).unwrap();
     assert!(json.contains(r#""type":"delta""#));
     assert!(json.contains(r#""content":"你好""#));
+    assert!(json.contains(r#""message_id":"msg-1""#));
 
     let done = StreamEvent::Done { usage: None };
     let json = serde_json::to_string(&done).unwrap();

--- a/docs/rfc/0006-core-config-provider.md
+++ b/docs/rfc/0006-core-config-provider.md
@@ -1,0 +1,433 @@
+# RFC 0006：CoreConfig 配置注入与热更新
+
+> 状态：草稿
+> 日期：2026-04-08
+> 关联：`crates/tiangong-core/src/core/mod.rs`
+
+## 1. 问题
+
+当前 TiangongCore 通过内部 `build_engine()` 函数自行从磁盘加载配置：
+
+```rust
+fn build_engine() -> RuntimeEngine {
+    let models_config = ModelsConfig::load();           // ~/.tiangong/models.json
+    let mcp_config = read("~/.tiangong/mcp.json");      // 硬编码路径
+    let skills_config = read("~/.tiangong/skills.json"); // 硬编码路径
+    // ...
+}
+```
+
+这带来以下问题：
+
+1. **配置路径硬编码**：Core 假设配置文件在 `~/.tiangong/`，无法自定义
+2. **与外部配置不同步**：GUI 的 TiangongState 维护一套配置（内存），Core 从磁盘读另一套，可能不一致
+3. **无法热更新**：用户在 GUI 中切换模型、安装 Skill，Core 不感知，需重启对话
+4. **不可嵌入**：第三方开发者无法自定义配置来源（如从数据库、远程服务加载）
+5. **配置加载职责混乱**：Core 既是执行引擎又是配置加载器，违反单一职责
+
+## 2. 目标
+
+- TiangongCore 只定义**最小配置契约**（CoreConfig），不关心配置从哪来
+- 配置通过**注入**而非自行加载，CLI/GUI/Server/第三方各自构建
+- 支持**热更新**：外部修改配置后，Core 下一轮自动生效
+- 第三方开发者可**零成本接入**：只需构造一个 CoreConfig 即可运行智能体
+
+## 3. 设计
+
+### 3.1 CoreConfig 最小契约
+
+定义在 `tiangong-core` 中，是 TiangongCore 运行所需的全部配置：
+
+```rust
+/// TiangongCore 运行所需的最小配置
+///
+/// 不包含 UI 偏好、session 策略、日志级别等外围配置。
+/// 只关心：用什么模型、有什么工具、什么权限。
+pub struct CoreConfig {
+    /// LLM 模型配置（Provider + Model + Routing）
+    pub models: ModelsConfig,
+    /// MCP 服务配置（server 列表）
+    pub mcp: McpConfig,
+    /// Skill 配置（已安装的 skill 列表）
+    pub skills: SkillsConfig,
+    /// 权限信任模式
+    pub trust_mode: TrustMode,
+    /// 上下文窗口大小（token 数）
+    pub context_limit: usize,
+}
+```
+
+| 字段 | 用途 | 变更频率 |
+|------|------|----------|
+| `models` | LLM 调用 + 多媒体能力判断（图片/语音/视频工具注入） | 低（用户切换模型） |
+| `mcp` | MCP server 列表 → 注册为 function tools | 低（用户添加/移除 server） |
+| `skills` | Skill 列表 → system prompt 描述 + get_skill_detail 工具 | 低（用户安装/卸载 skill） |
+| `trust_mode` | 工具执行前审批策略 | 极低 |
+| `context_limit` | Prompt 裁剪上限 | 极低 |
+
+### 3.2 CoreConfigProvider
+
+配置容器，支持无锁读和原子更新：
+
+```rust
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use arc_swap::ArcSwap;
+
+/// 配置提供者
+///
+/// 多线程安全：
+/// - 读操作无锁（ArcSwap::load，纳秒级）
+/// - 写操作原子替换（不阻塞读）
+/// - generation 递增用于快速变更检测
+pub struct CoreConfigProvider {
+    inner: Arc<ArcSwap<CoreConfig>>,
+    generation: Arc<AtomicU64>,
+}
+
+impl CoreConfigProvider {
+    /// 创建配置提供者
+    pub fn new(config: CoreConfig) -> Self { ... }
+
+    /// 获取当前配置快照（零成本，返回 Arc 引用）
+    pub fn snapshot(&self) -> Arc<CoreConfig> { ... }
+
+    /// 获取配置版本号（原子读，用于变更检测）
+    pub fn generation(&self) -> u64 { ... }
+
+    /// 更新配置（原子替换 + generation 递增）
+    pub fn update(&self, f: impl FnOnce(&mut CoreConfig)) { ... }
+
+    /// 整体替换配置
+    pub fn replace(&self, config: CoreConfig) { ... }
+}
+
+impl Clone for CoreConfigProvider {
+    // 浅拷贝：多个持有者共享同一配置
+    fn clone(&self) -> Self { ... }
+}
+```
+
+### 3.3 TiangongCore 接口变更
+
+```rust
+impl TiangongCore {
+    /// 创建新对话
+    pub fn new(
+        config: CoreConfigProvider,
+        stream_tx: Sender<StreamEvent>,
+    ) -> Self { ... }
+
+    /// 从已有 session 创建
+    pub fn with_session(
+        config: CoreConfigProvider,
+        session: Session,
+        stream_tx: Sender<StreamEvent>,
+    ) -> Self { ... }
+}
+```
+
+### 3.4 Worker 线程配置消费
+
+```rust
+fn worker_loop(
+    config: CoreConfigProvider,
+    session: Session,
+    stream_tx: Sender<StreamEvent>,
+    cmd_rx: Receiver<Command>,
+) -> Session {
+    let mut last_gen = 0u64;
+    let mut engine: Option<RuntimeEngine> = None;
+    let mut tools: Vec<FunctionToolSpec> = Vec::new();
+    let mut mcp_targets: HashMap<String, McpFunctionTarget> = HashMap::new();
+
+    loop {
+        // 配置变更检测（一次原子读，纳秒级）
+        let gen = config.generation();
+        if engine.is_none() || gen != last_gen {
+            let cfg = config.snapshot();
+            engine = Some(build_engine_from_config(&cfg));
+            (tools, mcp_targets) = init_tools(engine.as_ref().unwrap());
+            last_gen = gen;
+        }
+
+        match cmd_rx.recv() {
+            Ok(Command::Message(content)) => {
+                execute_turn(&mut session, &content, engine.as_ref().unwrap(), ...);
+            }
+            // ...
+        }
+    }
+}
+```
+
+## 4. 各端使用方式
+
+### 4.1 CLI
+
+```rust
+// CLI 拥有配置的完整控制权
+let config = CoreConfig::load_from_disk();  // tiangong-config 提供
+let provider = CoreConfigProvider::new(config);
+let core = TiangongCore::new(provider, stream_tx);
+
+// CLI 中用户执行 /model 切换模型
+provider.update(|c| {
+    c.models = new_models_config;
+});
+// 下一轮对话自动使用新模型
+```
+
+### 4.2 GUI
+
+```rust
+// GUI 创建全局 provider，所有 Core 共享
+let config = CoreConfig::load_from_disk();
+let provider = CoreConfigProvider::new(config);
+
+// 多会话共享同一 provider
+let core_a = TiangongCore::with_session(provider.clone(), session_a, tx_a);
+let core_b = TiangongCore::with_session(provider.clone(), session_b, tx_b);
+
+// 用户在设置面板切换模型 → 所有会话下一轮生效
+provider.update(|c| c.models = new_config);
+```
+
+### 4.3 Server
+
+```rust
+// Server 启动时加载配置
+let provider = CoreConfigProvider::new(CoreConfig::load_from_disk());
+
+// API 端点：POST /config/models
+async fn update_models(provider: &CoreConfigProvider, new_config: ModelsConfig) {
+    provider.update(|c| c.models = new_config);
+    // 所有活跃会话下一轮自动使用新配置
+}
+```
+
+### 4.4 第三方开发者（二次开发）
+
+```rust
+use tiangong_core::{CoreConfig, CoreConfigProvider, TiangongCore};
+
+// 最简使用：手动构建配置
+let config = CoreConfig {
+    models: ModelsConfig::from_env(),    // 从环境变量
+    mcp: McpConfig::default(),           // 无 MCP
+    skills: SkillsConfig::default(),     // 无 Skill
+    trust_mode: TrustMode::Full,         // 完全信任
+    context_limit: 32_768,
+};
+let provider = CoreConfigProvider::new(config);
+let (tx, rx) = std::sync::mpsc::channel();
+let core = TiangongCore::new(provider, tx);
+
+// 发送消息
+core.send_message("你好".to_string());
+
+// 消费事件流
+for event in rx.iter() {
+    match event {
+        StreamEvent::Delta { content } => print!("{content}"),
+        StreamEvent::Done { .. } => break,
+        _ => {}
+    }
+}
+```
+
+## 5. 配置层次
+
+```
+┌────────────────────────────────────────────────────────┐
+│  应用层配置（tiangong-config 或第三方实现）               │
+│  ├── UI 偏好、主题、快捷键                               │
+│  ├── Session 管理策略（自动保存、历史上限）               │
+│  ├── 日志级别、存储路径                                  │
+│  ├── Connector 配置（Telegram/Discord/...）              │
+│  ├── Server 配置（端口、认证）                           │
+│  └── 构建 CoreConfig ──────────────────────┐            │
+└────────────────────────────────────────────│────────────┘
+                                             ↓
+┌────────────────────────────────────────────────────────┐
+│  核心配置（CoreConfig，tiangong-core 定义）              │
+│  ├── models: ModelsConfig    → LLM 调用                 │
+│  ├── mcp: McpConfig          → MCP 工具注册             │
+│  ├── skills: SkillsConfig    → Skill 工具注册           │
+│  ├── trust_mode: TrustMode   → 权限策略                 │
+│  └── context_limit: usize    → 上下文裁剪               │
+└────────────────────────────────────────────────────────┘
+```
+
+**原则**：
+- CoreConfig 只包含 TiangongCore 运行**必需**的配置
+- 应用层配置可以任意丰富，但只向 Core 暴露 CoreConfig
+- 第三方开发者只需关心 CoreConfig，无需了解应用层配置
+
+## 6. MCP 能力缓存
+
+MCP 工具注册依赖**能力缓存**（全局 `capability_index`）。当前由 `load_mcp_capabilities_cache` 和 `refresh_mcp_capabilities_async` 管理。
+
+配置注入后的变更：
+- `CoreConfigProvider::update` 更新 MCP 配置时，同步触发能力刷新
+- 或者：将 MCP 能力缓存纳入 CoreConfig（`mcp_capabilities: Vec<(String, Vec<McpToolMeta>)>`），由外部负责填充
+- 推荐后者：Core 不发起网络请求，能力数据由外部提供
+
+```rust
+pub struct CoreConfig {
+    pub models: ModelsConfig,
+    pub mcp: McpConfig,
+    pub mcp_capabilities: Vec<(String, Vec<McpToolMeta>)>,  // 预填充的能力数据
+    pub skills: SkillsConfig,
+    pub trust_mode: TrustMode,
+    pub context_limit: usize,
+}
+```
+
+这样 Core 完全不依赖磁盘缓存和网络刷新，所有数据由外部注入。
+
+## 7. 实施计划
+
+### Phase A：CoreConfig + CoreConfigProvider
+1. 在 `tiangong-core` 中定义 `CoreConfig` 和 `CoreConfigProvider`
+2. 修改 `TiangongCore` 构造函数接收 `CoreConfigProvider`
+3. 修改 `worker_loop` 使用 provider 的 generation 检测 + snapshot
+4. 移除 `build_engine()` 中的磁盘加载逻辑
+
+### Phase B：各端适配
+1. CLI：创建 `CoreConfigProvider`，从磁盘加载初始配置
+2. GUI：`TiangongApp` 持有 `CoreConfigProvider`，配置变更时调用 `update`
+3. Server：启动时加载，API 端点触发 `update`
+
+### Phase C：tiangong-config 独立 crate（可选）
+1. 提取磁盘加载、持久化、文件监听为独立 crate
+2. 提供 `CoreConfig::load_from_disk()` 便捷方法
+3. CLI/GUI/Server 依赖 `tiangong-config`，第三方开发者可选
+
+## 8. 二次开发指南
+
+### 8.1 最小集成
+
+只需 `tiangong-core` 一个依赖：
+
+```toml
+[dependencies]
+tiangong-core = { path = "crates/tiangong-core" }
+tiangong-types = { path = "crates/tiangong-types" }
+```
+
+```rust
+use tiangong_core::core::TiangongCore;
+use tiangong_core::core_config::{CoreConfig, CoreConfigProvider};
+use tiangong_types::StreamEvent;
+
+fn main() {
+    let config = CoreConfig::builder()
+        .with_model("openai", "https://api.openai.com/v1", "sk-xxx", "gpt-4o")
+        .build();
+
+    let provider = CoreConfigProvider::new(config);
+    let (tx, rx) = std::sync::mpsc::channel();
+    let core = TiangongCore::new(provider, tx);
+
+    core.send_message("Hello".into());
+    for event in rx.iter() {
+        match event {
+            StreamEvent::Delta { content } => print!("{content}"),
+            StreamEvent::Done { .. } => break,
+            _ => {}
+        }
+    }
+}
+```
+
+### 8.2 添加 MCP 工具
+
+```rust
+use tiangong_core::agent_config::{McpConfig, McpServerConfig};
+
+let config = CoreConfig::builder()
+    .with_model("openai", "https://api.openai.com/v1", "sk-xxx", "gpt-4o")
+    .with_mcp_server(McpServerConfig {
+        name: "my-tools".into(),
+        command: "npx".into(),
+        args: vec!["my-mcp-server".into()],
+        enabled: true,
+        ..Default::default()
+    })
+    .build();
+```
+
+### 8.3 动态更新配置
+
+```rust
+let provider = CoreConfigProvider::new(initial_config);
+let core = TiangongCore::new(provider.clone(), tx);
+
+// 运行时切换模型（下一轮对话自动生效）
+provider.update(|c| {
+    c.models = ModelsConfig::from_single_provider(
+        "deepseek",
+        "https://api.deepseek.com/v1",
+        "sk-xxx",
+        "deepseek-chat",
+    );
+});
+
+// 运行时添加 MCP server（下一轮对话自动注册工具）
+provider.update(|c| {
+    c.mcp.servers.push(McpServerConfig { ... });
+    c.mcp_capabilities.push(("server-name".into(), tools));
+});
+```
+
+### 8.4 自定义配置来源
+
+```rust
+// 从数据库加载
+let config = load_config_from_database(&db)?;
+let provider = CoreConfigProvider::new(config);
+
+// 从远程配置中心加载
+let config = fetch_config_from_remote("https://config.example.com/agent")?;
+let provider = CoreConfigProvider::new(config);
+
+// 监听配置变更
+std::thread::spawn(move || {
+    loop {
+        let new_config = fetch_config_from_remote("...").unwrap();
+        provider.replace(new_config);
+        std::thread::sleep(Duration::from_secs(60));
+    }
+});
+```
+
+### 8.5 嵌入到现有系统
+
+```rust
+// 作为 HTTP 服务的后端
+async fn chat_handler(req: ChatRequest, provider: &CoreConfigProvider) -> ChatResponse {
+    let (tx, rx) = mpsc::channel();
+    let session = load_session(&req.session_id);
+    let core = TiangongCore::with_session(provider.clone(), session, tx);
+    core.send_message(req.message);
+
+    let mut response = String::new();
+    for event in rx.iter() {
+        if let StreamEvent::Delta { content } = event {
+            response.push_str(&content);
+        }
+        if matches!(event, StreamEvent::Done { .. }) {
+            break;
+        }
+    }
+    ChatResponse { content: response }
+}
+```
+
+## 9. 非目标
+
+- 不在 CoreConfig 中包含 UI/Server/Connector 配置
+- 不在 TiangongCore 中实现配置持久化（由外部负责）
+- 不在 TiangongCore 中发起网络请求加载配置（由外部注入）
+- 不改变 StreamEvent 输出协议

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -113,6 +113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5251,6 +5260,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-shell",
  "tiangong-cli",
+ "tiangong-config",
  "tiangong-connector",
  "tiangong-core",
  "tiangong-entry",
@@ -5272,8 +5282,20 @@ dependencies = [
  "crossterm 0.28.1",
  "ratatui",
  "termimad",
+ "tiangong-config",
  "tiangong-core",
  "tiangong-types",
+]
+
+[[package]]
+name = "tiangong-config"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tiangong-core",
+ "tracing",
 ]
 
 [[package]]
@@ -5295,6 +5317,7 @@ name = "tiangong-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-openai",
  "chrono",
  "diffy",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tiangong_entry = { path = "../crates/tiangong-entry", package = "tiangong-entry"
 tiangong_server = { path = "../crates/tiangong-server", package = "tiangong-server" }
 tiangong_connector = { path = "../crates/tiangong-connector", package = "tiangong-connector" }
 tiangong_media = { path = "../crates/tiangong-media", package = "tiangong-media" }
+tiangong_config = { path = "../crates/tiangong-config", package = "tiangong-config" }
 
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use tiangong_config::{CoreConfigProvider, load_core_config};
+use tiangong_config::{CoreConfigProvider, load_tiangong_config};
 use tiangong_core::core::TiangongCore;
 
 /// 天工应用状态
@@ -20,7 +20,7 @@ impl Default for TiangongApp {
         Self {
             state: Mutex::new(tiangong_core::app_state::TiangongState::load_or_default()),
             cores: Mutex::new(HashMap::new()),
-            config: CoreConfigProvider::new(load_core_config()),
+            config: load_tiangong_config().into_core_config_provider(),
         }
     }
 }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -58,7 +58,7 @@ impl TiangongApp {
         &self,
         session_id: &str,
         session: tiangong_core::session::Session,
-        stream_tx: std::sync::mpsc::Sender<tiangong_types::StreamEvent>,
+        stream_tx: std::sync::mpsc::Sender<tiangong_types::SessionStreamEvent>,
     ) -> (String, bool) {
         let mut cores = self.cores.lock().unwrap();
         if cores.contains_key(session_id) {
@@ -81,7 +81,7 @@ impl TiangongApp {
     /// 获取 core 的 session 快照（不消费 core）
     pub fn get_core_session(
         &self,
-        session_id: &str,
+        _session_id: &str,
     ) -> Option<tiangong_core::session::Session> {
         // core session 在消费线程中独占，无法直接读取
         // 只能在 into_session 时获取

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -1,15 +1,18 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+use tiangong_config::{CoreConfigProvider, load_core_config};
 use tiangong_core::core::TiangongCore;
 
 /// 天工应用状态
 ///
 /// state: 应用管理（会话列表、配置、持久化）
 /// cores: 活跃的对话核心（session_id → TiangongCore）
+/// config: 共享配置提供者（所有 Core 共享，GUI 修改配置后自动生效）
 pub struct TiangongApp {
     pub state: Mutex<tiangong_core::app_state::TiangongState>,
     pub cores: Mutex<HashMap<String, TiangongCore>>,
+    pub config: CoreConfigProvider,
 }
 
 impl Default for TiangongApp {
@@ -17,6 +20,7 @@ impl Default for TiangongApp {
         Self {
             state: Mutex::new(tiangong_core::app_state::TiangongState::load_or_default()),
             cores: Mutex::new(HashMap::new()),
+            config: CoreConfigProvider::new(load_core_config()),
         }
     }
 }
@@ -60,7 +64,7 @@ impl TiangongApp {
         if cores.contains_key(session_id) {
             return (session_id.to_string(), false); // 已存在，复用
         }
-        let core = TiangongCore::with_session(session, stream_tx);
+        let core = TiangongCore::with_session(self.config.clone(), session, stream_tx);
         let id = core.session_id().to_string();
         cores.insert(id.clone(), core);
         (id, true) // 新创建

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -128,7 +128,7 @@ pub fn send_message(
     state: State<TiangongApp>,
 ) -> Result<(), String> {
     use std::sync::mpsc;
-    use tiangong_types::StreamEvent;
+    use tiangong_types::{SessionStreamEvent, StreamEvent};
 
     // 准备 session
     let (session_id, session_snapshot) = state.with_state(|core_state| {
@@ -145,69 +145,80 @@ pub fn send_message(
     })?;
 
     // 获取或创建 TiangongCore
-    let (stream_tx, stream_rx) = mpsc::channel::<StreamEvent>();
+    let (stream_tx, stream_rx) = mpsc::channel::<SessionStreamEvent>();
     let (sid, is_new_core) = state.ensure_core(&session_id, session_snapshot, stream_tx);
-    // 发送消息（core 内部消费线程会 append 到 core session）
+    // 发送消息（core 内部会 append 到 core session 并推送 UserMessage 事件）
     state.send_to_core(&sid, content.clone());
-    // 同时往 TiangongState session 记录用户消息（前端 run_snapshot 显示用）
-    let _ = state.with_state(|core_state| {
-        if let Some(s) = core_state.sessions_mut().iter_mut().find(|s| s.id == sid) {
-            s.append_message(tiangong_core::session::MessageRole::User, content);
-        }
-        Ok(())
-    });
 
     // 只在新创建 core 时启动消费线程（复用 core 时旧消费线程仍在运行）
     if !is_new_core {
         return Ok(());
     }
 
-    // 消费 StreamEvent：emit 给前端 + 更新 RunStatus + Done 时同步 session
+    // 消费 SessionStreamEvent：emit 给前端 + 更新 RunStatus + Done 时同步 session
     let app_clone = app.clone();
-    let sid_for_thread = sid.clone();
     thread::spawn(move || {
-        let sid = sid_for_thread;
         let mut assistant_msg_id: Option<String> = None;
-        for event in stream_rx.iter() {
+        for session_event in stream_rx.iter() {
+            // 先 emit 完整事件给前端，再解构
+            let _ = app_clone.emit("stream_event", &session_event);
+
+            let sid = session_event.session_id;
+            let event = session_event.event;
             let is_done = matches!(event, StreamEvent::Done { .. });
             let is_error = matches!(event, StreamEvent::Error { .. });
 
-            // 直接 emit StreamEvent 给前端
-            let _ = app_clone.emit("stream_event", &event);
-
-            // 更新 session（Delta/Reasoning）+ RunStatus/usage
+            // 更新 session + RunStatus/usage
             let _ = app_clone.state::<TiangongApp>().with_state(|core_state| {
-                // Delta/Reasoning 写入 TiangongState session（前端流式显示需要）
                 if let Some(session) = core_state.sessions_mut().iter_mut().find(|s| s.id == sid) {
                     match &event {
-                        StreamEvent::Delta { content } => {
-                            if let Some(ref id) = assistant_msg_id {
-                                if let Some(msg) = session.messages.iter_mut().find(|m| m.id == *id) {
+                        StreamEvent::UserMessage { message_id, content } => {
+                            // Core 已记录用户消息，同步到 TiangongState session
+                            session.append_message_with_id(
+                                message_id.clone(),
+                                tiangong_core::session::MessageRole::User,
+                                content.clone(),
+                                String::new(),
+                            );
+                        }
+                        StreamEvent::Delta { message_id, content } => {
+                            // 使用 Core 预生成的 message_id 定位或创建 assistant 消息
+                            if assistant_msg_id.as_deref() == Some(message_id) {
+                                if let Some(msg) = session.messages.iter_mut().find(|m| m.id == *message_id) {
                                     msg.content.push_str(content);
                                 }
                             } else {
-                                session.append_message(tiangong_core::session::MessageRole::Assistant, String::new());
+                                session.append_message_with_id(
+                                    message_id.clone(),
+                                    tiangong_core::session::MessageRole::Assistant,
+                                    String::new(),
+                                    String::new(),
+                                );
                                 if let Some(msg) = session.messages.last_mut() {
                                     msg.content.push_str(content);
-                                    assistant_msg_id = Some(msg.id.clone());
                                 }
+                                assistant_msg_id = Some(message_id.clone());
                             }
                         }
-                        StreamEvent::Reasoning { content } => {
-                            if let Some(ref id) = assistant_msg_id {
-                                if let Some(msg) = session.messages.iter_mut().find(|m| m.id == *id) {
+                        StreamEvent::Reasoning { message_id, content } => {
+                            if assistant_msg_id.as_deref() == Some(message_id) {
+                                if let Some(msg) = session.messages.iter_mut().find(|m| m.id == *message_id) {
                                     msg.reasoning_content.push_str(content);
                                 }
                             } else {
-                                session.append_message(tiangong_core::session::MessageRole::Assistant, String::new());
+                                session.append_message_with_id(
+                                    message_id.clone(),
+                                    tiangong_core::session::MessageRole::Assistant,
+                                    String::new(),
+                                    String::new(),
+                                );
                                 if let Some(msg) = session.messages.last_mut() {
                                     msg.reasoning_content.push_str(content);
-                                    assistant_msg_id = Some(msg.id.clone());
                                 }
+                                assistant_msg_id = Some(message_id.clone());
                             }
                         }
                         StreamEvent::ToolCalls { names, .. } => {
-                            // 工具调用：记录 LLM 输出系统消息 + reset assistant id
                             session.append_message(
                                 tiangong_core::session::MessageRole::System,
                                 format!("LLM 输出\ntool_calls: {}", names.join(", ")),
@@ -216,7 +227,6 @@ pub fn send_message(
                         }
                         StreamEvent::ToolStart { .. } => {}
                         StreamEvent::ToolResult { name, ok, output } => {
-                            // 工具执行记录写入系统消息
                             let status = if *ok { "ok=true" } else { "ok=false" };
                             let preview = if output.chars().count() > 200 {
                                 format!("{}...", output.chars().take(200).collect::<String>())
@@ -229,7 +239,6 @@ pub fn send_message(
                             );
                         }
                         StreamEvent::Done { .. } | StreamEvent::Error { .. } => {
-                            // 一轮完成：reset assistant id，下一轮创建新消息
                             assistant_msg_id = None;
                         }
                         _ => {}
@@ -296,11 +305,17 @@ pub fn send_message(
             }
 
             if is_done || is_error {
-                // Done：持久化当前 TiangongState session + 生成标题
-                // 不 take core（保持活跃支持多轮对话）
+                // Done：先持久化，再异步生成标题（不阻塞消费线程）
                 let final_sid = sid.clone();
-                let _ = app_clone.state::<TiangongApp>().with_state(|core_state| {
-                    // 生成标题
+
+                // 提取标题生成所需数据（在锁内完成，避免长时间持锁）
+                let title_task = app_clone.state::<TiangongApp>().with_state(|core_state| {
+                    let _ = core_state.persist_session_and_app(&final_sid);
+                    let snapshot = build_full_snapshot_with_status(core_state, false);
+                    let _ = app_clone.emit("run_snapshot", &snapshot);
+                    let _ = app_clone.emit("sessions_updated", &());
+
+                    // 检查是否需要生成标题
                     if let Some(session) = core_state.sessions().iter().find(|s| s.id == final_sid) {
                         let is_default = session.title == "新对话"
                             || session.title.starts_with("会话 ");
@@ -311,27 +326,38 @@ pub fn send_message(
                                 .find(|m| m.role == tiangong_core::session::MessageRole::User)
                                 .map(|m| m.content.clone())
                             {
-                                let client = tiangong_core::model::SingleProviderClient::new(
-                                    core_state.store.provider.models_config.to_chat_provider_config(),
-                                );
-                                if let Ok(t) = client.complete_lite(&input) {
-                                    let clean = t.trim().trim_matches('"').to_string();
-                                    if !clean.is_empty() {
-                                        if let Some(s) = core_state.sessions_mut().iter_mut().find(|s| s.id == final_sid) {
-                                            s.title = clean;
-                                            s.updated_at = tiangong_core::session::now_text();
-                                        }
-                                    }
-                                }
+                                let provider_config = core_state.store.provider.models_config.to_chat_provider_config();
+                                return Ok(Some((input, provider_config)));
                             }
                         }
                     }
-                    let _ = core_state.persist_session_and_app(&final_sid);
-                    let snapshot = build_full_snapshot_with_status(core_state, false);
-                    let _ = app_clone.emit("run_snapshot", &snapshot);
-                    let _ = app_clone.emit("sessions_updated", &());
-                    Ok(())
+                    Ok(None)
                 });
+
+                // 异步生成标题（不阻塞消费线程）
+                if let Ok(Some((input, provider_config))) = title_task {
+                    let app_for_title = app_clone.clone();
+                    let sid_for_title = final_sid.clone();
+                    thread::spawn(move || {
+                        let client = tiangong_core::model::SingleProviderClient::new(provider_config);
+                        if let Ok(t) = client.complete_lite(&input) {
+                            let clean = t.trim().trim_matches('"').to_string();
+                            if !clean.is_empty() {
+                                let _ = app_for_title.state::<TiangongApp>().with_state(|core_state| {
+                                    if let Some(s) = core_state.sessions_mut().iter_mut().find(|s| s.id == sid_for_title) {
+                                        s.title = clean;
+                                        s.updated_at = tiangong_core::session::now_text();
+                                    }
+                                    let _ = core_state.persist_session_and_app(&sid_for_title);
+                                    let snapshot = build_full_snapshot_with_status(core_state, false);
+                                    let _ = app_for_title.emit("run_snapshot", &snapshot);
+                                    let _ = app_for_title.emit("sessions_updated", &());
+                                    Ok(())
+                                });
+                            }
+                        }
+                    });
+                }
                 // 不 break — 消费线程继续运行，等待下一轮消息的 StreamEvent
             }
         }


### PR DESCRIPTION
## Summary

- **SessionStreamEvent 包装**：Core 输出的所有 StreamEvent 携带 session_id，消费端可据此路由到正确会话
- **UserMessage 事件**：Core 收到用户消息后立即推送 UserMessage 事件，前端无需等待 LLM 响应即可显示用户消息
- **message_id 预生成**：Delta/Reasoning 事件携带 message_id，与最终 session 消息 ID 一致，前端可正确组装消息
- **ThinkTagFilter**：流式 `<think>` 标签过滤器，自动将标签内内容分离到 reasoning_content（兼容不使用 API reasoning_content 字段的模型）
- **标题生成异步化**：`complete_lite` 标题生成调用移至独立线程，不再阻塞消费线程

## Test plan

- [ ] GUI 模式发送消息，用户消息应在 LLM 响应前立即显示
- [ ] CLI 模式发送消息，确认流式输出正常（Delta/Reasoning 分离）
- [ ] 使用输出 `<think>` 标签的模型，确认 thinking 内容不出现在正文中
- [ ] 多轮对话验证 session_id 和 message_id 正确性
- [ ] 验证标题异步生成不阻塞后续消息响应