### PR TITLE
feat(core): LLM 请求错误自动重试 + 错误/重试通知到前端

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -363,6 +363,28 @@
 
 ---
 
+## Phase 13.5：LLM 请求容错 — **当前阶段**
+
+### A. LLM 请求重试机制
+- [x] 在 `model.rs` 中实现通用重试包装函数（指数退避，默认 3 次，初始 1s，×2）
+- [x] 识别可重试错误类型（429 速率限制、5xx 服务端错误、连接错误）
+- [x] 应用到所有 LLM 调用方法（complete / complete_stream / complete_with_functions / complete_with_functions_stream / complete_lite）
+- [x] 重试过程通过 `tracing::warn!` 记录日志
+
+### B. 错误与重试通知到前端
+- [x] `StreamEvent::Retry` 新增变体，重试时推送到前端
+- [x] `StreamEvent::Error` 错误信息写入 session 消息，前端可见
+- [x] GUI 前端错误消息红色醒目渲染、重试消息黄色提示渲染
+- [x] CLI 重试时输出黄色警告信息
+- [x] 底部状态栏显示重试进度和错误详情
+
+### C. 验证
+- [x] `cargo check --workspace` 通过
+- [x] `cargo clippy` 通过（tiangong-core / cli / types 零警告）
+- [x] `yarn build` 通过
+
+---
+
 ## Phase 14：CoreConfig 配置注入 — **当前阶段**
 
 > RFC：`docs/rfc/0006-core-config-provider.md`

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -202,6 +202,16 @@ impl ResponseState {
                 return true;
             }
 
+            StreamEvent::Retry {
+                message,
+                attempt,
+                max_attempts,
+            } => {
+                output::warn(&format!(
+                    "重试 ({attempt}/{max_attempts})：{message}"
+                ));
+            }
+
             StreamEvent::WorkerStarted {
                 worker_id: _,
                 worker_label,

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -165,7 +165,7 @@ fn worker_loop(
         let cfg_gen = config.generation();
         if engine.is_none() || cfg_gen != last_cfg_gen {
             let cfg = config.snapshot();
-            engine = Some(build_engine_from_config(&cfg));
+            engine = Some(build_engine_from_config(&cfg, &stream_tx));
             let e = engine.as_ref().unwrap();
             let (all_tools, new_mcp_targets) = execution_function_tools(&e.agent_config().mcp);
             let mut new_tools: Vec<FunctionToolSpec> = all_tools
@@ -619,8 +619,14 @@ fn force_final_response(
 }
 
 /// 从 CoreConfig 快照构建 RuntimeEngine
-fn build_engine_from_config(config: &crate::core_config::CoreConfig) -> RuntimeEngine {
+///
+/// `stream_tx` 用于在 LLM 请求重试时发送 `StreamEvent::Retry` 通知。
+fn build_engine_from_config(
+    config: &crate::core_config::CoreConfig,
+    stream_tx: &Sender<StreamEvent>,
+) -> RuntimeEngine {
     use crate::agent_config::AgentConfig;
+    use crate::model::OnRetryCallback;
     use crate::models_config::ModelsConfig;
 
     // 从 LlmConfig 构建兼容的 ModelsConfig（供 PromptAssembler 等旧代码使用）
@@ -633,8 +639,19 @@ fn build_engine_from_config(config: &crate::core_config::CoreConfig) -> RuntimeE
         trust_mode: config.trust_mode,
     };
 
+    // 构造重试回调：发送 StreamEvent::Retry 通知前端
+    let retry_tx = stream_tx.clone();
+    let on_retry: OnRetryCallback =
+        std::sync::Arc::new(move |attempt, max_attempts, _delay_ms, error_text| {
+            let _ = retry_tx.send(StreamEvent::Retry {
+                message: error_text.to_string(),
+                attempt,
+                max_attempts,
+            });
+        });
+
     RuntimeEngine::new(
-        SingleProviderClient::new(model_config),
+        SingleProviderClient::new(model_config).with_on_retry(on_retry),
         config.context_limit,
         agent_config,
     )

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
@@ -197,14 +198,37 @@ pub trait ModelClient {
     }
 }
 
-#[derive(Debug, Clone)]
+/// 重试回调类型：(attempt, max_attempts, delay_ms, error_text)
+pub type OnRetryCallback = Arc<dyn Fn(u32, u32, u64, &str) + Send + Sync>;
+
+#[derive(Clone)]
 pub struct SingleProviderClient {
     cfg: ModelProviderConfig,
+    /// 重试时的回调通知（可选）
+    on_retry: Option<OnRetryCallback>,
+}
+
+impl std::fmt::Debug for SingleProviderClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SingleProviderClient")
+            .field("cfg", &self.cfg)
+            .field("on_retry", &self.on_retry.is_some())
+            .finish()
+    }
 }
 
 impl SingleProviderClient {
     pub fn new(cfg: ModelProviderConfig) -> Self {
-        Self { cfg }
+        Self {
+            cfg,
+            on_retry: None,
+        }
+    }
+
+    /// 设置重试回调
+    pub fn with_on_retry(mut self, cb: OnRetryCallback) -> Self {
+        self.on_retry = Some(cb);
+        self
     }
 
     pub fn list_models(cfg: &ModelProviderConfig) -> Result<Vec<String>> {
@@ -305,10 +329,11 @@ impl SingleProviderClient {
 
         let response = runtime.block_on(async {
             timeout(Duration::from_millis(timeout_ms), async {
-                let mut stream = client
-                    .chat()
-                    .create_stream_byot::<_, Value>(request_json)
-                    .await?;
+                let chat = client.chat();
+                let mut stream = with_retry("流式模型请求", &self.on_retry, || {
+                    chat.create_stream_byot::<_, Value>(request_json.clone())
+                })
+                .await?;
                 let mut content = String::new();
                 let mut reasoning_content = String::new();
                 let mut chunks = 0usize;
@@ -529,10 +554,11 @@ impl SingleProviderClient {
 
         let response = runtime.block_on(async {
             timeout(Duration::from_millis(timeout_ms), async {
-                let mut stream = client
-                    .chat()
-                    .create_stream_byot::<_, Value>(request_json)
-                    .await?;
+                let chat = client.chat();
+                let mut stream = with_retry("流式工具调用", &self.on_retry, || {
+                    chat.create_stream_byot::<_, Value>(request_json.clone())
+                })
+                .await?;
 
                 let mut content = String::new();
                 let mut reasoning_content = String::new();
@@ -789,12 +815,15 @@ impl SingleProviderClient {
             .build()
             .context("初始化异步运行时失败")?;
 
+        let request_json =
+            serde_json::to_value(&request).context("序列化轻量级请求失败")?;
+        let chat = client.chat();
         let response = runtime.block_on(async {
             timeout(
                 Duration::from_millis(timeout_ms),
-                client
-                    .chat()
-                    .create_byot::<_, CreateChatCompletionResponse>(request),
+                with_retry("轻量级模型", &self.on_retry, || {
+                    chat.create_byot::<_, CreateChatCompletionResponse>(request_json.clone())
+                }),
             )
             .await
         });
@@ -907,10 +936,13 @@ impl ModelClient for SingleProviderClient {
             .build()
             .context("初始化异步运行时失败")?;
 
+        let chat = client.chat();
         let response = runtime.block_on(async {
             timeout(
                 Duration::from_millis(timeout_ms),
-                client.chat().create_byot::<_, Value>(request_json),
+                with_retry("模型请求", &self.on_retry, || {
+                    chat.create_byot::<_, Value>(request_json.clone())
+                }),
             )
             .await
         });
@@ -924,7 +956,7 @@ impl ModelClient for SingleProviderClient {
         let response = runtime.block_on(async {
             timeout(
                 Duration::from_millis(timeout_ms),
-                client.chat().create(request_for_fallback),
+                with_retry("模型请求回退", &self.on_retry, || chat.create(request_for_fallback.clone())),
             )
             .await
         });
@@ -1006,10 +1038,13 @@ impl ModelClient for SingleProviderClient {
             .build()
             .context("初始化异步运行时失败")?;
 
+        let chat = client.chat();
         let response = runtime.block_on(async {
             timeout(
                 Duration::from_millis(timeout_ms),
-                client.chat().create_byot::<_, Value>(request_json),
+                with_retry("工具调用", &self.on_retry, || {
+                    chat.create_byot::<_, Value>(request_json.clone())
+                }),
             )
             .await
         });
@@ -1206,6 +1241,96 @@ fn build_sdk_error_hint(error_text: &str) -> String {
         return "；当前网关返回的错误结构非 OpenAI 标准格式，请确认 API_BASE_URL 是否为 OpenAI 兼容接口".to_string();
     }
     String::new()
+}
+
+// ── 重试相关 ──────────────────────────────────────────────
+
+/// 最大重试次数
+const MAX_RETRIES: u32 = 3;
+/// 初始重试延迟（毫秒）
+const INITIAL_RETRY_DELAY_MS: u64 = 1000;
+/// 退避倍率
+const RETRY_BACKOFF_MULTIPLIER: u64 = 2;
+
+/// 判断 OpenAI SDK 错误是否可重试
+fn is_retryable_openai_error(err: &async_openai::error::OpenAIError) -> bool {
+    is_retryable_error_text(&err.to_string())
+}
+
+/// 判断错误文本是否表示可重试的错误
+fn is_retryable_error_text(text: &str) -> bool {
+    // 速率限制 (HTTP 429)
+    if text.contains("429")
+        || text.contains("Rate limit")
+        || text.contains("rate limit")
+        || text.contains("Rate limited")
+        || text.contains("访问量过大")
+        || text.contains("稍后再试")
+        || text.contains("too many requests")
+        || text.contains("Too Many Requests")
+    {
+        return true;
+    }
+    // 服务端错误 (5xx)
+    if text.contains("500 Internal Server Error")
+        || text.contains("502 Bad Gateway")
+        || text.contains("503 Service Unavailable")
+        || text.contains("504 Gateway Timeout")
+    {
+        return true;
+    }
+    // 连接错误
+    if text.contains("connection reset")
+        || text.contains("connection refused")
+        || text.contains("Connection reset")
+        || text.contains("Connection refused")
+    {
+        return true;
+    }
+    false
+}
+
+/// 带重试的异步调用（用于 OpenAI SDK 请求）
+///
+/// 遇到速率限制、5xx、连接错误时自动重试，采用指数退避策略。
+/// 可选的 `on_retry` 回调在每次重试前触发，用于通知上层。
+async fn with_retry<F, Fut, T>(
+    label: &str,
+    on_retry: &Option<OnRetryCallback>,
+    mut f: F,
+) -> Result<T, async_openai::error::OpenAIError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, async_openai::error::OpenAIError>>,
+{
+    let mut attempt = 0u32;
+    let mut delay_ms = INITIAL_RETRY_DELAY_MS;
+    loop {
+        match f().await {
+            Ok(result) => return Ok(result),
+            Err(err) => {
+                if attempt < MAX_RETRIES && is_retryable_openai_error(&err) {
+                    attempt += 1;
+                    let err_text = err.to_string();
+                    tracing::warn!(
+                        attempt = attempt,
+                        max_retries = MAX_RETRIES,
+                        delay_ms = delay_ms,
+                        error = %err_text,
+                        label = label,
+                        "LLM 请求失败，准备重试",
+                    );
+                    if let Some(cb) = on_retry {
+                        cb(attempt, MAX_RETRIES, delay_ms, &err_text);
+                    }
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                    delay_ms *= RETRY_BACKOFF_MULTIPLIER;
+                } else {
+                    return Err(err);
+                }
+            }
+        }
+    }
 }
 
 fn extract_delta_text(delta: &Value, field: &str) -> String {

--- a/crates/tiangong-types/src/stream.rs
+++ b/crates/tiangong-types/src/stream.rs
@@ -50,6 +50,12 @@ pub enum StreamEvent {
     },
     /// 执行出错
     Error { message: String },
+    /// LLM 请求重试中
+    Retry {
+        message: String,
+        attempt: u32,
+        max_attempts: u32,
+    },
 
     // ===== 多 Worker 并行执行事件 =====
     /// Worker 开始执行

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -74,6 +74,13 @@
 - GUI 消息文本必须去掉气泡边框和背景色，采用简洁无装饰风格。
 - CLI 必须从阻塞等待改为实时流式展示：思考过程、工具调用摘要、最终回复均实时输出。
 
+#### LLM 请求容错
+- LLM 请求遇到速率限制（429）、服务端错误（5xx）或超时时，必须自动重试。
+- 默认最大重试 3 次，采用指数退避策略（初始间隔 1 秒，倍率 ×2）。
+- 每次重试必须通过 `tracing::warn!` 记录日志（含重试次数、错误原因、等待时间）。
+- 非可重试错误（如 401 认证失败、400 参数错误）不进行重试，直接返回错误。
+- 重试逻辑必须覆盖所有 LLM 调用方法（complete / complete_stream / complete_with_functions / complete_with_functions_stream / complete_lite）。
+
 ### Should
 
 - Server 模式应支持 CORS 配置，方便 Web 前端调用。

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -721,6 +721,8 @@ function AgentTurn({
     | { type: "thinking"; content: string }
     | { type: "tool_group"; key: string; brief: string; tools: MessageItem[] }
     | { type: "assistant"; msg: MessageItem; isStreaming: boolean }
+    | { type: "error_system"; msg: MessageItem }
+    | { type: "retry_system"; msg: MessageItem }
     | { type: "other_system"; msg: MessageItem };
 
   const fragments: Fragment[] = [];
@@ -772,6 +774,12 @@ function AgentTurn({
         fragments.push({ type: "thinking", content: assistantReasoning });
       }
       fragments.push({ type: "assistant", msg, isStreaming });
+    } else if (msg.role === "System" && msg.content.startsWith("[错误]")) {
+      flushTools();
+      fragments.push({ type: "error_system", msg });
+    } else if (msg.role === "System" && msg.content.startsWith("[重试]")) {
+      flushTools();
+      fragments.push({ type: "retry_system", msg });
     } else if (msg.role === "System") {
       flushTools();
       fragments.push({ type: "other_system", msg });
@@ -848,6 +856,20 @@ function AgentTurn({
                 </div>
               )}
               {!isStreaming && msg.content && <MessageActions text={msg.content} showTts={hasTts} />}
+            </div>
+          );
+        }
+        if (frag.type === "error_system") {
+          return (
+            <div key={frag.msg.id} className="text-sm text-destructive bg-destructive/10 rounded-md px-3 py-2 my-1">
+              {frag.msg.content.replace("[错误] ", "")}
+            </div>
+          );
+        }
+        if (frag.type === "retry_system") {
+          return (
+            <div key={frag.msg.id} className="text-xs text-yellow-600 dark:text-yellow-400 bg-yellow-500/10 rounded-md px-3 py-1.5 my-0.5">
+              {frag.msg.content.replace("[重试] ", "")}
             </div>
           );
         }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -238,7 +238,26 @@ pub fn send_message(
                                 format!("工具执行 [{name}]\n{status} exit_code=0\nsummary: {name}\nstdout:\n{preview}"),
                             );
                         }
-                        StreamEvent::Done { .. } | StreamEvent::Error { .. } => {
+                        StreamEvent::Error { ref message } => {
+                            session.append_message(
+                                tiangong_core::session::MessageRole::System,
+                                format!("[错误] {message}"),
+                            );
+                            assistant_msg_id = None;
+                        }
+                        StreamEvent::Retry {
+                            ref message,
+                            attempt,
+                            max_attempts,
+                        } => {
+                            session.append_message(
+                                tiangong_core::session::MessageRole::System,
+                                format!(
+                                    "[重试] ({attempt}/{max_attempts}) {message}"
+                                ),
+                            );
+                        }
+                        StreamEvent::Done { .. } => {
                             assistant_msg_id = None;
                         }
                         _ => {}
@@ -285,8 +304,16 @@ pub fn send_message(
                             core_state.provider_label()
                         ));
                     }
-                    StreamEvent::Error { .. } => {
-                        core_state.report_run_idle("执行失败");
+                    StreamEvent::Error { ref message } => {
+                        core_state.report_run_idle(format!("执行失败：{message}"));
+                    }
+                    StreamEvent::Retry {
+                        attempt,
+                        max_attempts,
+                        ..
+                    } => {
+                        core_state.store.runtime.run.summary =
+                            format!("重试中 ({attempt}/{max_attempts})...");
                     }
                     _ => {}
                 }


### PR DESCRIPTION
## Summary

- LLM 请求遇到速率限制（429）、5xx 服务端错误、连接错误时自动重试（默认 3 次，指数退避 1s → 2s → 4s）
- 新增 `StreamEvent::Retry` 变体，重试过程实时通知前端
- `StreamEvent::Error` 错误信息写入 session 消息并在前端醒目展示
- GUI 错误消息红色渲染、重试消息黄色渲染、底部状态栏显示重试进度
- CLI 重试时输出黄色警告

## 改动文件

| 文件 | 说明 |
|------|------|
| `crates/tiangong-core/src/model.rs` | `with_retry` 重试包装 + `OnRetryCallback` + 覆盖全部 5 个 LLM 方法 |
| `crates/tiangong-types/src/stream.rs` | 新增 `StreamEvent::Retry` 变体 |
| `crates/tiangong-core/src/core/mod.rs` | 构建 engine 时注入重试回调，发送 Retry 事件 |
| `src-tauri/src/commands.rs` | Error/Retry 事件写入 session + 状态栏更新 |
| `frontend/src/components/MessageList.tsx` | 错误/重试消息渲染样式 |
| `crates/tiangong-cli/src/repl.rs` | CLI 处理 Retry 事件 |
| `docs/requirements.md` | 新增 LLM 请求容错需求 |
| `TODO.md` | 新增 Phase 13.5 任务条目 |

## Test plan

- [ ] 触发速率限制（429）时自动重试，前端显示黄色重试提示
- [ ] 重试耗尽后显示红色错误消息
- [ ] 底部状态栏实时显示"重试中 (1/3)..."
- [ ] CLI 模式下重试输出黄色警告
- [ ] 非可重试错误（401/400/404）不重试，直接显示错误