### PR TITLE
fix(core): reasoning-only 响应正常展示 + 最终回复落盘

### DIFF
--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -420,6 +420,9 @@ fn execute_turn_inner(
             };
             session.append_message(MessageRole::System, format_llm_output_message(&output));
 
+            // 最终回复落盘（确保崩溃时不丢失）
+            session.persist_to_disk();
+
             let _ = stream_tx.send(StreamEvent::Done {
                 usage: Some(tiangong_types::TokenUsage {
                     prompt_tokens: accumulated_usage.prompt_tokens,

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -864,7 +864,7 @@ function AgentTurn({
             <div key={msg.id} className="text-foreground" title={formatMessageTime(msg.created_at)}>
               {isStreaming ? (
                 <TypingMessage content={streamingContent} reasoningContent={_streamingReasoningContent} speed={300} />
-              ) : (
+              ) : msg.content ? (
                 <div>
                   <div className="prose prose-sm max-w-none break-words text-[13px] text-foreground prose-p:text-foreground prose-li:text-foreground prose-strong:text-foreground prose-headings:text-foreground prose-a:text-blue-400 prose-blockquote:text-foreground/80 prose-code:text-foreground">
                     <ReactMarkdown remarkPlugins={[remarkGfm]} components={MarkdownComponents as any}>
@@ -872,6 +872,8 @@ function AgentTurn({
                     </ReactMarkdown>
                   </div>
                 </div>
+              ) : (
+                <p className="text-xs text-muted-foreground italic">（模型未返回文本回复，请继续对话）</p>
               )}
               {!isStreaming && msg.content && <MessageActions text={msg.content} showTts={hasTts} />}
             </div>


### PR DESCRIPTION
## Summary

- 只有 reasoning 没有 text 的 LLM 响应视为有效，正常记录到 session
- `execute_turn_inner` 最终回复路径增加 `session.persist_to_disk()` 落盘
- 前端 assistant 消息 text 为空时显示提示"模型未返回文本回复，请继续对话"

## 问题背景

流式传输被 rate limit 中断时，可能只收到 reasoning 而没有 text。此前代码将这种情况作为有效响应处理但：
1. 前端渲染空白（空 text 的 ReactMarkdown 什么都不显示）
2. 最终回复路径没有调用 persist_to_disk，崩溃时数据丢失

## Test plan

- [ ] 模型只返回 reasoning 无 text 时，前端显示提示文案
- [ ] 用户可继续发送消息延续对话
- [ ] 最终回复后 session 已落盘到 ~/.tiangong/sessions/