### PR TITLE
feat(core): 监督模式工具审批 + 工具展示优化 + 多项修复

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3468,6 +3468,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-openai",
+ "backoff",
  "chrono",
  "diffy",
  "futures-util",

--- a/TODO.md
+++ b/TODO.md
@@ -378,7 +378,15 @@
 - [x] CLI 重试时输出黄色警告信息
 - [x] 底部状态栏显示重试进度和错误详情
 
-### C. 验证
+### C. 监督模式工具审批 + 工具展示优化
+- [x] 监督模式下工具执行前权限检查，Elevated/Critical 工具发送 `ApprovalNeeded` 事件
+- [x] Core 阻塞等待用户审批响应，支持允许/拒绝/取消
+- [x] 修复 `cancel_turn` 和 `respond_approval` 命令路由到 TiangongCore
+- [x] `StreamEvent::ToolStart` 携带 `args_summary`，展示实际命令和参数
+- [x] 前端工具展示解析 `工具执行 [xxx]` 格式，折叠摘要包含命令信息
+- [x] CLI 审批交互（y/n 确认）
+
+### D. 验证
 - [x] `cargo check --workspace` 通过
 - [x] `cargo clippy` 通过（tiangong-core / cli / types 零警告）
 - [x] `yarn build` 通过

--- a/crates/tiangong-cli/src/lib.rs
+++ b/crates/tiangong-cli/src/lib.rs
@@ -6,5 +6,11 @@ mod output;
 mod repl;
 
 pub fn run_cli() -> anyhow::Result<()> {
-    repl::run()
+    repl::run(None)
+}
+
+pub fn run_cli_with_trust_mode(
+    trust_mode: Option<tiangong_core::permission::TrustMode>,
+) -> anyhow::Result<()> {
+    repl::run(trust_mode)
 }

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -13,12 +13,17 @@ use crate::completion;
 use crate::input::InputReader;
 use crate::output;
 
-pub fn run() -> Result<()> {
+pub fn run(trust_mode: Option<tiangong_core::permission::TrustMode>) -> Result<()> {
     let mut state = TiangongState::load_or_default();
     let app_config = load_tiangong_config();
     let config = app_config.into_core_config_provider();
     let (stream_tx, stream_rx) = mpsc::channel::<SessionStreamEvent>();
     let core = TiangongCore::new(config, stream_tx);
+
+    // CLI --trust-mode 参数覆盖
+    if let Some(mode) = trust_mode {
+        core.set_trust_mode(mode);
+    }
     let mut reader = InputReader::new();
     let mut draft_new_session = true;
 
@@ -77,7 +82,7 @@ pub fn run() -> Result<()> {
         core.send_message(trimmed.to_string());
 
         // 处理响应流
-        handle_response(&stream_rx);
+        handle_response(&stream_rx, &core);
 
         output::separator();
     }
@@ -92,13 +97,13 @@ pub fn run() -> Result<()> {
 }
 
 /// 处理完整的响应流
-fn handle_response(rx: &mpsc::Receiver<SessionStreamEvent>) {
+fn handle_response(rx: &mpsc::Receiver<SessionStreamEvent>, core: &TiangongCore) {
     let mut state = ResponseState::new();
 
     loop {
         match rx.recv_timeout(std::time::Duration::from_secs(300)) {
             Ok(session_event) => {
-                if state.process(&session_event.event) {
+                if state.process(&session_event.event, core) {
                     break;
                 }
             }
@@ -130,7 +135,7 @@ impl ResponseState {
     }
 
     /// 处理单个事件，返回 true 表示本轮结束
-    fn process(&mut self, event: &StreamEvent) -> bool {
+    fn process(&mut self, event: &StreamEvent, core: &TiangongCore) -> bool {
         match event {
             StreamEvent::UserMessage { .. } => {
                 // CLI 模式下用户消息由 REPL 自己显示，忽略
@@ -175,8 +180,15 @@ impl ResponseState {
                 self.has_delta = false;
             }
 
-            StreamEvent::ToolStart { name, .. } => {
-                output::tool_start(name);
+            StreamEvent::ToolStart {
+                name,
+                args_summary,
+            } => {
+                if args_summary.is_empty() {
+                    output::tool_start(name);
+                } else {
+                    output::tool_start(&format!("{name} {args_summary}"));
+                }
             }
 
             StreamEvent::ToolResult { name, ok, output } => {
@@ -184,11 +196,32 @@ impl ResponseState {
             }
 
             StreamEvent::ApprovalNeeded {
+                request_id,
                 tool_name,
                 args_summary,
-                ..
             } => {
                 output::approval_needed(tool_name, args_summary);
+                // 等待用户输入 y/n
+                let approved = loop {
+                    eprint!("\x1b[1;33m  允许执行？(y/n): \x1b[0m");
+                    let mut buf = String::new();
+                    if std::io::stdin().read_line(&mut buf).is_err() {
+                        break false;
+                    }
+                    match buf.trim().to_lowercase().as_str() {
+                        "y" | "yes" => break true,
+                        "n" | "no" => break false,
+                        _ => {
+                            eprintln!("  请输入 y 或 n");
+                        }
+                    }
+                };
+                core.respond_approval(request_id.clone(), approved);
+                if approved {
+                    output::status("已允许");
+                } else {
+                    output::warn("已拒绝");
+                }
             }
 
             StreamEvent::Done { .. } => {

--- a/crates/tiangong-core/Cargo.toml
+++ b/crates/tiangong-core/Cargo.toml
@@ -12,6 +12,7 @@ scru128 = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-openai = { git = "https://github.com/silent-rs/async-openai", branch = "main", package = "async-openai", features = ["byot", "chat-completion", "model"] }
+backoff = "0.4"
 tokio = { version = "1", features = ["rt", "time", "process", "io-util"] }
 rmcp = { version = "0.17.0", default-features = false, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, RwLock};
 use std::thread::{self, JoinHandle};
 
 use crate::agents::execution_mcp_agent::{McpFunctionTarget, execution_function_tools};
@@ -44,6 +45,8 @@ pub struct TiangongCore {
     worker: Option<JoinHandle<Session>>,
     /// 会话 ID
     session_id: String,
+    /// 独立的信任模式（共享引用，实时生效）
+    shared_trust_mode: Arc<RwLock<crate::permission::TrustMode>>,
 }
 
 impl TiangongCore {
@@ -59,15 +62,20 @@ impl TiangongCore {
         session: Session,
         stream_tx: Sender<SessionStreamEvent>,
     ) -> Self {
+        let initial_trust_mode = config.snapshot().trust_mode;
+        let shared_trust_mode = Arc::new(RwLock::new(initial_trust_mode));
         let session_id = session.id.clone();
         let (cmd_tx, cmd_rx) = mpsc::channel::<Command>();
 
-        let worker = thread::spawn(move || worker_loop(config, session, stream_tx, cmd_rx));
+        let worker_trust_mode = shared_trust_mode.clone();
+        let worker =
+            thread::spawn(move || worker_loop(config, session, stream_tx, cmd_rx, worker_trust_mode));
 
         Self {
             cmd_tx: Some(cmd_tx),
             worker: Some(worker),
             session_id,
+            shared_trust_mode,
         }
     }
 
@@ -94,6 +102,13 @@ impl TiangongCore {
 
     pub fn session_id(&self) -> &str {
         &self.session_id
+    }
+
+    /// 设置信任模式（实时生效，当前对话下一次工具调用立即感知）
+    pub fn set_trust_mode(&self, mode: crate::permission::TrustMode) {
+        if let Ok(mut guard) = self.shared_trust_mode.write() {
+            *guard = mode;
+        }
     }
 
     /// 关闭并获取最终 session
@@ -127,6 +142,7 @@ fn worker_loop(
     mut session: Session,
     external_tx: Sender<SessionStreamEvent>,
     cmd_rx: Receiver<Command>,
+    shared_trust_mode: Arc<RwLock<crate::permission::TrustMode>>,
 ) -> Session {
     let session_id = session.id.clone();
     let mut last_cfg_gen = 0u64;
@@ -165,7 +181,11 @@ fn worker_loop(
         let cfg_gen = config.generation();
         if engine.is_none() || cfg_gen != last_cfg_gen {
             let cfg = config.snapshot();
-            engine = Some(build_engine_from_config(&cfg, &stream_tx));
+            engine = Some(build_engine_from_config(
+                &cfg,
+                &stream_tx,
+                shared_trust_mode.clone(),
+            ));
             let e = engine.as_ref().unwrap();
             let (all_tools, new_mcp_targets) = execution_function_tools(&e.agent_config().mcp);
             let mut new_tools: Vec<FunctionToolSpec> = all_tools
@@ -243,6 +263,7 @@ pub(crate) fn execute_turn_standalone(
 /// 首先判断是否需要多代理并行执行，如需要则拆分并行；
 /// 否则走标准的 ReAct 循环。
 /// 每轮之间检查 cmd_rx：新消息注入上下文，cancel 立即生效。
+#[allow(clippy::too_many_arguments)]
 fn execute_turn(
     session: &mut Session,
     user_input: &str,
@@ -454,16 +475,102 @@ fn execute_turn_inner(
 
         // 执行工具
         for call in &response.tool_calls {
+            let args_summary = format_call_args_summary(call);
+
+            // 权限检查（在执行前完成，trust_mode 通过 shared Arc 实时生效）
+            use crate::permission::PermissionDecision;
+            let decision = engine.check_tool_permission(&call.name);
+            match decision {
+                PermissionDecision::Approved => {}
+                PermissionDecision::Denied { reason } => {
+                    let _ = stream_tx.send(StreamEvent::ToolResult {
+                        name: call.name.clone(),
+                        ok: false,
+                        output: format!("权限拒绝：{reason}"),
+                    });
+                    loop_context.push(Message {
+                        id: scru128::new().to_string(),
+                        role: MessageRole::System,
+                        content: format!("工具 {} 执行失败：权限拒绝 - {reason}", call.name),
+                        reasoning_content: String::new(),
+                        worker_id: None,
+                        created_at: now_text(),
+                    });
+                    continue;
+                }
+                PermissionDecision::NeedsApproval { request_id } => {
+                    // 发送审批请求
+                    let _ = stream_tx.send(StreamEvent::ApprovalNeeded {
+                        request_id: request_id.clone(),
+                        tool_name: call.name.clone(),
+                        args_summary: args_summary.clone(),
+                    });
+
+                    // 阻塞等待用户审批
+                    let approved = loop {
+                        match cmd_rx.recv() {
+                            Ok(Command::Approval {
+                                request_id: rid,
+                                approved,
+                            }) if rid == request_id => {
+                                break approved;
+                            }
+                            Ok(Command::Cancel) => {
+                                let _ = stream_tx.send(StreamEvent::Error {
+                                    message: "已取消".into(),
+                                });
+                                return accumulated_usage;
+                            }
+                            Ok(Command::Message(content)) => {
+                                session
+                                    .append_message(MessageRole::User, content.clone());
+                                loop_context.push(Message {
+                                    id: scru128::new().to_string(),
+                                    role: MessageRole::User,
+                                    content,
+                                    reasoning_content: String::new(),
+                                    worker_id: None,
+                                    created_at: now_text(),
+                                });
+                            }
+                            Ok(Command::Shutdown) => return accumulated_usage,
+                            _ => {}
+                        }
+                    };
+
+                    if !approved {
+                        let _ = stream_tx.send(StreamEvent::ToolResult {
+                            name: call.name.clone(),
+                            ok: false,
+                            output: "用户拒绝执行".to_string(),
+                        });
+                        session.append_message(
+                            MessageRole::System,
+                            format!("工具 {} 被用户拒绝执行", call.name),
+                        );
+                        loop_context.push(Message {
+                            id: scru128::new().to_string(),
+                            role: MessageRole::System,
+                            content: format!("工具 {} 被用户拒绝执行", call.name),
+                            reasoning_content: String::new(),
+                            worker_id: None,
+                            created_at: now_text(),
+                        });
+                        continue;
+                    }
+                }
+            }
+
             let _ = stream_tx.send(StreamEvent::ToolStart {
                 name: call.name.clone(),
-                summary: String::new(),
+                args_summary: args_summary.clone(),
             });
 
             let result =
                 engine.execute_tool_call(call, mcp_targets, &engine.agent_config().mcp);
 
             let _ = stream_tx.send(StreamEvent::ToolResult {
-                name: result.summary.clone(),
+                name: call.name.clone(),
                 ok: result.ok,
                 output: result.stdout.clone(),
             });
@@ -494,6 +601,9 @@ fn execute_turn_inner(
                 created_at: now_text(),
             });
         }
+
+        // 工具调用完成后增量持久化（防止崩溃丢失中间数据）
+        session.persist_to_disk();
 
         // 每轮之间检查用户命令（非阻塞）
         while let Ok(cmd) = cmd_rx.try_recv() {
@@ -621,9 +731,11 @@ fn force_final_response(
 /// 从 CoreConfig 快照构建 RuntimeEngine
 ///
 /// `stream_tx` 用于在 LLM 请求重试时发送 `StreamEvent::Retry` 通知。
+/// `shared_trust_mode` 是 TiangongCore 持有的独立信任模式，RuntimeEngine 共享此引用。
 fn build_engine_from_config(
     config: &crate::core_config::CoreConfig,
     stream_tx: &Sender<StreamEvent>,
+    shared_trust_mode: Arc<RwLock<crate::permission::TrustMode>>,
 ) -> RuntimeEngine {
     use crate::agent_config::AgentConfig;
     use crate::model::OnRetryCallback;
@@ -642,7 +754,7 @@ fn build_engine_from_config(
     // 构造重试回调：发送 StreamEvent::Retry 通知前端
     let retry_tx = stream_tx.clone();
     let on_retry: OnRetryCallback =
-        std::sync::Arc::new(move |attempt, max_attempts, _delay_ms, error_text| {
+        Arc::new(move |attempt, max_attempts, _delay_ms, error_text| {
             let _ = retry_tx.send(StreamEvent::Retry {
                 message: error_text.to_string(),
                 attempt,
@@ -650,11 +762,81 @@ fn build_engine_from_config(
             });
         });
 
-    RuntimeEngine::new(
+    RuntimeEngine::with_shared_trust_mode(
         SingleProviderClient::new(model_config).with_on_retry(on_retry),
         config.context_limit,
         agent_config,
+        shared_trust_mode,
     )
     .with_models_config(models_config)
     .with_core_config(config.clone())
+}
+
+/// 格式化工具调用参数摘要（用于 ToolStart 和 ApprovalNeeded 事件）
+fn format_call_args_summary(call: &crate::model::ModelFunctionCall) -> String {
+    use serde_json::Value;
+
+    let args = &call.arguments;
+    if !args.is_object() || args.as_object().is_none_or(|m| m.is_empty()) {
+        return String::new();
+    }
+
+    // run_command / run_shell 特殊处理：直接展示命令
+    if call.name == "run_command" || call.name == "run_shell" {
+        if let Some(cmd) = args.get("command").and_then(Value::as_str) {
+            return cmd.to_string();
+        }
+        // shell 脚本模式
+        if let Some(script) = args.get("script").and_then(Value::as_str) {
+            let shell = args
+                .get("shell")
+                .and_then(Value::as_str)
+                .unwrap_or("auto");
+            return format!("[{shell}] {script}");
+        }
+    }
+
+    // write_file 特殊处理
+    if call.name == "write_file"
+        && let Some(path) = args.get("path").and_then(Value::as_str)
+    {
+        let len = args
+            .get("content")
+            .and_then(Value::as_str)
+            .map(|c| c.len())
+            .unwrap_or(0);
+        return format!("{path} ({len} bytes)");
+    }
+
+    // read_file / list_directory
+    if (call.name == "read_file" || call.name == "list_directory")
+        && let Some(path) = args.get("path").and_then(Value::as_str)
+    {
+        return path.to_string();
+    }
+
+    // 通用：key=value 格式，截断长值（按字符截断，避免 UTF-8 边界 panic）
+    let obj = args.as_object().unwrap();
+    obj.iter()
+        .map(|(k, v)| {
+            let val = match v {
+                Value::String(s) if s.chars().count() > 80 => {
+                    let truncated: String = s.chars().take(77).collect();
+                    format!("{truncated}...")
+                }
+                Value::String(s) => s.clone(),
+                other => {
+                    let s = other.to_string();
+                    if s.chars().count() > 80 {
+                        let truncated: String = s.chars().take(77).collect();
+                        format!("{truncated}...")
+                    } else {
+                        s
+                    }
+                }
+            };
+            format!("{k}={val}")
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -316,7 +316,7 @@ impl SingleProviderClient {
         let config = OpenAIConfig::new()
             .with_api_key(token.to_string())
             .with_api_base(api_base);
-        let client = OpenAIClient::with_config(config);
+        let client = build_no_retry_client(config);
         let mut request_json = serde_json::to_value(&request).context("序列化流式请求失败")?;
         inject_temperature_config(&mut request_json);
         inject_thinking_config(&mut request_json);
@@ -540,7 +540,7 @@ impl SingleProviderClient {
         let config = OpenAIConfig::new()
             .with_api_key(token.to_string())
             .with_api_base(api_base);
-        let client = OpenAIClient::with_config(config);
+        let client = build_no_retry_client(config);
         let mut request_json = serde_json::to_value(&request).context("序列化请求失败")?;
         inject_temperature_config(&mut request_json);
         inject_thinking_config(&mut request_json);
@@ -808,7 +808,7 @@ impl SingleProviderClient {
         let config = OpenAIConfig::new()
             .with_api_key(token.to_string())
             .with_api_base(api_base);
-        let client = OpenAIClient::with_config(config);
+        let client = build_no_retry_client(config);
 
         let runtime = TokioRuntimeBuilder::new_current_thread()
             .enable_all()
@@ -926,7 +926,7 @@ impl ModelClient for SingleProviderClient {
         let config = OpenAIConfig::new()
             .with_api_key(token.to_string())
             .with_api_base(api_base);
-        let client = OpenAIClient::with_config(config);
+        let client = build_no_retry_client(config);
         let mut request_json = serde_json::to_value(&request).context("序列化请求失败")?;
         inject_temperature_config(&mut request_json);
         inject_thinking_config(&mut request_json);
@@ -1027,7 +1027,7 @@ impl ModelClient for SingleProviderClient {
         let config = OpenAIConfig::new()
             .with_api_key(token.to_string())
             .with_api_base(api_base);
-        let client = OpenAIClient::with_config(config);
+        let client = build_no_retry_client(config);
         let mut request_json = serde_json::to_value(&request).context("序列化请求失败")?;
         inject_temperature_config(&mut request_json);
         inject_thinking_config(&mut request_json);
@@ -1231,6 +1231,21 @@ fn normalize_api_base(base_url: &str) -> Result<String> {
     let cleaned = trimmed.trim_end_matches('/');
     let cleaned = cleaned.strip_suffix("/chat/completions").unwrap_or(cleaned);
     Ok(cleaned.to_string())
+}
+
+/// 创建禁用内部 backoff 的 OpenAI 客户端
+///
+/// async-openai 默认有 ExponentialBackoff（最长 15 分钟）。
+/// 禁用后由 `with_retry` 统一管理重试，确保 StreamEvent::Retry 能正确触发。
+fn build_no_retry_client(config: OpenAIConfig) -> OpenAIClient<OpenAIConfig> {
+    // 设置极小的 max_elapsed_time 确保 async-openai 不做任何内部重试。
+    // Duration::ZERO 在 backoff 首次调用时 elapsed ≈ 0 可能仍允许 1 次重试，
+    // 使用 1ns 确保 elapsed > max_elapsed_time 立即停止。
+    let no_retry = backoff::ExponentialBackoff {
+        max_elapsed_time: Some(Duration::from_nanos(1)),
+        ..Default::default()
+    };
+    OpenAIClient::build(reqwest::Client::new(), config, no_retry)
 }
 
 fn build_sdk_error_hint(error_text: &str) -> String {

--- a/crates/tiangong-core/src/runtime.rs
+++ b/crates/tiangong-core/src/runtime.rs
@@ -160,7 +160,18 @@ impl RuntimeEngine {
         )
     }
 
+    /// 对工具进行权限检查（暴露给 core 层在执行前调用）
+    pub(crate) fn check_tool_permission(
+        &self,
+        tool_name: &str,
+    ) -> crate::permission::PermissionDecision {
+        self.permission_gate.check(tool_name)
+    }
+
     /// 执行单个工具调用（本地工具、MCP 工具、多媒体生成或后台任务）
+    ///
+    /// 注意：权限检查已由调用方（core/mod.rs）在执行前完成，
+    /// 此方法内部的权限检查改为仅 Denied 拦截，NeedsApproval 由调用方处理。
     pub(crate) fn execute_tool_call(
         &self,
         call: &ModelFunctionCall,
@@ -181,12 +192,8 @@ impl RuntimeEngine {
                     execution: None,
                 };
             }
-            PermissionDecision::NeedsApproval { request_id } => {
-                // Phase 3 中将改为暂停等待审批，当前在非 FullTrust 模式下记录日志并放行
-                tracing::info!(
-                    "权限审批请求 {request_id}：工具 {} 需要用户确认（当前自动放行）",
-                    call.name
-                );
+            PermissionDecision::NeedsApproval { .. } => {
+                // 审批已由调用方（core/mod.rs execute_turn_inner）完成，此处放行
             }
         }
 

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -222,6 +222,31 @@ impl Session {
         }
     }
 
+    /// 将 session 持久化到 `~/.tiangong/sessions/{id}.json`
+    ///
+    /// Core 在工具调用等关键节点调用此方法，确保中间数据不会因崩溃丢失。
+    pub fn persist_to_disk(&self) {
+        let home = std::env::var_os("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let sessions_dir = home.join(".tiangong").join("sessions");
+        if std::fs::create_dir_all(&sessions_dir).is_err() {
+            tracing::warn!("创建 sessions 目录失败");
+            return;
+        }
+        let path = sessions_dir.join(format!("{}.json", self.id));
+        match serde_json::to_string_pretty(self) {
+            Ok(content) => {
+                if let Err(err) = std::fs::write(&path, content) {
+                    tracing::warn!(error = %err, "session 持久化写入失败");
+                }
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "session 序列化失败");
+            }
+        }
+    }
+
     pub fn append_message(&mut self, role: MessageRole, content: impl Into<String>) {
         self.append_message_with_reasoning(role, content, String::new());
     }

--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -20,7 +20,11 @@ pub(crate) enum MainCommand {
     #[command(about = "启动桌面 UI")]
     Ui,
     #[command(about = "启动 CLI 模式")]
-    Cli,
+    Cli {
+        /// 信任模式（full_trust / supervised）
+        #[arg(long = "trust-mode", value_enum, help = "强制指定信任模式")]
+        trust_mode: Option<TrustModeArg>,
+    },
     #[command(about = "启动 Server 模式")]
     Server(ServerArgs),
     #[command(about = "MCP 配置管理")]
@@ -45,6 +49,9 @@ pub(crate) struct ServerArgs {
     /// 后台运行
     #[arg(short, long, help = "后台运行")]
     pub(crate) daemon: bool,
+    /// 信任模式
+    #[arg(long = "trust-mode", value_enum, help = "强制指定信任模式")]
+    pub(crate) trust_mode: Option<TrustModeArg>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -63,6 +70,23 @@ pub(crate) struct McpArgs {
 pub(crate) struct SkillArgs {
     #[command(subcommand)]
     pub(crate) command: SkillSubcommand,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum TrustModeArg {
+    /// 完全信任（工具自动执行，无审批）
+    FullTrust,
+    /// 监督模式（高风险工具需要用户审批）
+    Supervised,
+}
+
+impl TrustModeArg {
+    pub(crate) fn to_trust_mode(self) -> tiangong_core::permission::TrustMode {
+        match self {
+            TrustModeArg::FullTrust => tiangong_core::permission::TrustMode::FullTrust,
+            TrustModeArg::Supervised => tiangong_core::permission::TrustMode::Supervised,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/tiangong-entry/src/lib.rs
+++ b/crates/tiangong-entry/src/lib.rs
@@ -27,7 +27,9 @@ pub fn run() -> anyhow::Result<()> {
         Some(MainCommand::Server(args)) => server::run_server_command(args),
         Some(MainCommand::Mcp(args)) => mcp::run_mcp_command(args),
         Some(MainCommand::Skill(args)) => skill::run_skill_command(args),
-        Some(MainCommand::Cli) => tiangong_cli::run_cli(),
+        Some(MainCommand::Cli { trust_mode }) => {
+            tiangong_cli::run_cli_with_trust_mode(trust_mode.map(|m| m.to_trust_mode()))
+        }
         None | Some(MainCommand::Ui) => Err(anyhow::anyhow!("UI 模式请通过 Tauri 桌面应用启动")),
     }
 }

--- a/crates/tiangong-media/src/openai_stt.rs
+++ b/crates/tiangong-media/src/openai_stt.rs
@@ -113,7 +113,7 @@ impl SpeechRecognizer for OpenAIWhisper {
             serde_json::from_str(&resp_text).with_context(|| {
                 format!(
                     "解析 Whisper 响应失败，原始响应：{}",
-                    &resp_text[..resp_text.len().min(500)]
+                    &resp_text.chars().take(500).collect::<String>()
                 )
             })?;
 

--- a/crates/tiangong-types/src/stream.rs
+++ b/crates/tiangong-types/src/stream.rs
@@ -22,7 +22,10 @@ pub enum StreamEvent {
         content: String,
     },
     /// 工具开始执行
-    ToolStart { name: String, summary: String },
+    ToolStart {
+        name: String,
+        args_summary: String,
+    },
     /// 工具执行结果
     ToolResult {
         name: String,

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -28,6 +28,19 @@ import { api } from "@/api/tauri";
 import { useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
+/** 格式化消息时间（hover 显示） */
+function formatMessageTime(createdAt?: string): string {
+  if (!createdAt) return "";
+  try {
+    const d = new Date(createdAt);
+    if (isNaN(d.getTime())) return createdAt;
+    const pad = (n: number) => n.toString().padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  } catch {
+    return createdAt;
+  }
+}
+
 function MessageActions({ text, showTts }: { text: string; showTts: boolean }) {
   const [copied, setCopied] = useState(false);
   const [playing, setPlaying] = useState(false);
@@ -529,7 +542,7 @@ export function MessageList() {
               const voiceInfo = voiceMessages[message.id];
               return (
                 <div key={group.key} className="mt-3 first:mt-0">
-                  <div className="flex justify-end">
+                  <div className="flex justify-end" title={formatMessageTime(message.created_at)}>
                     <div className="max-w-[100%] text-muted-foreground">
                       {voiceInfo ? (
                         <VoiceBubble
@@ -717,8 +730,8 @@ function AgentTurn({
 
   // 将消息序列解析为渲染片段
   type Fragment =
-    | { type: "explanation"; text: string }
-    | { type: "thinking"; content: string }
+    | { type: "explanation"; text: string; time?: string }
+    | { type: "thinking"; content: string; time?: string }
     | { type: "tool_group"; key: string; brief: string; tools: MessageItem[] }
     | { type: "assistant"; msg: MessageItem; isStreaming: boolean }
     | { type: "error_system"; msg: MessageItem }
@@ -749,14 +762,14 @@ function AgentTurn({
       const reasoning = msg.reasoning_content?.trim() || "";
       if (reasoning && !shownReasonings.has(reasoning)) {
         shownReasonings.add(reasoning);
-        fragments.push({ type: "thinking", content: reasoning });
+        fragments.push({ type: "thinking", content: reasoning, time: msg.created_at });
       }
       // 提取解释文本
       const explanation = extractLlmExplanation(msg.content);
       if (explanation) {
-        fragments.push({ type: "explanation", text: explanation });
+        fragments.push({ type: "explanation", text: explanation, time: msg.created_at });
       }
-    } else if (msg.role === "System" && (msg.content.includes("tool_name:") || msg.content.includes("exit_code"))) {
+    } else if (msg.role === "System" && (msg.content.includes("tool_name:") || msg.content.includes("exit_code") || msg.content.startsWith("工具执行 ["))) {
       pendingTools.push(msg);
     } else if (msg.role === "Assistant") {
       flushTools();
@@ -771,7 +784,7 @@ function AgentTurn({
       const assistantReasoning = msg.reasoning_content?.trim() || "";
       if (assistantReasoning && !shownReasonings.has(assistantReasoning)) {
         shownReasonings.add(assistantReasoning);
-        fragments.push({ type: "thinking", content: assistantReasoning });
+        fragments.push({ type: "thinking", content: assistantReasoning, time: msg.created_at });
       }
       fragments.push({ type: "assistant", msg, isStreaming });
     } else if (msg.role === "System" && msg.content.startsWith("[错误]")) {
@@ -792,7 +805,7 @@ function AgentTurn({
     const meta = getSystemMessageMeta(tool.content);
     const expanded = expandedItems.has(tool.id);
     return (
-      <div key={tool.id}>
+      <div key={tool.id} title={formatMessageTime(tool.created_at)}>
         <button
           className="w-full flex items-center gap-2 px-2 py-0.5 rounded text-xs text-muted-foreground hover:bg-muted/50 transition-colors text-left"
           onClick={() => toggleItem(tool.id)}
@@ -815,19 +828,24 @@ function AgentTurn({
     <div className="space-y-1.5">
       {fragments.map((frag, i) => {
         if (frag.type === "thinking") {
-          return <ThinkingBlock key={`think-${i}`} content={frag.content} defaultExpanded={false} />;
+          return (
+            <div key={`think-${i}`} title={formatMessageTime(frag.time)}>
+              <ThinkingBlock content={frag.content} defaultExpanded={false} />
+            </div>
+          );
         }
         if (frag.type === "explanation") {
           return (
-            <p key={`expl-${i}`} className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap break-words">
+            <p key={`expl-${i}`} className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap break-words" title={formatMessageTime(frag.time)}>
               {frag.text}
             </p>
           );
         }
         if (frag.type === "tool_group") {
           const collapsed = collapsedToolGroups.has(frag.key);
+          const groupTime = frag.tools.length > 0 ? formatMessageTime(frag.tools[0].created_at) : "";
           return (
-            <div key={`tools-${frag.key}`}>
+            <div key={`tools-${frag.key}`} title={groupTime}>
               <button
                 className="flex items-center gap-2 px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted/50 rounded transition-colors"
                 onClick={() => toggleToolGroup(frag.key)}
@@ -843,7 +861,7 @@ function AgentTurn({
         if (frag.type === "assistant") {
           const { msg, isStreaming } = frag;
           return (
-            <div key={msg.id} className="text-foreground">
+            <div key={msg.id} className="text-foreground" title={formatMessageTime(msg.created_at)}>
               {isStreaming ? (
                 <TypingMessage content={streamingContent} reasoningContent={_streamingReasoningContent} speed={300} />
               ) : (
@@ -892,14 +910,17 @@ function getSystemMessageMeta(content: string) {
     const label = match ? match[1] : "LLM";
     return { icon: Cpu, label, summary: content.split("\n")[0] };
   }
-  if (content.includes("tool_name:") || content.includes("exit_code")) {
-    const nameMatch = content.match(/tool_name:\s*(\S+)/);
-    const codeMatch = content.match(/exit_code=(\d+)/);
+  if (content.includes("tool_name:") || content.includes("exit_code") || content.startsWith("工具执行 [")) {
+    const nameMatch = content.match(/tool_name:\s*(\S+)/) || content.match(/^工具执行 \[(.+?)\]/);
     const okMatch = content.match(/ok=(\w+)/);
+    const cmdMatch = content.match(/命令:\s*(.+)/);
     const parts = [];
     if (nameMatch) parts.push(nameMatch[1]);
-    if (codeMatch) parts.push(`exit=${codeMatch[1]}`);
     if (okMatch) parts.push(okMatch[1] === "true" ? "OK" : "FAIL");
+    if (cmdMatch) {
+      const cmd = cmdMatch[1];
+      parts.push(cmd.length > 60 ? cmd.slice(0, 57) + "..." : cmd);
+    }
     return {
       icon: Terminal,
       label: "工具执行",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5319,6 +5319,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-openai",
+ "backoff",
  "chrono",
  "diffy",
  "futures-util",

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -94,6 +94,39 @@ impl TiangongApp {
         cores.remove(session_id)
     }
 
+    /// 取消指定会话的执行
+    pub fn cancel_core(&self, session_id: &str) {
+        let cores = self.cores.lock().unwrap();
+        if let Some(core) = cores.get(session_id) {
+            core.cancel();
+        }
+    }
+
+    /// 向指定会话的 core 发送审批响应
+    pub fn respond_approval_to_core(
+        &self,
+        session_id: &str,
+        request_id: String,
+        approved: bool,
+    ) {
+        let cores = self.cores.lock().unwrap();
+        if let Some(core) = cores.get(session_id) {
+            core.respond_approval(request_id, approved);
+        }
+    }
+
+    /// 设置指定会话 core 的信任模式（实时生效）
+    pub fn set_core_trust_mode(
+        &self,
+        session_id: &str,
+        mode: tiangong_core::permission::TrustMode,
+    ) {
+        let cores = self.cores.lock().unwrap();
+        if let Some(core) = cores.get(session_id) {
+            core.set_trust_mode(mode);
+        }
+    }
+
     /// 检查 session 是否有活跃 core
     pub fn is_session_executing(&self, session_id: &str) -> bool {
         let cores = self.cores.lock().unwrap();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -159,6 +159,7 @@ pub fn send_message(
     let app_clone = app.clone();
     thread::spawn(move || {
         let mut assistant_msg_id: Option<String> = None;
+        let mut last_tool_args_summary = String::new();
         for session_event in stream_rx.iter() {
             // 先 emit 完整事件给前端，再解构
             let _ = app_clone.emit("stream_event", &session_event);
@@ -225,18 +226,33 @@ pub fn send_message(
                             );
                             assistant_msg_id = None;
                         }
-                        StreamEvent::ToolStart { .. } => {}
-                        StreamEvent::ToolResult { name, ok, output } => {
+                        StreamEvent::ToolStart { ref args_summary, .. } => {
+                            last_tool_args_summary = args_summary.clone();
+                        }
+                        StreamEvent::ToolResult { ref name, ok, ref output } => {
                             let status = if *ok { "ok=true" } else { "ok=false" };
                             let preview = if output.chars().count() > 200 {
                                 format!("{}...", output.chars().take(200).collect::<String>())
                             } else {
                                 output.clone()
                             };
+                            let mut lines = vec![format!("工具执行 [{name}]")];
+                            if !last_tool_args_summary.is_empty() {
+                                lines.push(format!("命令: {last_tool_args_summary}"));
+                            }
+                            lines.push(format!("{status} exit_code=0"));
+                            lines.push(format!("summary: {name}"));
+                            if !preview.trim().is_empty() {
+                                lines.push(format!("stdout:\n{preview}"));
+                            }
                             session.append_message(
                                 tiangong_core::session::MessageRole::System,
-                                format!("工具执行 [{name}]\n{status} exit_code=0\nsummary: {name}\nstdout:\n{preview}"),
+                                lines.join("\n"),
                             );
+                            last_tool_args_summary.clear();
+                        }
+                        StreamEvent::ApprovalNeeded { .. } => {
+                            // 审批请求不写入 session（前端通过 RunStatus 展示审批 UI）
                         }
                         StreamEvent::Error { ref message } => {
                             session.append_message(
@@ -265,8 +281,31 @@ pub fn send_message(
                 }
                 // RunStatus/usage 更新
                 match &event {
-                    StreamEvent::ToolStart { name, .. } => {
-                        core_state.store.runtime.run.summary = format!("正在执行：{name}");
+                    StreamEvent::ApprovalNeeded {
+                        ref request_id,
+                        ref tool_name,
+                        ref args_summary,
+                    } => {
+                        core_state.store.runtime.run.status =
+                            tiangong_core::runtime::RunStatus::WaitingApproval;
+                        core_state.store.runtime.run.summary = if args_summary.is_empty() {
+                            format!("工具 {tool_name} 需要确认")
+                        } else {
+                            format!("{tool_name}: {args_summary}")
+                        };
+                        core_state.store.runtime.run.approval_request_id =
+                            Some(request_id.clone());
+                    }
+                    StreamEvent::ToolStart { name, ref args_summary } => {
+                        // 审批通过后恢复执行状态
+                        core_state.store.runtime.run.status =
+                            tiangong_core::runtime::RunStatus::Executing;
+                        core_state.store.runtime.run.approval_request_id = None;
+                        core_state.store.runtime.run.summary = if args_summary.is_empty() {
+                            format!("正在执行：{name}")
+                        } else {
+                            format!("正在执行：{name} {args_summary}")
+                        };
                     }
                     StreamEvent::ToolResult { name, ok, .. } => {
                         let s = if *ok { "✓" } else { "✗" };
@@ -314,6 +353,12 @@ pub fn send_message(
                     } => {
                         core_state.store.runtime.run.summary =
                             format!("重试中 ({attempt}/{max_attempts})...");
+                    }
+                    StreamEvent::Reasoning { .. } => {
+                        core_state.store.runtime.run.summary = "正在思考...".to_string();
+                    }
+                    StreamEvent::Delta { .. } => {
+                        core_state.store.runtime.run.summary = "正在回复...".to_string();
                     }
                     _ => {}
                 }
@@ -396,7 +441,10 @@ pub fn send_message(
 /// 取消当前执行
 #[tauri::command]
 pub fn cancel_turn(state: State<TiangongApp>) -> Result<bool, String> {
-    state.with_state(|core_state| core_state.cancel_pending_turn())
+    let session_id =
+        state.with_state_read(|core_state| Ok(core_state.active_session_id().to_string()))?;
+    state.cancel_core(&session_id);
+    Ok(true)
 }
 
 /// 向正在执行的 turn 追加用户消息
@@ -412,9 +460,10 @@ pub fn respond_approval(
     approved: bool,
     state: State<TiangongApp>,
 ) -> Result<bool, String> {
-    state.with_state(|core_state| {
-        core_state.respond_to_approval(&request_id, approved)
-    })
+    let session_id =
+        state.with_state_read(|core_state| Ok(core_state.active_session_id().to_string()))?;
+    state.respond_approval_to_core(&session_id, request_id, approved);
+    Ok(true)
 }
 
 /// 获取当前信任模式
@@ -433,12 +482,19 @@ pub fn get_trust_mode(state: State<TiangongApp>) -> Result<String, String> {
 /// 设置信任模式
 #[tauri::command]
 pub fn set_trust_mode(mode: String, state: State<TiangongApp>) -> Result<(), String> {
-    state.with_state(|core_state| {
-        let trust_mode: tiangong_core::permission::TrustMode =
-            serde_json::from_value(serde_json::Value::String(mode))
-                .map_err(|e| anyhow::anyhow!("无效的信任模式: {e}"))?;
-        core_state.set_trust_mode(trust_mode)
-    })
+    let trust_mode: tiangong_core::permission::TrustMode =
+        serde_json::from_value(serde_json::Value::String(mode))
+            .map_err(|e| format!("无效的信任模式: {e}"))?;
+
+    // 更新 TiangongState（持久化）
+    state.with_state(|core_state| core_state.set_trust_mode(trust_mode))?;
+
+    // 实时更新当前活跃 core 的信任模式（立即生效）
+    let session_id =
+        state.with_state_read(|core_state| Ok(core_state.active_session_id().to_string()))?;
+    state.set_core_trust_mode(&session_id, trust_mode);
+
+    Ok(())
 }
 
 /// 获取会话成本统计


### PR DESCRIPTION
## Summary

- 监督模式下 Elevated/Critical 工具（run_command 等）执行前发送 ApprovalNeeded 事件，阻塞等待用户审批
- TiangongCore 持有独立 `Arc<RwLock<TrustMode>>`，GUI 切换信任模式对当前对话实时生效
- 修复 `cancel_turn`/`respond_approval` 路由（之前是 no-op）
- CLI/Server 支持 `--trust-mode full-trust|supervised` 参数
- ToolStart 携带 args_summary，前端展示实际命令和参数
- GUI 消息 hover 显示时间
- 禁用 async-openai 内部 backoff，确保 StreamEvent::Retry 正确触发
- 修复 UTF-8 字符边界 panic（中文截断）
- Core 工具调用后增量持久化 session（防崩溃丢失数据）

## 改动文件

| 文件 | 说明 |
|------|------|
| `core/mod.rs` | 审批流程 + format_call_args_summary + 增量持久化 + UTF-8 修复 |
| `runtime.rs` | check_tool_permission 暴露 + sync_trust_mode 移除 |
| `session.rs` | Session::persist_to_disk() |
| `model.rs` | build_no_retry_client 禁用内部 backoff |
| `stream.rs` | ToolStart.args_summary + Retry 变体 |
| `app.rs` | cancel_core / respond_approval_to_core / set_core_trust_mode |
| `commands.rs` | 审批路由修复 + 状态栏更新 + 工具消息格式 |
| `repl.rs` | CLI 审批交互 + trust_mode 参数 |
| `args.rs` | --trust-mode CLI/Server 参数 |
| `MessageList.tsx` | hover 时间 + 工具命令展示 + 错误/重试样式 |
| `openai_stt.rs` | UTF-8 安全截断 |

## Test plan

- [ ] 监督模式下 run_command 弹出审批，允许后执行，拒绝后跳过
- [ ] 信任模式下工具自动执行无审批
- [ ] GUI 切换信任/监督模式对当前对话立即生效
- [ ] CLI `--trust-mode supervised` 工具调用提示 y/n
- [ ] 工具展示显示实际命令（如 curl URL）
- [ ] 消息 hover 显示时间
- [ ] Rate limited 时前端显示重试提示
- [ ] 进程崩溃后重启，已完成的工具调用数据不丢失