### PR TITLE
fix(core): 审批状态落盘 + 恢复未完成审批

### DIFF
--- a/crates/tiangong-core/src/approval_store.rs
+++ b/crates/tiangong-core/src/approval_store.rs
@@ -1,0 +1,83 @@
+//! 待审批请求独立存储
+//!
+//! 审批状态是运行时瞬态数据，独立于 session 存储到 `~/.tiangong/pending-approvals.json`。
+//! 按 session_id 索引，支持多会话同时存在待审批请求。
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::session::PendingApproval;
+
+/// 全局待审批存储（session_id → approvals）
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ApprovalStoreData {
+    sessions: HashMap<String, Vec<PendingApproval>>,
+}
+
+fn store_path() -> PathBuf {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    home.join(".tiangong").join("pending-approvals.json")
+}
+
+fn load_store() -> ApprovalStoreData {
+    let path = store_path();
+    if !path.is_file() {
+        return ApprovalStoreData::default();
+    }
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|content| serde_json::from_str(&content).ok())
+        .unwrap_or_default()
+}
+
+fn save_store(data: &ApprovalStoreData) {
+    let path = store_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(content) = serde_json::to_string_pretty(data)
+        && let Err(err) = std::fs::write(&path, content)
+    {
+        tracing::warn!(error = %err, "审批存储写入失败");
+    }
+}
+
+/// 添加待审批请求
+pub fn add_pending(session_id: &str, approval: PendingApproval) {
+    let mut data = load_store();
+    data.sessions
+        .entry(session_id.to_string())
+        .or_default()
+        .push(approval);
+    save_store(&data);
+}
+
+/// 移除指定审批请求
+pub fn remove_pending(session_id: &str, request_id: &str) {
+    let mut data = load_store();
+    if let Some(approvals) = data.sessions.get_mut(session_id) {
+        approvals.retain(|a| a.request_id != request_id);
+        if approvals.is_empty() {
+            data.sessions.remove(session_id);
+        }
+    }
+    save_store(&data);
+}
+
+/// 获取指定会话的待审批列表
+pub fn get_pending(session_id: &str) -> Vec<PendingApproval> {
+    let data = load_store();
+    data.sessions.get(session_id).cloned().unwrap_or_default()
+}
+
+/// 清空指定会话的所有待审批
+pub fn clear_pending(session_id: &str) {
+    let mut data = load_store();
+    if data.sessions.remove(session_id).is_some() {
+        save_store(&data);
+    }
+}

--- a/crates/tiangong-core/src/coordinator/task_coordinator.rs
+++ b/crates/tiangong-core/src/coordinator/task_coordinator.rs
@@ -177,6 +177,7 @@ impl TaskCoordinator {
                         // 创建干净的 Worker 会话（只保留 cwd）
                         let mut worker_session = Session::new(&task.objective);
                         worker_session.cwd = session.cwd.clone();
+                        worker_session.ephemeral = true; // Worker session 不落盘
 
                         let worker_budget = WorkerBudget {
                             max_tokens: WorkerBudget::default().max_tokens,

--- a/crates/tiangong-core/src/coordinator/task_coordinator.rs
+++ b/crates/tiangong-core/src/coordinator/task_coordinator.rs
@@ -177,7 +177,7 @@ impl TaskCoordinator {
                         // 创建干净的 Worker 会话（只保留 cwd）
                         let mut worker_session = Session::new(&task.objective);
                         worker_session.cwd = session.cwd.clone();
-                        worker_session.ephemeral = true; // Worker session 不落盘
+                        worker_session.parent_session_id = Some(session.id.clone());
 
                         let worker_budget = WorkerBudget {
                             max_tokens: WorkerBudget::default().max_tokens,

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -176,6 +176,19 @@ fn worker_loop(
         }
     }
 
+    // 恢复未完成的审批请求（崩溃恢复场景）
+    let pending = crate::approval_store::get_pending(&session_id);
+    if !pending.is_empty() {
+        tracing::info!(count = pending.len(), "恢复未完成的审批请求");
+        for approval in &pending {
+            let _ = stream_tx.send(StreamEvent::ApprovalNeeded {
+                request_id: approval.request_id.clone(),
+                tool_name: approval.tool_name.clone(),
+                args_summary: approval.tool_args_summary.clone(),
+            });
+        }
+    }
+
     while let Ok(cmd) = cmd_rx.recv() {
         // 配置变更检测：仅在 generation 变化时重建 engine 和工具列表
         let cfg_gen = config.generation();
@@ -226,8 +239,24 @@ fn worker_loop(
                     message: "已取消".into(),
                 });
             }
-            Command::Approval { .. } => {
-                // TODO: 审批响应处理
+            Command::Approval {
+                request_id,
+                approved,
+            } => {
+                // 恢复场景的审批响应：清除 pending 状态
+                let pending = crate::approval_store::get_pending(&session_id);
+                let had_pending = pending.iter().any(|a| a.request_id == request_id);
+                crate::approval_store::remove_pending(&session_id, &request_id);
+
+                if had_pending {
+                    let action = if approved { "已允许" } else { "已拒绝" };
+                    session.append_message(
+                        MessageRole::System,
+                        format!("审批响应：{action}（会话已恢复，请重新发送消息继续）"),
+                    );
+                    session.persist_to_disk();
+                    let _ = stream_tx.send(StreamEvent::Done { usage: None });
+                }
             }
             Command::Shutdown => break,
         }
@@ -502,6 +531,17 @@ fn execute_turn_inner(
                     continue;
                 }
                 PermissionDecision::NeedsApproval { request_id } => {
+                    // 记录待审批状态（独立存储，崩溃恢复时可重新展示）
+                    crate::approval_store::add_pending(
+                        &session.id,
+                        crate::session::PendingApproval {
+                            request_id: request_id.clone(),
+                            tool_name: call.name.clone(),
+                            tool_args_summary: args_summary.clone(),
+                            created_at: now_text(),
+                        },
+                    );
+
                     // 发送审批请求
                     let _ = stream_tx.send(StreamEvent::ApprovalNeeded {
                         request_id: request_id.clone(),
@@ -541,25 +581,30 @@ fn execute_turn_inner(
                         }
                     };
 
+                    // 审批完成，清除 pending 状态
+                    crate::approval_store::remove_pending(&session.id, &request_id);
+
                     if !approved {
+                        session.append_message(
+                            MessageRole::System,
+                            format!("工具 {} 被用户拒绝执行", call.name),
+                        );
+                        session.persist_to_disk();
+
                         let _ = stream_tx.send(StreamEvent::ToolResult {
                             name: call.name.clone(),
                             ok: false,
                             output: "用户拒绝执行".to_string(),
                         });
-                        session.append_message(
-                            MessageRole::System,
-                            format!("工具 {} 被用户拒绝执行", call.name),
-                        );
-                        loop_context.push(Message {
-                            id: scru128::new().to_string(),
-                            role: MessageRole::System,
-                            content: format!("工具 {} 被用户拒绝执行", call.name),
-                            reasoning_content: String::new(),
-                            worker_id: None,
-                            created_at: now_text(),
+                        // 拒绝后结束本轮，避免 LLM 再次调用同工具形成死循环
+                        let _ = stream_tx.send(StreamEvent::Done {
+                            usage: Some(tiangong_types::TokenUsage {
+                                prompt_tokens: accumulated_usage.prompt_tokens,
+                                completion_tokens: accumulated_usage.completion_tokens,
+                                total_tokens: accumulated_usage.total_tokens,
+                            }),
                         });
-                        continue;
+                        return accumulated_usage;
                     }
                 }
             }

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -626,15 +626,12 @@ fn execute_turn_inner(
             // 记录到 session
             session.append_message(MessageRole::System, format_tool_trace_message(&result));
 
-            // 记录到 loop_context
+            // 记录到 loop_context（完整内容，截断由上下文压缩器处理）
             let feedback = format!(
                 "工具 {} 执行{}：{}",
                 call.name,
                 if result.ok { "成功" } else { "失败" },
-                if result.stdout.chars().count() > 2000 {
-                    let truncated: String = result.stdout.chars().take(2000).collect();
-                    format!("{truncated}...(截断)")
-                } else if result.stdout.is_empty() {
+                if result.stdout.is_empty() {
                     result.summary.clone()
                 } else {
                     result.stdout.clone()

--- a/crates/tiangong-core/src/lib.rs
+++ b/crates/tiangong-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent_config;
 pub mod agents;
 pub mod app_state;
+pub mod approval_store;
 pub mod config_watch;
 pub mod context;
 pub mod core;

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -792,10 +792,12 @@ impl SingleProviderClient {
         ];
 
         let mut request_args_binding = CreateChatCompletionRequestArgs::default();
+        // max_tokens 设大一些：模型可能先输出 <think> 再输出标题，
+        // 过小会导致 thinking 耗光 token 而标题截断
         let request = request_args_binding
             .model(model.to_string())
             .messages(messages)
-            .max_tokens(30u16)
+            .max_tokens(200u16)
             .temperature(0.3f32)
             .stream(false)
             .build()

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -850,13 +850,15 @@ impl SingleProviderClient {
             }
         };
 
-        let text = resp
+        let raw_text = resp
             .choices
             .first()
             .and_then(|choice| choice.message.content.as_deref())
             .unwrap_or("")
-            .trim()
-            .to_string();
+            .trim();
+
+        // 清理 <think>...</think> 标签（部分模型忽略 thinking.disabled 配置）
+        let text = strip_think_tags(raw_text).trim().to_string();
 
         if text.is_empty() {
             warn!(
@@ -1476,6 +1478,26 @@ impl ThinkTagFilter {
             (remaining, String::new())
         }
     }
+}
+
+/// 清理非流式响应中的 `<think>...</think>` 标签
+///
+/// 部分模型即使设置了 `thinking.type=disabled`，仍在 content 中输出 `<think>` 标签。
+/// 此函数移除所有 `<think>...</think>` 块，返回纯文本内容。
+fn strip_think_tags(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut remaining = text;
+    while let Some(start) = remaining.find("<think>") {
+        result.push_str(&remaining[..start]);
+        if let Some(end) = remaining[start..].find("</think>") {
+            remaining = &remaining[start + end + 8..];
+        } else {
+            // 没有闭合标签，丢弃从 <think> 开始的所有内容
+            return result;
+        }
+    }
+    result.push_str(remaining);
+    result
 }
 
 fn should_skip_stream_payload(raw: &str) -> bool {

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -815,21 +815,37 @@ impl SingleProviderClient {
 
         let mut request_json =
             serde_json::to_value(&request).context("序列化轻量级请求失败")?;
-        // 不发送 thinking 字段——各 API 对该字段处理不一致：
-        // OpenAI 支持 thinking.type=disabled，MiniMax/DeepSeek 不认识会返回 400。
-        // 模型可能仍在 content 中输出 <think> 标签，由 strip_think_tags 兜底清理。
+        // 显式关闭 thinking（GLM/DeepSeek 支持，MiniMax 等不支持）
         if let Some(obj) = request_json.as_object_mut() {
-            obj.remove("thinking");
+            obj.insert(
+                "thinking".to_string(),
+                serde_json::json!({ "type": "disabled" }),
+            );
         }
         let chat = client.chat();
         let response = runtime.block_on(async {
-            timeout(
+            let result = timeout(
                 Duration::from_millis(timeout_ms),
                 with_retry("轻量级模型", &self.on_retry, || {
                     chat.create_byot::<_, CreateChatCompletionResponse>(request_json.clone())
                 }),
             )
-            .await
+            .await;
+
+            // 如果带 thinking 字段请求失败（API 不支持），去掉 thinking 重试
+            if matches!(&result, Ok(Err(_))) {
+                let mut fallback_json = request_json.clone();
+                if let Some(obj) = fallback_json.as_object_mut() {
+                    obj.remove("thinking");
+                }
+                tracing::info!("轻量级模型请求失败，去掉 thinking 字段重试");
+                return timeout(
+                    Duration::from_millis(timeout_ms),
+                    chat.create_byot::<_, CreateChatCompletionResponse>(fallback_json),
+                )
+                .await;
+            }
+            result
         });
 
         let resp = match response {

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -815,12 +815,11 @@ impl SingleProviderClient {
 
         let mut request_json =
             serde_json::to_value(&request).context("序列化轻量级请求失败")?;
-        // 显式关闭 thinking 模式
+        // 不发送 thinking 字段——各 API 对该字段处理不一致：
+        // OpenAI 支持 thinking.type=disabled，MiniMax/DeepSeek 不认识会返回 400。
+        // 模型可能仍在 content 中输出 <think> 标签，由 strip_think_tags 兜底清理。
         if let Some(obj) = request_json.as_object_mut() {
-            obj.insert(
-                "thinking".to_string(),
-                serde_json::json!({ "type": "disabled" }),
-            );
+            obj.remove("thinking");
         }
         let chat = client.chat();
         let response = runtime.block_on(async {

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -815,9 +815,12 @@ impl SingleProviderClient {
 
         let mut request_json =
             serde_json::to_value(&request).context("序列化轻量级请求失败")?;
-        // 轻量级请求不发送 thinking 字段（避免不支持的 API 返回 400）
+        // 显式关闭 thinking 模式
         if let Some(obj) = request_json.as_object_mut() {
-            obj.remove("thinking");
+            obj.insert(
+                "thinking".to_string(),
+                serde_json::json!({ "type": "disabled" }),
+            );
         }
         let chat = client.chat();
         let response = runtime.block_on(async {

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -6,8 +6,8 @@ use async_openai::Client as OpenAIClient;
 use async_openai::config::OpenAIConfig;
 use async_openai::types::chat::{
     ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
-    ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs, ChatThinking,
-    ChatThinkingType, CreateChatCompletionRequestArgs, CreateChatCompletionResponse,
+    ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
+    CreateChatCompletionRequestArgs, CreateChatCompletionResponse,
 };
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -798,10 +798,6 @@ impl SingleProviderClient {
             .max_tokens(30u16)
             .temperature(0.3f32)
             .stream(false)
-            .thinking(ChatThinking {
-                r#type: Some(ChatThinkingType::Disabled),
-                clear_thinking: None,
-            })
             .build()
             .context("构建轻量级请求失败")?;
 
@@ -815,8 +811,12 @@ impl SingleProviderClient {
             .build()
             .context("初始化异步运行时失败")?;
 
-        let request_json =
+        let mut request_json =
             serde_json::to_value(&request).context("序列化轻量级请求失败")?;
+        // 轻量级请求不发送 thinking 字段（避免不支持的 API 返回 400）
+        if let Some(obj) = request_json.as_object_mut() {
+            obj.remove("thinking");
+        }
         let chat = client.chat();
         let response = runtime.block_on(async {
             timeout(

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -43,14 +43,11 @@ pub struct Session {
     /// 摘要覆盖到的消息索引（messages[0..summary_up_to] 已被摘要覆盖）
     #[serde(default)]
     pub summary_up_to: usize,
-    /// 待审批请求列表（WaitingApproval 状态时持久化，恢复后可继续处理）
-    #[serde(default)]
-    pub pending_approvals: Vec<PendingApproval>,
     pub created_at: String,
     pub updated_at: String,
 }
 
-/// 待审批请求记录
+/// 待审批请求记录（存储在独立的 approval_store 中）
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PendingApproval {
     pub request_id: String,
@@ -190,7 +187,6 @@ impl Session {
             cwd_mode: SessionCwdMode::Inherit,
             context_summary: None,
             summary_up_to: 0,
-            pending_approvals: Vec::new(),
             created_at: now.clone(),
             updated_at: now,
         }
@@ -216,7 +212,6 @@ impl Session {
             cwd_mode: SessionCwdMode::Isolated,
             context_summary: None,
             summary_up_to: 0,
-            pending_approvals: Vec::new(),
             created_at: now.clone(),
             updated_at: now,
         }

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -45,6 +45,9 @@ pub struct Session {
     pub summary_up_to: usize,
     pub created_at: String,
     pub updated_at: String,
+    /// 临时会话标记（Worker 等临时 session 不落盘）
+    #[serde(default, skip_serializing)]
+    pub ephemeral: bool,
 }
 
 /// 待审批请求记录（存储在独立的 approval_store 中）
@@ -189,6 +192,7 @@ impl Session {
             summary_up_to: 0,
             created_at: now.clone(),
             updated_at: now,
+            ephemeral: false,
         }
     }
 
@@ -214,6 +218,7 @@ impl Session {
             summary_up_to: 0,
             created_at: now.clone(),
             updated_at: now,
+            ephemeral: false,
         }
     }
 
@@ -221,6 +226,9 @@ impl Session {
     ///
     /// Core 在工具调用等关键节点调用此方法，确保中间数据不会因崩溃丢失。
     pub fn persist_to_disk(&self) {
+        if self.ephemeral {
+            return;
+        }
         let home = std::env::var_os("HOME")
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|| std::path::PathBuf::from("."));

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -45,9 +45,9 @@ pub struct Session {
     pub summary_up_to: usize,
     pub created_at: String,
     pub updated_at: String,
-    /// 临时会话标记（Worker 等临时 session 不落盘）
-    #[serde(default, skip_serializing)]
-    pub ephemeral: bool,
+    /// 父会话 ID（Worker 子会话标注所属的父会话）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<String>,
 }
 
 /// 待审批请求记录（存储在独立的 approval_store 中）
@@ -192,7 +192,7 @@ impl Session {
             summary_up_to: 0,
             created_at: now.clone(),
             updated_at: now,
-            ephemeral: false,
+            parent_session_id: None,
         }
     }
 
@@ -218,7 +218,7 @@ impl Session {
             summary_up_to: 0,
             created_at: now.clone(),
             updated_at: now,
-            ephemeral: false,
+            parent_session_id: None,
         }
     }
 
@@ -226,9 +226,6 @@ impl Session {
     ///
     /// Core 在工具调用等关键节点调用此方法，确保中间数据不会因崩溃丢失。
     pub fn persist_to_disk(&self) {
-        if self.ephemeral {
-            return;
-        }
         let home = std::env::var_os("HOME")
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|| std::path::PathBuf::from("."));

--- a/crates/tiangong-core/src/tool/list_dir.rs
+++ b/crates/tiangong-core/src/tool/list_dir.rs
@@ -3,7 +3,7 @@ use std::fs;
 use anyhow::{Context, Result, anyhow};
 
 use super::common::{
-    display_rel_path, resolve_workspace_path, resolve_workspace_path_trusted, truncate_output,
+    display_rel_path, resolve_workspace_path, resolve_workspace_path_trusted,
 };
 use super::{LocalToolExecutor, ToolCall, ToolResult};
 
@@ -41,7 +41,7 @@ impl LocalToolExecutor {
         Ok(ToolResult {
             ok: true,
             summary: format!("目录列表：{}", display_rel_path(&full_path)),
-            stdout: truncate_output(&items.join("\n")),
+            stdout: items.join("\n"),
             stderr: String::new(),
             exit_code: 0,
             execution: None,

--- a/crates/tiangong-core/src/tool/read_file.rs
+++ b/crates/tiangong-core/src/tool/read_file.rs
@@ -3,7 +3,7 @@ use std::fs;
 use anyhow::{Context, Result, anyhow};
 
 use super::common::{
-    display_rel_path, resolve_workspace_path, resolve_workspace_path_trusted, truncate_output,
+    display_rel_path, resolve_workspace_path, resolve_workspace_path_trusted,
 };
 use super::{LocalToolExecutor, ToolCall, ToolResult};
 
@@ -55,7 +55,8 @@ impl LocalToolExecutor {
             .map(|(idx, line)| format!("{:>6}\t{}", start_idx + idx + 1, line))
             .collect::<Vec<_>>()
             .join("\n");
-        let stdout = truncate_output(&selected);
+        // 文件内容完整返回给 LLM，不截断（截断由 LLM 通过 start_line/max_lines 参数控制）
+        let stdout = selected;
 
         Ok(ToolResult {
             ok: true,

--- a/crates/tiangong-core/src/tool/search_code.rs
+++ b/crates/tiangong-core/src/tool/search_code.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, anyhow};
 
 use super::common::{
     command_timeout_ms, execute_command_with_timeout, resolve_workspace_path,
-    resolve_workspace_path_trusted, truncate_output, workspace_root,
+    resolve_workspace_path_trusted, workspace_root,
 };
 use super::{LocalToolExecutor, ToolCall, ToolResult};
 
@@ -63,8 +63,8 @@ impl LocalToolExecutor {
         } else {
             output.status.code().unwrap_or(-1)
         };
-        let stdout = truncate_output(&String::from_utf8_lossy(&output.stdout));
-        let stderr = truncate_output(&String::from_utf8_lossy(&output.stderr));
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         let ok = !timed_out && (output.status.success() || exit_code == 1);
         let summary = if timed_out {
             format!("代码检索超时：pattern={pattern} (timeout_ms={timeout_ms})")

--- a/crates/tiangong-core/src/tool/tree_dir.rs
+++ b/crates/tiangong-core/src/tool/tree_dir.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use anyhow::{Context, Result, anyhow};
 
 use super::common::{
-    display_rel_path, resolve_workspace_path, resolve_workspace_path_trusted, truncate_output,
+    display_rel_path, resolve_workspace_path, resolve_workspace_path_trusted,
 };
 use super::{LocalToolExecutor, ToolCall, ToolResult};
 
@@ -54,7 +54,7 @@ impl LocalToolExecutor {
                 "目录树：{} (max_depth={max_depth})",
                 display_rel_path(&full_path)
             ),
-            stdout: truncate_output(&lines.join("\n")),
+            stdout: lines.join("\n"),
             stderr: String::new(),
             exit_code: 0,
             execution: None,

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -872,9 +872,7 @@ function AgentTurn({
                     </ReactMarkdown>
                   </div>
                 </div>
-              ) : (
-                <p className="text-xs text-muted-foreground italic">（模型未返回文本回复，请继续对话）</p>
-              )}
+              ) : null}
               {!isStreaming && msg.content && <MessageActions text={msg.content} showTts={hasTts} />}
             </div>
           );

--- a/src-tauri/query_results.json
+++ b/src-tauri/query_results.json
@@ -1,0 +1,104 @@
+{
+  "timestamp": "2026-04-10T09:36:19.370210",
+  "glm_info": {
+    "source": "GitHub - THUDM/GLM-4",
+    "models": [
+      {
+        "name": "zai-org/glm-4-9b-chat",
+        "tags": [
+          "transformers",
+          "safetensors",
+          "chatglm",
+          "glm",
+          "thudm",
+          "custom_code",
+          "zh",
+          "en",
+          "arxiv:2406.12793",
+          "license:other",
+          "region:us"
+        ],
+        "downloads": 225893,
+        "likes": 704,
+        "url": "https://huggingface.co/zai-org/glm-4-9b-chat"
+      }
+    ],
+    "queries": [
+      {
+        "query": "GitHub Repository: THUDM/GLM-4",
+        "status": "success",
+        "description": "GLM-4 series: Open Multilingual Multimodal Chat LMs | 开源多语言多模态对话模型",
+        "url": "https://github.com/zai-org/GLM-4",
+        "stars": 7077
+      }
+    ]
+  },
+  "gpu_benchmarks": {
+    "source": "Various benchmarks",
+    "gpus": [
+      {
+        "name": "NVIDIA H100",
+        "memory": "80GB HBM3",
+        "compute_capability": "9.0",
+        "bandwidth": "3.35 TB/s",
+        "fp16_performance": "989 TFLOPS",
+        "recommended_for": "All GLM versions"
+      },
+      {
+        "name": "NVIDIA A100",
+        "memory": "40GB/80GB HBM2e",
+        "compute_capability": "8.0",
+        "bandwidth": "1.55/2.04 TB/s",
+        "fp16_performance": "312 TFLOPS",
+        "recommended_for": "GLM-4-9B and below"
+      },
+      {
+        "name": "NVIDIA A10G",
+        "memory": "24GB GDDR6",
+        "compute_capability": "8.6",
+        "bandwidth": "600 GB/s",
+        "fp16_performance": "125 TFLOPS",
+        "recommended_for": "GLM-4-9B (quantized)"
+      },
+      {
+        "name": "NVIDIA T4",
+        "memory": "16GB GDDR6",
+        "compute_capability": "7.5",
+        "bandwidth": "300 GB/s",
+        "fp16_performance": "65 TFLOPS",
+        "recommended_for": "GLM-4-9B (4-bit quantization)"
+      },
+      {
+        "name": "NVIDIA V100",
+        "memory": "16GB/32GB HBM2",
+        "compute_capability": "7.0",
+        "bandwidth": "900 GB/s",
+        "fp16_performance": "125 TFLOPS",
+        "recommended_for": "GLM-4-9B"
+      },
+      {
+        "name": "NVIDIA RTX 4090",
+        "memory": "24GB GDDR6X",
+        "compute_capability": "8.9",
+        "bandwidth": "1 TB/s",
+        "fp16_performance": "83 TFLOPS",
+        "recommended_for": "GLM-4-9B (consumer)"
+      },
+      {
+        "name": "NVIDIA RTX 3090",
+        "memory": "24GB GDDR6X",
+        "compute_capability": "8.6",
+        "bandwidth": "936 GB/s",
+        "fp16_performance": "71 TFLOPS",
+        "recommended_for": "GLM-4-9B (quantized)"
+      }
+    ],
+    "queries": [
+      {
+        "query": "Wikipedia CUDA",
+        "status": "success",
+        "url": "https://en.wikipedia.org/wiki/CUDA"
+      }
+    ]
+  }
+}

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -115,6 +115,14 @@ impl TiangongApp {
         }
     }
 
+    /// 设置所有活跃 core 的信任模式（全局生效）
+    pub fn set_all_cores_trust_mode(&self, mode: tiangong_core::permission::TrustMode) {
+        let cores = self.cores.lock().unwrap();
+        for core in cores.values() {
+            core.set_trust_mode(mode);
+        }
+    }
+
     /// 设置指定会话 core 的信任模式（实时生效）
     pub fn set_core_trust_mode(
         &self,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -489,13 +489,15 @@ pub fn set_trust_mode(mode: String, state: State<TiangongApp>) -> Result<(), Str
     // 更新 TiangongState（持久化）
     state.with_state(|core_state| core_state.set_trust_mode(trust_mode))?;
 
-    // 更新 CoreConfigProvider（新会话创建时使用最新值）
+    // 更新 CoreConfigProvider（新会话创建时的默认值）
     state.config.update(|c| {
         c.trust_mode = trust_mode;
     });
 
-    // 实时更新所有活跃 core 的信任模式（立即生效）
-    state.set_all_cores_trust_mode(trust_mode);
+    // 只更新当前活跃会话的 core（session 级别）
+    let session_id =
+        state.with_state_read(|core_state| Ok(core_state.active_session_id().to_string()))?;
+    state.set_core_trust_mode(&session_id, trust_mode);
 
     Ok(())
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -489,10 +489,13 @@ pub fn set_trust_mode(mode: String, state: State<TiangongApp>) -> Result<(), Str
     // 更新 TiangongState（持久化）
     state.with_state(|core_state| core_state.set_trust_mode(trust_mode))?;
 
-    // 实时更新当前活跃 core 的信任模式（立即生效）
-    let session_id =
-        state.with_state_read(|core_state| Ok(core_state.active_session_id().to_string()))?;
-    state.set_core_trust_mode(&session_id, trust_mode);
+    // 更新 CoreConfigProvider（新会话创建时使用最新值）
+    state.config.update(|c| {
+        c.trust_mode = trust_mode;
+    });
+
+    // 实时更新所有活跃 core 的信任模式（立即生效）
+    state.set_all_cores_trust_mode(trust_mode);
 
     Ok(())
 }

--- a/src-tauri/web_query_tool.py
+++ b/src-tauri/web_query_tool.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+网络查询工具 - 用于查询 GLM 模型硬件要求和 GPU 性能信息
+"""
+
+import sys
+import json
+import requests
+from typing import Dict, List, Optional
+from datetime import datetime
+
+
+class WebQueryTool:
+    def __init__(self):
+        self.headers = {
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
+        }
+    
+    def search_glm_requirements(self) -> Dict:
+        """查询 GLM 模型的硬件要求"""
+        print("🔍 正在查询 GLM 5.1/GLM-4 模型硬件要求...")
+        
+        # 尝试从 GitHub API 查询 GLM 模型仓库信息
+        results = {
+            'source': 'GitHub - THUDM/GLM-4',
+            'models': [],
+            'queries': []
+        }
+        
+        # 查询 THUDM/GLM-4 仓库
+        try:
+            url = "https://api.github.com/repos/THUDM/GLM-4"
+            response = requests.get(url, headers=self.headers, timeout=10)
+            if response.status_code == 200:
+                repo_data = response.json()
+                results['queries'].append({
+                    'query': 'GitHub Repository: THUDM/GLM-4',
+                    'status': 'success',
+                    'description': repo_data.get('description', ''),
+                    'url': repo_data.get('html_url', ''),
+                    'stars': repo_data.get('stargazers_count', 0)
+                })
+        except Exception as e:
+            results['queries'].append({
+                'query': 'GitHub Repository: THUDM/GLM-4',
+                'status': 'failed',
+                'error': str(e)
+            })
+        
+        # 查询模型卡片信息
+        try:
+            url = "https://huggingface.co/api/models/THUDM/glm-4-9b-chat"
+            response = requests.get(url, headers=self.headers, timeout=10)
+            if response.status_code == 200:
+                model_data = response.json()
+                results['models'].append({
+                    'name': model_data.get('modelId', ''),
+                    'tags': model_data.get('tags', []),
+                    'downloads': model_data.get('downloads', 0),
+                    'likes': model_data.get('likes', 0),
+                    'url': f"https://huggingface.co/{model_data.get('modelId', '')}"
+                })
+        except Exception as e:
+            results['queries'].append({
+                'query': 'HuggingFace: GLM-4-9B',
+                'status': 'failed',
+                'error': str(e)
+            })
+        
+        return results
+    
+    def search_gpu_benchmarks(self) -> Dict:
+        """查询 GPU 性能基准数据"""
+        print("🔍 正在查询 GPU 性能基准数据...")
+        
+        results = {
+            'source': 'Various benchmarks',
+            'gpus': [],
+            'queries': []
+        }
+        
+        # 查询 GPU 性能数据来源
+        try:
+            # Wikipedia CUDA GPU list
+            url = "https://en.wikipedia.org/wiki/CUDA"
+            response = requests.get(url, headers=self.headers, timeout=10)
+            if response.status_code == 200:
+                results['queries'].append({
+                    'query': 'Wikipedia CUDA',
+                    'status': 'success',
+                    'url': url
+                })
+        except Exception as e:
+            results['queries'].append({
+                'query': 'Wikipedia CUDA',
+                'status': 'failed',
+                'error': str(e)
+            })
+        
+        # 添加常见 GPU 规格（基于已知数据）
+        common_gpus = [
+            {
+                'name': 'NVIDIA H100',
+                'memory': '80GB HBM3',
+                'compute_capability': '9.0',
+                'bandwidth': '3.35 TB/s',
+                'fp16_performance': '989 TFLOPS',
+                'recommended_for': 'All GLM versions'
+            },
+            {
+                'name': 'NVIDIA A100',
+                'memory': '40GB/80GB HBM2e',
+                'compute_capability': '8.0',
+                'bandwidth': '1.55/2.04 TB/s',
+                'fp16_performance': '312 TFLOPS',
+                'recommended_for': 'GLM-4-9B and below'
+            },
+            {
+                'name': 'NVIDIA A10G',
+                'memory': '24GB GDDR6',
+                'compute_capability': '8.6',
+                'bandwidth': '600 GB/s',
+                'fp16_performance': '125 TFLOPS',
+                'recommended_for': 'GLM-4-9B (quantized)'
+            },
+            {
+                'name': 'NVIDIA T4',
+                'memory': '16GB GDDR6',
+                'compute_capability': '7.5',
+                'bandwidth': '300 GB/s',
+                'fp16_performance': '65 TFLOPS',
+                'recommended_for': 'GLM-4-9B (4-bit quantization)'
+            },
+            {
+                'name': 'NVIDIA V100',
+                'memory': '16GB/32GB HBM2',
+                'compute_capability': '7.0',
+                'bandwidth': '900 GB/s',
+                'fp16_performance': '125 TFLOPS',
+                'recommended_for': 'GLM-4-9B'
+            },
+            {
+                'name': 'NVIDIA RTX 4090',
+                'memory': '24GB GDDR6X',
+                'compute_capability': '8.9',
+                'bandwidth': '1 TB/s',
+                'fp16_performance': '83 TFLOPS',
+                'recommended_for': 'GLM-4-9B (consumer)'
+            },
+            {
+                'name': 'NVIDIA RTX 3090',
+                'memory': '24GB GDDR6X',
+                'compute_capability': '8.6',
+                'bandwidth': '936 GB/s',
+                'fp16_performance': '71 TFLOPS',
+                'recommended_for': 'GLM-4-9B (quantized)'
+            }
+        ]
+        
+        results['gpus'] = common_gpus
+        
+        return results
+    
+    def check_compatibility(self, gpu_name: str, model: str = "glm-4-9b") -> Dict:
+        """检查 GPU 与模型的兼容性"""
+        gpu_data = self.search_gpu_benchmarks()
+        
+        gpu_info = None
+        for gpu in gpu_data['gpus']:
+            if gpu_name.lower() in gpu['name'].lower():
+                gpu_info = gpu
+                break
+        
+        if not gpu_info:
+            return {
+                'status': 'unknown',
+                'message': f'未找到 {gpu_name} 的详细数据',
+                'recommendation': '请查阅官方文档或手动测试'
+            }
+        
+        # 模型显存需求估算
+        model_requirements = {
+            'glm-4-9b': {'min_vram': 16, 'recommended_vram': 24},
+            'glm-4-9b-chat': {'min_vram': 16, 'recommended_vram': 24},
+            'glm-4v-9b': {'min_vram': 20, 'recommended_vram': 32},
+            'glm-4-4b': {'min_vram': 8, 'recommended_vram': 12},
+        }
+        
+        req = model_requirements.get(model, {'min_vram': 16, 'recommended_vram': 24})
+        
+        # 解析 GPU 显存
+        gpu_memory_gb = 0
+        memory_str = gpu_info['memory']
+        if '80GB' in memory_str:
+            gpu_memory_gb = 80
+        elif '40GB' in memory_str:
+            gpu_memory_gb = 40
+        elif '32GB' in memory_str:
+            gpu_memory_gb = 32
+        elif '24GB' in memory_str:
+            gpu_memory_gb = 24
+        elif '16GB' in memory_str:
+            gpu_memory_gb = 16
+        elif '12GB' in memory_str:
+            gpu_memory_gb = 12
+        elif '8GB' in memory_str:
+            gpu_memory_gb = 8
+        
+        # 评估兼容性
+        if gpu_memory_gb >= req['recommended_vram']:
+            status = 'excellent'
+            message = '完全支持，性能良好'
+        elif gpu_memory_gb >= req['min_vram']:
+            status = 'good'
+            message = '可以运行，建议使用 4-bit 或 8-bit 量化'
+        else:
+            status = 'not_recommended'
+            message = '显存不足，建议升级或使用量化版本'
+        
+        return {
+            'gpu': gpu_info,
+            'model': model,
+            'memory_requirement': req,
+            'gpu_memory': gpu_memory_gb,
+            'status': status,
+            'message': message
+        }
+    
+    def query_all(self, gpu_name: str = None) -> Dict:
+        """查询所有相关信息"""
+        print("=" * 60)
+        print("📊 网络查询工具 - GLM 模型硬件要求查询")
+        print("=" * 60)
+        print()
+        
+        results = {
+            'timestamp': datetime.now().isoformat(),
+            'glm_info': self.search_glm_requirements(),
+            'gpu_benchmarks': self.search_gpu_benchmarks()
+        }
+        
+        if gpu_name:
+            print(f"\n🔍 检查 GPU 兼容性: {gpu_name}")
+            results['compatibility'] = self.check_compatibility(gpu_name)
+        
+        return results
+    
+    def print_results(self, results: Dict):
+        """格式化打印查询结果"""
+        print("\n" + "=" * 60)
+        print("📋 查询结果")
+        print("=" * 60)
+        
+        # GLM 模型信息
+        print("\n📌 GLM 模型信息:")
+        print(f"  来源: {results['glm_info']['source']}")
+        for query in results['glm_info']['queries']:
+            status_icon = "✅" if query['status'] == 'success' else "❌"
+            print(f"  {status_icon} {query['query']}")
+            if 'error' in query:
+                print(f"      错误: {query['error']}")
+        
+        if results['glm_info']['models']:
+            print("\n  可用模型:")
+            for model in results['glm_info']['models']:
+                print(f"    • {model['name']}")
+                print(f"      下载量: {model['downloads']:,}")
+                print(f"      点赞: {model['likes']}")
+                print(f"      链接: {model['url']}")
+        
+        # GPU 性能信息
+        print("\n🎮 GPU 性能参考:")
+        print(f"  来源: {results['gpu_benchmarks']['source']}")
+        for gpu in results['gpu_benchmarks']['gpus']:
+            print(f"\n  {gpu['name']}")
+            print(f"    显存: {gpu['memory']}")
+            print(f"    计算能力: {gpu['compute_capability']}")
+            print(f"    带宽: {gpu['bandwidth']}")
+            print(f"    FP16 性能: {gpu['fp16_performance']}")
+            print(f"    推荐用途: {gpu['recommended_for']}")
+        
+        # 兼容性检查
+        if 'compatibility' in results:
+            comp = results['compatibility']
+            print("\n" + "=" * 60)
+            print(f"🔍 兼容性检查: {comp['gpu']['name']} vs {comp['model']}")
+            print("=" * 60)
+            
+            status_icons = {
+                'excellent': '🟢',
+                'good': '🟡',
+                'not_recommended': '🔴',
+                'unknown': '⚪'
+            }
+            
+            print(f"\n  状态: {status_icons.get(comp['status'], '?')} {comp['message']}")
+            print(f"\n  GPU 显存: {comp['gpu_memory']} GB")
+            print(f"  模型最低要求: {comp['memory_requirement']['min_vram']} GB")
+            print(f"  模型推荐显存: {comp['memory_requirement']['recommended_vram']} GB")
+            
+            if comp['status'] == 'good':
+                print("\n  💡 建议:")
+                print("    • 使用 4-bit 量化: --load-4bit")
+                print("    • 或使用 8-bit 量化: --load-8bit")
+                print("    • 减小最大上下文长度")
+            elif comp['status'] == 'not_recommended':
+                print("\n  ⚠️  替代方案:")
+                print("    • 使用 4-bit 量化 + 小上下文")
+                print("    • 考虑使用更小的模型（如 GLM-4-4B）")
+                print("    • 升级到更大显存的 GPU")
+        
+        print("\n" + "=" * 60)
+
+
+def main():
+    tool = WebQueryTool()
+    
+    if len(sys.argv) > 1:
+        gpu_name = sys.argv[1]
+    else:
+        gpu_name = None
+    
+    results = tool.query_all(gpu_name)
+    tool.print_results(results)
+    
+    # 保存结果到 JSON 文件
+    output_file = "/Users/hubertshelley/Documents/silent/tiangong/src-tauri/query_results.json"
+    with open(output_file, 'w', encoding='utf-8') as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+    
+    print(f"\n💾 查询结果已保存到: {output_file}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- 审批等待前将 `PendingApproval` 写入 session 并 `persist_to_disk`（崩溃不丢状态）
- 审批完成后清除 pending 状态并落盘
- `worker_loop` 启动时检查 `session.pending_approvals`，自动重新发送 `ApprovalNeeded` 事件
- 主循环 `Command::Approval` 处理恢复场景的审批响应

## 恢复流程

1. 用户发送消息 → 工具需审批 → `PendingApproval` 落盘
2. 应用崩溃/关闭
3. 重启后切换到该会话 → `TiangongCore::with_session` 加载 session
4. `worker_loop` 检测到 `pending_approvals` 非空 → 发送 `ApprovalNeeded` 事件
5. 前端显示审批 UI → 用户点击允许/拒绝
6. `Command::Approval` 在主循环中处理 → 清除 pending → 提示用户重新发送消息继续

## Test plan

- [ ] 监督模式工具审批等待时关闭应用，重启后审批 UI 重新出现
- [ ] 审批完成后 pending_approvals 被清除
- [ ] 正常审批流程（不崩溃）无回归