### PR TITLE
feat(config): Lite 轻量文本模型配置

### DIFF
--- a/crates/tiangong-config/src/config.rs
+++ b/crates/tiangong-config/src/config.rs
@@ -130,6 +130,7 @@ impl TiangongConfig {
 
         LlmConfig {
             chat: resolve(ModelCapability::Chat).unwrap_or_default(),
+            lite: resolve(ModelCapability::Lite),
             image_generation: resolve(ModelCapability::ImageGeneration),
             tts: resolve(ModelCapability::Tts),
             stt: resolve(ModelCapability::Stt),

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -762,14 +762,30 @@ fn build_engine_from_config(
             });
         });
 
-    RuntimeEngine::with_shared_trust_mode(
-        SingleProviderClient::new(model_config).with_on_retry(on_retry),
+    let mut engine = RuntimeEngine::with_shared_trust_mode(
+        SingleProviderClient::new(model_config).with_on_retry(on_retry.clone()),
         config.context_limit,
         agent_config,
         shared_trust_mode,
     )
     .with_models_config(models_config)
-    .with_core_config(config.clone())
+    .with_core_config(config.clone());
+
+    // 如果配置了独立的 lite 端点，构建 lite client
+    if let Some(ref lite_endpoint) = config.llm.lite {
+        let lite_config = crate::model::ModelProviderConfig {
+            api_auth_token: lite_endpoint.api_key.clone(),
+            api_base_url: lite_endpoint.base_url.clone(),
+            api_timeout_ms: lite_endpoint.timeout_ms.to_string(),
+            api_model: lite_endpoint.model.clone(),
+            api_lite_model: lite_endpoint.model.clone(),
+        };
+        engine = engine.with_lite_client(
+            SingleProviderClient::new(lite_config).with_on_retry(on_retry),
+        );
+    }
+
+    engine
 }
 
 /// 格式化工具调用参数摘要（用于 ToolStart 和 ApprovalNeeded 事件）

--- a/crates/tiangong-core/src/core_config.rs
+++ b/crates/tiangong-core/src/core_config.rs
@@ -56,6 +56,9 @@ impl Default for ModelEndpoint {
 pub struct LlmConfig {
     /// 主 Chat 端点（必须）
     pub chat: ModelEndpoint,
+    /// 轻量级文本端点（标题生成、意图分类等简单任务，未配置时回退到 chat）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lite: Option<ModelEndpoint>,
     /// 图片生成端点
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_generation: Option<ModelEndpoint>,

--- a/crates/tiangong-core/src/models_config.rs
+++ b/crates/tiangong-core/src/models_config.rs
@@ -17,6 +17,8 @@ use crate::model::ModelProviderConfig;
 #[serde(rename_all = "snake_case")]
 pub enum ModelCapability {
     Chat,
+    /// 轻量级文本模型（标题生成、意图分类等简单任务）
+    Lite,
     Multimodal,
     ImageGeneration,
     VideoGeneration,
@@ -29,6 +31,7 @@ impl ModelCapability {
     pub fn all() -> &'static [ModelCapability] {
         &[
             ModelCapability::Chat,
+            ModelCapability::Lite,
             ModelCapability::Multimodal,
             ModelCapability::ImageGeneration,
             ModelCapability::VideoGeneration,
@@ -41,6 +44,7 @@ impl ModelCapability {
     pub fn display_name(&self) -> &'static str {
         match self {
             ModelCapability::Chat => "对话",
+            ModelCapability::Lite => "轻量文本",
             ModelCapability::Multimodal => "多模态",
             ModelCapability::ImageGeneration => "图片生成",
             ModelCapability::VideoGeneration => "视频生成",
@@ -53,6 +57,7 @@ impl ModelCapability {
     pub fn intent_label(&self) -> &'static str {
         match self {
             ModelCapability::Chat => "SIMPLE",
+            ModelCapability::Lite => "LITE",
             ModelCapability::Multimodal => "MULTIMODAL",
             ModelCapability::ImageGeneration => "IMAGE",
             ModelCapability::VideoGeneration => "VIDEO",
@@ -67,6 +72,7 @@ impl ModelCapability {
             ModelCapability::Chat => {
                 "简单对话（问候、闲聊、知识问答、翻译、解释概念等不需要执行工具或命令的请求）"
             }
+            ModelCapability::Lite => "轻量文本任务（标题生成、意图分类等内部任务，不参与意图路由）",
             ModelCapability::Multimodal => "多模态请求（需要理解图片、音频等多种输入形式）",
             ModelCapability::ImageGeneration => "图片生成请求（用户要求生成、绘制、创作图片）",
             ModelCapability::VideoGeneration => "视频生成请求（用户要求生成、制作视频）",
@@ -353,6 +359,22 @@ impl ModelsConfig {
             }
         } else {
             ModelProviderConfig::from_env()
+        }
+    }
+
+    /// 从 lite routing 生成 ModelProviderConfig（未配置时回退到 chat）
+    pub fn to_lite_provider_config(&self) -> ModelProviderConfig {
+        if let Some(resolved) = self.resolve_for_capability(ModelCapability::Lite) {
+            ModelProviderConfig {
+                api_auth_token: resolved.api_key,
+                api_base_url: resolved.base_url,
+                api_timeout_ms: resolved.timeout_ms.to_string(),
+                api_model: resolved.model.clone(),
+                api_lite_model: resolved.model,
+            }
+        } else {
+            // 回退到 chat 配置
+            self.to_chat_provider_config()
         }
     }
 }

--- a/crates/tiangong-core/src/runtime.rs
+++ b/crates/tiangong-core/src/runtime.rs
@@ -63,6 +63,8 @@ pub struct TurnExecution {
 #[derive(Debug, Clone)]
 pub struct RuntimeEngine {
     client: SingleProviderClient,
+    /// 轻量级文本模型客户端（标题生成等简单任务，未配置时为 None，回退到 client）
+    lite_client: Option<SingleProviderClient>,
     tool_executor: LocalToolExecutor,
     pub context_limit: usize,
     agent_config: AgentConfig,
@@ -84,6 +86,7 @@ impl RuntimeEngine {
             });
         Self {
             client,
+            lite_client: None,
             tool_executor: LocalToolExecutor::from_agent_config(&agent_config),
             context_limit,
             agent_config,
@@ -109,6 +112,7 @@ impl RuntimeEngine {
         );
         Self {
             client,
+            lite_client: None,
             tool_executor: LocalToolExecutor::from_agent_config(&agent_config)
                 .with_shared_trust_mode(shared_trust_mode),
             context_limit,
@@ -117,6 +121,12 @@ impl RuntimeEngine {
             core_config: None,
             permission_gate,
         }
+    }
+
+    /// 设置轻量级文本模型客户端
+    pub fn with_lite_client(mut self, client: SingleProviderClient) -> Self {
+        self.lite_client = Some(client);
+        self
     }
 
     pub fn with_models_config(mut self, config: ModelsConfig) -> Self {
@@ -137,6 +147,10 @@ impl RuntimeEngine {
     /// 获取模型客户端引用
     pub fn client(&self) -> &SingleProviderClient {
         &self.client
+    }
+    /// 获取轻量级模型客户端（未配置时回退到主客户端）
+    pub fn lite_client(&self) -> &SingleProviderClient {
+        self.lite_client.as_ref().unwrap_or(&self.client)
     }
     /// 获取 AgentConfig 引用
     pub fn agent_config(&self) -> &AgentConfig {

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -615,7 +615,7 @@ function ModelsSection({
       <div>
         <Label className="text-xs">能力</Label>
         <div className="flex flex-wrap gap-1.5 mt-1">
-          {capabilities.map((cap) => (
+          {capabilities.filter((cap) => cap.key !== 'lite').map((cap) => (
             <button
               key={cap.key}
               className={`px-2 py-0.5 text-xs rounded border transition-colors ${
@@ -831,7 +831,11 @@ function RoutingSection({
                     {modelKeys
                       .filter((mk) => {
                         const m = config.models[mk];
-                        return m.capabilities.length === 0 || m.capabilities.includes(cap.key);
+                        if (m.capabilities.length === 0) return true;
+                        if (m.capabilities.includes(cap.key)) return true;
+                        // lite 路由也可以选择 chat 文本模型
+                        if (cap.key === 'lite' && m.capabilities.includes('chat')) return true;
+                        return false;
                       })
                       .map((mk) => (
                         <SelectItem key={mk} value={mk}>{mk}</SelectItem>

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -398,7 +398,7 @@ pub fn send_message(
                                 .find(|m| m.role == tiangong_core::session::MessageRole::User)
                                 .map(|m| m.content.clone())
                             {
-                                let provider_config = core_state.store.provider.models_config.to_chat_provider_config();
+                                let provider_config = core_state.store.provider.models_config.to_lite_provider_config();
                                 return Ok(Some((input, provider_config)));
                             }
                         }


### PR DESCRIPTION
## Summary

- `ModelCapability::Lite` 新增能力类型，用于标题生成、意图分类等简单任务
- `LlmConfig.lite` 支持独立端点配置（可使用不同 provider/model）
- `RuntimeEngine.lite_client` 独立客户端，未配置时回退到主 client
- `ModelsConfig.to_lite_provider_config()` 从 routing 解析 lite 配置
- 标题生成改用 lite 配置
- GUI routing 页面自动显示 lite 路由，从 chat 文本模型中选择
- 添加模型时能力列表不显示 lite 选项（仅在 routing 中配置）

## Test plan

- [ ] 不配置 lite routing 时自动回退到 chat 模型生成标题
- [ ] 配置 lite routing 后使用指定模型生成标题
- [ ] GUI 设置 → Routing 页面显示 "轻量文本 (lite)" 行
- [ ] lite 路由下拉显示 chat 和 lite 能力的模型
- [ ] 添加模型时能力选择不显示 lite 选项