### PR TITLE
feat(core): add anthropic provider support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,25 +130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-anthropic"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55f84bfda9889ff5e5052bbe16e681e90142eeb28e4c61cf380b1fed104dc73"
-dependencies = [
- "backoff",
- "derive_builder",
- "reqwest 0.12.28",
- "reqwest-eventsource",
- "secrecy 0.10.3",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3438,6 +3419,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiangong-anthropic"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "reqwest 0.12.28",
+ "reqwest-eventsource",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tiangong-cli"
 version = "0.1.0"
 dependencies = [
@@ -3541,7 +3534,6 @@ name = "tiangong-llm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-anthropic",
  "async-openai",
  "async-trait",
  "backoff",
@@ -3550,6 +3542,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tiangong-anthropic",
  "tiangong-types",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,9 +3422,9 @@ dependencies = [
 name = "tiangong-anthropic"
 version = "0.1.0"
 dependencies = [
+ "eventsource-stream",
  "futures-util",
  "reqwest 0.12.28",
- "reqwest-eventsource",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-anthropic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55f84bfda9889ff5e5052bbe16e681e90142eeb28e4c61cf380b1fed104dc73"
+dependencies = [
+ "backoff",
+ "derive_builder",
+ "reqwest 0.12.28",
+ "reqwest-eventsource",
+ "secrecy 0.10.3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3478,6 +3497,7 @@ dependencies = [
  "scru128 3.6.1",
  "serde",
  "serde_json",
+ "tiangong-llm",
  "tiangong-media",
  "tiangong-types",
  "tokio",
@@ -3512,6 +3532,25 @@ dependencies = [
  "serde_json",
  "tiangong-core",
  "tiangong-media",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tiangong-llm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-anthropic",
+ "async-openai",
+ "async-trait",
+ "backoff",
+ "futures-util",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tiangong-types",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/tiangong-types",
+    "crates/tiangong-anthropic",
     "crates/tiangong-llm",
     "crates/tiangong-core",
     "crates/tiangong-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/tiangong-types",
+    "crates/tiangong-llm",
     "crates/tiangong-core",
     "crates/tiangong-cli",
     "crates/tiangong-entry",

--- a/PLAN.md
+++ b/PLAN.md
@@ -9,12 +9,12 @@
 - 安全目标：Server 模式默认安全（本地绑定、Token 认证），Connector 鉴权白名单制。
 - 工程目标：按 Phase 增量交付，每个 Phase 保证功能不回退。
 
-## 当前执行策略（2026-04-03）
+## 当前执行策略（2026-04-13）
 - 架构 RFC：`docs/rfc/0004-full-stack-agent-platform.md`
 - 架构基准：`docs/desktop-agent-technical-architecture.md`
 - 差距分析：`docs/architecture-gap-analysis.md`
-- Phase 1~9 已完成，Phase 10（友好交互改造）进行中。
-- 当前目标：对照架构文档补全运行时基础设施（统一任务模型、查询编排层、后台任务回流、恢复能力）。
+- Phase 1~14 主体已完成，GUI 手工验证剩余收尾项。
+- 当前目标：抽离 LLM 协议层，新增 Anthropic Messages 请求支持，避免对话链路继续绑定 OpenAI 兼容协议。
 
 ## 里程碑
 
@@ -119,6 +119,12 @@
 - Phase A：定义 CoreConfig + CoreConfigProvider，修改 TiangongCore 构造函数
 - Phase B：CLI/GUI/Server 适配，使用 CoreConfigProvider 注入配置
 - Phase C：tiangong-config 独立 crate（可选），提供磁盘加载、持久化、文件监听
+
+### Phase 15（LLM 协议抽象与 Anthropic 支持）— **待启动**
+- Provider 配置增加协议类型，区分 OpenAI 兼容与 Anthropic。
+- `tiangong-core` 抽离统一 LLM 客户端接口，避免请求组装与响应解析绑定单一协议。
+- 对话、流式输出、工具调用、轻量模型调用补齐 Anthropic Messages 适配。
+- GUI / CLI / Server 共享同一套协议能力判断与错误处理。
 
 ## 参考文档
 - 项目说明：`README.md`

--- a/PLAN.md
+++ b/PLAN.md
@@ -123,7 +123,7 @@
 ### Phase 15（LLM 协议抽象与 Anthropic 支持）— **进行中**
 - Provider 配置增加协议类型，区分 OpenAI 兼容与 Anthropic。
 - 新增独立 crate `tiangong-llm`，统一承载 Provider 抽象、领域模型、错误类型与各协议适配。
-- 在 `tiangong-core` 内部维护统一 Provider 抽象和领域模型，Anthropic provider 先通过 `async-anthropic` 适配，保证未来可替换为原生 `reqwest + serde` 实现。
+- 在 `tiangong-core` 内部维护统一 Provider 抽象和领域模型，Anthropic transport 下沉到独立 crate `tiangong-anthropic`，使用原生 `reqwest + serde` 实现 Messages 与 SSE 解析，`tiangong-llm` 仅负责协议抽象与 provider 封装。
 - `async-openai` 也迁入 `tiangong-llm` 作为 OpenAI 兼容 provider，避免协议实现继续散落在 `tiangong-core`。
 - 对话、流式输出、工具调用、轻量模型调用补齐 Anthropic Messages 适配。
 - GUI / CLI / Server 共享同一套协议能力判断与错误处理。

--- a/PLAN.md
+++ b/PLAN.md
@@ -120,9 +120,11 @@
 - Phase B：CLI/GUI/Server 适配，使用 CoreConfigProvider 注入配置
 - Phase C：tiangong-config 独立 crate（可选），提供磁盘加载、持久化、文件监听
 
-### Phase 15（LLM 协议抽象与 Anthropic 支持）— **待启动**
+### Phase 15（LLM 协议抽象与 Anthropic 支持）— **进行中**
 - Provider 配置增加协议类型，区分 OpenAI 兼容与 Anthropic。
-- `tiangong-core` 抽离统一 LLM 客户端接口，避免请求组装与响应解析绑定单一协议。
+- 新增独立 crate `tiangong-llm`，统一承载 Provider 抽象、领域模型、错误类型与各协议适配。
+- 在 `tiangong-core` 内部维护统一 Provider 抽象和领域模型，Anthropic provider 先通过 `async-anthropic` 适配，保证未来可替换为原生 `reqwest + serde` 实现。
+- `async-openai` 也迁入 `tiangong-llm` 作为 OpenAI 兼容 provider，避免协议实现继续散落在 `tiangong-core`。
 - 对话、流式输出、工具调用、轻量模型调用补齐 Anthropic Messages 适配。
 - GUI / CLI / Server 共享同一套协议能力判断与错误处理。
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO - 天工全栈平台重构任务清单
 
-> 最后更新：2026-04-13
+> 最后更新：2026-04-14
 > 当前主线 RFC：`docs/rfc/0004-full-stack-agent-platform.md`
 > 参考：`PLAN.md`、`docs/requirements.md`
 
@@ -37,30 +37,35 @@
 
 ---
 
-## Phase 15：LLM 协议抽象与 Anthropic 支持 — **待启动**
+## Phase 15：LLM 协议抽象与 Anthropic 支持 — **进行中**
 
 ### A. Provider 协议建模
 
-- [ ] `ModelsConfig::ProviderConfig` 增加协议类型字段，支持 `openai_compatible` / `anthropic`
-- [ ] 保持旧配置兼容：未配置协议类型时默认视为 `openai_compatible`
-- [ ] GUI / CLI 配置读写链路透传协议类型
+- [x] `ModelsConfig::ProviderConfig` 增加协议类型字段，支持 `openai_compatible` / `anthropic`
+- [x] 保持旧配置兼容：未配置协议类型时默认视为 `openai_compatible`
+- [x] GUI / CLI 配置读写链路透传协议类型
 
 ### B. Core 协议抽象
 
-- [ ] 将 `model.rs` 中 OpenAI 专有请求组装与响应解析拆分为协议适配层
-- [ ] 保持 `ModelClient` 统一接口不变，避免上层 Runtime / Core / CLI / GUI 感知协议差异
-- [ ] 保留现有重试、错误提示与 `StreamEvent::Retry` 语义
+- [x] 新增独立 crate `tiangong-llm`
+- [x] 将 Anthropic / OpenAI provider 抽到 `tiangong-llm`
+- [ ] 清理 `tiangong-core/src/model.rs` 中剩余兼容桥接和旧 helper
+- [x] 保持 `ModelClient` 统一接口不变，避免上层 Runtime / Core / CLI / GUI 感知协议差异
+- [x] 保留现有重试、错误提示与 `StreamEvent::Retry` 语义
 
 ### C. Anthropic Messages 适配
 
-- [ ] 支持 Anthropic 普通对话请求（`complete`）
-- [ ] 支持 Anthropic 流式对话请求（`complete_stream`）
-- [ ] 支持 Anthropic 工具调用请求（`complete_with_functions` / `complete_with_functions_stream`）
-- [ ] 支持 `lite` 模型调用与 `chat` 路由分离
+- [x] 在 `tiangong-core` 内部新增统一 LLM Provider 抽象、领域模型和错误边界
+- [x] Anthropic provider 内部接入 `async-anthropic`，第三方类型不泄漏到上层
+- [x] Rust 侧 Anthropic 主链路切换到内部 provider 适配层，不保留手写 HTTP 作为主实现
+- [x] 支持 Anthropic 普通对话请求（`complete`）
+- [x] 支持 Anthropic 流式对话请求（`complete_stream`）
+- [x] 支持 Anthropic 工具调用请求（`complete_with_functions` / `complete_with_functions_stream`）
+- [x] 支持 `lite` 模型调用与 `chat` 路由分离
 
 ### D. 集成与验证
 
-- [ ] `cargo check --workspace` 通过
-- [ ] `cargo clippy --workspace --all-targets --tests --benches -- -D warnings` 通过
-- [ ] `cargo nextest run --workspace` 通过
-- [ ] `yarn --cwd frontend build` 通过
+- [x] `cargo check --workspace` 通过
+- [x] `cargo clippy --workspace --all-targets --tests --benches -- -D warnings` 通过
+- [x] `cargo nextest run --workspace` 通过
+- [x] `yarn --cwd frontend build` 通过

--- a/TODO.md
+++ b/TODO.md
@@ -56,8 +56,10 @@
 ### C. Anthropic Messages 适配
 
 - [x] 在 `tiangong-core` 内部新增统一 LLM Provider 抽象、领域模型和错误边界
-- [x] Anthropic provider 内部接入 `async-anthropic`，第三方类型不泄漏到上层
-- [x] Rust 侧 Anthropic 主链路切换到内部 provider 适配层，不保留手写 HTTP 作为主实现
+- [x] 新增独立 crate `tiangong-anthropic`
+- [x] `tiangong-anthropic` 内部使用 `reqwest + serde` 实现 Anthropic Messages 与 SSE
+- [x] `tiangong-llm` 的 Anthropic provider 切换到 `tiangong-anthropic`，第三方类型不泄漏到上层
+- [x] 删除 Anthropic 路径对 `async-anthropic` / `anthropic-async` 的依赖
 - [x] 支持 Anthropic 普通对话请求（`complete`）
 - [x] 支持 Anthropic 流式对话请求（`complete_stream`）
 - [x] 支持 Anthropic 工具调用请求（`complete_with_functions` / `complete_with_functions_stream`）

--- a/TODO.md
+++ b/TODO.md
@@ -1,397 +1,26 @@
 # TODO - 天工全栈平台重构任务清单
 
-> 最后更新：2026-04-03
+> 最后更新：2026-04-13
 > 当前主线 RFC：`docs/rfc/0004-full-stack-agent-platform.md`
 > 参考：`PLAN.md`、`docs/requirements.md`
 
 ---
 
-## Phase 2：Skill 管理 MVP（已完成 ✅）
-
-- [x] Skill 支持安装、启停、卸载、列表、详情
-- [x] `/skill` 管理交互对齐 `/mcp`
-- [x] 动态 Step 执行闭环
-- [x] Skill 锁文件（skills-lock.json / mcp-lock.json）
-- [x] MCP 托管映射（卸载 skill 时自动清理无引用的托管 MCP server）
-- [x] 事务回滚（安装失败时 RAII 自动回滚已复制文件）
-- [x] 审计日志（~/.tiangong/audit.jsonl，记录 skill/mcp 操作）
-
----
-
-## Phase 3：Workspace 拆分与核心抽离（已完成 ✅）
-
-### A. Workspace 基础结构
-
-- [x] 创建 `crates/` 目录与 workspace Cargo.toml
-- [x] 新建 `crates/tiangong-core/Cargo.toml`，迁移核心依赖
-- [x] 新建 `crates/tiangong-cli/Cargo.toml`，CLI 依赖
-- [x] 新建 `crates/tiangong-entry/Cargo.toml`，命令路由
-- [x] 调整主 `Cargo.toml` 为 workspace 根配置
-- [x] 创建空骨架 crate：tiangong-server/gateway/connector/media
-
-### B. 核心引擎迁移 (tiangong-core)
-
-- [x] 迁移 `src/core/*` → `crates/tiangong-core/src/`
-- [x] 路径替换 `crate::core::` → `crate::`
-- [x] 新增 `context/` 上下文管理模块（压缩器 + 组织器）
-- [x] 新增 `plugin/` 插件框架（类型 + 注册表 + 生命周期）
-- [x] 修复原有编译错误（model.rs 类型导入、lite_model、tracing 宏）
-- [x] 修复可见性问题（pub(in crate::app_state) → pub）
-- [x] 确保 `tiangong-core` 可独立编译，无 UI 依赖
-
-### C. CLI 前端 (tiangong-cli)
-
-- [x] Codex 风格 REPL（对话自然滚动，终端原生文本选择）
-- [x] 交互式输入（crossterm raw mode 行编辑、历史导航）
-- [x] `/` 命令补全 + `@` 提及补全（自动弹出竖排候选列表）
-- [x] ratatui modal 管理界面（/sessions、/mcp、/skill）
-- [x] 命令系统（/new、/model、/config、/cancel、/help）
-- [x] 草稿会话（启动不创建空会话，首次发送才记录）
-
-### D. GUI 前端（src-tauri）
-
-- [x] src-tauri 保持独立 Tauri workspace
-- [x] 路径更新 `tiangong_core::core::` → `tiangong_core::`
-- [x] 编译验证通过
-
-### E. 主入口统一 (tiangong-entry)
-
-- [x] 迁移 `src/entry/*` → `crates/tiangong-entry/src/`
-- [x] 路径替换 + 可见性调整
-- [x] CLI 命令恢复：`Some(MainCommand::Cli)` → `tiangong_cli::run_cli()`
-
-### F. 验证与交付
-
-- [x] `cargo fmt -- --check` 通过
-- [x] `cargo check --workspace` 通过
-- [x] `cargo clippy --workspace --all-targets --tests --benches -- -D warnings` 通过
-- [x] CLI 功能可用（REPL + 命令 + modal 管理）
-- [x] src-tauri 编译通过
-- [x] 死代码清理（src/ui/、src/cli/、src/lib.rs、src/core/、src/entry/）
-
----
-
-## 后续阶段（待展开）
-
-### Phase 4：Server 模式（已完成 ✅）
-- [x] 新建 `crates/tiangong-server`
-- [x] 实现 REST API（/chat /sessions /mcp /skills /health /shutdown）
-- [x] 实现 WebSocket 流式通信（/api/v1/ws，EventBus 事件推送）
-- [x] API Token 认证（Bearer Token）
-- [x] `-d` / `--daemon` 后台运行支持（PID 文件管理）
-- [x] `tiangong server stop` 停止后台 Server
-- [x] Server 启动时自动加载已启用 Connector（connectors.json）
-
-### Phase 5：Gateway 与事件总线（已完成 ✅）
-- [x] 实现 EventBus（tokio broadcast，会话/Agent/Connector/系统事件）
-- [x] 实现 Gateway 消息路由（MessageRouter）
-- [x] 统一消息模型（IncomingMessage/OutgoingMessage/MessageContent）
-
-### Phase 6：Connector 框架（已完成 ✅）
-- [x] 定义 Connector trait（async start/stop/send_message/health_check）
-- [x] 实现 Webhook Connector（最小实现）
-- [x] ConnectorManager（注册/启停/健康检查）
-- [x] ConnectorConfig/ConnectorType（Webhook/Telegram/Discord/Lark）
-- [x] 实现 Telegram Connector（teloxide，feature gate `telegram`）
-- [x] 实现 Discord Connector（serenity，feature gate `discord`）
-- [x] 实现飞书/Lark Connector（reqwest HTTP API，feature gate `lark`）
-
-### Phase 7：多媒体能力（框架已完成 ✅）
-- [x] ImageGenerator trait + 请求/响应类型
-- [x] VideoGenerator trait + 异步任务类型
-- [x] SpeechRecognizer trait（STT）
-- [x] SpeechSynthesizer trait（TTS）+ VoiceInfo
-- [x] MediaTask 异步任务管理类型
-- [x] 图片生成后端实现（OpenAI DALL-E / GPT-Image，reqwest）
-- [x] 视频生成占位（StubVideoGenerator，待 Sora/Kling API 稳定后接入）
-- [x] 语音识别后端实现（OpenAI Whisper，multipart 上传）
-- [x] 语音合成后端实现（OpenAI TTS，6 个预定义音色）
-- [x] MediaAgent 聚合器（builder 模式，能力检查）
-- [x] Connector 语音消息自动转文字（Gateway MessageRouter 自动 STT）
-
-### Phase 8：生产化与完善（已完成 ✅）
-- [x] 日志分级（支持 `TIANGONG_LOG` 环境变量按模块调级别）
-- [x] 错误恢复（启动时 recover_interrupted_tasks + auto_resume_unfinished_plan）
-- [x] 敏感配置脱敏（model auth_token + server auth_token 脱敏显示）
-- [x] 配置热重载（ConfigWatcher 轮询文件修改时间 + Notify 通知）
-
----
-
-## Phase 9：模型配置重构与多媒体集成 — **当前阶段**
-
-### A. 模型配置重构（已完成 ✅）
-- [x] ModelsConfig 替换 ModelProviderConfig 为唯一模型配置源
-- [x] Provider + Model + Routing 三层架构
-- [x] ModelsConfig.to_chat_provider_config() 自动生成内部配置
-- [x] 移除旧版 draft 字段和 legacy API
-- [x] 设置页面自动保存（debounce 500ms）
-- [x] 选择 Provider 后可获取模型列表快速配置
-- [x] 模型标识名自动生成
-
-### B. GUI 升级（已完成 ✅）
-- [x] shadcn/ui dashboard 风格重构（Sidebar + Header + Tabs + Card + Select）
-- [x] 暗/亮/跟随系统主题切换
-- [x] macOS 红绿灯对齐（trafficLightPosition）
-- [x] 消息展示优化（系统消息分组折叠、间距缩减、文字对比度）
-- [x] 输入框嵌入式发送按钮
-- [x] 会话标题 LLM 自动生成
-- [x] 空会话过滤 + 会话列表按更新时间倒序
-
-### C. 执行优化（已完成 ✅）
-- [x] 意图分类快速路径：简单对话跳过 planning + execution
-- [x] poll_pending_turn 修复（消息回复链路）
-- [x] 完成后状态重置为 idle
-
-### D. 上下文摘要压缩（已完成 ✅）
-- [x] ContextCompressor 重写：LLM 摘要优先，滑动窗口回退
-- [x] ContextOrganizer 集成到 RuntimeEngine，替代硬编码滑动窗口
-- [x] ReAct 循环内 loop_messages 累积压缩（基于 API 返回的精确 prompt_tokens 触发）
-- [x] 双重 token 判断：首次用字符估算预判，后续用 API 精确 prompt_tokens 驱动
-
-### E. 多媒体能力集成到执行引擎（已完成 ✅）
-
-#### E1. 图片生成集成
-- [x] `generate_image` 工具注入（prompt + width/height/style 可选参数）
-- [x] `handle_media_generation` 调用 OpenAI 兼容 API 生成图片
-- [x] 返回 Markdown 图片语法，前端 ReactMarkdown 自动渲染
-- [x] 前端图片最大宽度限制 + 点击全屏放大
-
-#### E2. 语音合成/识别集成
-- [x] `text_to_speech` 工具注入（text + voice/speed/output_path 参数）
-- [x] 调用 OpenAI TTS 后端，音频保存到 `~/.tiangong/media/`
-- [x] `speech_to_text` 工具注入（file_path + language 参数）
-- [x] 调用 OpenAI Whisper 后端，返回转录文本
-
-#### E3. 视频生成
-- [x] 视频生成通过 Skill 机制处理（无稳定 API，不内置）
-
-### F. 验证
-- [x] `cargo check --workspace` 通过
-- [x] `cargo clippy --workspace --all-targets --tests --benches -- -D warnings` 通过
-- [x] 前端 `yarn build` 通过
-
----
-
-## Phase 10：友好交互改造 — **当前阶段**
-
-### A. GUI 样式简化（已完成 ✅）
-- [x] 去掉 Assistant/User 头像图标
-- [x] 去掉消息气泡边框和背景色
-- [x] 调整因头像而存在的间距
-- [x] 审批请求和思考中指示器同步去掉头像
-
-### B. GUI 解释文本独立流式展示（已完成 ✅）
-- [x] useStore 新增流式系统消息追踪状态
-- [x] SystemMessageGroup 改造：活跃 round 以流式文本块展示（不折叠）
-- [x] 工具调用消息保持现有折叠展示方式不变
-
-### C. CLI 实时流式展示（已完成 ✅）
-- [x] repl.rs 轮询循环从阻塞等待改为边轮询边输出增量
-- [x] output.rs 新增流式输出函数（解释文本、工具摘要、增量输出）
-- [x] 追踪消息增量，实现系统消息和助手消息的实时展示
-
-### D. 验证
-- [x] `cargo check --workspace` 通过
-- [x] `cargo clippy --workspace --all-targets --tests --benches -- -D warnings` 通过
-- [x] 前端 `yarn build` 通过
-
----
-
-## Phase 11：架构补全 — 运行时基础设施 — **当前阶段**
-
-> 差距分析文档：`docs/architecture-gap-analysis.md`
-> 基准文档：`docs/desktop-agent-technical-architecture.md`
-
-### Phase 11-A：基础设施（高优先级）
-
-#### A1. 统一任务模型（GAP-5）
-- [x] 新建 `src/task/mod.rs` 模块入口
-- [x] 新建 `src/task/model.rs`：定义 `UnifiedTask` 结构和 `UnifiedTaskStatus` 枚举
-  - 状态：Queued / Running / Blocked / WaitingApproval / Backgrounded / Completed / Failed / Cancelled
-  - 字段：id / input_summary / agent_id / progress / result_location / session_id / work_dir / created_at / updated_at
-- [x] 新建 `src/task/state_machine.rs`：状态转换验证（只允许合法转换）
-- [x] 新建 `src/task/registry.rs`：统一任务注册表（替代 BackgroundTask 的独立 registry）
-- [x] RunStatus 保留为 UI 展示层状态（与 UnifiedTaskStatus 不同层面概念）
-- [x] TaskStatus ↔ UnifiedTaskStatus 互转实现（From trait）
-- [x] `lib.rs` 注册 `task` 模块
-- [x] 验证：`cargo check --workspace` 通过
-
-#### A2. 查询编排层独立抽象（GAP-1 + GAP-3）
-- [x] 新建 `src/orchestrator/mod.rs` 模块入口
-- [x] 新建 `src/orchestrator/types.rs`：扩展 `QueryMode` 枚举
-  - DirectAnswer / SingleToolExecution / MultiStepExecution / TaskSplit / BackgroundExecution
-- [x] 新建 `src/orchestrator/query_orchestrator.rs`：`QueryOrchestrator` 控制中心
-  - 接受事件 → 判断打断 → 路由决策
-  - LLM 分类器判断执行模式
-- [x] 修改 `turn_runner.rs`：Init 阶段默认使用 MultiStepExecution
-- [x] 修改 `context/assembler.rs`：QueryMode 重导出自 orchestrator，使用 needs_tools() 统一判断
-- [x] `lib.rs` 注册 `orchestrator` 模块
-- [x] 验证：`cargo check --workspace` 通过
-
-### Phase 11-B：执行闭环（高优先级）
-
-#### B1. 后台任务回流与通知（GAP-6）
-- [x] 新建 `src/task/notification.rs`：任务完成通知机制
-  - 任务完成 → 生成 `RuntimeEvent`（TaskCompleted/TaskFailed）
-  - 通过 channel（TaskNotificationBus）发布
-- [x] 后台任务回流通过 LoopEvent::BackgroundTaskDone 在 EventLoop 中处理
-- [x] 当前通过 query_task 工具拉取结果（推模式后续扩展）
-- [x] 验证：`cargo check --workspace` 通过
-
-#### B2. 恢复与持久化增强（GAP-9）
-- [x] 新建 `src/task/persistence.rs`：任务状态持久化
-- [x] 新建 `src/task/recovery.rs`：启动恢复逻辑
-- [x] 修改 `app_state/facade/lifecycle.rs`：启动时加载并清理持久化的 EventLoop 状态
-- [x] 验证：`cargo check --workspace` 通过
-
-### Phase 11-C：能力增强（中优先级）
-
-#### C1. 上下文装配层增强（GAP-2）
-- [x] 新建 `src/context/memory.rs`：用户偏好与长期记忆
-- [x] 新建 `src/context/retriever.rs`：检索接口（预留 trait）
-- [x] EventLoopRunner::call_llm 首轮注入记忆上下文
-- [x] 验证：`cargo check --workspace` 通过
-
-#### C2. 多代理 Worker 隔离增强（GAP-4）
-- [x] 修改 `src/coordinator/types.rs`：WorkerBudget 增加 max_tool_calls，WorkerContext 增加 is_tool_allowed()
-- [x] 修改 `src/coordinator/worker.rs`：执行完成后检查 token/时长预算超限并记录警告
-- [x] 修改 `src/coordinator/task_coordinator.rs`：多 Worker 模式注入独立预算（轮次/工具/时长限制）
-- [x] 验证：`cargo check --workspace` 通过
-
-#### C3. 权限细粒度控制（GAP-7）
-- [x] 修改 `src/permission.rs`：PathRule + NetworkRule
-- [x] 新增 `PermissionGate::check_path()` 和 `check_network()`
-- [x] 修改 `src/observe/audit.rs`：AuditRecord 增加 args_summary 字段和 with_args_summary()
-- [x] 验证：`cargo check --workspace` 通过
-
-#### C4. 观测与成本治理闭环（GAP-10）
-- [x] 修改 `src/observe/cost.rs`：新增 RequestCost / TaskCost / SessionCost 三层
-- [x] 新建 `src/observe/collector.rs`：统一采集入口 ObserveCollector
-- [x] ObserveCollector 集成到 EventLoopRunner，每次 LLM 调用自动记录成本
-- [x] 验证：`cargo check --workspace` 通过
-
-### Phase 11-D：远程能力（低优先级）
-
-#### D1. 远程接入角色模型（GAP-8）
-- [x] 新建 `tiangong-gateway/src/role.rs`：RemoteRole 枚举（Controller/Approver/Observer）
-- [x] 修改 `tiangong-gateway/src/message.rs`：IncomingMessage 增加 sender_role
-- [x] 修改 `tiangong-gateway/src/router.rs`：handle_incoming 入口根据角色限制操作
-- [x] 验证：`cargo check --workspace` 通过
-
-### Phase 11-E：最终验证（已完成 ✅）
-- [x] `cargo fmt -- --check` 通过
-- [x] `cargo check --workspace` 通过
-- [x] `cargo clippy --workspace --all-targets --tests --benches -- -D warnings` 通过
-- [x] `cargo nextest run --workspace --no-tests pass` 通过
-
----
-
-## Phase 12：事件驱动循环运行时 — **当前阶段**
-
-> RFC：`docs/rfc/0005-event-loop-runtime.md`
-
-### Phase 12-A：EventLoopRunner 核心 + 挂起/恢复（已完成 ✅）
-
-- [x] 新建 `src/event_loop/mod.rs` 模块入口
-- [x] 新建 `src/event_loop/types.rs`：LoopEvent / LoopPhase / LoopState 类型定义
-- [x] 新建 `src/event_loop/runner.rs`：EventLoopRunner 核心循环
-- [x] 新建 `src/event_loop/context.rs`：事件到上下文的转换逻辑
-- [x] `lib.rs` 注册 `event_loop` 模块
-- [x] 验证：`cargo check --workspace` 通过
-
-### Phase 12-B：LoopHost trait + ActiveLoops 管理器（已完成 ✅）
-
-- [x] 新建 `src/event_loop/host.rs`：LoopHost trait
-- [x] 新建 `src/event_loop/active_loops.rs`：MultiLoopHost（多会话管理）
-- [x] 新建 `src/event_loop/cli_host.rs`：CliLoopHost（单会话）
-- [x] 验证：`cargo check --workspace` 通过
-
-### Phase 12-C：生命周期管理与持久化（已完成 ✅）
-
-- [x] 新建 `src/event_loop/persistence.rs`：PersistedLoopState 读写
-- [x] 实现 shutdown_all()：Running→中断保存、Suspended→写盘
-- [x] 实现 restore_from_disk()：启动时扫描恢复
-- [x] 实现 cleanup_inactive()：超时 loop 写盘移除
-- [x] 验证：`cargo check --workspace` 通过
-
-### Phase 12-D：集成与清理
-
-- [x] 修改 `app_state/services/turn/start.rs`：用 EventLoopRunner 替代 TurnRunner/TaskCoordinator
-- [x] ControlSignal → LoopEvent 兼容层，poll 逻辑完全复用
-- [x] CLI 已通过 TiangongState 间接使用 EventLoopRunner（无需额外改造）
-- [x] TurnRunner 仍被 Worker 使用，保留；旧代码后续随 Worker 重构清理
-- [x] 验证：完整检查链通过
-
----
-
-## Phase 13：TiangongCore 纯粹化 + 统一类型 — **当前阶段**
-
-### 已完成
-
-- [x] 新增 `TiangongCore`：单一对话处理核心（sender 推送模式）
-  - send_message / cancel / respond_approval / into_session
-  - 内部消费线程独占 session，统一事件循环（CoreEvent）
-  - EventLoopRunner 空闲时阻塞等待，支持持续输入
-- [x] 新增 `tiangong-types` 独立 crate
-  - Message / MessageRole / Session / TokenUsage / RunStatus / StreamEvent
-  - StreamEvent 带 serde tag JSON 序列化
-- [x] Prompt 分层装配系统（prompt/ 模块）
-- [x] poll 事件处理统一（process_turn_event）
-- [x] GUI send_message 接入 TiangongCore
-- [x] CLI 中文 panic 修复（补全 + reasoning 截断）
-
-### 类型迁移（已完成 ✅）
-
-- [x] TokenUsage → `pub use tiangong_types::TokenUsage`
-- [x] RunStatus → `pub use tiangong_types::RunStatus`
-- [x] StreamEvent → `pub use tiangong_types::StreamEvent`
-- [x] Message / MessageRole / now_text → `pub use tiangong_types::{...}`
-
-### 待完成
-
-- [x] GUI emit("stream_event") 直接推送 StreamEvent
-- [x] CLI 接入 TiangongCore（直接消费 StreamEvent）
-- [x] src-tauri 依赖 tiangong-types
-- [x] 删除旧 LoopHost/ActiveLoops/CliLoopHost（-433 行）
-- [x] TurnRunner/ControlSignal/EventLoopRunner 已删除（并行智能体集成后清理）
-- [x] src-tauri/types.rs DTO 转换层删除，共享消息类型改为直接复用 tiangong-types
-- [x] GUI TTS/STT 命令改为复用 tiangong-core 媒体服务，消除对 tiangong-media 的重复直连
-- [x] 补充统一能力查询接口（has_model_capability / get_available_capabilities）
-- [x] GUI 全链路功能验证通过
-- [x] CLI 交互优化（类似 codex/claude code 风格）
-- [x] 并行智能体（TaskCoordinator/Worker）集成到 TiangongCore
-- [x] 统一用户输入通道（消除消息重复）
-- [x] CLI 会话持久化
-
----
-
-## Phase 13.5：LLM 请求容错 — **当前阶段**
-
-### A. LLM 请求重试机制
-- [x] 在 `model.rs` 中实现通用重试包装函数（指数退避，默认 3 次，初始 1s，×2）
-- [x] 识别可重试错误类型（429 速率限制、5xx 服务端错误、连接错误）
-- [x] 应用到所有 LLM 调用方法（complete / complete_stream / complete_with_functions / complete_with_functions_stream / complete_lite）
-- [x] 重试过程通过 `tracing::warn!` 记录日志
-
-### B. 错误与重试通知到前端
-- [x] `StreamEvent::Retry` 新增变体，重试时推送到前端
-- [x] `StreamEvent::Error` 错误信息写入 session 消息，前端可见
-- [x] GUI 前端错误消息红色醒目渲染、重试消息黄色提示渲染
-- [x] CLI 重试时输出黄色警告信息
-- [x] 底部状态栏显示重试进度和错误详情
-
-### C. 监督模式工具审批 + 工具展示优化
-- [x] 监督模式下工具执行前权限检查，Elevated/Critical 工具发送 `ApprovalNeeded` 事件
-- [x] Core 阻塞等待用户审批响应，支持允许/拒绝/取消
-- [x] 修复 `cancel_turn` 和 `respond_approval` 命令路由到 TiangongCore
-- [x] `StreamEvent::ToolStart` 携带 `args_summary`，展示实际命令和参数
-- [x] 前端工具展示解析 `工具执行 [xxx]` 格式，折叠摘要包含命令信息
-- [x] CLI 审批交互（y/n 确认）
-
-### D. 验证
-- [x] `cargo check --workspace` 通过
-- [x] `cargo clippy` 通过（tiangong-core / cli / types 零警告）
-- [x] `yarn build` 通过
+## 已完成阶段摘要
+
+- `Phase 2`：Skill 管理 MVP 已完成，包含安装、启停、卸载、锁文件、托管 MCP 清理、事务回滚与审计。
+- `Phase 3`：Workspace 拆分与核心抽离已完成，`tiangong-core` / `tiangong-cli` / `tiangong-entry` / `src-tauri` 已稳定运行。
+- `Phase 4`：Server 模式已完成，REST、WebSocket、Token 认证、后台运行与停止命令已落地。
+- `Phase 5`：Gateway 与 EventBus 已完成，统一消息模型和消息路由已投入使用。
+- `Phase 6`：Connector 框架已完成，Webhook、Telegram、Discord、Lark 已接入。
+- `Phase 7`：多媒体框架已完成，图片生成、STT、TTS 与媒体任务模型已接入主链路。
+- `Phase 8`：生产化增强已完成，日志分级、错误恢复、配置脱敏、配置热重载已上线。
+- `Phase 9`：模型配置重构与多媒体集成已完成，`ModelsConfig` 三层架构与多媒体 routing 已稳定。
+- `Phase 10`：GUI/CLI 友好交互改造已完成，解释文本和工具调用支持实时展示。
+- `Phase 11`：运行时基础设施补全已完成，统一任务模型、查询编排、恢复、权限和成本治理已落地。
+- `Phase 12`：事件驱动循环运行时已完成，EventLoopRunner 已替代旧的主执行链。
+- `Phase 13`：`TiangongCore` 纯粹化与统一类型已完成，CLI/GUI/Server 已统一到核心流事件接口。
+- `Phase 13.5`：LLM 请求容错已完成，重试、错误展示、审批流程和工具展示优化已接入。
 
 ---
 
@@ -399,23 +28,39 @@
 
 > RFC：`docs/rfc/0006-core-config-provider.md`
 
-### Phase A：CoreConfig + CoreConfigProvider
-
-- [x] 定义 `CoreConfig` 结构（models/mcp/skills/trust_mode/context_limit）
-- [x] 实现 `CoreConfigProvider`（ArcSwap + generation 原子计数）
-- [x] 修改 `TiangongCore` 构造函数接收 `CoreConfigProvider`
-- [x] 修改 `worker_loop` 使用 generation 检测 + snapshot 重建 engine
-- [x] 移除 `build_engine()` 中的磁盘加载逻辑
-
-### Phase B：各端适配
-
-- [x] CLI：创建 CoreConfigProvider，从磁盘加载初始配置，并在 `/model` `/config set` `/mcp` `/skill` 变更后同步
-- [x] GUI：TiangongApp 持有 CoreConfigProvider，模型/MCP/Skill/TrustMode 变更时同步 update
-- [x] Server/Connector：共享 Server 上下文持有 CoreConfigProvider，REST/WS/MessageRouter 处理消息前同步配置快照
-
 ### Phase C：验证
 
-- [x] cargo clippy --workspace 通过
-- [x] cargo nextest run --workspace 通过
+- [x] `cargo clippy --workspace` 通过
+- [x] `cargo nextest run --workspace` 通过
 - [ ] GUI 验证：切换模型/MCP/Skill 后下一轮对话生效
 - [x] CLI 验证：`/model deepseek-chat` 后发送 `你好`，成功按新 routing 完成下一轮回复
+
+---
+
+## Phase 15：LLM 协议抽象与 Anthropic 支持 — **待启动**
+
+### A. Provider 协议建模
+
+- [ ] `ModelsConfig::ProviderConfig` 增加协议类型字段，支持 `openai_compatible` / `anthropic`
+- [ ] 保持旧配置兼容：未配置协议类型时默认视为 `openai_compatible`
+- [ ] GUI / CLI 配置读写链路透传协议类型
+
+### B. Core 协议抽象
+
+- [ ] 将 `model.rs` 中 OpenAI 专有请求组装与响应解析拆分为协议适配层
+- [ ] 保持 `ModelClient` 统一接口不变，避免上层 Runtime / Core / CLI / GUI 感知协议差异
+- [ ] 保留现有重试、错误提示与 `StreamEvent::Retry` 语义
+
+### C. Anthropic Messages 适配
+
+- [ ] 支持 Anthropic 普通对话请求（`complete`）
+- [ ] 支持 Anthropic 流式对话请求（`complete_stream`）
+- [ ] 支持 Anthropic 工具调用请求（`complete_with_functions` / `complete_with_functions_stream`）
+- [ ] 支持 `lite` 模型调用与 `chat` 路由分离
+
+### D. 集成与验证
+
+- [ ] `cargo check --workspace` 通过
+- [ ] `cargo clippy --workspace --all-targets --tests --benches -- -D warnings` 通过
+- [ ] `cargo nextest run --workspace` 通过
+- [ ] `yarn --cwd frontend build` 通过

--- a/crates/tiangong-anthropic/Cargo.toml
+++ b/crates/tiangong-anthropic/Cargo.toml
@@ -9,5 +9,5 @@ thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
-reqwest-eventsource = "0.6"
+eventsource-stream = "0.2"
 futures-util = "0.3"

--- a/crates/tiangong-anthropic/Cargo.toml
+++ b/crates/tiangong-anthropic/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tiangong-anthropic"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+
+[dependencies]
+thiserror = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest-eventsource = "0.6"
+futures-util = "0.3"

--- a/crates/tiangong-anthropic/src/client.rs
+++ b/crates/tiangong-anthropic/src/client.rs
@@ -120,14 +120,7 @@ async fn parse_error_response(response: reqwest::Response) -> AnthropicError {
     let status = response.status();
     let body = response.bytes().await.unwrap_or_default();
     let body_text = String::from_utf8_lossy(&body).to_string();
-
-    match status.as_u16() {
-        400 => AnthropicError::InvalidRequest(body_text),
-        401 | 403 => AnthropicError::Authentication(body_text),
-        429 => AnthropicError::RateLimited(body_text),
-        _ if status.is_server_error() => AnthropicError::Transport(body_text),
-        _ => AnthropicError::Api(body_text),
-    }
+    classify_http_error(status, body_text)
 }
 
 async fn parse_json_response<T: serde::de::DeserializeOwned>(
@@ -141,13 +134,7 @@ async fn parse_json_response<T: serde::de::DeserializeOwned>(
 
     if !status.is_success() {
         let body_text = String::from_utf8_lossy(&body).to_string();
-        return Err(match status.as_u16() {
-            400 => AnthropicError::InvalidRequest(body_text),
-            401 | 403 => AnthropicError::Authentication(body_text),
-            429 => AnthropicError::RateLimited(body_text),
-            _ if status.is_server_error() => AnthropicError::Transport(body_text),
-            _ => AnthropicError::Api(body_text),
-        });
+        return Err(classify_http_error(status, body_text));
     }
 
     serde_json::from_slice(&body).map_err(|err| {
@@ -156,6 +143,28 @@ async fn parse_json_response<T: serde::de::DeserializeOwned>(
             String::from_utf8_lossy(&body[..body.len().min(512)])
         ))
     })
+}
+
+fn classify_http_error(status: reqwest::StatusCode, body_text: String) -> AnthropicError {
+    if is_rate_limited_status_or_body(status, &body_text) {
+        return AnthropicError::RateLimited(body_text);
+    }
+
+    match status.as_u16() {
+        400 => AnthropicError::InvalidRequest(body_text),
+        401 | 403 => AnthropicError::Authentication(body_text),
+        _ if status.is_server_error() => AnthropicError::Transport(body_text),
+        _ => AnthropicError::Api(body_text),
+    }
+}
+
+fn is_rate_limited_status_or_body(status: reqwest::StatusCode, body_text: &str) -> bool {
+    let lower = body_text.to_ascii_lowercase();
+    matches!(status.as_u16(), 429 | 529)
+        || lower.contains("rate limit")
+        || lower.contains("too many requests")
+        || lower.contains("overloaded_error")
+        || lower.contains("\"type\":\"overloaded_error\"")
 }
 
 fn parse_sse_event(event_type: &str, data: &str) -> Result<StreamEvent, AnthropicError> {
@@ -233,8 +242,6 @@ fn parse_sse_event(event_type: &str, data: &str) -> Result<StreamEvent, Anthropi
                 .map_err(|err| AnthropicError::Serialization(err.to_string()))?,
         }),
         "message_stop" => Ok(StreamEvent::MessageStop),
-        other => Err(AnthropicError::Stream(format!(
-            "不支持的 SSE 事件：{other}"
-        ))),
+        _other => Ok(StreamEvent::Unknown),
     }
 }

--- a/crates/tiangong-anthropic/src/client.rs
+++ b/crates/tiangong-anthropic/src/client.rs
@@ -1,6 +1,6 @@
+use eventsource_stream::Eventsource;
 use futures_util::StreamExt;
 use futures_util::stream;
-use reqwest_eventsource::{Event, RequestBuilderExt};
 use serde_json::Value;
 
 use crate::config::AnthropicConfig;
@@ -46,20 +46,26 @@ impl AnthropicClient {
         mut request: MessagesCreateRequest,
     ) -> Result<EventStream, AnthropicError> {
         request.stream = Some(true);
-        let es = self
+        let response = self
             .request_builder("/v1/messages")
+            .header(reqwest::header::ACCEPT, "text/event-stream")
             .json(&request)
-            .eventsource()
-            .map_err(|err| AnthropicError::Stream(err.to_string()))?;
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
 
-        let stream = stream::unfold(es, |mut es| async move {
-            match es.next().await {
-                Some(Ok(Event::Open)) => Some((Ok(StreamEvent::Ping), es)),
-                Some(Ok(Event::Message(msg))) => {
-                    let item = parse_sse_event(&msg.event, &msg.data);
-                    Some((item, es))
+        if !response.status().is_success() {
+            return Err(parse_error_response(response).await);
+        }
+
+        let sse_stream = response.bytes_stream().eventsource();
+        let stream = stream::unfold(sse_stream, |mut sse_stream| async move {
+            match sse_stream.next().await {
+                Some(Ok(message)) => {
+                    let item = parse_sse_event(&message.event, &message.data);
+                    Some((item, sse_stream))
                 }
-                Some(Err(err)) => Some((Err(AnthropicError::Stream(err.to_string())), es)),
+                Some(Err(err)) => Some((Err(AnthropicError::Stream(err.to_string())), sse_stream)),
                 None => None,
             }
         });
@@ -107,6 +113,20 @@ fn map_reqwest_error(err: reqwest::Error) -> AnthropicError {
         AnthropicError::Transport(format!("timeout: {err}"))
     } else {
         AnthropicError::Transport(err.to_string())
+    }
+}
+
+async fn parse_error_response(response: reqwest::Response) -> AnthropicError {
+    let status = response.status();
+    let body = response.bytes().await.unwrap_or_default();
+    let body_text = String::from_utf8_lossy(&body).to_string();
+
+    match status.as_u16() {
+        400 => AnthropicError::InvalidRequest(body_text),
+        401 | 403 => AnthropicError::Authentication(body_text),
+        429 => AnthropicError::RateLimited(body_text),
+        _ if status.is_server_error() => AnthropicError::Transport(body_text),
+        _ => AnthropicError::Api(body_text),
     }
 }
 

--- a/crates/tiangong-anthropic/src/client.rs
+++ b/crates/tiangong-anthropic/src/client.rs
@@ -1,0 +1,220 @@
+use futures_util::StreamExt;
+use futures_util::stream;
+use reqwest_eventsource::{Event, RequestBuilderExt};
+use serde_json::Value;
+
+use crate::config::AnthropicConfig;
+use crate::error::AnthropicError;
+use crate::types::{
+    ContentBlockDeltaData, ContentBlockStartData, EventStream, MessageDeltaData, MessageStartData,
+    MessagesCreateRequest, MessagesCreateResponse, ModelsListResponse, StreamEvent,
+};
+
+#[derive(Clone)]
+pub struct AnthropicClient {
+    http_client: reqwest::Client,
+    config: AnthropicConfig,
+}
+
+impl AnthropicClient {
+    pub fn from_config(config: AnthropicConfig) -> Result<Self, AnthropicError> {
+        let http_client = reqwest::Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|err| AnthropicError::Transport(err.to_string()))?;
+        Ok(Self {
+            http_client,
+            config,
+        })
+    }
+
+    pub async fn create(
+        &self,
+        request: MessagesCreateRequest,
+    ) -> Result<MessagesCreateResponse, AnthropicError> {
+        let response = self
+            .request_builder("/v1/messages")
+            .json(&request)
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        parse_json_response(response).await
+    }
+
+    pub async fn create_stream(
+        &self,
+        mut request: MessagesCreateRequest,
+    ) -> Result<EventStream, AnthropicError> {
+        request.stream = Some(true);
+        let es = self
+            .request_builder("/v1/messages")
+            .json(&request)
+            .eventsource()
+            .map_err(|err| AnthropicError::Stream(err.to_string()))?;
+
+        let stream = stream::unfold(es, |mut es| async move {
+            match es.next().await {
+                Some(Ok(Event::Open)) => Some((Ok(StreamEvent::Ping), es)),
+                Some(Ok(Event::Message(msg))) => {
+                    let item = parse_sse_event(&msg.event, &msg.data);
+                    Some((item, es))
+                }
+                Some(Err(err)) => Some((Err(AnthropicError::Stream(err.to_string())), es)),
+                None => None,
+            }
+        });
+        Ok(Box::pin(stream))
+    }
+
+    pub async fn list_models(&self) -> Result<ModelsListResponse, AnthropicError> {
+        let response = self
+            .request_builder("/v1/models")
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        parse_json_response(response).await
+    }
+
+    fn request_builder(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!(
+            "{}/{}",
+            self.config.base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        );
+        let mut builder = self
+            .http_client
+            .post(url.clone())
+            .header("x-api-key", &self.config.api_key)
+            .header("anthropic-version", &self.config.api_version)
+            .header(reqwest::header::ACCEPT, "application/json");
+        if path == "/v1/models" {
+            builder = self
+                .http_client
+                .get(url)
+                .header("x-api-key", &self.config.api_key)
+                .header("anthropic-version", &self.config.api_version)
+                .header(reqwest::header::ACCEPT, "application/json");
+        }
+        if let Some(beta) = &self.config.beta {
+            builder = builder.header("anthropic-beta", beta);
+        }
+        builder
+    }
+}
+
+fn map_reqwest_error(err: reqwest::Error) -> AnthropicError {
+    if err.is_timeout() {
+        AnthropicError::Transport(format!("timeout: {err}"))
+    } else {
+        AnthropicError::Transport(err.to_string())
+    }
+}
+
+async fn parse_json_response<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T, AnthropicError> {
+    let status = response.status();
+    let body = response
+        .bytes()
+        .await
+        .map_err(|err| AnthropicError::Transport(err.to_string()))?;
+
+    if !status.is_success() {
+        let body_text = String::from_utf8_lossy(&body).to_string();
+        return Err(match status.as_u16() {
+            400 => AnthropicError::InvalidRequest(body_text),
+            401 | 403 => AnthropicError::Authentication(body_text),
+            429 => AnthropicError::RateLimited(body_text),
+            _ if status.is_server_error() => AnthropicError::Transport(body_text),
+            _ => AnthropicError::Api(body_text),
+        });
+    }
+
+    serde_json::from_slice(&body).map_err(|err| {
+        AnthropicError::Serialization(format!(
+            "{err}: {}",
+            String::from_utf8_lossy(&body[..body.len().min(512)])
+        ))
+    })
+}
+
+fn parse_sse_event(event_type: &str, data: &str) -> Result<StreamEvent, AnthropicError> {
+    if event_type == "ping" {
+        return Ok(StreamEvent::Ping);
+    }
+    if event_type == "error" {
+        let payload: Value = serde_json::from_str(data)
+            .map_err(|err| AnthropicError::Serialization(err.to_string()))?;
+        return Ok(StreamEvent::Error {
+            message: payload.to_string(),
+        });
+    }
+
+    let value: Value =
+        serde_json::from_str(data).map_err(|err| AnthropicError::Serialization(err.to_string()))?;
+    match event_type {
+        "message_start" => Ok(StreamEvent::MessageStart {
+            message: serde_json::from_value::<MessageStartData>(
+                value
+                    .get("message")
+                    .cloned()
+                    .ok_or_else(|| AnthropicError::Serialization(data.to_string()))?,
+            )
+            .map_err(|err| AnthropicError::Serialization(err.to_string()))?,
+        }),
+        "content_block_start" => Ok(StreamEvent::ContentBlockStart {
+            index: value
+                .get("index")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| AnthropicError::Serialization(data.to_string()))?
+                as usize,
+            content_block: serde_json::from_value::<ContentBlockStartData>(
+                value
+                    .get("content_block")
+                    .cloned()
+                    .ok_or_else(|| AnthropicError::Serialization(data.to_string()))?,
+            )
+            .map_err(|err| AnthropicError::Serialization(err.to_string()))?,
+        }),
+        "content_block_delta" => Ok(StreamEvent::ContentBlockDelta {
+            index: value
+                .get("index")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| AnthropicError::Serialization(data.to_string()))?
+                as usize,
+            delta: serde_json::from_value::<ContentBlockDeltaData>(
+                value
+                    .get("delta")
+                    .cloned()
+                    .ok_or_else(|| AnthropicError::Serialization(data.to_string()))?,
+            )
+            .map_err(|err| AnthropicError::Serialization(err.to_string()))?,
+        }),
+        "content_block_stop" => Ok(StreamEvent::ContentBlockStop {
+            index: value
+                .get("index")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| AnthropicError::Serialization(data.to_string()))?
+                as usize,
+        }),
+        "message_delta" => Ok(StreamEvent::MessageDelta {
+            delta: serde_json::from_value::<MessageDeltaData>(
+                value
+                    .get("delta")
+                    .cloned()
+                    .ok_or_else(|| AnthropicError::Serialization(data.to_string()))?,
+            )
+            .map_err(|err| AnthropicError::Serialization(err.to_string()))?,
+            usage: value
+                .get("usage")
+                .cloned()
+                .map(serde_json::from_value)
+                .transpose()
+                .map_err(|err| AnthropicError::Serialization(err.to_string()))?,
+        }),
+        "message_stop" => Ok(StreamEvent::MessageStop),
+        other => Err(AnthropicError::Stream(format!(
+            "不支持的 SSE 事件：{other}"
+        ))),
+    }
+}

--- a/crates/tiangong-anthropic/src/config.rs
+++ b/crates/tiangong-anthropic/src/config.rs
@@ -1,0 +1,22 @@
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct AnthropicConfig {
+    pub api_key: String,
+    pub base_url: String,
+    pub timeout: Duration,
+    pub api_version: String,
+    pub beta: Option<String>,
+}
+
+impl AnthropicConfig {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            base_url: "https://api.anthropic.com".to_string(),
+            timeout: Duration::from_secs(60),
+            api_version: "2023-06-01".to_string(),
+            beta: None,
+        }
+    }
+}

--- a/crates/tiangong-anthropic/src/error.rs
+++ b/crates/tiangong-anthropic/src/error.rs
@@ -1,0 +1,34 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone)]
+pub enum AnthropicError {
+    #[error("配置错误：{0}")]
+    Config(String),
+
+    #[error("传输错误：{0}")]
+    Transport(String),
+
+    #[error("认证失败：{0}")]
+    Authentication(String),
+
+    #[error("请求无效：{0}")]
+    InvalidRequest(String),
+
+    #[error("请求被限流：{0}")]
+    RateLimited(String),
+
+    #[error("序列化失败：{0}")]
+    Serialization(String),
+
+    #[error("流式处理失败：{0}")]
+    Stream(String),
+
+    #[error("Anthropic API 错误：{0}")]
+    Api(String),
+}
+
+impl AnthropicError {
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, Self::Transport(_) | Self::RateLimited(_))
+    }
+}

--- a/crates/tiangong-anthropic/src/lib.rs
+++ b/crates/tiangong-anthropic/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod client;
+pub mod config;
+pub mod error;
+pub mod types;
+
+pub use client::AnthropicClient;
+pub use config::AnthropicConfig;
+pub use error::AnthropicError;

--- a/crates/tiangong-anthropic/src/types.rs
+++ b/crates/tiangong-anthropic/src/types.rs
@@ -137,11 +137,13 @@ pub struct MessagesCreateRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MessagesCreateResponse {
+    #[serde(default)]
     pub id: String,
     #[serde(rename = "type")]
     pub kind: String,
     pub role: MessageRole,
     pub content: Vec<ContentBlock>,
+    #[serde(default)]
     pub model: String,
     #[serde(default)]
     pub stop_reason: Option<String>,
@@ -172,7 +174,9 @@ pub struct ModelsListResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MessageStartData {
+    #[serde(default)]
     pub id: String,
+    #[serde(default)]
     pub model: String,
     pub role: MessageRole,
     #[serde(default)]
@@ -261,6 +265,7 @@ pub enum StreamEvent {
     Error {
         message: String,
     },
+    Unknown,
 }
 
 pub type EventStream = BoxStream<'static, Result<StreamEvent, AnthropicError>>;

--- a/crates/tiangong-anthropic/src/types.rs
+++ b/crates/tiangong-anthropic/src/types.rs
@@ -45,7 +45,8 @@ pub enum ContentBlockParam {
     },
     Thinking {
         thinking: String,
-        signature: String,
+        #[serde(default)]
+        signature: Option<String>,
     },
     RedactedThinking {
         data: String,
@@ -72,7 +73,8 @@ pub enum ContentBlock {
     },
     Thinking {
         thinking: String,
-        signature: String,
+        #[serde(default)]
+        signature: Option<String>,
     },
     RedactedThinking {
         data: String,

--- a/crates/tiangong-anthropic/src/types.rs
+++ b/crates/tiangong-anthropic/src/types.rs
@@ -1,0 +1,264 @@
+use futures_util::stream::BoxStream;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::AnthropicError;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct Usage {
+    #[serde(default)]
+    pub input_tokens: Option<u64>,
+    #[serde(default)]
+    pub output_tokens: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageRole {
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Message {
+    pub role: MessageRole,
+    pub content: Vec<ContentBlockParam>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlockParam {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        content: Option<Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+    },
+    Thinking {
+        thinking: String,
+        signature: String,
+    },
+    RedactedThinking {
+        data: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlock {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        #[serde(default)]
+        content: Option<Value>,
+        #[serde(default)]
+        is_error: Option<bool>,
+    },
+    Thinking {
+        thinking: String,
+        signature: String,
+    },
+    RedactedThinking {
+        data: String,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolChoice {
+    Auto,
+    Any,
+    Tool {
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        disable_parallel_tool_use: Option<bool>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Tool {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub input_schema: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ThinkingConfig {
+    Enabled { budget_tokens: u32 },
+    Disabled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MessagesCreateRequest {
+    pub model: String,
+    pub max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    pub messages: Vec<Message>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_sequences: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Tool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ThinkingConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MessagesCreateResponse {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub role: MessageRole,
+    pub content: Vec<ContentBlock>,
+    pub model: String,
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+    #[serde(default)]
+    pub stop_sequence: Option<String>,
+    #[serde(default)]
+    pub usage: Option<Usage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelInfo {
+    pub id: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelsListResponse {
+    #[serde(default)]
+    pub data: Vec<ModelInfo>,
+    #[serde(default)]
+    pub has_more: bool,
+    #[serde(default)]
+    pub first_id: Option<String>,
+    #[serde(default)]
+    pub last_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MessageStartData {
+    pub id: String,
+    pub model: String,
+    pub role: MessageRole,
+    #[serde(default)]
+    pub content: Vec<ContentBlock>,
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+    #[serde(default)]
+    pub stop_sequence: Option<String>,
+    #[serde(default)]
+    pub usage: Option<Usage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlockStartData {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    Thinking {
+        #[serde(default)]
+        thinking: String,
+        #[serde(default)]
+        signature: String,
+    },
+    RedactedThinking {
+        data: String,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlockDeltaData {
+    TextDelta {
+        text: String,
+    },
+    InputJsonDelta {
+        partial_json: String,
+    },
+    ThinkingDelta {
+        thinking: String,
+    },
+    SignatureDelta {
+        signature: String,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageDeltaData {
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+    #[serde(default)]
+    pub stop_sequence: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum StreamEvent {
+    MessageStart {
+        message: MessageStartData,
+    },
+    ContentBlockStart {
+        index: usize,
+        content_block: ContentBlockStartData,
+    },
+    ContentBlockDelta {
+        index: usize,
+        delta: ContentBlockDeltaData,
+    },
+    ContentBlockStop {
+        index: usize,
+    },
+    MessageDelta {
+        delta: MessageDeltaData,
+        usage: Option<Usage>,
+    },
+    MessageStop,
+    Ping,
+    Error {
+        message: String,
+    },
+}
+
+pub type EventStream = BoxStream<'static, Result<StreamEvent, AnthropicError>>;

--- a/crates/tiangong-core/Cargo.toml
+++ b/crates/tiangong-core/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 tiangong-types = { path = "../tiangong-types" }
+tiangong-llm = { path = "../tiangong-llm" }
 anyhow = "1"
 arc-swap = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }

--- a/crates/tiangong-core/src/agents/execution_completion_agent.rs
+++ b/crates/tiangong-core/src/agents/execution_completion_agent.rs
@@ -74,6 +74,9 @@ pub(crate) fn infer_completion_signal_with_llm(
         user_input: prompt,
         context: context.to_vec(),
         assembled_system_prompt: None,
+        thinking: Some(crate::model::ModelThinkingConfig {
+            budget_tokens: 2048,
+        }),
     };
     let response = client.complete_stream(&request, on_chunk)?;
     accumulated_usage.accumulate(&response.usage);
@@ -155,6 +158,9 @@ pub(crate) fn review_completion_signal_with_llm(
         user_input: prompt,
         context: context.to_vec(),
         assembled_system_prompt: None,
+        thinking: Some(crate::model::ModelThinkingConfig {
+            budget_tokens: 2048,
+        }),
     };
     let response = client.complete_stream(&request, on_chunk)?;
     accumulated_usage.accumulate(&response.usage);

--- a/crates/tiangong-core/src/agents/planning_agent.rs
+++ b/crates/tiangong-core/src/agents/planning_agent.rs
@@ -151,6 +151,9 @@ fn build_plan_with_agent_inner(
         user_input: build_planing_prompt(user_input, &input_list, &skill_hints, &mcp_hints),
         context: session.recent_messages(context_limit),
         assembled_system_prompt: None,
+        thinking: Some(crate::model::ModelThinkingConfig {
+            budget_tokens: 4096,
+        }),
     };
     let response = client
         .complete_stream(&request, on_delta)

--- a/crates/tiangong-core/src/agents/skill_convert_agent.rs
+++ b/crates/tiangong-core/src/agents/skill_convert_agent.rs
@@ -32,6 +32,9 @@ pub fn convert_external_skill_with_agent(
         user_input: prompt,
         context: Vec::<Message>::new(),
         assembled_system_prompt: None,
+        thinking: Some(crate::model::ModelThinkingConfig {
+            budget_tokens: 4096,
+        }),
     };
     let response = client
         .complete(&request)

--- a/crates/tiangong-core/src/context/compressor.rs
+++ b/crates/tiangong-core/src/context/compressor.rs
@@ -169,6 +169,7 @@ impl ContextCompressor {
             user_input: prompt,
             context: Vec::new(),
             assembled_system_prompt: None,
+            thinking: None,
         };
         let resp = client.complete(&req)?;
         Ok(resp.text)
@@ -242,6 +243,7 @@ pub fn compress_loop_messages(
         user_input: prompt,
         context: Vec::new(),
         assembled_system_prompt: None,
+        thinking: None,
     };
 
     let summary = match client.complete(&req) {

--- a/crates/tiangong-core/src/coordinator/task_coordinator.rs
+++ b/crates/tiangong-core/src/coordinator/task_coordinator.rs
@@ -41,6 +41,7 @@ impl TaskCoordinator {
             user_input: prompt,
             context: Vec::new(),
             assembled_system_prompt: None,
+            thinking: None,
         };
 
         match self.engine.client().complete(&req) {
@@ -125,6 +126,9 @@ impl TaskCoordinator {
             user_input: prompt,
             context: Vec::new(),
             assembled_system_prompt: None,
+            thinking: Some(crate::model::ModelThinkingConfig {
+                budget_tokens: 2048,
+            }),
         };
 
         let resp = self.engine.client().complete(&req)?;
@@ -267,6 +271,9 @@ impl TaskCoordinator {
                 user_input: prompt,
                 context: Vec::new(),
                 assembled_system_prompt: None,
+                thinking: Some(crate::model::ModelThinkingConfig {
+                    budget_tokens: 2048,
+                }),
             };
 
             // 流式合成，实时推送

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -421,6 +421,9 @@ fn execute_turn_inner(
             user_input: assembled.user_input.clone(),
             context: assembled.build_messages(),
             assembled_system_prompt: Some(system_prompt),
+            thinking: Some(crate::model::ModelThinkingConfig {
+                budget_tokens: 4096,
+            }),
         };
 
         // 预生成本轮 assistant 消息 ID（Delta/Reasoning 事件先于消息创建）
@@ -742,6 +745,9 @@ fn force_final_response(
         user_input: assembled.user_input.clone(),
         context: assembled.build_messages(),
         assembled_system_prompt: Some(system_prompt),
+        thinking: Some(crate::model::ModelThinkingConfig {
+            budget_tokens: 4096,
+        }),
     };
 
     // 预生成 message_id
@@ -757,6 +763,12 @@ fn force_final_response(
                     let _ = tx.send(StreamEvent::Delta {
                         message_id: msg_id_for_cb.clone(),
                         content: delta.content.clone(),
+                    });
+                }
+                if !delta.reasoning_content.is_empty() {
+                    let _ = tx.send(StreamEvent::Reasoning {
+                        message_id: msg_id_for_cb.clone(),
+                        content: delta.reasoning_content.clone(),
                     });
                 }
             }) {
@@ -776,6 +788,12 @@ fn force_final_response(
                     let _ = stream_tx.send(StreamEvent::Delta {
                         message_id: msg_id_non_stream,
                         content: r.text.clone(),
+                    });
+                }
+                if !r.reasoning_content.is_empty() {
+                    let _ = stream_tx.send(StreamEvent::Reasoning {
+                        message_id: pending_msg_id.clone(),
+                        content: r.reasoning_content.clone(),
                     });
                 }
                 r

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -853,6 +853,7 @@ fn build_engine_from_config(
             api_auth_token: lite_endpoint.api_key.clone(),
             api_base_url: lite_endpoint.base_url.clone(),
             api_timeout_ms: lite_endpoint.timeout_ms.to_string(),
+            api_protocol: lite_endpoint.protocol,
             api_model: lite_endpoint.model.clone(),
             api_lite_model: lite_endpoint.model.clone(),
         };

--- a/crates/tiangong-core/src/core_config.rs
+++ b/crates/tiangong-core/src/core_config.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use arc_swap::ArcSwap;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::agent_config::{McpConfig, McpServerConfig, SkillsConfig};
 use crate::mcp::McpToolMeta;
@@ -37,6 +38,8 @@ pub struct ModelEndpoint {
     /// 请求超时（毫秒）
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
+    #[serde(default)]
+    pub options: Value,
 }
 
 fn default_timeout_ms() -> u64 {
@@ -51,6 +54,7 @@ impl Default for ModelEndpoint {
             model: String::new(),
             protocol: ProviderProtocol::default(),
             timeout_ms: DEFAULT_TIMEOUT_MS,
+            options: Value::Object(serde_json::Map::new()),
         }
     }
 }
@@ -90,6 +94,7 @@ impl LlmConfig {
                 model: resolved.model,
                 protocol: resolved.protocol,
                 timeout_ms: resolved.timeout_ms,
+                options: resolved.options,
             })
         };
 
@@ -161,6 +166,7 @@ impl CoreConfigBuilder {
             model: model.to_string(),
             protocol: ProviderProtocol::default(),
             timeout_ms: DEFAULT_TIMEOUT_MS,
+            options: Value::Object(serde_json::Map::new()),
         };
         self
     }

--- a/crates/tiangong-core/src/core_config.rs
+++ b/crates/tiangong-core/src/core_config.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::agent_config::{McpConfig, McpServerConfig, SkillsConfig};
 use crate::mcp::McpToolMeta;
+use crate::model::ProviderProtocol;
 use crate::models_config::{ModelCapability, ModelsConfig};
 use crate::permission::TrustMode;
 
@@ -30,6 +31,9 @@ pub struct ModelEndpoint {
     pub api_key: String,
     /// 模型名称
     pub model: String,
+    /// Provider 协议
+    #[serde(default)]
+    pub protocol: ProviderProtocol,
     /// 请求超时（毫秒）
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
@@ -45,6 +49,7 @@ impl Default for ModelEndpoint {
             base_url: String::new(),
             api_key: String::new(),
             model: String::new(),
+            protocol: ProviderProtocol::default(),
             timeout_ms: DEFAULT_TIMEOUT_MS,
         }
     }
@@ -83,6 +88,7 @@ impl LlmConfig {
                 base_url: resolved.base_url,
                 api_key: resolved.api_key,
                 model: resolved.model,
+                protocol: resolved.protocol,
                 timeout_ms: resolved.timeout_ms,
             })
         };
@@ -153,6 +159,7 @@ impl CoreConfigBuilder {
             base_url: base_url.to_string(),
             api_key: api_key.to_string(),
             model: model.to_string(),
+            protocol: ProviderProtocol::default(),
             timeout_ms: DEFAULT_TIMEOUT_MS,
         };
         self
@@ -318,5 +325,34 @@ mod tests {
             ..Default::default()
         });
         assert!(llm.image_generation.is_some());
+    }
+
+    #[test]
+    fn llm_config_from_models_config_preserves_protocol() {
+        let mut models = ModelsConfig::default();
+        models.providers.insert(
+            "anthropic".to_string(),
+            crate::models_config::ProviderConfig {
+                base_url: "https://api.anthropic.com".into(),
+                api_key: "sk-ant".into(),
+                timeout_ms: 30_000,
+                protocol: ProviderProtocol::Anthropic,
+            },
+        );
+        models.models.insert(
+            "chat-model".to_string(),
+            crate::models_config::ModelEntry {
+                provider: "anthropic".into(),
+                model: "claude-sonnet-4".into(),
+                capabilities: vec![ModelCapability::Chat],
+                options: serde_json::json!({}),
+            },
+        );
+        models
+            .routing
+            .insert(ModelCapability::Chat, "chat-model".into());
+
+        let llm = LlmConfig::from_models_config(&models);
+        assert_eq!(llm.chat.protocol, ProviderProtocol::Anthropic);
     }
 }

--- a/crates/tiangong-core/src/execution/step_executor.rs
+++ b/crates/tiangong-core/src/execution/step_executor.rs
@@ -67,6 +67,9 @@ pub fn execute_single_plan_step_with_execution_agent(
             user_input: round_prompt,
             context: loop_context.clone(),
             assembled_system_prompt: None,
+            thinking: Some(crate::model::ModelThinkingConfig {
+                budget_tokens: 4096,
+            }),
         };
         let response =
             client.complete_with_functions_stream(&request, &function_tools, on_chunk)?;

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -760,92 +760,84 @@ fn collect_provider_text(response: &ProviderResponse) -> String {
         .join("")
 }
 
-fn consume_provider_stream_events(
-    stream: ProviderStream,
+async fn consume_provider_stream_events_async(
+    mut stream: ProviderStream,
     on_delta: &mut dyn FnMut(&ModelStreamChunk),
 ) -> Result<ModelFunctionResponse> {
-    let runtime = TokioRuntimeBuilder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("初始化异步运行时失败")?;
+    let mut text = String::new();
+    let mut reasoning_content = String::new();
+    let mut usage = TokenUsageData::default();
+    let mut tool_calls: std::collections::BTreeMap<String, (String, String)> =
+        std::collections::BTreeMap::new();
 
-    runtime.block_on(async {
-        let mut stream = stream;
-        let mut text = String::new();
-        let mut reasoning_content = String::new();
-        let mut usage = TokenUsageData::default();
-        let mut tool_calls: std::collections::BTreeMap<String, (String, String)> =
-            std::collections::BTreeMap::new();
-
-        while let Some(event) = stream.next().await {
-            match event.map_err(map_llm_error)? {
-                ProviderStreamEvent::ReasoningDelta(delta) => {
-                    if !delta.is_empty() {
-                        reasoning_content.push_str(&delta);
-                        on_delta(&ModelStreamChunk {
-                            content: String::new(),
-                            reasoning_content: delta.clone(),
-                        });
-                    }
+    while let Some(event) = stream.next().await {
+        match event.map_err(map_llm_error)? {
+            ProviderStreamEvent::ReasoningDelta(delta) => {
+                if !delta.is_empty() {
+                    reasoning_content.push_str(&delta);
+                    on_delta(&ModelStreamChunk {
+                        content: String::new(),
+                        reasoning_content: delta.clone(),
+                    });
                 }
-                ProviderStreamEvent::TextDelta(delta) => {
-                    if !delta.is_empty() {
-                        text.push_str(&delta);
-                        on_delta(&ModelStreamChunk {
-                            content: delta,
-                            reasoning_content: String::new(),
-                        });
-                    }
-                }
-                ProviderStreamEvent::ToolCallStart(call) => {
-                    let args = if call.arguments.is_null() || call.arguments == json!({}) {
-                        String::new()
-                    } else {
-                        call.arguments.to_string()
-                    };
-                    tool_calls.insert(call.id.clone(), (call.name, args));
-                }
-                ProviderStreamEvent::ToolCallDelta {
-                    call_id,
-                    partial_json,
-                } => {
-                    let entry = tool_calls
-                        .entry(call_id)
-                        .or_insert_with(|| (String::new(), String::new()));
-                    entry.1.push_str(&partial_json);
-                }
-                ProviderStreamEvent::Usage(stream_usage) => usage = stream_usage,
-                ProviderStreamEvent::Error(message) => return Err(anyhow!(message)),
-                ProviderStreamEvent::MessageStart
-                | ProviderStreamEvent::ToolCallEnd { .. }
-                | ProviderStreamEvent::MessageEnd => {}
             }
-        }
-
-        let tool_calls = tool_calls
-            .into_iter()
-            .filter(|(_, (name, _))| !name.is_empty())
-            .map(|(id, (name, raw_args))| ModelFunctionCall {
-                id,
-                name,
-                arguments: if raw_args.trim().is_empty() {
-                    json!({})
+            ProviderStreamEvent::TextDelta(delta) => {
+                if !delta.is_empty() {
+                    text.push_str(&delta);
+                    on_delta(&ModelStreamChunk {
+                        content: delta,
+                        reasoning_content: String::new(),
+                    });
+                }
+            }
+            ProviderStreamEvent::ToolCallStart(call) => {
+                let args = if call.arguments.is_null() || call.arguments == json!({}) {
+                    String::new()
                 } else {
-                    serde_json::from_str(&raw_args).unwrap_or_else(|_| json!({}))
-                },
-            })
-            .collect::<Vec<_>>();
-
-        if text.trim().is_empty() && reasoning_content.trim().is_empty() && tool_calls.is_empty() {
-            return Err(anyhow!("Anthropic 流式响应缺少文本、思考内容和工具调用"));
+                    call.arguments.to_string()
+                };
+                tool_calls.insert(call.id.clone(), (call.name, args));
+            }
+            ProviderStreamEvent::ToolCallDelta {
+                call_id,
+                partial_json,
+            } => {
+                let entry = tool_calls
+                    .entry(call_id)
+                    .or_insert_with(|| (String::new(), String::new()));
+                entry.1.push_str(&partial_json);
+            }
+            ProviderStreamEvent::Usage(stream_usage) => usage = stream_usage,
+            ProviderStreamEvent::Error(message) => return Err(anyhow!(message)),
+            ProviderStreamEvent::MessageStart
+            | ProviderStreamEvent::ToolCallEnd { .. }
+            | ProviderStreamEvent::MessageEnd => {}
         }
+    }
 
-        Ok(ModelFunctionResponse {
-            text: text.trim().to_string(),
-            reasoning_content: reasoning_content.trim().to_string(),
-            usage: usage.into(),
-            tool_calls,
+    let tool_calls = tool_calls
+        .into_iter()
+        .filter(|(_, (name, _))| !name.is_empty())
+        .map(|(id, (name, raw_args))| ModelFunctionCall {
+            id,
+            name,
+            arguments: if raw_args.trim().is_empty() {
+                json!({})
+            } else {
+                serde_json::from_str(&raw_args).unwrap_or_else(|_| json!({}))
+            },
         })
+        .collect::<Vec<_>>();
+
+    if text.trim().is_empty() && reasoning_content.trim().is_empty() && tool_calls.is_empty() {
+        return Err(anyhow!("Anthropic 流式响应缺少文本、思考内容和工具调用"));
+    }
+
+    Ok(ModelFunctionResponse {
+        text: text.trim().to_string(),
+        reasoning_content: reasoning_content.trim().to_string(),
+        usage: usage.into(),
+        tool_calls,
     })
 }
 
@@ -871,14 +863,14 @@ fn consume_provider_stream(
     request: ProviderRequest,
     on_delta: &mut dyn FnMut(&ModelStreamChunk),
 ) -> Result<ModelResponse> {
-    let stream = TokioRuntimeBuilder::new_current_thread()
+    let response = TokioRuntimeBuilder::new_current_thread()
         .enable_all()
         .build()
         .context("初始化异步运行时失败")?
-        .block_on(provider.stream(request))
-        .map_err(map_llm_error)?;
-
-    let response = consume_provider_stream_events(stream, on_delta)?;
+        .block_on(async {
+            let stream = provider.stream(request).await.map_err(map_llm_error)?;
+            consume_provider_stream_events_async(stream, on_delta).await
+        })?;
     Ok(ModelResponse {
         text: response.text,
         reasoning_content: response.reasoning_content,
@@ -893,13 +885,14 @@ fn convert_stream_to_function_response(
     request: ProviderRequest,
     on_delta: &mut dyn FnMut(&ModelStreamChunk),
 ) -> Result<ModelFunctionResponse> {
-    let stream = TokioRuntimeBuilder::new_current_thread()
+    TokioRuntimeBuilder::new_current_thread()
         .enable_all()
         .build()
         .context("初始化异步运行时失败")?
-        .block_on(provider.stream(request))
-        .map_err(map_llm_error)?;
-    consume_provider_stream_events(stream, on_delta)
+        .block_on(async {
+            let stream = provider.stream(request).await.map_err(map_llm_error)?;
+            consume_provider_stream_events_async(stream, on_delta).await
+        })
 }
 
 fn map_llm_error(error: tiangong_llm::error::LlmError) -> anyhow::Error {

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -1,16 +1,9 @@
-use std::io::{BufRead, BufReader};
 use std::sync::Arc;
 use std::time::Duration;
 
 use crate::mcp::build_mcp_tools_system_prompt;
 use crate::session::{Message, MessageRole};
 use anyhow::{Context, Result, anyhow};
-use async_openai::Client as OpenAIClient;
-use async_openai::config::OpenAIConfig;
-use async_openai::types::chat::{
-    ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
-    ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
-};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
@@ -20,7 +13,7 @@ use tiangong_llm::message::{
 use tiangong_llm::provider::LlmProvider;
 use tiangong_llm::providers::anthropic::{AnthropicConfig, AnthropicProvider};
 use tiangong_llm::providers::openai::{OpenAiCompatibleConfig, OpenAiCompatibleProvider};
-use tiangong_llm::request::ProviderRequest;
+use tiangong_llm::request::{ProviderRequest, ThinkingConfig as LlmThinkingConfig};
 use tiangong_llm::response::ProviderResponse;
 use tiangong_llm::stream::{ProviderStream, ProviderStreamEvent};
 use tiangong_llm::tool::{ToolCall as LlmToolCall, ToolChoice as LlmToolChoice, ToolSpec};
@@ -36,8 +29,13 @@ pub struct ModelRequest {
     pub user_input: String,
     pub context: Vec<Message>,
     /// 已由 PromptAssembler 装配的 system prompt。
-    /// 设置此字段后 build_openai_messages 跳过自己的环境注入。
     pub assembled_system_prompt: Option<String>,
+    pub thinking: Option<ModelThinkingConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelThinkingConfig {
+    pub budget_tokens: u32,
 }
 
 impl ModelRequest {
@@ -53,7 +51,13 @@ impl ModelRequest {
             user_input,
             context,
             assembled_system_prompt: Some(system_prompt),
+            thinking: None,
         }
+    }
+
+    pub fn with_thinking_budget(mut self, budget_tokens: u32) -> Self {
+        self.thinking = Some(ModelThinkingConfig { budget_tokens });
+        self
     }
 }
 
@@ -325,8 +329,7 @@ impl SingleProviderClient {
         }
 
         let provider = self.build_anthropic_provider(timeout_ms)?;
-        let request =
-            build_anthropic_provider_request(req, model, anthropic_max_tokens(), functions);
+        let request = build_provider_request(req, model, anthropic_max_tokens(), functions);
         let response = self.block_on_llm(provider.complete(request))?;
         convert_provider_response_to_function_response(response)
     }
@@ -358,6 +361,7 @@ impl SingleProviderClient {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
+            thinking: None,
         };
         let response = self.block_on_llm(provider.complete(request))?;
         let text = strip_think_tags(&collect_provider_text(&response))
@@ -446,6 +450,7 @@ impl SingleProviderClient {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
+            thinking: None,
         };
         let response = self.block_on_llm(provider.complete(request))?;
         Ok(collect_provider_text(&response).trim().to_string())
@@ -563,600 +568,9 @@ impl ModelClient for SingleProviderClient {
     }
 }
 
-#[allow(dead_code)]
-fn build_openai_messages(req: &ModelRequest) -> Result<Vec<ChatCompletionRequestMessage>> {
-    let mut messages = Vec::new();
-
-    // 如果已由 PromptAssembler 装配，使用装配好的 system prompt，不再自行注入环境信息
-    let system_texts = if let Some(ref assembled) = req.assembled_system_prompt {
-        let mut texts = vec![assembled.clone()];
-        // context 中的 System 消息仍然追加（attachment 等）
-        for msg in &req.context {
-            if msg.role == MessageRole::System && !msg.content.trim().is_empty() {
-                texts.push(msg.content.clone());
-            }
-        }
-        // context 中的 User/Assistant 消息
-        for msg in &req.context {
-            match msg.role {
-                MessageRole::User => {
-                    messages.push(
-                        ChatCompletionRequestUserMessageArgs::default()
-                            .content(msg.content.clone())
-                            .build()
-                            .context("构建 user 消息失败")?
-                            .into(),
-                    );
-                }
-                MessageRole::Assistant => {
-                    messages.push(
-                        ChatCompletionRequestAssistantMessageArgs::default()
-                            .content(msg.content.clone())
-                            .build()
-                            .context("构建 assistant 消息失败")?
-                            .into(),
-                    );
-                }
-                _ => {}
-            }
-        }
-        texts
-    } else {
-        // 旧路径：自行注入环境信息（兼容 TurnRunner / Worker）
-        let mut texts = vec![
-            format!("当前会话：{}", req.session_title),
-            format!("当前工作目录：{}", current_working_directory_text()),
-            format!("允许文件操作目录：{}", allowed_file_roots_text()),
-        ];
-        if let Some(mcp_tools_prompt) = build_mcp_tools_system_prompt(24) {
-            texts.push(mcp_tools_prompt);
-        }
-        for msg in &req.context {
-            match msg.role {
-                MessageRole::System => {
-                    if !msg.content.trim().is_empty() {
-                        texts.push(msg.content.clone());
-                    }
-                }
-                MessageRole::User => {
-                    messages.push(
-                        ChatCompletionRequestUserMessageArgs::default()
-                            .content(msg.content.clone())
-                            .build()
-                            .context("构建 user 消息失败")?
-                            .into(),
-                    );
-                }
-                MessageRole::Assistant => {
-                    messages.push(
-                        ChatCompletionRequestAssistantMessageArgs::default()
-                            .content(msg.content.clone())
-                            .build()
-                            .context("构建 assistant 消息失败")?
-                            .into(),
-                    );
-                }
-            }
-        }
-        texts
-    };
-
-    messages.insert(
-        0,
-        ChatCompletionRequestSystemMessageArgs::default()
-            .content(system_texts.join("\n"))
-            .build()
-            .context("构建 system 消息失败")?
-            .into(),
-    );
-
-    // 用户输入统一通过 context 传递（session history），不再单独追加。
-    // 仅在旧路径（无 assembled_system_prompt）时追加 user_input 作为兼容。
-    if req.assembled_system_prompt.is_none() && !req.user_input.is_empty() {
-        messages.push(
-            ChatCompletionRequestUserMessageArgs::default()
-                .content(req.user_input.clone())
-                .build()
-                .context("构建当前 user 消息失败")?
-                .into(),
-        );
-    }
-
-    Ok(messages)
-}
-
-#[allow(dead_code)]
-fn build_anthropic_request_body(
-    req: &ModelRequest,
-    model: &str,
-    max_tokens: u32,
-    functions: &[FunctionToolSpec],
-    stream: bool,
-) -> Result<Value> {
-    let (system, messages) = build_anthropic_messages(req)?;
-    let mut body = json!({
-        "model": model,
-        "max_tokens": max_tokens,
-        "messages": messages,
-    });
-
-    if !system.is_empty() {
-        body["system"] = Value::String(system);
-    }
-    if stream {
-        body["stream"] = Value::Bool(true);
-    }
-    if !functions.is_empty() {
-        body["tools"] = Value::Array(
-            functions
-                .iter()
-                .map(|tool| {
-                    json!({
-                        "name": tool.name,
-                        "description": tool.description,
-                        "input_schema": tool.parameters,
-                    })
-                })
-                .collect(),
-        );
-    }
-
-    Ok(body)
-}
-
-#[allow(dead_code)]
-fn build_anthropic_messages(req: &ModelRequest) -> Result<(String, Vec<Value>)> {
-    let mut messages = Vec::new();
-
-    let system_texts = if let Some(ref assembled) = req.assembled_system_prompt {
-        let mut texts = vec![assembled.clone()];
-        for msg in &req.context {
-            if msg.role == MessageRole::System && !msg.content.trim().is_empty() {
-                texts.push(msg.content.clone());
-            }
-        }
-        for msg in &req.context {
-            if let Some(payload) = anthropic_message_from_session(msg) {
-                messages.push(payload);
-            }
-        }
-        texts
-    } else {
-        let mut texts = vec![
-            format!("当前会话：{}", req.session_title),
-            format!("当前工作目录：{}", current_working_directory_text()),
-            format!("允许文件操作目录：{}", allowed_file_roots_text()),
-        ];
-        if let Some(mcp_tools_prompt) = build_mcp_tools_system_prompt(24) {
-            texts.push(mcp_tools_prompt);
-        }
-        for msg in &req.context {
-            match msg.role {
-                MessageRole::System => {
-                    if !msg.content.trim().is_empty() {
-                        texts.push(msg.content.clone());
-                    }
-                }
-                _ => {
-                    if let Some(payload) = anthropic_message_from_session(msg) {
-                        messages.push(payload);
-                    }
-                }
-            }
-        }
-        texts
-    };
-
-    if req.assembled_system_prompt.is_none() && !req.user_input.is_empty() {
-        messages.push(json!({
-            "role": "user",
-            "content": [{ "type": "text", "text": req.user_input }],
-        }));
-    }
-
-    Ok((system_texts.join("\n"), messages))
-}
-
-#[allow(dead_code)]
-fn anthropic_message_from_session(msg: &Message) -> Option<Value> {
-    let role = match msg.role {
-        MessageRole::User => "user",
-        MessageRole::Assistant => "assistant",
-        MessageRole::System => return None,
-    };
-
-    let mut parts = Vec::new();
-    if !msg.content.trim().is_empty() {
-        parts.push(msg.content.trim().to_string());
-    }
-    if !msg.reasoning_content.trim().is_empty() {
-        parts.push(format!("[思考]\n{}", msg.reasoning_content.trim()));
-    }
-    if parts.is_empty() {
-        return None;
-    }
-
-    Some(json!({
-        "role": role,
-        "content": [{ "type": "text", "text": parts.join("\n\n") }],
-    }))
-}
-
-#[allow(dead_code)]
-fn normalize_anthropic_base(api_base: &str) -> Result<String> {
-    let trimmed = api_base.trim().trim_end_matches('/');
-    if trimmed.is_empty() {
-        return Err(anyhow!("API_BASE_URL 不能为空"));
-    }
-    if trimmed.ends_with("/v1") {
-        Ok(trimmed.to_string())
-    } else {
-        Ok(format!("{trimmed}/v1"))
-    }
-}
-
-#[allow(dead_code)]
-fn anthropic_version_header() -> &'static str {
-    "2023-06-01"
-}
-
 fn anthropic_max_tokens() -> u32 {
     configured_max_tokens().map(u32::from).unwrap_or(4096)
 }
-
-#[allow(dead_code)]
-fn anthropic_post_json(
-    client: &reqwest::blocking::Client,
-    url: &str,
-    token: &str,
-    body: &Value,
-    on_retry: &Option<OnRetryCallback>,
-    label: &str,
-) -> Result<Value> {
-    let body_text = serde_json::to_string(body).context("序列化 Anthropic 请求失败")?;
-    let response = with_retry_http(label, on_retry, || {
-        let resp = client
-            .post(url)
-            .header("x-api-key", token)
-            .header("anthropic-version", anthropic_version_header())
-            .header("content-type", "application/json")
-            .body(body_text.clone())
-            .send()
-            .map_err(map_reqwest_retry_error)?;
-        anthropic_check_response(resp)
-    })
-    .map_err(|err| anyhow!(err.to_string()))?;
-
-    let text = response.text().context("读取 Anthropic 响应失败")?;
-    serde_json::from_str(&text).with_context(|| format!("解析 Anthropic 响应失败：{text}"))
-}
-
-#[allow(dead_code)]
-fn anthropic_post_stream(
-    client: &reqwest::blocking::Client,
-    url: &str,
-    token: &str,
-    body: &Value,
-    on_retry: &Option<OnRetryCallback>,
-    label: &str,
-) -> Result<reqwest::blocking::Response> {
-    let body_text = serde_json::to_string(body).context("序列化 Anthropic 流式请求失败")?;
-    with_retry_http(label, on_retry, || {
-        let resp = client
-            .post(url)
-            .header("x-api-key", token)
-            .header("anthropic-version", anthropic_version_header())
-            .header("content-type", "application/json")
-            .body(body_text.clone())
-            .send()
-            .map_err(map_reqwest_retry_error)?;
-        anthropic_check_response(resp)
-    })
-    .map_err(|err| anyhow!(err.to_string()))
-}
-
-#[allow(dead_code)]
-fn anthropic_check_response(
-    resp: reqwest::blocking::Response,
-) -> std::result::Result<reqwest::blocking::Response, HttpRetryError> {
-    let status = resp.status();
-    if status.is_success() {
-        return Ok(resp);
-    }
-
-    let retryable = status.as_u16() == 429 || status.is_server_error();
-    let body = resp.text().unwrap_or_default();
-    let message = extract_anthropic_error_message(&body)
-        .unwrap_or_else(|| format!("Anthropic 请求失败：HTTP {status}，响应：{body}"));
-    Err(HttpRetryError::new(message, retryable))
-}
-
-#[allow(dead_code)]
-fn parse_anthropic_function_response(payload: &Value) -> Result<ModelFunctionResponse> {
-    let mut text = String::new();
-    let mut reasoning_content = String::new();
-    let mut tool_calls = Vec::new();
-
-    if let Some(content) = payload.get("content").and_then(Value::as_array) {
-        for block in content {
-            match block
-                .get("type")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-            {
-                "text" => {
-                    if let Some(piece) = block.get("text").and_then(Value::as_str) {
-                        text.push_str(piece);
-                    }
-                }
-                "thinking" => {
-                    if let Some(piece) = block.get("thinking").and_then(Value::as_str) {
-                        reasoning_content.push_str(piece);
-                    }
-                }
-                "tool_use" => {
-                    let id = block
-                        .get("id")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default()
-                        .to_string();
-                    let name = block
-                        .get("name")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default()
-                        .to_string();
-                    let arguments = block.get("input").cloned().unwrap_or_else(|| json!({}));
-                    if !name.is_empty() {
-                        tool_calls.push(ModelFunctionCall {
-                            id,
-                            name,
-                            arguments,
-                        });
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    let input_tokens = payload
-        .get("usage")
-        .and_then(|usage| usage.get("input_tokens"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0) as usize;
-    let output_tokens = payload
-        .get("usage")
-        .and_then(|usage| usage.get("output_tokens"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0) as usize;
-
-    if text.trim().is_empty() && reasoning_content.trim().is_empty() && tool_calls.is_empty() {
-        return Err(anyhow!("Anthropic 响应缺少文本和工具调用"));
-    }
-
-    Ok(ModelFunctionResponse {
-        text: text.trim().to_string(),
-        reasoning_content: reasoning_content.trim().to_string(),
-        usage: TokenUsage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-        },
-        tool_calls,
-    })
-}
-
-#[allow(dead_code)]
-fn parse_anthropic_stream_response(
-    resp: reqwest::blocking::Response,
-    on_delta: &mut dyn FnMut(&ModelStreamChunk),
-) -> Result<ModelFunctionResponse> {
-    let mut reader = BufReader::new(resp);
-    let mut current_event = String::new();
-    let mut data_lines: Vec<String> = Vec::new();
-    let mut text = String::new();
-    let mut reasoning_content = String::new();
-    let mut input_tokens = 0usize;
-    let mut output_tokens = 0usize;
-    let mut tool_calls_map: std::collections::BTreeMap<u64, (String, String, String)> =
-        std::collections::BTreeMap::new();
-
-    let mut process_payload = |event_name: &str, raw_data: &str| -> Result<()> {
-        if raw_data.trim().is_empty() || raw_data.trim() == "[DONE]" || event_name == "ping" {
-            return Ok(());
-        }
-
-        let payload: Value = serde_json::from_str(raw_data)
-            .with_context(|| format!("解析 Anthropic SSE 事件失败：{raw_data}"))?;
-        let payload_type = payload
-            .get("type")
-            .and_then(Value::as_str)
-            .unwrap_or(event_name);
-
-        if let Some(usage) = payload.get("usage") {
-            if let Some(v) = usage.get("input_tokens").and_then(Value::as_u64) {
-                input_tokens = v as usize;
-            }
-            if let Some(v) = usage.get("output_tokens").and_then(Value::as_u64) {
-                output_tokens = v as usize;
-            }
-        }
-        if let Some(message_usage) = payload
-            .get("message")
-            .and_then(|message| message.get("usage"))
-        {
-            if let Some(v) = message_usage.get("input_tokens").and_then(Value::as_u64) {
-                input_tokens = v as usize;
-            }
-            if let Some(v) = message_usage.get("output_tokens").and_then(Value::as_u64) {
-                output_tokens = v as usize;
-            }
-        }
-
-        match payload_type {
-            "content_block_start" => {
-                let index = payload.get("index").and_then(Value::as_u64).unwrap_or(0);
-                if let Some(block) = payload.get("content_block") {
-                    match block
-                        .get("type")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default()
-                    {
-                        "tool_use" => {
-                            let id = block
-                                .get("id")
-                                .and_then(Value::as_str)
-                                .unwrap_or_default()
-                                .to_string();
-                            let name = block
-                                .get("name")
-                                .and_then(Value::as_str)
-                                .unwrap_or_default()
-                                .to_string();
-                            let input = block
-                                .get("input")
-                                .and_then(|input| {
-                                    if input.is_object() {
-                                        Some(input.to_string())
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .unwrap_or_default();
-                            tool_calls_map.insert(index, (id, name, input));
-                        }
-                        "thinking" => {
-                            if let Some(piece) = block.get("thinking").and_then(Value::as_str) {
-                                reasoning_content.push_str(piece);
-                                on_delta(&ModelStreamChunk {
-                                    content: String::new(),
-                                    reasoning_content: piece.to_string(),
-                                });
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            "content_block_delta" => {
-                let index = payload.get("index").and_then(Value::as_u64).unwrap_or(0);
-                if let Some(delta) = payload.get("delta") {
-                    match delta
-                        .get("type")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default()
-                    {
-                        "text_delta" => {
-                            if let Some(piece) = delta.get("text").and_then(Value::as_str) {
-                                text.push_str(piece);
-                                on_delta(&ModelStreamChunk {
-                                    content: piece.to_string(),
-                                    reasoning_content: String::new(),
-                                });
-                            }
-                        }
-                        "thinking_delta" => {
-                            if let Some(piece) = delta.get("thinking").and_then(Value::as_str) {
-                                reasoning_content.push_str(piece);
-                                on_delta(&ModelStreamChunk {
-                                    content: String::new(),
-                                    reasoning_content: piece.to_string(),
-                                });
-                            }
-                        }
-                        "input_json_delta" => {
-                            if let Some(partial) = delta.get("partial_json").and_then(Value::as_str)
-                            {
-                                let entry = tool_calls_map.entry(index).or_insert_with(|| {
-                                    (String::new(), String::new(), String::new())
-                                });
-                                entry.2.push_str(partial);
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            _ => {}
-        }
-
-        Ok(())
-    };
-
-    loop {
-        let mut line = String::new();
-        let read = reader
-            .read_line(&mut line)
-            .context("读取 Anthropic SSE 流失败")?;
-        if read == 0 {
-            break;
-        }
-
-        let line = line.trim_end_matches(['\r', '\n']);
-        if line.is_empty() {
-            if !data_lines.is_empty() {
-                process_payload(&current_event, &data_lines.join("\n"))?;
-                current_event.clear();
-                data_lines.clear();
-            }
-            continue;
-        }
-
-        if let Some(rest) = line.strip_prefix("event:") {
-            current_event = rest.trim().to_string();
-            continue;
-        }
-        if let Some(rest) = line.strip_prefix("data:") {
-            data_lines.push(rest.trim_start().to_string());
-        }
-    }
-
-    if !data_lines.is_empty() {
-        process_payload(&current_event, &data_lines.join("\n"))?;
-    }
-
-    let tool_calls = tool_calls_map
-        .into_values()
-        .filter(|(_, name, _)| !name.is_empty())
-        .map(|(id, name, args)| {
-            let arguments = serde_json::from_str::<Value>(&args)
-                .ok()
-                .filter(|value| value.is_object())
-                .unwrap_or_else(|| json!({}));
-            ModelFunctionCall {
-                id,
-                name,
-                arguments,
-            }
-        })
-        .collect::<Vec<_>>();
-
-    if text.trim().is_empty() && reasoning_content.trim().is_empty() && tool_calls.is_empty() {
-        return Err(anyhow!("Anthropic 流式响应缺少文本和工具调用"));
-    }
-
-    Ok(ModelFunctionResponse {
-        text: text.trim().to_string(),
-        reasoning_content: reasoning_content.trim().to_string(),
-        usage: TokenUsage {
-            prompt_tokens: input_tokens,
-            completion_tokens: output_tokens,
-            total_tokens: input_tokens + output_tokens,
-        },
-        tool_calls,
-    })
-}
-
-#[allow(dead_code)]
-fn extract_anthropic_error_message(body: &str) -> Option<String> {
-    let payload: Value = serde_json::from_str(body).ok()?;
-    let message = payload
-        .get("error")
-        .and_then(|error| error.get("message"))
-        .and_then(Value::as_str)?;
-    Some(format!("Anthropic 请求失败：{message}"))
-}
-
 fn build_anthropic_provider_from_config(
     cfg: &ModelProviderConfig,
     timeout_ms: u64,
@@ -1191,15 +605,6 @@ fn build_openai_provider_from_config(
     Ok(OpenAiCompatibleProvider::new(config))
 }
 
-fn build_anthropic_provider_request(
-    req: &ModelRequest,
-    model: &str,
-    max_tokens: u32,
-    functions: &[FunctionToolSpec],
-) -> ProviderRequest {
-    build_provider_request(req, model, max_tokens, functions)
-}
-
 fn build_provider_request(
     req: &ModelRequest,
     model: &str,
@@ -1225,6 +630,9 @@ fn build_provider_request(
         top_p: None,
         stop_sequences: Vec::new(),
         metadata: None,
+        thinking: req.thinking.as_ref().map(|thinking| LlmThinkingConfig {
+            budget_tokens: thinking.budget_tokens,
+        }),
     }
 }
 
@@ -1352,7 +760,7 @@ fn collect_provider_text(response: &ProviderResponse) -> String {
         .join("")
 }
 
-fn consume_anthropic_stream(
+fn consume_provider_stream_events(
     stream: ProviderStream,
     on_delta: &mut dyn FnMut(&ModelStreamChunk),
 ) -> Result<ModelFunctionResponse> {
@@ -1364,6 +772,7 @@ fn consume_anthropic_stream(
     runtime.block_on(async {
         let mut stream = stream;
         let mut text = String::new();
+        let mut reasoning_content = String::new();
         let mut usage = TokenUsageData::default();
         let mut tool_calls: std::collections::BTreeMap<String, (String, String)> =
             std::collections::BTreeMap::new();
@@ -1372,6 +781,7 @@ fn consume_anthropic_stream(
             match event.map_err(map_llm_error)? {
                 ProviderStreamEvent::ReasoningDelta(delta) => {
                     if !delta.is_empty() {
+                        reasoning_content.push_str(&delta);
                         on_delta(&ModelStreamChunk {
                             content: String::new(),
                             reasoning_content: delta.clone(),
@@ -1426,13 +836,13 @@ fn consume_anthropic_stream(
             })
             .collect::<Vec<_>>();
 
-        if text.trim().is_empty() && tool_calls.is_empty() {
-            return Err(anyhow!("Anthropic 流式响应缺少文本和工具调用"));
+        if text.trim().is_empty() && reasoning_content.trim().is_empty() && tool_calls.is_empty() {
+            return Err(anyhow!("Anthropic 流式响应缺少文本、思考内容和工具调用"));
         }
 
         Ok(ModelFunctionResponse {
             text: text.trim().to_string(),
-            reasoning_content: String::new(),
+            reasoning_content: reasoning_content.trim().to_string(),
             usage: usage.into(),
             tool_calls,
         })
@@ -1468,7 +878,7 @@ fn consume_provider_stream(
         .block_on(provider.stream(request))
         .map_err(map_llm_error)?;
 
-    let response = consume_anthropic_stream(stream, on_delta)?;
+    let response = consume_provider_stream_events(stream, on_delta)?;
     Ok(ModelResponse {
         text: response.text,
         reasoning_content: response.reasoning_content,
@@ -1489,7 +899,7 @@ fn convert_stream_to_function_response(
         .context("初始化异步运行时失败")?
         .block_on(provider.stream(request))
         .map_err(map_llm_error)?;
-    consume_anthropic_stream(stream, on_delta)
+    consume_provider_stream_events(stream, on_delta)
 }
 
 fn map_llm_error(error: tiangong_llm::error::LlmError) -> anyhow::Error {
@@ -1508,209 +918,10 @@ fn allowed_file_roots_text() -> String {
     format!("{workspace}；{temp}")
 }
 
-/// 规范化 API 基础地址
-///
-/// 仅做基本清理（去空格、去尾部斜杠、去意外拼接的 /chat/completions），
-/// 不自动补充版本路径——版本由用户在 provider base_url 中指定。
-#[allow(dead_code)]
-fn normalize_api_base(base_url: &str) -> Result<String> {
-    let trimmed = base_url.trim();
-    if trimmed.is_empty() {
-        return Err(anyhow!("API_BASE_URL 不能为空"));
-    }
-
-    let cleaned = trimmed.trim_end_matches('/');
-    let cleaned = cleaned.strip_suffix("/chat/completions").unwrap_or(cleaned);
-    Ok(cleaned.to_string())
-}
-
-/// 创建禁用内部 backoff 的 OpenAI 客户端
-///
-/// async-openai 默认有 ExponentialBackoff（最长 15 分钟）。
-/// 禁用后由 `with_retry` 统一管理重试，确保 StreamEvent::Retry 能正确触发。
-#[allow(dead_code)]
-fn build_no_retry_client(config: OpenAIConfig) -> OpenAIClient<OpenAIConfig> {
-    // 设置极小的 max_elapsed_time 确保 async-openai 不做任何内部重试。
-    // Duration::ZERO 在 backoff 首次调用时 elapsed ≈ 0 可能仍允许 1 次重试，
-    // 使用 1ns 确保 elapsed > max_elapsed_time 立即停止。
-    let no_retry = backoff::ExponentialBackoff {
-        max_elapsed_time: Some(Duration::from_nanos(1)),
-        ..Default::default()
-    };
-    OpenAIClient::build(reqwest::Client::new(), config, no_retry)
-}
-
-#[allow(dead_code)]
-fn build_sdk_error_hint(error_text: &str) -> String {
-    if error_text.contains("/chat/completions") && error_text.contains("404") {
-        return "；请检查 API_BASE_URL 是否包含正确的版本路径（如 .../v1）".to_string();
-    }
-    if error_text.contains("expected struct ApiError") {
-        return "；当前网关返回的错误结构非 OpenAI 标准格式，请确认 API_BASE_URL 是否为 OpenAI 兼容接口".to_string();
-    }
-    String::new()
-}
-
 // ── 重试相关 ──────────────────────────────────────────────
 
 /// 最大重试次数
 const MAX_RETRIES: u32 = 3;
-/// 初始重试延迟（毫秒）
-const INITIAL_RETRY_DELAY_MS: u64 = 1000;
-/// 退避倍率
-const RETRY_BACKOFF_MULTIPLIER: u64 = 2;
-
-#[derive(Debug)]
-#[allow(dead_code)]
-struct HttpRetryError {
-    message: String,
-    retryable: bool,
-}
-
-impl HttpRetryError {
-    fn new(message: impl Into<String>, retryable: bool) -> Self {
-        Self {
-            message: message.into(),
-            retryable,
-        }
-    }
-}
-
-impl std::fmt::Display for HttpRetryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.message.fmt(f)
-    }
-}
-
-impl std::error::Error for HttpRetryError {}
-
-/// 判断 OpenAI SDK 错误是否可重试
-#[allow(dead_code)]
-fn is_retryable_openai_error(err: &async_openai::error::OpenAIError) -> bool {
-    is_retryable_error_text(&err.to_string())
-}
-
-#[allow(dead_code)]
-fn map_reqwest_retry_error(err: reqwest::Error) -> HttpRetryError {
-    let retryable = err.is_timeout() || err.is_connect() || err.is_request();
-    HttpRetryError::new(format!("HTTP 请求失败：{err}"), retryable)
-}
-
-/// 判断错误文本是否表示可重试的错误
-#[allow(dead_code)]
-fn is_retryable_error_text(text: &str) -> bool {
-    // 速率限制 (HTTP 429)
-    if text.contains("429")
-        || text.contains("Rate limit")
-        || text.contains("rate limit")
-        || text.contains("Rate limited")
-        || text.contains("访问量过大")
-        || text.contains("稍后再试")
-        || text.contains("too many requests")
-        || text.contains("Too Many Requests")
-    {
-        return true;
-    }
-    // 服务端错误 (5xx)
-    if text.contains("500 Internal Server Error")
-        || text.contains("502 Bad Gateway")
-        || text.contains("503 Service Unavailable")
-        || text.contains("504 Gateway Timeout")
-    {
-        return true;
-    }
-    // 连接错误
-    if text.contains("connection reset")
-        || text.contains("connection refused")
-        || text.contains("Connection reset")
-        || text.contains("Connection refused")
-    {
-        return true;
-    }
-    false
-}
-
-/// 带重试的异步调用（用于 OpenAI SDK 请求）
-///
-/// 遇到速率限制、5xx、连接错误时自动重试，采用指数退避策略。
-/// 可选的 `on_retry` 回调在每次重试前触发，用于通知上层。
-#[allow(dead_code)]
-async fn with_retry<F, Fut, T>(
-    label: &str,
-    on_retry: &Option<OnRetryCallback>,
-    mut f: F,
-) -> Result<T, async_openai::error::OpenAIError>
-where
-    F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = Result<T, async_openai::error::OpenAIError>>,
-{
-    let mut attempt = 0u32;
-    let mut delay_ms = INITIAL_RETRY_DELAY_MS;
-    loop {
-        match f().await {
-            Ok(result) => return Ok(result),
-            Err(err) => {
-                if attempt < MAX_RETRIES && is_retryable_openai_error(&err) {
-                    attempt += 1;
-                    let err_text = err.to_string();
-                    tracing::warn!(
-                        attempt = attempt,
-                        max_retries = MAX_RETRIES,
-                        delay_ms = delay_ms,
-                        error = %err_text,
-                        label = label,
-                        "LLM 请求失败，准备重试",
-                    );
-                    if let Some(cb) = on_retry {
-                        cb(attempt, MAX_RETRIES, delay_ms, &err_text);
-                    }
-                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-                    delay_ms *= RETRY_BACKOFF_MULTIPLIER;
-                } else {
-                    return Err(err);
-                }
-            }
-        }
-    }
-}
-
-#[allow(dead_code)]
-fn with_retry_http<F, T>(
-    label: &str,
-    on_retry: &Option<OnRetryCallback>,
-    mut f: F,
-) -> std::result::Result<T, HttpRetryError>
-where
-    F: FnMut() -> std::result::Result<T, HttpRetryError>,
-{
-    let mut attempt = 0u32;
-    let mut delay_ms = INITIAL_RETRY_DELAY_MS;
-    loop {
-        match f() {
-            Ok(result) => return Ok(result),
-            Err(err) => {
-                if attempt < MAX_RETRIES && err.retryable {
-                    attempt += 1;
-                    tracing::warn!(
-                        attempt = attempt,
-                        max_retries = MAX_RETRIES,
-                        delay_ms = delay_ms,
-                        error = %err,
-                        label = label,
-                        "LLM 请求失败，准备重试",
-                    );
-                    if let Some(cb) = on_retry {
-                        cb(attempt, MAX_RETRIES, delay_ms, &err.to_string());
-                    }
-                    std::thread::sleep(Duration::from_millis(delay_ms));
-                    delay_ms *= RETRY_BACKOFF_MULTIPLIER;
-                } else {
-                    return Err(err);
-                }
-            }
-        }
-    }
-}
 
 #[allow(dead_code)]
 fn extract_delta_text(delta: &Value, field: &str) -> String {

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -1,23 +1,33 @@
+use std::io::{BufRead, BufReader};
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::mcp::build_mcp_tools_system_prompt;
+use crate::session::{Message, MessageRole};
 use anyhow::{Context, Result, anyhow};
 use async_openai::Client as OpenAIClient;
 use async_openai::config::OpenAIConfig;
 use async_openai::types::chat::{
     ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
     ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
-    CreateChatCompletionRequestArgs, CreateChatCompletionResponse,
 };
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
+use tiangong_llm::message::{
+    ChatMessage, MessageContent as LlmMessageContent, MessageRole as LlmMessageRole,
+};
+use tiangong_llm::provider::LlmProvider;
+use tiangong_llm::providers::anthropic::{AnthropicConfig, AnthropicProvider};
+use tiangong_llm::providers::openai::{OpenAiCompatibleConfig, OpenAiCompatibleProvider};
+use tiangong_llm::request::ProviderRequest;
+use tiangong_llm::response::ProviderResponse;
+use tiangong_llm::stream::{ProviderStream, ProviderStreamEvent};
+use tiangong_llm::tool::{ToolCall as LlmToolCall, ToolChoice as LlmToolChoice, ToolSpec};
+use tiangong_llm::usage::TokenUsageData;
 use tokio::runtime::Builder as TokioRuntimeBuilder;
-use tokio::time::timeout;
 
-use crate::mcp::build_mcp_tools_system_prompt;
-use crate::session::{Message, MessageRole};
-
+pub use tiangong_llm::ProviderProtocol;
 pub use tiangong_types::TokenUsage;
 
 #[derive(Debug, Clone)]
@@ -92,6 +102,8 @@ pub struct ModelProviderConfig {
     pub api_base_url: String,
     #[serde(rename = "API_TIMEOUT_MS", default = "default_api_timeout_ms")]
     pub api_timeout_ms: String,
+    #[serde(rename = "API_PROTOCOL", default)]
+    pub api_protocol: ProviderProtocol,
     #[serde(rename = "API_MODEL", default = "default_api_model")]
     pub api_model: String,
     #[serde(rename = "API_LITE_MODEL", default)]
@@ -105,12 +117,17 @@ impl ModelProviderConfig {
         let api_base_url = std::env::var("API_BASE_URL").unwrap_or_else(|_| default_api_base_url());
         let api_timeout_ms =
             std::env::var("API_TIMEOUT_MS").unwrap_or_else(|_| default_api_timeout_ms());
+        let api_protocol = std::env::var("API_PROTOCOL")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or_default();
         let api_model = std::env::var("API_MODEL").unwrap_or_else(|_| default_api_model());
         let api_lite_model = std::env::var("API_LITE_MODEL").unwrap_or_default();
         Self {
             api_auth_token,
             api_base_url,
             api_timeout_ms,
+            api_protocol,
             api_model,
             api_lite_model,
         }
@@ -238,48 +255,115 @@ impl SingleProviderClient {
         }
 
         let timeout_ms = parse_timeout_ms(&cfg.api_timeout_ms)?;
-        let api_base = normalize_api_base(&cfg.api_base_url)?;
-
-        // 直接发 HTTP 请求而非使用 SDK 的 models().list()，
-        // 因为部分 API 供应商（如 DeepSeek）返回的模型对象缺少 `created` 等字段，
-        // SDK 的严格反序列化会失败。
-        let url = format!("{api_base}/models");
-        let http_client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_millis(timeout_ms))
+        if cfg.api_protocol == ProviderProtocol::Anthropic {
+            let provider = build_anthropic_provider_from_config(cfg, timeout_ms, None)?;
+            let runtime = TokioRuntimeBuilder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("初始化异步运行时失败")?;
+            let mut models = runtime
+                .block_on(provider.list_models())
+                .map(|items| items.into_iter().map(|item| item.id).collect::<Vec<_>>())
+                .map_err(map_llm_error)?;
+            models.sort();
+            models.dedup();
+            return Ok(models);
+        }
+        let provider = build_openai_provider_from_config(cfg, timeout_ms, None)?;
+        let runtime = TokioRuntimeBuilder::new_current_thread()
+            .enable_all()
             .build()
-            .context("创建 HTTP 客户端失败")?;
-
-        let resp = http_client
-            .get(&url)
-            .header("Authorization", format!("Bearer {token}"))
-            .send()
-            .with_context(|| format!("请求模型列表失败：{url}"))?;
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().unwrap_or_default();
-            return Err(anyhow!("获取模型列表失败：HTTP {status}，响应：{body}"));
-        }
-
-        let body = resp.text().context("读取模型列表响应失败")?;
-
-        // 宽松反序列化：只需要 id 字段
-        #[derive(serde::Deserialize)]
-        struct ModelEntry {
-            id: String,
-        }
-        #[derive(serde::Deserialize)]
-        struct ModelsResponse {
-            data: Vec<ModelEntry>,
-        }
-
-        let parsed: ModelsResponse = serde_json::from_str(&body)
-            .with_context(|| format!("failed to deserialize api response: {body}"))?;
-
-        let mut models = parsed.data.into_iter().map(|m| m.id).collect::<Vec<_>>();
+            .context("初始化异步运行时失败")?;
+        let mut models = runtime
+            .block_on(provider.list_models())
+            .map(|items| items.into_iter().map(|item| item.id).collect::<Vec<_>>())
+            .map_err(map_llm_error)?;
         models.sort();
         models.dedup();
         Ok(models)
+    }
+
+    fn protocol(&self) -> ProviderProtocol {
+        self.cfg.api_protocol
+    }
+
+    fn build_anthropic_provider(&self, timeout_ms: u64) -> Result<AnthropicProvider> {
+        build_anthropic_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())
+    }
+
+    fn block_on_llm<F, T>(&self, future: F) -> Result<T>
+    where
+        F: std::future::Future<Output = std::result::Result<T, tiangong_llm::error::LlmError>>,
+    {
+        let runtime = TokioRuntimeBuilder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("初始化异步运行时失败")?;
+        runtime.block_on(future).map_err(map_llm_error)
+    }
+
+    fn complete_anthropic(&self, req: &ModelRequest) -> Result<ModelResponse> {
+        let response = self.complete_with_functions_anthropic(req, &[])?;
+        Ok(ModelResponse {
+            text: response.text,
+            reasoning_content: response.reasoning_content,
+            usage: response.usage,
+            output_mode: "anthropic-non-stream".to_string(),
+            output_chunk_count: 1,
+        })
+    }
+
+    fn complete_with_functions_anthropic(
+        &self,
+        req: &ModelRequest,
+        functions: &[FunctionToolSpec],
+    ) -> Result<ModelFunctionResponse> {
+        let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
+        let model = self.cfg.api_model.trim();
+        if model.is_empty() {
+            return Err(anyhow!("API_MODEL 不能为空，无法发起 Anthropic 请求"));
+        }
+
+        let provider = self.build_anthropic_provider(timeout_ms)?;
+        let request =
+            build_anthropic_provider_request(req, model, anthropic_max_tokens(), functions);
+        let response = self.block_on_llm(provider.complete(request))?;
+        convert_provider_response_to_function_response(response)
+    }
+
+    fn complete_lite_anthropic(&self, prompt: &str) -> Result<String> {
+        let timeout_ms = 30_000u64;
+        let model = self.cfg.lite_model().trim();
+        if model.is_empty() {
+            return Err(anyhow!(
+                "API_MODEL 不能为空，无法发起 Anthropic 轻量模型请求"
+            ));
+        }
+
+        let provider = self.build_anthropic_provider(timeout_ms)?;
+        let request = ProviderRequest {
+            model: model.to_string(),
+            system: Some(
+                "你是会话标题生成助手。根据用户输入生成简洁的标题，要求：\
+1. 标题不超过10个汉字\
+2. 直接返回标题，不要任何解释或额外文字\
+3. 标题要概括性强，简洁明了"
+                    .to_string(),
+            ),
+            messages: vec![ChatMessage::text(LlmMessageRole::User, prompt)],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: Some(200),
+            temperature: Some(0.3),
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+        };
+        let response = self.block_on_llm(provider.complete(request))?;
+        let text = strip_think_tags(&collect_provider_text(&response))
+            .trim()
+            .to_string();
+        Ok(text)
     }
 
     pub fn complete_stream_with_callback<F>(
@@ -290,222 +374,21 @@ impl SingleProviderClient {
     where
         F: FnMut(&ModelStreamChunk),
     {
-        let token = self.cfg.api_auth_token.trim();
-        if token.is_empty() {
-            return Err(anyhow!("API_AUTH_TOKEN 不能为空，无法发起流式模型请求"));
-        }
-
         let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
         let model = self.cfg.api_model.trim();
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起流式模型请求"));
         }
-
-        let api_base = normalize_api_base(&self.cfg.api_base_url)?;
-        let messages = build_openai_messages(req)?;
-        let mut request_args_binding = CreateChatCompletionRequestArgs::default();
-        let mut request_args = request_args_binding
-            .model(model.to_string())
-            .messages(messages);
-        if let Some(max_tokens) = configured_max_tokens() {
-            request_args = request_args.max_tokens(max_tokens);
-        }
-        let mut request = request_args.build().context("构建 OpenAI 流式请求失败")?;
-        request.stream = Some(true);
-
-        let config = OpenAIConfig::new()
-            .with_api_key(token.to_string())
-            .with_api_base(api_base);
-        let client = build_no_retry_client(config);
-        let mut request_json = serde_json::to_value(&request).context("序列化流式请求失败")?;
-        inject_temperature_config(&mut request_json);
-        inject_thinking_config(&mut request_json);
-        inject_stream_usage_option(&mut request_json);
-
-        let runtime = TokioRuntimeBuilder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("初始化异步运行时失败")?;
-
-        let response = runtime.block_on(async {
-            timeout(Duration::from_millis(timeout_ms), async {
-                let chat = client.chat();
-                let mut stream = with_retry("流式模型请求", &self.on_retry, || {
-                    chat.create_stream_byot::<_, Value>(request_json.clone())
-                })
-                .await?;
-                let mut content = String::new();
-                let mut reasoning_content = String::new();
-                let mut chunks = 0usize;
-                let mut has_think_output = false;
-                let mut stream_usage = (0usize, 0usize, 0usize); // (prompt, completion, total)
-                let mut think_filter = ThinkTagFilter::new();
-
-                while let Some(item) = stream.next().await {
-                    let payload = match item {
-                        Ok(payload) => payload,
-                        Err(err) => {
-                            if let async_openai::error::OpenAIError::JSONDeserialize(_, raw) = &err
-                                && should_skip_stream_payload(raw)
-                            {
-                                continue;
-                            }
-                            return Err(err);
-                        }
-                    };
-
-                    // 提取流式最后 chunk 中的 usage 数据
-                    if let Some(usage) = payload.get("usage") {
-                        if let Some(v) = usage.get("prompt_tokens").and_then(Value::as_u64) {
-                            stream_usage.0 = v as usize;
-                        }
-                        if let Some(v) = usage.get("completion_tokens").and_then(Value::as_u64) {
-                            stream_usage.1 = v as usize;
-                        }
-                        if let Some(v) = usage.get("total_tokens").and_then(Value::as_u64) {
-                            stream_usage.2 = v as usize;
-                        }
-                    }
-
-                    if let Some(choices) = payload.get("choices").and_then(Value::as_array) {
-                        for choice in choices {
-                            let delta = choice.get("delta").unwrap_or(&Value::Null);
-
-                            let think_delta = extract_delta_text(delta, "reasoning_content");
-                            if !think_delta.is_empty() {
-                                has_think_output = true;
-                                push_stream_piece(
-                                    ModelStreamChunk {
-                                        content: String::new(),
-                                        reasoning_content: think_delta.clone(),
-                                    },
-                                    &mut on_delta,
-                                    &mut content,
-                                    &mut reasoning_content,
-                                    &mut chunks,
-                                );
-                            }
-
-                            let content_delta = extract_delta_text(delta, "content");
-                            if !content_delta.is_empty() {
-                                let (filtered_content, filtered_reasoning) =
-                                    think_filter.filter(&content_delta);
-                                if !filtered_reasoning.is_empty() {
-                                    has_think_output = true;
-                                    push_stream_piece(
-                                        ModelStreamChunk {
-                                            content: String::new(),
-                                            reasoning_content: filtered_reasoning,
-                                        },
-                                        &mut on_delta,
-                                        &mut content,
-                                        &mut reasoning_content,
-                                        &mut chunks,
-                                    );
-                                }
-                                if !filtered_content.is_empty() {
-                                    push_stream_piece(
-                                        ModelStreamChunk {
-                                            content: filtered_content,
-                                            reasoning_content: String::new(),
-                                        },
-                                        &mut on_delta,
-                                        &mut content,
-                                        &mut reasoning_content,
-                                        &mut chunks,
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // 刷出 <think> 过滤器缓冲区残留
-                let (flush_content, flush_reasoning) = think_filter.flush();
-                if !flush_reasoning.is_empty() {
-                    push_stream_piece(
-                        ModelStreamChunk {
-                            content: String::new(),
-                            reasoning_content: flush_reasoning,
-                        },
-                        &mut on_delta,
-                        &mut content,
-                        &mut reasoning_content,
-                        &mut chunks,
-                    );
-                }
-                if !flush_content.is_empty() {
-                    push_stream_piece(
-                        ModelStreamChunk {
-                            content: flush_content,
-                            reasoning_content: String::new(),
-                        },
-                        &mut on_delta,
-                        &mut content,
-                        &mut reasoning_content,
-                        &mut chunks,
-                    );
-                }
-
-                Ok::<
-                    (String, String, usize, bool, (usize, usize, usize)),
-                    async_openai::error::OpenAIError,
-                >((
-                    content,
-                    reasoning_content,
-                    chunks,
-                    has_think_output,
-                    stream_usage,
-                ))
-            })
-            .await
-        });
-
-        let byot_outcome = match response {
-            Ok(Ok(payload)) => Some(payload),
-            Ok(Err(_)) => None,
-            Err(_) => None,
-        };
-
-        if let Some((text, reasoning_content, chunks, has_think_output, stream_usage)) =
-            byot_outcome
-        {
-            let text = text.trim().to_string();
-            let reasoning_content = reasoning_content.trim().to_string();
-            if (!text.is_empty() || !reasoning_content.is_empty()) && chunks > 0 {
-                return Ok(ModelResponse {
-                    text,
-                    reasoning_content,
-                    usage: TokenUsage {
-                        prompt_tokens: stream_usage.0,
-                        completion_tokens: stream_usage.1,
-                        total_tokens: stream_usage.2,
-                    },
-                    output_mode: if has_think_output {
-                        "stream-think".to_string()
-                    } else {
-                        "stream".to_string()
-                    },
-                    output_chunk_count: chunks.max(1),
-                });
+        let request = build_provider_request(req, model, anthropic_max_tokens(), &[]);
+        let provider = match self.protocol() {
+            ProviderProtocol::Anthropic => {
+                ProviderDispatch::Anthropic(Box::new(self.build_anthropic_provider(timeout_ms)?))
             }
-        }
-
-        // 当流式 BYOT 路径失败时，转为非流式补偿请求，避免吞掉 reasoning_content。
-        let fallback_resp = self.complete(req)?;
-        if !fallback_resp.reasoning_content.is_empty() {
-            on_delta(&ModelStreamChunk {
-                content: String::new(),
-                reasoning_content: fallback_resp.reasoning_content.clone(),
-            });
-        }
-        if !fallback_resp.text.is_empty() {
-            on_delta(&ModelStreamChunk {
-                content: fallback_resp.text.clone(),
-                reasoning_content: String::new(),
-            });
-        }
-        Ok(fallback_resp)
+            ProviderProtocol::OpenAiCompatible => ProviderDispatch::OpenAi(Box::new(
+                build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?,
+            )),
+        };
+        consume_provider_stream(provider, request, &mut on_delta)
     }
 
     /// 流式函数调用：实时输出 thinking，同时累积 tool_calls
@@ -515,386 +398,57 @@ impl SingleProviderClient {
         functions: &[FunctionToolSpec],
         on_delta: &mut dyn FnMut(&ModelStreamChunk),
     ) -> Result<ModelFunctionResponse> {
-        let token = self.cfg.api_auth_token.trim();
-        if token.is_empty() {
-            return Err(anyhow!("API_AUTH_TOKEN 不能为空，无法发起流式工具模型请求"));
-        }
-
         let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
         let model = self.cfg.api_model.trim();
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起流式工具模型请求"));
         }
-
-        let api_base = normalize_api_base(&self.cfg.api_base_url)?;
-        let messages = build_openai_messages(req)?;
-        let mut request_args_binding = CreateChatCompletionRequestArgs::default();
-        let request_args = request_args_binding
-            .model(model.to_string())
-            .messages(messages);
-        let mut request = request_args
-            .build()
-            .context("构建流式 function call 请求失败")?;
-        request.stream = Some(true);
-
-        let config = OpenAIConfig::new()
-            .with_api_key(token.to_string())
-            .with_api_base(api_base);
-        let client = build_no_retry_client(config);
-        let mut request_json = serde_json::to_value(&request).context("序列化请求失败")?;
-        inject_temperature_config(&mut request_json);
-        inject_thinking_config(&mut request_json);
-        inject_stream_usage_option(&mut request_json);
-        inject_function_tools(&mut request_json, functions);
-
-        let runtime = TokioRuntimeBuilder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("初始化异步运行时失败")?;
-
-        let response = runtime.block_on(async {
-            timeout(Duration::from_millis(timeout_ms), async {
-                let chat = client.chat();
-                let mut stream = with_retry("流式工具调用", &self.on_retry, || {
-                    chat.create_stream_byot::<_, Value>(request_json.clone())
-                })
-                .await?;
-
-                let mut content = String::new();
-                let mut reasoning_content = String::new();
-                // tool_calls 按 index 累积：index -> (id, name, arguments)
-                let mut tool_calls_map: std::collections::BTreeMap<u64, (String, String, String)> =
-                    std::collections::BTreeMap::new();
-                let mut stream_usage = (0usize, 0usize, 0usize);
-                let mut think_filter = ThinkTagFilter::new();
-
-                while let Some(item) = stream.next().await {
-                    let payload = match item {
-                        Ok(payload) => payload,
-                        Err(err) => {
-                            if let async_openai::error::OpenAIError::JSONDeserialize(_, raw) = &err
-                                && should_skip_stream_payload(raw)
-                            {
-                                continue;
-                            }
-                            return Err(err);
-                        }
-                    };
-
-                    // 提取流式最后 chunk 中的 usage 数据
-                    if let Some(usage) = payload.get("usage") {
-                        if let Some(v) = usage.get("prompt_tokens").and_then(Value::as_u64) {
-                            stream_usage.0 = v as usize;
-                        }
-                        if let Some(v) = usage.get("completion_tokens").and_then(Value::as_u64) {
-                            stream_usage.1 = v as usize;
-                        }
-                        if let Some(v) = usage.get("total_tokens").and_then(Value::as_u64) {
-                            stream_usage.2 = v as usize;
-                        }
-                    }
-
-                    if let Some(choices) = payload.get("choices").and_then(Value::as_array) {
-                        for choice in choices {
-                            let delta = choice.get("delta").unwrap_or(&Value::Null);
-
-                            // 流式输出 reasoning_content（API 原生字段）
-                            let think_delta = extract_delta_text(delta, "reasoning_content");
-                            if !think_delta.is_empty() {
-                                reasoning_content.push_str(&think_delta);
-                                on_delta(&ModelStreamChunk {
-                                    content: String::new(),
-                                    reasoning_content: think_delta,
-                                });
-                            }
-
-                            // 流式输出 content（经 <think> 标签过滤）
-                            let content_delta = extract_delta_text(delta, "content");
-                            if !content_delta.is_empty() {
-                                let (filtered_content, filtered_reasoning) =
-                                    think_filter.filter(&content_delta);
-                                if !filtered_reasoning.is_empty() {
-                                    reasoning_content.push_str(&filtered_reasoning);
-                                    on_delta(&ModelStreamChunk {
-                                        content: String::new(),
-                                        reasoning_content: filtered_reasoning,
-                                    });
-                                }
-                                if !filtered_content.is_empty() {
-                                    content.push_str(&filtered_content);
-                                    on_delta(&ModelStreamChunk {
-                                        content: filtered_content,
-                                        reasoning_content: String::new(),
-                                    });
-                                }
-                            }
-
-                            // 累积 tool_calls
-                            if let Some(tool_calls) =
-                                delta.get("tool_calls").and_then(Value::as_array)
-                            {
-                                for tc in tool_calls {
-                                    let index =
-                                        tc.get("index").and_then(Value::as_u64).unwrap_or(0);
-                                    let entry = tool_calls_map.entry(index).or_insert_with(|| {
-                                        (String::new(), String::new(), String::new())
-                                    });
-                                    if let Some(id) = tc.get("id").and_then(Value::as_str) {
-                                        entry.0 = id.to_string();
-                                    }
-                                    if let Some(func) = tc.get("function") {
-                                        if let Some(name) = func.get("name").and_then(Value::as_str)
-                                        {
-                                            entry.1 = name.to_string();
-                                        }
-                                        if let Some(args) =
-                                            func.get("arguments").and_then(Value::as_str)
-                                        {
-                                            entry.2.push_str(args);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // 刷出 <think> 过滤器缓冲区残留
-                let (flush_content, flush_reasoning) = think_filter.flush();
-                if !flush_reasoning.is_empty() {
-                    reasoning_content.push_str(&flush_reasoning);
-                    on_delta(&ModelStreamChunk {
-                        content: String::new(),
-                        reasoning_content: flush_reasoning,
-                    });
-                }
-                if !flush_content.is_empty() {
-                    content.push_str(&flush_content);
-                    on_delta(&ModelStreamChunk {
-                        content: flush_content,
-                        reasoning_content: String::new(),
-                    });
-                }
-
-                Ok::<_, async_openai::error::OpenAIError>((
-                    content,
-                    reasoning_content,
-                    tool_calls_map,
-                    stream_usage,
-                ))
-            })
-            .await
-        });
-
-        match response {
-            Ok(Ok((text, reasoning, tool_calls_map, stream_usage))) => {
-                let tool_calls = tool_calls_map
-                    .into_values()
-                    .filter(|(_, name, _)| !name.is_empty())
-                    .map(|(id, name, args)| {
-                        let arguments = serde_json::from_str::<Value>(&args)
-                            .ok()
-                            .filter(|v| v.is_object())
-                            .unwrap_or_else(|| Value::Object(Map::new()));
-                        ModelFunctionCall {
-                            id,
-                            name,
-                            arguments,
-                        }
-                    })
-                    .collect::<Vec<_>>();
-
-                let text = text.trim().to_string();
-                let reasoning_content = reasoning.trim().to_string();
-
-                if text.is_empty() && reasoning_content.is_empty() && tool_calls.is_empty() {
-                    // 流式路径未获取到有效内容，回退到非流式
-                    let fallback = self.complete_with_functions(req, functions)?;
-                    if !fallback.reasoning_content.is_empty() {
-                        on_delta(&ModelStreamChunk {
-                            content: String::new(),
-                            reasoning_content: fallback.reasoning_content.clone(),
-                        });
-                    }
-                    return Ok(fallback);
-                }
-
-                Ok(ModelFunctionResponse {
-                    text,
-                    reasoning_content,
-                    usage: TokenUsage {
-                        prompt_tokens: stream_usage.0,
-                        completion_tokens: stream_usage.1,
-                        total_tokens: stream_usage.2,
-                    },
-                    tool_calls,
-                })
+        let request = build_provider_request(req, model, anthropic_max_tokens(), functions);
+        let provider = match self.protocol() {
+            ProviderProtocol::Anthropic => {
+                ProviderDispatch::Anthropic(Box::new(self.build_anthropic_provider(timeout_ms)?))
             }
-            _ => {
-                // 流式失败，回退到非流式
-                let fallback = self.complete_with_functions(req, functions)?;
-                if !fallback.reasoning_content.is_empty() {
-                    on_delta(&ModelStreamChunk {
-                        content: String::new(),
-                        reasoning_content: fallback.reasoning_content.clone(),
-                    });
-                }
-                Ok(fallback)
-            }
-        }
+            ProviderProtocol::OpenAiCompatible => ProviderDispatch::OpenAi(Box::new(
+                build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?,
+            )),
+        };
+        convert_stream_to_function_response(provider, request, on_delta)
     }
 
     /// 使用轻量级模型完成简单任务（如会话名称生成）
     /// 如果未配置轻量级模型，则使用主模型
     /// 该方法使用更短的超时时间和较低温度以获得更确定的结果
     pub fn complete_lite(&self, prompt: &str) -> Result<String> {
-        use tracing::{info, warn};
-
-        let token = self.cfg.api_auth_token.trim();
-        if token.is_empty() {
-            return Err(anyhow!("API_AUTH_TOKEN 不能为空，无法发起轻量级模型请求"));
+        if self.protocol() == ProviderProtocol::Anthropic {
+            return self.complete_lite_anthropic(prompt);
         }
-
-        // 轻量级任务使用更短的超时（30 秒）
         let timeout_ms = 30_000u64;
-        // lite_model() 会自动回退到主模型
         let model = self.cfg.lite_model().trim();
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起轻量级模型请求"));
         }
-
-        info!(
-            model = %model,
-            lite_model_config = %self.cfg.api_lite_model,
-            timeout_ms = timeout_ms,
-            prompt_length = prompt.len(),
-            "开始调用轻量级模型"
-        );
-
-        let api_base = normalize_api_base(&self.cfg.api_base_url)?;
-
-        let messages = vec![
-            ChatCompletionRequestSystemMessageArgs::default()
-                .content(
-                    "你是会话标题生成助手。根据用户输入生成简洁的标题，要求：\
+        let provider =
+            build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?;
+        let request = ProviderRequest {
+            model: model.to_string(),
+            system: Some(
+                "你是会话标题生成助手。根据用户输入生成简洁的标题，要求：\
                     1. 标题不超过10个汉字\
                     2. 直接返回标题，不要任何解释或额外文字\
-                    3. 标题要概括性强，简洁明了",
-                )
-                .build()
-                .context("构建 system 消息失败")?
-                .into(),
-            ChatCompletionRequestUserMessageArgs::default()
-                .content(prompt.to_string())
-                .build()
-                .context("构建 user 消息失败")?
-                .into(),
-        ];
-
-        let mut request_args_binding = CreateChatCompletionRequestArgs::default();
-        // max_tokens 设大一些：模型可能先输出 <think> 再输出标题，
-        // 过小会导致 thinking 耗光 token 而标题截断
-        let request = request_args_binding
-            .model(model.to_string())
-            .messages(messages)
-            .max_tokens(200u16)
-            .temperature(0.3f32)
-            .stream(false)
-            .build()
-            .context("构建轻量级请求失败")?;
-
-        let config = OpenAIConfig::new()
-            .with_api_key(token.to_string())
-            .with_api_base(api_base);
-        let client = build_no_retry_client(config);
-
-        let runtime = TokioRuntimeBuilder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("初始化异步运行时失败")?;
-
-        let mut request_json = serde_json::to_value(&request).context("序列化轻量级请求失败")?;
-        // 显式关闭 thinking（GLM/DeepSeek 支持，MiniMax 等不支持）
-        if let Some(obj) = request_json.as_object_mut() {
-            obj.insert(
-                "thinking".to_string(),
-                serde_json::json!({ "type": "disabled" }),
-            );
-        }
-        let chat = client.chat();
-        let response = runtime.block_on(async {
-            let result = timeout(
-                Duration::from_millis(timeout_ms),
-                with_retry("轻量级模型", &self.on_retry, || {
-                    chat.create_byot::<_, CreateChatCompletionResponse>(request_json.clone())
-                }),
-            )
-            .await;
-
-            // 如果带 thinking 字段请求失败（API 不支持），去掉 thinking 重试
-            if matches!(&result, Ok(Err(_))) {
-                let mut fallback_json = request_json.clone();
-                if let Some(obj) = fallback_json.as_object_mut() {
-                    obj.remove("thinking");
-                }
-                tracing::info!("轻量级模型请求失败，去掉 thinking 字段重试");
-                return timeout(
-                    Duration::from_millis(timeout_ms),
-                    chat.create_byot::<_, CreateChatCompletionResponse>(fallback_json),
-                )
-                .await;
-            }
-            result
-        });
-
-        let resp = match response {
-            Ok(Ok(resp)) => resp,
-            Ok(Err(err)) => {
-                let hint = build_sdk_error_hint(&err.to_string());
-                tracing::error!(
-                    model = %model,
-                    error = %err,
-                    timeout_ms = %timeout_ms,
-                    "轻量级模型请求失败",
-                );
-                return Err(anyhow!("轻量级模型请求失败：{err}{hint}"));
-            }
-            Err(_) => {
-                tracing::error!(
-                    model = %model,
-                    timeout_ms = %timeout_ms,
-                    "轻量级模型请求超时",
-                );
-                return Err(anyhow!("轻量级模型请求超时：{timeout_ms}ms"));
-            }
+                    3. 标题要概括性强，简洁明了"
+                    .to_string(),
+            ),
+            messages: vec![ChatMessage::text(LlmMessageRole::User, prompt)],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: Some(200),
+            temperature: Some(0.3),
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
         };
-
-        let raw_text = resp
-            .choices
-            .first()
-            .and_then(|choice| choice.message.content.as_deref())
-            .unwrap_or("")
-            .trim();
-
-        // 清理 <think>...</think> 标签（部分模型忽略 thinking.disabled 配置）
-        let text = strip_think_tags(raw_text).trim().to_string();
-
-        if text.is_empty() {
-            warn!(
-                model = %model,
-                response = ?resp,
-                "轻量级模型返回空响应",
-            );
-        } else {
-            info!(
-                model = %model,
-                response_length = text.len(),
-                response_preview = %text.chars().take(20).collect::<String>(),
-                "轻量级模型返回成功",
-            );
-        }
-
-        Ok(text)
+        let response = self.block_on_llm(provider.complete(request))?;
+        Ok(collect_provider_text(&response).trim().to_string())
     }
 }
 
@@ -920,9 +474,8 @@ impl ModelClient for SingleProviderClient {
     }
 
     fn complete(&self, req: &ModelRequest) -> Result<ModelResponse> {
-        let token = self.cfg.api_auth_token.trim();
-        if token.is_empty() {
-            return Err(anyhow!("API_AUTH_TOKEN 不能为空，无法发起模型请求"));
+        if self.protocol() == ProviderProtocol::Anthropic {
+            return self.complete_anthropic(req);
         }
 
         let timeout_ms = parse_timeout_ms(&self.cfg.api_timeout_ms)?;
@@ -930,91 +483,14 @@ impl ModelClient for SingleProviderClient {
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起模型请求"));
         }
-
-        let api_base = normalize_api_base(&self.cfg.api_base_url)?;
-        let messages = build_openai_messages(req)?;
-        let mut request_args_binding = CreateChatCompletionRequestArgs::default();
-        let mut request_args = request_args_binding
-            .model(model.to_string())
-            .messages(messages);
-        if let Some(max_tokens) = configured_max_tokens() {
-            request_args = request_args.max_tokens(max_tokens);
-        }
-        let mut request = request_args.build().context("构建 OpenAI 请求失败")?;
-        request.stream = Some(false);
-        let request_for_fallback = request.clone();
-
-        let config = OpenAIConfig::new()
-            .with_api_key(token.to_string())
-            .with_api_base(api_base);
-        let client = build_no_retry_client(config);
-        let mut request_json = serde_json::to_value(&request).context("序列化请求失败")?;
-        inject_temperature_config(&mut request_json);
-        inject_thinking_config(&mut request_json);
-
-        let runtime = TokioRuntimeBuilder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("初始化异步运行时失败")?;
-
-        let chat = client.chat();
-        let response = runtime.block_on(async {
-            timeout(
-                Duration::from_millis(timeout_ms),
-                with_retry("模型请求", &self.on_retry, || {
-                    chat.create_byot::<_, Value>(request_json.clone())
-                }),
-            )
-            .await
-        });
-
-        if let Ok(Ok(payload)) = response
-            && let Some(resp) = parse_non_stream_byot_response(&payload)
-        {
-            return Ok(resp);
-        }
-
-        let response = runtime.block_on(async {
-            timeout(
-                Duration::from_millis(timeout_ms),
-                with_retry("模型请求回退", &self.on_retry, || {
-                    chat.create(request_for_fallback.clone())
-                }),
-            )
-            .await
-        });
-
-        let response = match response {
-            Ok(Ok(resp)) => resp,
-            Ok(Err(err)) => {
-                let hint = build_sdk_error_hint(&err.to_string());
-                return Err(anyhow!("OpenAI SDK 请求失败：{err}{hint}"));
-            }
-            Err(_) => return Err(anyhow!("模型请求超时：{timeout_ms}ms")),
-        };
-
-        let text = response
-            .choices
-            .first()
-            .and_then(|choice| choice.message.content.as_deref())
-            .map(str::trim)
-            .filter(|v| !v.is_empty())
-            .map(|v| v.to_string())
-            .ok_or_else(|| anyhow!("模型响应缺少文本内容"))?;
-
-        let usage = response.usage.as_ref();
-        let prompt_tokens = usage.map(|u| u.prompt_tokens as usize).unwrap_or(0);
-        let completion_tokens = usage.map(|u| u.completion_tokens as usize).unwrap_or(0);
-        let total_tokens = usage.map(|u| u.total_tokens as usize).unwrap_or(0);
-
+        let provider =
+            build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?;
+        let request = build_provider_request(req, model, anthropic_max_tokens(), &[]);
+        let response = self.block_on_llm(provider.complete(request))?;
         Ok(ModelResponse {
-            text,
-            reasoning_content: String::new(),
-            usage: TokenUsage {
-                prompt_tokens,
-                completion_tokens,
-                total_tokens,
-            },
+            text: collect_provider_text(&response).trim().to_string(),
+            reasoning_content: response.reasoning_content.unwrap_or_default(),
+            usage: response.usage.unwrap_or_default().into(),
             output_mode: "non-stream".to_string(),
             output_chunk_count: 1,
         })
@@ -1025,9 +501,8 @@ impl ModelClient for SingleProviderClient {
         req: &ModelRequest,
         functions: &[FunctionToolSpec],
     ) -> Result<ModelFunctionResponse> {
-        let token = self.cfg.api_auth_token.trim();
-        if token.is_empty() {
-            return Err(anyhow!("API_AUTH_TOKEN 不能为空，无法发起工具模型请求"));
+        if self.protocol() == ProviderProtocol::Anthropic {
+            return self.complete_with_functions_anthropic(req, functions);
         }
 
         let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
@@ -1035,51 +510,11 @@ impl ModelClient for SingleProviderClient {
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起工具模型请求"));
         }
-
-        let api_base = normalize_api_base(&self.cfg.api_base_url)?;
-        let messages = build_openai_messages(req)?;
-        let mut request_args_binding = CreateChatCompletionRequestArgs::default();
-        let request_args = request_args_binding
-            .model(model.to_string())
-            .messages(messages);
-        let mut request = request_args
-            .build()
-            .context("构建 function call 请求失败")?;
-        request.stream = Some(false);
-
-        let config = OpenAIConfig::new()
-            .with_api_key(token.to_string())
-            .with_api_base(api_base);
-        let client = build_no_retry_client(config);
-        let mut request_json = serde_json::to_value(&request).context("序列化请求失败")?;
-        inject_temperature_config(&mut request_json);
-        inject_thinking_config(&mut request_json);
-        inject_function_tools(&mut request_json, functions);
-
-        let runtime = TokioRuntimeBuilder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("初始化异步运行时失败")?;
-
-        let chat = client.chat();
-        let response = runtime.block_on(async {
-            timeout(
-                Duration::from_millis(timeout_ms),
-                with_retry("工具调用", &self.on_retry, || {
-                    chat.create_byot::<_, Value>(request_json.clone())
-                }),
-            )
-            .await
-        });
-
-        match response {
-            Ok(Ok(payload)) => parse_function_byot_response(&payload),
-            Ok(Err(err)) => {
-                let hint = build_sdk_error_hint(&err.to_string());
-                Err(anyhow!("OpenAI SDK 工具调用请求失败：{err}{hint}"))
-            }
-            Err(_) => Err(anyhow!("工具调用请求超时：{timeout_ms}ms")),
-        }
+        let provider =
+            build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?;
+        let request = build_provider_request(req, model, anthropic_max_tokens(), functions);
+        let response = self.block_on_llm(provider.complete(request))?;
+        convert_provider_response_to_function_response(response)
     }
 
     fn complete_with_functions_stream(
@@ -1128,6 +563,7 @@ impl ModelClient for SingleProviderClient {
     }
 }
 
+#[allow(dead_code)]
 fn build_openai_messages(req: &ModelRequest) -> Result<Vec<ChatCompletionRequestMessage>> {
     let mut messages = Vec::new();
 
@@ -1229,6 +665,837 @@ fn build_openai_messages(req: &ModelRequest) -> Result<Vec<ChatCompletionRequest
     Ok(messages)
 }
 
+#[allow(dead_code)]
+fn build_anthropic_request_body(
+    req: &ModelRequest,
+    model: &str,
+    max_tokens: u32,
+    functions: &[FunctionToolSpec],
+    stream: bool,
+) -> Result<Value> {
+    let (system, messages) = build_anthropic_messages(req)?;
+    let mut body = json!({
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": messages,
+    });
+
+    if !system.is_empty() {
+        body["system"] = Value::String(system);
+    }
+    if stream {
+        body["stream"] = Value::Bool(true);
+    }
+    if !functions.is_empty() {
+        body["tools"] = Value::Array(
+            functions
+                .iter()
+                .map(|tool| {
+                    json!({
+                        "name": tool.name,
+                        "description": tool.description,
+                        "input_schema": tool.parameters,
+                    })
+                })
+                .collect(),
+        );
+    }
+
+    Ok(body)
+}
+
+#[allow(dead_code)]
+fn build_anthropic_messages(req: &ModelRequest) -> Result<(String, Vec<Value>)> {
+    let mut messages = Vec::new();
+
+    let system_texts = if let Some(ref assembled) = req.assembled_system_prompt {
+        let mut texts = vec![assembled.clone()];
+        for msg in &req.context {
+            if msg.role == MessageRole::System && !msg.content.trim().is_empty() {
+                texts.push(msg.content.clone());
+            }
+        }
+        for msg in &req.context {
+            if let Some(payload) = anthropic_message_from_session(msg) {
+                messages.push(payload);
+            }
+        }
+        texts
+    } else {
+        let mut texts = vec![
+            format!("当前会话：{}", req.session_title),
+            format!("当前工作目录：{}", current_working_directory_text()),
+            format!("允许文件操作目录：{}", allowed_file_roots_text()),
+        ];
+        if let Some(mcp_tools_prompt) = build_mcp_tools_system_prompt(24) {
+            texts.push(mcp_tools_prompt);
+        }
+        for msg in &req.context {
+            match msg.role {
+                MessageRole::System => {
+                    if !msg.content.trim().is_empty() {
+                        texts.push(msg.content.clone());
+                    }
+                }
+                _ => {
+                    if let Some(payload) = anthropic_message_from_session(msg) {
+                        messages.push(payload);
+                    }
+                }
+            }
+        }
+        texts
+    };
+
+    if req.assembled_system_prompt.is_none() && !req.user_input.is_empty() {
+        messages.push(json!({
+            "role": "user",
+            "content": [{ "type": "text", "text": req.user_input }],
+        }));
+    }
+
+    Ok((system_texts.join("\n"), messages))
+}
+
+#[allow(dead_code)]
+fn anthropic_message_from_session(msg: &Message) -> Option<Value> {
+    let role = match msg.role {
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::System => return None,
+    };
+
+    let mut parts = Vec::new();
+    if !msg.content.trim().is_empty() {
+        parts.push(msg.content.trim().to_string());
+    }
+    if !msg.reasoning_content.trim().is_empty() {
+        parts.push(format!("[思考]\n{}", msg.reasoning_content.trim()));
+    }
+    if parts.is_empty() {
+        return None;
+    }
+
+    Some(json!({
+        "role": role,
+        "content": [{ "type": "text", "text": parts.join("\n\n") }],
+    }))
+}
+
+#[allow(dead_code)]
+fn normalize_anthropic_base(api_base: &str) -> Result<String> {
+    let trimmed = api_base.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Err(anyhow!("API_BASE_URL 不能为空"));
+    }
+    if trimmed.ends_with("/v1") {
+        Ok(trimmed.to_string())
+    } else {
+        Ok(format!("{trimmed}/v1"))
+    }
+}
+
+#[allow(dead_code)]
+fn anthropic_version_header() -> &'static str {
+    "2023-06-01"
+}
+
+fn anthropic_max_tokens() -> u32 {
+    configured_max_tokens().map(u32::from).unwrap_or(4096)
+}
+
+#[allow(dead_code)]
+fn anthropic_post_json(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    token: &str,
+    body: &Value,
+    on_retry: &Option<OnRetryCallback>,
+    label: &str,
+) -> Result<Value> {
+    let body_text = serde_json::to_string(body).context("序列化 Anthropic 请求失败")?;
+    let response = with_retry_http(label, on_retry, || {
+        let resp = client
+            .post(url)
+            .header("x-api-key", token)
+            .header("anthropic-version", anthropic_version_header())
+            .header("content-type", "application/json")
+            .body(body_text.clone())
+            .send()
+            .map_err(map_reqwest_retry_error)?;
+        anthropic_check_response(resp)
+    })
+    .map_err(|err| anyhow!(err.to_string()))?;
+
+    let text = response.text().context("读取 Anthropic 响应失败")?;
+    serde_json::from_str(&text).with_context(|| format!("解析 Anthropic 响应失败：{text}"))
+}
+
+#[allow(dead_code)]
+fn anthropic_post_stream(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    token: &str,
+    body: &Value,
+    on_retry: &Option<OnRetryCallback>,
+    label: &str,
+) -> Result<reqwest::blocking::Response> {
+    let body_text = serde_json::to_string(body).context("序列化 Anthropic 流式请求失败")?;
+    with_retry_http(label, on_retry, || {
+        let resp = client
+            .post(url)
+            .header("x-api-key", token)
+            .header("anthropic-version", anthropic_version_header())
+            .header("content-type", "application/json")
+            .body(body_text.clone())
+            .send()
+            .map_err(map_reqwest_retry_error)?;
+        anthropic_check_response(resp)
+    })
+    .map_err(|err| anyhow!(err.to_string()))
+}
+
+#[allow(dead_code)]
+fn anthropic_check_response(
+    resp: reqwest::blocking::Response,
+) -> std::result::Result<reqwest::blocking::Response, HttpRetryError> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+
+    let retryable = status.as_u16() == 429 || status.is_server_error();
+    let body = resp.text().unwrap_or_default();
+    let message = extract_anthropic_error_message(&body)
+        .unwrap_or_else(|| format!("Anthropic 请求失败：HTTP {status}，响应：{body}"));
+    Err(HttpRetryError::new(message, retryable))
+}
+
+#[allow(dead_code)]
+fn parse_anthropic_function_response(payload: &Value) -> Result<ModelFunctionResponse> {
+    let mut text = String::new();
+    let mut reasoning_content = String::new();
+    let mut tool_calls = Vec::new();
+
+    if let Some(content) = payload.get("content").and_then(Value::as_array) {
+        for block in content {
+            match block
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+            {
+                "text" => {
+                    if let Some(piece) = block.get("text").and_then(Value::as_str) {
+                        text.push_str(piece);
+                    }
+                }
+                "thinking" => {
+                    if let Some(piece) = block.get("thinking").and_then(Value::as_str) {
+                        reasoning_content.push_str(piece);
+                    }
+                }
+                "tool_use" => {
+                    let id = block
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let name = block
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let arguments = block.get("input").cloned().unwrap_or_else(|| json!({}));
+                    if !name.is_empty() {
+                        tool_calls.push(ModelFunctionCall {
+                            id,
+                            name,
+                            arguments,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let input_tokens = payload
+        .get("usage")
+        .and_then(|usage| usage.get("input_tokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let output_tokens = payload
+        .get("usage")
+        .and_then(|usage| usage.get("output_tokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+
+    if text.trim().is_empty() && reasoning_content.trim().is_empty() && tool_calls.is_empty() {
+        return Err(anyhow!("Anthropic 响应缺少文本和工具调用"));
+    }
+
+    Ok(ModelFunctionResponse {
+        text: text.trim().to_string(),
+        reasoning_content: reasoning_content.trim().to_string(),
+        usage: TokenUsage {
+            prompt_tokens: input_tokens,
+            completion_tokens: output_tokens,
+            total_tokens: input_tokens + output_tokens,
+        },
+        tool_calls,
+    })
+}
+
+#[allow(dead_code)]
+fn parse_anthropic_stream_response(
+    resp: reqwest::blocking::Response,
+    on_delta: &mut dyn FnMut(&ModelStreamChunk),
+) -> Result<ModelFunctionResponse> {
+    let mut reader = BufReader::new(resp);
+    let mut current_event = String::new();
+    let mut data_lines: Vec<String> = Vec::new();
+    let mut text = String::new();
+    let mut reasoning_content = String::new();
+    let mut input_tokens = 0usize;
+    let mut output_tokens = 0usize;
+    let mut tool_calls_map: std::collections::BTreeMap<u64, (String, String, String)> =
+        std::collections::BTreeMap::new();
+
+    let mut process_payload = |event_name: &str, raw_data: &str| -> Result<()> {
+        if raw_data.trim().is_empty() || raw_data.trim() == "[DONE]" || event_name == "ping" {
+            return Ok(());
+        }
+
+        let payload: Value = serde_json::from_str(raw_data)
+            .with_context(|| format!("解析 Anthropic SSE 事件失败：{raw_data}"))?;
+        let payload_type = payload
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or(event_name);
+
+        if let Some(usage) = payload.get("usage") {
+            if let Some(v) = usage.get("input_tokens").and_then(Value::as_u64) {
+                input_tokens = v as usize;
+            }
+            if let Some(v) = usage.get("output_tokens").and_then(Value::as_u64) {
+                output_tokens = v as usize;
+            }
+        }
+        if let Some(message_usage) = payload
+            .get("message")
+            .and_then(|message| message.get("usage"))
+        {
+            if let Some(v) = message_usage.get("input_tokens").and_then(Value::as_u64) {
+                input_tokens = v as usize;
+            }
+            if let Some(v) = message_usage.get("output_tokens").and_then(Value::as_u64) {
+                output_tokens = v as usize;
+            }
+        }
+
+        match payload_type {
+            "content_block_start" => {
+                let index = payload.get("index").and_then(Value::as_u64).unwrap_or(0);
+                if let Some(block) = payload.get("content_block") {
+                    match block
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                    {
+                        "tool_use" => {
+                            let id = block
+                                .get("id")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                                .to_string();
+                            let name = block
+                                .get("name")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                                .to_string();
+                            let input = block
+                                .get("input")
+                                .and_then(|input| {
+                                    if input.is_object() {
+                                        Some(input.to_string())
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .unwrap_or_default();
+                            tool_calls_map.insert(index, (id, name, input));
+                        }
+                        "thinking" => {
+                            if let Some(piece) = block.get("thinking").and_then(Value::as_str) {
+                                reasoning_content.push_str(piece);
+                                on_delta(&ModelStreamChunk {
+                                    content: String::new(),
+                                    reasoning_content: piece.to_string(),
+                                });
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            "content_block_delta" => {
+                let index = payload.get("index").and_then(Value::as_u64).unwrap_or(0);
+                if let Some(delta) = payload.get("delta") {
+                    match delta
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                    {
+                        "text_delta" => {
+                            if let Some(piece) = delta.get("text").and_then(Value::as_str) {
+                                text.push_str(piece);
+                                on_delta(&ModelStreamChunk {
+                                    content: piece.to_string(),
+                                    reasoning_content: String::new(),
+                                });
+                            }
+                        }
+                        "thinking_delta" => {
+                            if let Some(piece) = delta.get("thinking").and_then(Value::as_str) {
+                                reasoning_content.push_str(piece);
+                                on_delta(&ModelStreamChunk {
+                                    content: String::new(),
+                                    reasoning_content: piece.to_string(),
+                                });
+                            }
+                        }
+                        "input_json_delta" => {
+                            if let Some(partial) = delta.get("partial_json").and_then(Value::as_str)
+                            {
+                                let entry = tool_calls_map.entry(index).or_insert_with(|| {
+                                    (String::new(), String::new(), String::new())
+                                });
+                                entry.2.push_str(partial);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    };
+
+    loop {
+        let mut line = String::new();
+        let read = reader
+            .read_line(&mut line)
+            .context("读取 Anthropic SSE 流失败")?;
+        if read == 0 {
+            break;
+        }
+
+        let line = line.trim_end_matches(['\r', '\n']);
+        if line.is_empty() {
+            if !data_lines.is_empty() {
+                process_payload(&current_event, &data_lines.join("\n"))?;
+                current_event.clear();
+                data_lines.clear();
+            }
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix("event:") {
+            current_event = rest.trim().to_string();
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.trim_start().to_string());
+        }
+    }
+
+    if !data_lines.is_empty() {
+        process_payload(&current_event, &data_lines.join("\n"))?;
+    }
+
+    let tool_calls = tool_calls_map
+        .into_values()
+        .filter(|(_, name, _)| !name.is_empty())
+        .map(|(id, name, args)| {
+            let arguments = serde_json::from_str::<Value>(&args)
+                .ok()
+                .filter(|value| value.is_object())
+                .unwrap_or_else(|| json!({}));
+            ModelFunctionCall {
+                id,
+                name,
+                arguments,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if text.trim().is_empty() && reasoning_content.trim().is_empty() && tool_calls.is_empty() {
+        return Err(anyhow!("Anthropic 流式响应缺少文本和工具调用"));
+    }
+
+    Ok(ModelFunctionResponse {
+        text: text.trim().to_string(),
+        reasoning_content: reasoning_content.trim().to_string(),
+        usage: TokenUsage {
+            prompt_tokens: input_tokens,
+            completion_tokens: output_tokens,
+            total_tokens: input_tokens + output_tokens,
+        },
+        tool_calls,
+    })
+}
+
+#[allow(dead_code)]
+fn extract_anthropic_error_message(body: &str) -> Option<String> {
+    let payload: Value = serde_json::from_str(body).ok()?;
+    let message = payload
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)?;
+    Some(format!("Anthropic 请求失败：{message}"))
+}
+
+fn build_anthropic_provider_from_config(
+    cfg: &ModelProviderConfig,
+    timeout_ms: u64,
+    on_retry: Option<OnRetryCallback>,
+) -> Result<AnthropicProvider> {
+    let token = cfg.api_auth_token.trim();
+    if token.is_empty() {
+        return Err(anyhow!("API_AUTH_TOKEN 不能为空，无法发起 Anthropic 请求"));
+    }
+
+    let mut config = AnthropicConfig::new(token.to_string());
+    config.base_url = Some(cfg.api_base_url.clone());
+    config.timeout = Duration::from_millis(timeout_ms);
+    config.max_retries = MAX_RETRIES;
+    config.retry_notifier = on_retry;
+    AnthropicProvider::from_config(config).map_err(map_llm_error)
+}
+
+fn build_openai_provider_from_config(
+    cfg: &ModelProviderConfig,
+    timeout_ms: u64,
+    on_retry: Option<OnRetryCallback>,
+) -> Result<OpenAiCompatibleProvider> {
+    let token = cfg.api_auth_token.trim();
+    if token.is_empty() {
+        return Err(anyhow!("API_AUTH_TOKEN 不能为空，无法发起 OpenAI 兼容请求"));
+    }
+    let mut config = OpenAiCompatibleConfig::new(token.to_string(), cfg.api_base_url.clone());
+    config.timeout = Duration::from_millis(timeout_ms);
+    config.max_retries = MAX_RETRIES;
+    config.retry_notifier = on_retry;
+    Ok(OpenAiCompatibleProvider::new(config))
+}
+
+fn build_anthropic_provider_request(
+    req: &ModelRequest,
+    model: &str,
+    max_tokens: u32,
+    functions: &[FunctionToolSpec],
+) -> ProviderRequest {
+    build_provider_request(req, model, max_tokens, functions)
+}
+
+fn build_provider_request(
+    req: &ModelRequest,
+    model: &str,
+    max_tokens: u32,
+    functions: &[FunctionToolSpec],
+) -> ProviderRequest {
+    let (system, messages) = build_provider_messages(req);
+    ProviderRequest {
+        model: model.to_string(),
+        system: (!system.trim().is_empty()).then_some(system),
+        messages,
+        tools: functions
+            .iter()
+            .map(|tool| ToolSpec {
+                name: tool.name.clone(),
+                description: tool.description.clone(),
+                input_schema: tool.parameters.clone(),
+            })
+            .collect(),
+        tool_choice: (!functions.is_empty()).then_some(LlmToolChoice::Auto),
+        max_tokens: Some(max_tokens),
+        temperature: configured_temperature_f32(),
+        top_p: None,
+        stop_sequences: Vec::new(),
+        metadata: None,
+    }
+}
+
+fn build_provider_messages(req: &ModelRequest) -> (String, Vec<ChatMessage>) {
+    let mut messages = Vec::new();
+
+    let system_texts = if let Some(ref assembled) = req.assembled_system_prompt {
+        let mut texts = vec![assembled.clone()];
+        for msg in &req.context {
+            if msg.role == MessageRole::System && !msg.content.trim().is_empty() {
+                texts.push(msg.content.clone());
+            }
+        }
+        for msg in &req.context {
+            if let Some(message) = provider_message_from_session(msg) {
+                messages.push(message);
+            }
+        }
+        texts
+    } else {
+        let mut texts = vec![
+            format!("当前会话：{}", req.session_title),
+            format!("当前工作目录：{}", current_working_directory_text()),
+            format!("允许文件操作目录：{}", allowed_file_roots_text()),
+        ];
+        if let Some(mcp_tools_prompt) = build_mcp_tools_system_prompt(24) {
+            texts.push(mcp_tools_prompt);
+        }
+        for msg in &req.context {
+            match msg.role {
+                MessageRole::System => {
+                    if !msg.content.trim().is_empty() {
+                        texts.push(msg.content.clone());
+                    }
+                }
+                _ => {
+                    if let Some(message) = provider_message_from_session(msg) {
+                        messages.push(message);
+                    }
+                }
+            }
+        }
+        texts
+    };
+
+    if req.assembled_system_prompt.is_none() && !req.user_input.is_empty() {
+        messages.push(ChatMessage::text(
+            LlmMessageRole::User,
+            req.user_input.clone(),
+        ));
+    }
+
+    (system_texts.join("\n"), messages)
+}
+
+fn provider_message_from_session(msg: &Message) -> Option<ChatMessage> {
+    let role = match msg.role {
+        MessageRole::User => LlmMessageRole::User,
+        MessageRole::Assistant => LlmMessageRole::Assistant,
+        MessageRole::System => return None,
+    };
+
+    let mut parts = Vec::new();
+    if !msg.content.trim().is_empty() {
+        parts.push(msg.content.trim().to_string());
+    }
+    if !msg.reasoning_content.trim().is_empty() {
+        parts.push(format!("[思考]\n{}", msg.reasoning_content.trim()));
+    }
+    if parts.is_empty() {
+        return None;
+    }
+
+    Some(ChatMessage::new(
+        role,
+        vec![LlmMessageContent::Text(parts.join("\n\n"))],
+    ))
+}
+
+fn convert_provider_response_to_function_response(
+    response: ProviderResponse,
+) -> Result<ModelFunctionResponse> {
+    let text = collect_provider_text(&response);
+    let reasoning_content = response.reasoning_content.clone().unwrap_or_default();
+    let tool_calls = response
+        .assistant_message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            LlmMessageContent::ToolCall(LlmToolCall {
+                id,
+                name,
+                arguments,
+            }) if !name.is_empty() => Some(ModelFunctionCall {
+                id: id.clone(),
+                name: name.clone(),
+                arguments: arguments.clone(),
+            }),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    if text.trim().is_empty() && reasoning_content.trim().is_empty() && tool_calls.is_empty() {
+        return Err(anyhow!("Anthropic 响应缺少文本和工具调用"));
+    }
+
+    Ok(ModelFunctionResponse {
+        text: text.trim().to_string(),
+        reasoning_content,
+        usage: response.usage.unwrap_or_default().into(),
+        tool_calls,
+    })
+}
+
+fn collect_provider_text(response: &ProviderResponse) -> String {
+    response
+        .assistant_message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            LlmMessageContent::Text(text) => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn consume_anthropic_stream(
+    stream: ProviderStream,
+    on_delta: &mut dyn FnMut(&ModelStreamChunk),
+) -> Result<ModelFunctionResponse> {
+    let runtime = TokioRuntimeBuilder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("初始化异步运行时失败")?;
+
+    runtime.block_on(async {
+        let mut stream = stream;
+        let mut text = String::new();
+        let mut usage = TokenUsageData::default();
+        let mut tool_calls: std::collections::BTreeMap<String, (String, String)> =
+            std::collections::BTreeMap::new();
+
+        while let Some(event) = stream.next().await {
+            match event.map_err(map_llm_error)? {
+                ProviderStreamEvent::ReasoningDelta(delta) => {
+                    if !delta.is_empty() {
+                        on_delta(&ModelStreamChunk {
+                            content: String::new(),
+                            reasoning_content: delta.clone(),
+                        });
+                    }
+                }
+                ProviderStreamEvent::TextDelta(delta) => {
+                    if !delta.is_empty() {
+                        text.push_str(&delta);
+                        on_delta(&ModelStreamChunk {
+                            content: delta,
+                            reasoning_content: String::new(),
+                        });
+                    }
+                }
+                ProviderStreamEvent::ToolCallStart(call) => {
+                    let args = if call.arguments.is_null() || call.arguments == json!({}) {
+                        String::new()
+                    } else {
+                        call.arguments.to_string()
+                    };
+                    tool_calls.insert(call.id.clone(), (call.name, args));
+                }
+                ProviderStreamEvent::ToolCallDelta {
+                    call_id,
+                    partial_json,
+                } => {
+                    let entry = tool_calls
+                        .entry(call_id)
+                        .or_insert_with(|| (String::new(), String::new()));
+                    entry.1.push_str(&partial_json);
+                }
+                ProviderStreamEvent::Usage(stream_usage) => usage = stream_usage,
+                ProviderStreamEvent::Error(message) => return Err(anyhow!(message)),
+                ProviderStreamEvent::MessageStart
+                | ProviderStreamEvent::ToolCallEnd { .. }
+                | ProviderStreamEvent::MessageEnd => {}
+            }
+        }
+
+        let tool_calls = tool_calls
+            .into_iter()
+            .filter(|(_, (name, _))| !name.is_empty())
+            .map(|(id, (name, raw_args))| ModelFunctionCall {
+                id,
+                name,
+                arguments: if raw_args.trim().is_empty() {
+                    json!({})
+                } else {
+                    serde_json::from_str(&raw_args).unwrap_or_else(|_| json!({}))
+                },
+            })
+            .collect::<Vec<_>>();
+
+        if text.trim().is_empty() && tool_calls.is_empty() {
+            return Err(anyhow!("Anthropic 流式响应缺少文本和工具调用"));
+        }
+
+        Ok(ModelFunctionResponse {
+            text: text.trim().to_string(),
+            reasoning_content: String::new(),
+            usage: usage.into(),
+            tool_calls,
+        })
+    })
+}
+
+enum ProviderDispatch {
+    Anthropic(Box<AnthropicProvider>),
+    OpenAi(Box<OpenAiCompatibleProvider>),
+}
+
+impl ProviderDispatch {
+    async fn stream(
+        self,
+        request: ProviderRequest,
+    ) -> std::result::Result<ProviderStream, tiangong_llm::error::LlmError> {
+        match self {
+            ProviderDispatch::Anthropic(provider) => provider.stream(request).await,
+            ProviderDispatch::OpenAi(provider) => provider.stream(request).await,
+        }
+    }
+}
+
+fn consume_provider_stream(
+    provider: ProviderDispatch,
+    request: ProviderRequest,
+    on_delta: &mut dyn FnMut(&ModelStreamChunk),
+) -> Result<ModelResponse> {
+    let stream = TokioRuntimeBuilder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("初始化异步运行时失败")?
+        .block_on(provider.stream(request))
+        .map_err(map_llm_error)?;
+
+    let response = consume_anthropic_stream(stream, on_delta)?;
+    Ok(ModelResponse {
+        text: response.text,
+        reasoning_content: response.reasoning_content,
+        usage: response.usage,
+        output_mode: "stream".to_string(),
+        output_chunk_count: 1,
+    })
+}
+
+fn convert_stream_to_function_response(
+    provider: ProviderDispatch,
+    request: ProviderRequest,
+    on_delta: &mut dyn FnMut(&ModelStreamChunk),
+) -> Result<ModelFunctionResponse> {
+    let stream = TokioRuntimeBuilder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("初始化异步运行时失败")?
+        .block_on(provider.stream(request))
+        .map_err(map_llm_error)?;
+    consume_anthropic_stream(stream, on_delta)
+}
+
+fn map_llm_error(error: tiangong_llm::error::LlmError) -> anyhow::Error {
+    anyhow!(error.to_string())
+}
+
 fn current_working_directory_text() -> String {
     std::env::current_dir()
         .map(|path| path.display().to_string())
@@ -1245,6 +1512,7 @@ fn allowed_file_roots_text() -> String {
 ///
 /// 仅做基本清理（去空格、去尾部斜杠、去意外拼接的 /chat/completions），
 /// 不自动补充版本路径——版本由用户在 provider base_url 中指定。
+#[allow(dead_code)]
 fn normalize_api_base(base_url: &str) -> Result<String> {
     let trimmed = base_url.trim();
     if trimmed.is_empty() {
@@ -1260,6 +1528,7 @@ fn normalize_api_base(base_url: &str) -> Result<String> {
 ///
 /// async-openai 默认有 ExponentialBackoff（最长 15 分钟）。
 /// 禁用后由 `with_retry` 统一管理重试，确保 StreamEvent::Retry 能正确触发。
+#[allow(dead_code)]
 fn build_no_retry_client(config: OpenAIConfig) -> OpenAIClient<OpenAIConfig> {
     // 设置极小的 max_elapsed_time 确保 async-openai 不做任何内部重试。
     // Duration::ZERO 在 backoff 首次调用时 elapsed ≈ 0 可能仍允许 1 次重试，
@@ -1271,6 +1540,7 @@ fn build_no_retry_client(config: OpenAIConfig) -> OpenAIClient<OpenAIConfig> {
     OpenAIClient::build(reqwest::Client::new(), config, no_retry)
 }
 
+#[allow(dead_code)]
 fn build_sdk_error_hint(error_text: &str) -> String {
     if error_text.contains("/chat/completions") && error_text.contains("404") {
         return "；请检查 API_BASE_URL 是否包含正确的版本路径（如 .../v1）".to_string();
@@ -1290,12 +1560,44 @@ const INITIAL_RETRY_DELAY_MS: u64 = 1000;
 /// 退避倍率
 const RETRY_BACKOFF_MULTIPLIER: u64 = 2;
 
+#[derive(Debug)]
+#[allow(dead_code)]
+struct HttpRetryError {
+    message: String,
+    retryable: bool,
+}
+
+impl HttpRetryError {
+    fn new(message: impl Into<String>, retryable: bool) -> Self {
+        Self {
+            message: message.into(),
+            retryable,
+        }
+    }
+}
+
+impl std::fmt::Display for HttpRetryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.message.fmt(f)
+    }
+}
+
+impl std::error::Error for HttpRetryError {}
+
 /// 判断 OpenAI SDK 错误是否可重试
+#[allow(dead_code)]
 fn is_retryable_openai_error(err: &async_openai::error::OpenAIError) -> bool {
     is_retryable_error_text(&err.to_string())
 }
 
+#[allow(dead_code)]
+fn map_reqwest_retry_error(err: reqwest::Error) -> HttpRetryError {
+    let retryable = err.is_timeout() || err.is_connect() || err.is_request();
+    HttpRetryError::new(format!("HTTP 请求失败：{err}"), retryable)
+}
+
 /// 判断错误文本是否表示可重试的错误
+#[allow(dead_code)]
 fn is_retryable_error_text(text: &str) -> bool {
     // 速率限制 (HTTP 429)
     if text.contains("429")
@@ -1332,6 +1634,7 @@ fn is_retryable_error_text(text: &str) -> bool {
 ///
 /// 遇到速率限制、5xx、连接错误时自动重试，采用指数退避策略。
 /// 可选的 `on_retry` 回调在每次重试前触发，用于通知上层。
+#[allow(dead_code)]
 async fn with_retry<F, Fut, T>(
     label: &str,
     on_retry: &Option<OnRetryCallback>,
@@ -1371,6 +1674,45 @@ where
     }
 }
 
+#[allow(dead_code)]
+fn with_retry_http<F, T>(
+    label: &str,
+    on_retry: &Option<OnRetryCallback>,
+    mut f: F,
+) -> std::result::Result<T, HttpRetryError>
+where
+    F: FnMut() -> std::result::Result<T, HttpRetryError>,
+{
+    let mut attempt = 0u32;
+    let mut delay_ms = INITIAL_RETRY_DELAY_MS;
+    loop {
+        match f() {
+            Ok(result) => return Ok(result),
+            Err(err) => {
+                if attempt < MAX_RETRIES && err.retryable {
+                    attempt += 1;
+                    tracing::warn!(
+                        attempt = attempt,
+                        max_retries = MAX_RETRIES,
+                        delay_ms = delay_ms,
+                        error = %err,
+                        label = label,
+                        "LLM 请求失败，准备重试",
+                    );
+                    if let Some(cb) = on_retry {
+                        cb(attempt, MAX_RETRIES, delay_ms, &err.to_string());
+                    }
+                    std::thread::sleep(Duration::from_millis(delay_ms));
+                    delay_ms *= RETRY_BACKOFF_MULTIPLIER;
+                } else {
+                    return Err(err);
+                }
+            }
+        }
+    }
+}
+
+#[allow(dead_code)]
 fn extract_delta_text(delta: &Value, field: &str) -> String {
     let Some(raw) = delta.get(field) else {
         return String::new();
@@ -1399,6 +1741,7 @@ fn extract_delta_text(delta: &Value, field: &str) -> String {
     }
 }
 
+#[allow(dead_code)]
 fn push_stream_piece(
     piece: ModelStreamChunk,
     on_delta: &mut impl FnMut(&ModelStreamChunk),
@@ -1420,6 +1763,7 @@ fn push_stream_piece(
 /// 某些模型不使用 API 级别的 `reasoning_content` 字段，
 /// 而是在 `content` 中输出 `<think>...</think>` 标签。
 /// 此过滤器跨 chunk 追踪状态，将标签内的内容转移到 `reasoning_content`。
+#[allow(dead_code)]
 struct ThinkTagFilter {
     /// 是否处于 `<think>` 块内
     inside_think: bool,
@@ -1427,6 +1771,7 @@ struct ThinkTagFilter {
     buf: String,
 }
 
+#[allow(dead_code)]
 impl ThinkTagFilter {
     fn new() -> Self {
         Self {
@@ -1523,6 +1868,7 @@ fn strip_think_tags(text: &str) -> String {
     result
 }
 
+#[allow(dead_code)]
 fn should_skip_stream_payload(raw: &str) -> bool {
     let normalized = raw.trim().to_ascii_lowercase();
     normalized.is_empty()
@@ -1532,6 +1878,7 @@ fn should_skip_stream_payload(raw: &str) -> bool {
         || normalized.contains("\"event\":\"ping\"")
 }
 
+#[allow(dead_code)]
 fn inject_thinking_config(payload: &mut Value) {
     let Some(obj) = payload.as_object_mut() else {
         return;
@@ -1544,6 +1891,7 @@ fn inject_thinking_config(payload: &mut Value) {
     obj.insert("thinking".to_string(), thinking);
 }
 
+#[allow(dead_code)]
 fn clear_thinking() -> bool {
     match std::env::var("API_CLEAR_THINKING") {
         Ok(v) => !matches!(
@@ -1555,6 +1903,7 @@ fn clear_thinking() -> bool {
 }
 
 /// 注入 stream_options.include_usage = true，使流式响应最后一个 chunk 返回 usage 数据
+#[allow(dead_code)]
 fn inject_stream_usage_option(payload: &mut Value) {
     let Some(obj) = payload.as_object_mut() else {
         return;
@@ -1562,6 +1911,7 @@ fn inject_stream_usage_option(payload: &mut Value) {
     obj.insert("stream_options".to_string(), json!({"include_usage": true}));
 }
 
+#[allow(dead_code)]
 fn inject_temperature_config(payload: &mut Value) {
     let Some(temp) = configured_temperature_number() else {
         return;
@@ -1572,6 +1922,7 @@ fn inject_temperature_config(payload: &mut Value) {
     obj.insert("temperature".to_string(), Value::Number(temp));
 }
 
+#[allow(dead_code)]
 fn inject_function_tools(payload: &mut Value, functions: &[FunctionToolSpec]) {
     let Some(obj) = payload.as_object_mut() else {
         return;
@@ -1601,6 +1952,12 @@ fn configured_temperature_number() -> Option<serde_json::Number> {
     }
     let rounded = (value * 100.0).round() / 100.0;
     serde_json::Number::from_f64(rounded)
+}
+
+fn configured_temperature_f32() -> Option<f32> {
+    configured_temperature_number()
+        .and_then(|value| value.as_f64())
+        .map(|value| value as f32)
 }
 
 fn configured_max_tokens() -> Option<u16> {
@@ -1637,6 +1994,7 @@ fn default_api_model() -> String {
     "gpt-4o-mini".to_string()
 }
 
+#[allow(dead_code)]
 fn parse_non_stream_byot_response(payload: &Value) -> Option<ModelResponse> {
     let choice = payload
         .get("choices")
@@ -1686,6 +2044,7 @@ fn parse_non_stream_byot_response(payload: &Value) -> Option<ModelResponse> {
     })
 }
 
+#[allow(dead_code)]
 fn parse_function_byot_response(payload: &Value) -> Result<ModelFunctionResponse> {
     let choice = payload
         .get("choices")
@@ -1744,6 +2103,7 @@ fn parse_function_byot_response(payload: &Value) -> Result<ModelFunctionResponse
     })
 }
 
+#[allow(dead_code)]
 fn parse_function_call_item(item: &Value) -> Option<ModelFunctionCall> {
     let name = item
         .get("function")

--- a/crates/tiangong-core/src/models_config.rs
+++ b/crates/tiangong-core/src/models_config.rs
@@ -324,7 +324,7 @@ impl ModelsConfig {
                         provider: provider_key,
                         model: endpoint.model.clone(),
                         capabilities: vec![cap],
-                        options: default_options(),
+                        options: endpoint.options.clone(),
                     },
                 );
                 routing.insert(cap, model_key);

--- a/crates/tiangong-core/src/models_config.rs
+++ b/crates/tiangong-core/src/models_config.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::model::ModelProviderConfig;
+use crate::model::{ModelProviderConfig, ProviderProtocol};
 
 // ---------------------------------------------------------------------------
 // 核心类型
@@ -127,6 +127,8 @@ pub struct ProviderConfig {
     pub api_key: String, // 支持 ${ENV_VAR} 引用
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
+    #[serde(default)]
+    pub protocol: ProviderProtocol,
 }
 
 fn default_timeout_ms() -> u64 {
@@ -165,6 +167,7 @@ pub struct ResolvedModel {
     pub base_url: String,
     pub api_key: String, // 已解析环境变量
     pub timeout_ms: u64,
+    pub protocol: ProviderProtocol,
     pub model: String,
     pub options: Value,
 }
@@ -251,6 +254,7 @@ impl ModelsConfig {
             base_url: legacy.api_base_url.clone(),
             api_key: legacy.api_auth_token.clone(),
             timeout_ms: legacy.api_timeout_ms.parse::<u64>().unwrap_or(60_000),
+            protocol: legacy.api_protocol,
         };
         providers.insert("default".to_string(), provider);
 
@@ -310,6 +314,7 @@ impl ModelsConfig {
                         base_url: endpoint.base_url.clone(),
                         api_key: endpoint.api_key.clone(),
                         timeout_ms: endpoint.timeout_ms,
+                        protocol: endpoint.protocol,
                     },
                 );
                 let model_key = format!("{name}-model");
@@ -373,6 +378,7 @@ impl ModelsConfig {
             base_url: provider.base_url.clone(),
             api_key: Self::resolve_api_key(&provider.api_key),
             timeout_ms: provider.timeout_ms,
+            protocol: provider.protocol,
             model: model_entry.model.clone(),
             options: model_entry.options.clone(),
         })
@@ -395,6 +401,7 @@ impl ModelsConfig {
                 api_auth_token: resolved.api_key,
                 api_base_url: resolved.base_url,
                 api_timeout_ms: resolved.timeout_ms.to_string(),
+                api_protocol: resolved.protocol,
                 api_model: resolved.model,
                 api_lite_model: String::new(),
             }
@@ -410,6 +417,7 @@ impl ModelsConfig {
                 api_auth_token: resolved.api_key,
                 api_base_url: resolved.base_url,
                 api_timeout_ms: resolved.timeout_ms.to_string(),
+                api_protocol: resolved.protocol,
                 api_model: resolved.model.clone(),
                 api_lite_model: resolved.model,
             }

--- a/crates/tiangong-core/src/orchestrator/query_orchestrator.rs
+++ b/crates/tiangong-core/src/orchestrator/query_orchestrator.rs
@@ -115,6 +115,7 @@ impl QueryOrchestrator {
             user_input: prompt.clone(),
             context: Vec::new(),
             assembled_system_prompt: None,
+            thinking: None,
         };
 
         let resp = client.complete(&req)?;

--- a/crates/tiangong-llm/Cargo.toml
+++ b/crates/tiangong-llm/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tiangong-llm"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+
+[dependencies]
+tiangong-types = { path = "../tiangong-types" }
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+async-trait = "0.1"
+async-openai = { git = "https://github.com/silent-rs/async-openai", branch = "main", package = "async-openai", features = ["byot", "chat-completion", "model"] }
+async-anthropic = "0.6.0"
+backoff = "0.4"
+tokio = { version = "1", features = ["rt", "time"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+futures-util = "0.3"
+tracing = "0.1"

--- a/crates/tiangong-llm/Cargo.toml
+++ b/crates/tiangong-llm/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]
+tiangong-anthropic = { path = "../tiangong-anthropic" }
 tiangong-types = { path = "../tiangong-types" }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
@@ -12,7 +13,6 @@ serde_json = "1"
 thiserror = "2"
 async-trait = "0.1"
 async-openai = { git = "https://github.com/silent-rs/async-openai", branch = "main", package = "async-openai", features = ["byot", "chat-completion", "model"] }
-async-anthropic = "0.6.0"
 backoff = "0.4"
 tokio = { version = "1", features = ["rt", "time"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/crates/tiangong-llm/src/error.rs
+++ b/crates/tiangong-llm/src/error.rs
@@ -1,0 +1,47 @@
+use thiserror::Error;
+
+/// LLM provider 统一错误模型。
+#[derive(Debug, Error, Clone)]
+pub enum LlmError {
+    #[error("配置错误：{0}")]
+    Configuration(String),
+
+    #[error("传输错误：{0}")]
+    Transport(String),
+
+    #[error("请求超时：{0}ms")]
+    Timeout(u64),
+
+    #[error("请求被限流：{0}")]
+    RateLimited(String),
+
+    #[error("认证失败：{0}")]
+    Authentication(String),
+
+    #[error("请求无效：{0}")]
+    InvalidRequest(String),
+
+    #[error("序列化失败：{0}")]
+    Serialization(String),
+
+    #[error("流式处理失败：{0}")]
+    Stream(String),
+
+    #[error("{provider} provider 错误：{message}")]
+    Provider {
+        provider: &'static str,
+        message: String,
+    },
+
+    #[error("不支持的能力：{0}")]
+    UnsupportedFeature(String),
+}
+
+impl LlmError {
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Transport(_) | Self::Timeout(_) | Self::RateLimited(_)
+        )
+    }
+}

--- a/crates/tiangong-llm/src/lib.rs
+++ b/crates/tiangong-llm/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod error;
+pub mod message;
+pub mod model;
+pub mod provider;
+pub mod providers;
+pub mod request;
+pub mod response;
+pub mod stream;
+pub mod tool;
+pub mod usage;
+
+pub use model::{ProviderModelInfo, ProviderProtocol};

--- a/crates/tiangong-llm/src/message.rs
+++ b/crates/tiangong-llm/src/message.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+
+use crate::tool::{ToolCall, ToolResult};
+
+/// 统一消息角色。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+/// 预留的图片内容结构。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImageContent {
+    pub mime_type: String,
+    pub data: String,
+}
+
+/// 统一消息内容。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageContent {
+    Text(String),
+    ToolCall(ToolCall),
+    ToolResult(ToolResult),
+    Image(ImageContent),
+}
+
+/// 统一聊天消息。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub role: MessageRole,
+    pub content: Vec<MessageContent>,
+}
+
+impl ChatMessage {
+    pub fn new(role: MessageRole, content: Vec<MessageContent>) -> Self {
+        Self { role, content }
+    }
+
+    pub fn text(role: MessageRole, text: impl Into<String>) -> Self {
+        Self {
+            role,
+            content: vec![MessageContent::Text(text.into())],
+        }
+    }
+}

--- a/crates/tiangong-llm/src/mod.rs
+++ b/crates/tiangong-llm/src/mod.rs
@@ -1,0 +1,10 @@
+pub mod error;
+pub mod message;
+pub mod model;
+pub mod provider;
+pub mod providers;
+pub mod request;
+pub mod response;
+pub mod stream;
+pub mod tool;
+pub mod usage;

--- a/crates/tiangong-llm/src/model.rs
+++ b/crates/tiangong-llm/src/model.rs
@@ -1,0 +1,41 @@
+use std::str::FromStr;
+
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+
+/// Provider 协议类型。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderProtocol {
+    #[default]
+    OpenAiCompatible,
+    Anthropic,
+}
+
+impl ProviderProtocol {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ProviderProtocol::OpenAiCompatible => "openai_compatible",
+            ProviderProtocol::Anthropic => "anthropic",
+        }
+    }
+}
+
+impl FromStr for ProviderProtocol {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim() {
+            "" | "openai_compatible" => Ok(ProviderProtocol::OpenAiCompatible),
+            "anthropic" => Ok(ProviderProtocol::Anthropic),
+            other => Err(anyhow!("不支持的 provider 协议：{other}")),
+        }
+    }
+}
+
+/// Provider 暴露的模型信息。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderModelInfo {
+    pub id: String,
+    pub display_name: Option<String>,
+}

--- a/crates/tiangong-llm/src/provider.rs
+++ b/crates/tiangong-llm/src/provider.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+
+use crate::error::LlmError;
+use crate::model::ProviderModelInfo;
+use crate::request::ProviderRequest;
+use crate::response::ProviderResponse;
+use crate::stream::ProviderStream;
+
+/// Provider 能力说明。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderCapabilities {
+    pub streaming: bool,
+    pub tool_calling: bool,
+    pub system_prompt: bool,
+    pub list_models: bool,
+}
+
+/// 统一 LLM provider trait。
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    fn capabilities(&self) -> ProviderCapabilities;
+
+    async fn complete(&self, req: ProviderRequest) -> Result<ProviderResponse, LlmError>;
+
+    async fn stream(&self, req: ProviderRequest) -> Result<ProviderStream, LlmError>;
+
+    async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError>;
+}

--- a/crates/tiangong-llm/src/providers/anthropic/client.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/client.rs
@@ -1,262 +1,93 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use backoff::ExponentialBackoff;
-use serde::Deserialize;
+use tiangong_anthropic::types::{EventStream, MessagesCreateRequest, MessagesCreateResponse};
+use tiangong_anthropic::{
+    AnthropicClient as NativeAnthropicClient, AnthropicConfig as NativeAnthropicConfig,
+};
 
 use crate::error::LlmError;
 use crate::model::ProviderModelInfo;
 use crate::providers::anthropic::config::AnthropicConfig;
 use crate::providers::anthropic::error::map_anthropic_error;
-use crate::providers::anthropic::stream::AnthropicSdkStream;
 
 #[async_trait]
 pub(crate) trait AnthropicTransport: Send + Sync {
     async fn create(
         &self,
-        request: async_anthropic::types::CreateMessagesRequest,
-    ) -> Result<async_anthropic::types::CreateMessagesResponse, LlmError>;
+        request: MessagesCreateRequest,
+    ) -> Result<MessagesCreateResponse, LlmError>;
 
-    async fn create_stream(
-        &self,
-        request: async_anthropic::types::CreateMessagesRequest,
-    ) -> Result<AnthropicSdkStream, LlmError>;
+    async fn create_stream(&self, request: MessagesCreateRequest) -> Result<EventStream, LlmError>;
 
     async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError>;
 }
 
 #[derive(Clone)]
-pub struct AsyncAnthropicTransport {
-    client: async_anthropic::Client,
-    http_client: reqwest::Client,
-    base_url: String,
-    api_key: String,
-    api_version: String,
-    beta: Option<String>,
+pub struct NativeAnthropicTransport {
+    client: NativeAnthropicClient,
 }
 
-impl AsyncAnthropicTransport {
+impl NativeAnthropicTransport {
     pub fn new(config: &AnthropicConfig) -> Result<Self, LlmError> {
-        let http_client = reqwest::Client::builder()
-            .timeout(config.timeout)
-            .build()
-            .map_err(|err| LlmError::Transport(format!("构建 Anthropic HTTP 客户端失败：{err}")))?;
-
-        let no_retry = ExponentialBackoff {
-            max_elapsed_time: Some(Duration::from_nanos(1)),
-            ..Default::default()
-        };
-
-        let api_version = config.resolve_api_version();
-        let base_url = config
-            .normalized_base_url()
-            .unwrap_or_else(|| "https://api.anthropic.com".to_string());
-
-        let mut builder_binding = async_anthropic::Client::builder();
-        let mut builder = builder_binding
-            .http_client(http_client.clone())
-            .api_key(config.api_key.clone())
-            .version(api_version.clone())
-            .backoff(no_retry);
-
-        builder = builder.base_url(base_url.clone());
-        if let Some(beta) = &config.beta {
-            builder = builder.beta(beta.clone());
+        let mut native = NativeAnthropicConfig::new(config.api_key.clone());
+        if let Some(base_url) = config.normalized_base_url() {
+            native.base_url = base_url;
         }
+        native.timeout = config.timeout;
+        native.api_version = config.resolve_api_version();
+        native.beta = config.beta.clone();
 
-        let client = builder.build().map_err(|err| {
-            LlmError::Configuration(format!("构建 Anthropic SDK 客户端失败：{err}"))
-        })?;
-
-        Ok(Self {
-            client,
-            http_client,
-            base_url,
-            api_key: config.api_key.clone(),
-            api_version,
-            beta: config.beta.clone(),
-        })
+        let client = NativeAnthropicClient::from_config(native).map_err(map_anthropic_error)?;
+        Ok(Self { client })
     }
 }
 
 #[async_trait]
-impl AnthropicTransport for AsyncAnthropicTransport {
+impl AnthropicTransport for NativeAnthropicTransport {
     async fn create(
         &self,
-        request: async_anthropic::types::CreateMessagesRequest,
-    ) -> Result<async_anthropic::types::CreateMessagesResponse, LlmError> {
+        request: MessagesCreateRequest,
+    ) -> Result<MessagesCreateResponse, LlmError> {
         self.client
-            .messages()
             .create(request)
             .await
             .map_err(map_anthropic_error)
     }
 
-    async fn create_stream(
-        &self,
-        request: async_anthropic::types::CreateMessagesRequest,
-    ) -> Result<AnthropicSdkStream, LlmError> {
-        Ok(self.client.messages().create_stream(request).await)
+    async fn create_stream(&self, request: MessagesCreateRequest) -> Result<EventStream, LlmError> {
+        self.client
+            .create_stream(request)
+            .await
+            .map_err(map_anthropic_error)
     }
 
     async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
-        let url = format!("{}/v1/models", self.base_url.trim_end_matches('/'));
-        let mut request = self
-            .http_client
-            .get(url)
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", &self.api_version)
-            .header(reqwest::header::ACCEPT, "application/json");
-        if let Some(beta) = &self.beta {
-            request = request.header("anthropic-beta", beta);
-        }
-
-        let response = request.send().await.map_err(|err| {
-            if err.is_timeout() {
-                LlmError::Timeout(0)
-            } else {
-                LlmError::Transport(err.to_string())
-            }
-        })?;
-        let status = response.status();
-        let body = response
-            .text()
+        let response = self
+            .client
+            .list_models()
             .await
-            .map_err(|err| LlmError::Transport(format!("读取 Anthropic 响应体失败：{err}")))?;
-
-        if !status.is_success() {
-            return Err(map_list_models_http_error(status, &body));
-        }
-
-        parse_models_response(&body)
+            .map_err(map_anthropic_error)?;
+        Ok(response
+            .data
+            .into_iter()
+            .map(|item| ProviderModelInfo {
+                id: item.id.clone(),
+                display_name: item.display_name.or(Some(item.id)),
+            })
+            .collect())
     }
 }
 
 #[derive(Clone)]
-pub(crate) struct AnthropicClient<T = AsyncAnthropicTransport> {
+pub(crate) struct AnthropicClient<T = NativeAnthropicTransport> {
     transport: T,
     config: AnthropicConfig,
 }
 
-#[derive(Debug, Deserialize)]
-struct AnthropicModelsEnvelope {
-    #[serde(default)]
-    data: Vec<AnthropicModelEntry>,
-}
-
-#[derive(Debug, Deserialize)]
-struct AnthropicModelEntry {
-    id: String,
-    #[serde(default)]
-    display_name: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct AnthropicDirectModelEntry {
-    id: String,
-    #[serde(default)]
-    display_name: Option<String>,
-}
-
-fn parse_models_response(body: &str) -> Result<Vec<ProviderModelInfo>, LlmError> {
-    if let Ok(response) = serde_json::from_str::<AnthropicModelsEnvelope>(body) {
-        return Ok(response
-            .data
-            .into_iter()
-            .map(|model| ProviderModelInfo {
-                display_name: model.display_name.or_else(|| Some(model.id.clone())),
-                id: model.id,
-            })
-            .collect());
-    }
-
-    if let Ok(response) = serde_json::from_str::<Vec<AnthropicDirectModelEntry>>(body) {
-        return Ok(response
-            .into_iter()
-            .map(|model| ProviderModelInfo {
-                display_name: model.display_name.or_else(|| Some(model.id.clone())),
-                id: model.id,
-            })
-            .collect());
-    }
-
-    Err(LlmError::Serialization(format!(
-        "解析 Anthropic 模型列表失败，响应体前 512 字节：{}",
-        body.chars().take(512).collect::<String>()
-    )))
-}
-
-fn map_list_models_http_error(status: reqwest::StatusCode, body: &str) -> LlmError {
-    let message = body.chars().take(512).collect::<String>();
-    match status {
-        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
-            LlmError::Authentication(format!("请检查 Anthropic API Key：{message}"))
-        }
-        reqwest::StatusCode::TOO_MANY_REQUESTS => LlmError::RateLimited(message),
-        reqwest::StatusCode::BAD_REQUEST => LlmError::InvalidRequest(message),
-        _ if status.is_server_error() => LlmError::Transport(format!(
-            "Anthropic 模型列表请求失败，HTTP {}: {}",
-            status.as_u16(),
-            message
-        )),
-        _ => LlmError::Provider {
-            provider: "anthropic",
-            message: format!("模型列表请求失败，HTTP {}: {}", status.as_u16(), message),
-        },
-    }
-}
-
-#[cfg(test)]
-mod unit_tests {
-    use super::parse_models_response;
-
-    #[test]
-    fn parse_official_models_response() {
-        let models = parse_models_response(
-            r#"{
-                "data":[
-                    {
-                        "type":"model",
-                        "id":"claude-sonnet-4-20250514",
-                        "display_name":"Claude Sonnet 4",
-                        "created_at":"2025-05-14T00:00:00Z"
-                    }
-                ],
-                "has_more":false,
-                "first_id":"claude-sonnet-4-20250514",
-                "last_id":"claude-sonnet-4-20250514"
-            }"#,
-        )
-        .expect("parse official response");
-
-        assert_eq!(models.len(), 1);
-        assert_eq!(models[0].id, "claude-sonnet-4-20250514");
-        assert_eq!(models[0].display_name.as_deref(), Some("Claude Sonnet 4"));
-    }
-
-    #[test]
-    fn parse_proxy_models_response_without_display_name() {
-        let models = parse_models_response(
-            r#"{
-                "data":[
-                    {"id":"claude-3-5-sonnet-latest","object":"model"}
-                ]
-            }"#,
-        )
-        .expect("parse proxy response");
-
-        assert_eq!(models.len(), 1);
-        assert_eq!(models[0].id, "claude-3-5-sonnet-latest");
-        assert_eq!(
-            models[0].display_name.as_deref(),
-            Some("claude-3-5-sonnet-latest")
-        );
-    }
-}
-
-impl AnthropicClient<AsyncAnthropicTransport> {
+impl AnthropicClient<NativeAnthropicTransport> {
     pub fn from_config(config: AnthropicConfig) -> Result<Self, LlmError> {
-        let transport = AsyncAnthropicTransport::new(&config)?;
+        let transport = NativeAnthropicTransport::new(&config)?;
         Ok(Self { transport, config })
     }
 }
@@ -272,8 +103,8 @@ where
 
     pub async fn create(
         &self,
-        request: async_anthropic::types::CreateMessagesRequest,
-    ) -> Result<async_anthropic::types::CreateMessagesResponse, LlmError> {
+        request: MessagesCreateRequest,
+    ) -> Result<MessagesCreateResponse, LlmError> {
         let model = request.model.clone();
         self.run_with_retry("anthropic_complete", "anthropic", &model, false, || {
             let request = request.clone();
@@ -284,8 +115,8 @@ where
 
     pub async fn create_stream(
         &self,
-        request: async_anthropic::types::CreateMessagesRequest,
-    ) -> Result<AnthropicSdkStream, LlmError> {
+        request: MessagesCreateRequest,
+    ) -> Result<EventStream, LlmError> {
         let model = request.model.clone();
         self.run_with_retry("anthropic_stream", "anthropic", &model, true, || {
             let request = request.clone();

--- a/crates/tiangong-llm/src/providers/anthropic/client.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/client.rs
@@ -1,0 +1,380 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use backoff::ExponentialBackoff;
+use serde::Deserialize;
+
+use crate::error::LlmError;
+use crate::model::ProviderModelInfo;
+use crate::providers::anthropic::config::AnthropicConfig;
+use crate::providers::anthropic::error::map_anthropic_error;
+use crate::providers::anthropic::stream::AnthropicSdkStream;
+
+#[async_trait]
+pub(crate) trait AnthropicTransport: Send + Sync {
+    async fn create(
+        &self,
+        request: async_anthropic::types::CreateMessagesRequest,
+    ) -> Result<async_anthropic::types::CreateMessagesResponse, LlmError>;
+
+    async fn create_stream(
+        &self,
+        request: async_anthropic::types::CreateMessagesRequest,
+    ) -> Result<AnthropicSdkStream, LlmError>;
+
+    async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError>;
+}
+
+#[derive(Clone)]
+pub struct AsyncAnthropicTransport {
+    client: async_anthropic::Client,
+    http_client: reqwest::Client,
+    base_url: String,
+    api_key: String,
+    api_version: String,
+    beta: Option<String>,
+}
+
+impl AsyncAnthropicTransport {
+    pub fn new(config: &AnthropicConfig) -> Result<Self, LlmError> {
+        let http_client = reqwest::Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|err| LlmError::Transport(format!("构建 Anthropic HTTP 客户端失败：{err}")))?;
+
+        let no_retry = ExponentialBackoff {
+            max_elapsed_time: Some(Duration::from_nanos(1)),
+            ..Default::default()
+        };
+
+        let api_version = config.resolve_api_version();
+        let base_url = config
+            .normalized_base_url()
+            .unwrap_or_else(|| "https://api.anthropic.com".to_string());
+
+        let mut builder_binding = async_anthropic::Client::builder();
+        let mut builder = builder_binding
+            .http_client(http_client.clone())
+            .api_key(config.api_key.clone())
+            .version(api_version.clone())
+            .backoff(no_retry);
+
+        builder = builder.base_url(base_url.clone());
+        if let Some(beta) = &config.beta {
+            builder = builder.beta(beta.clone());
+        }
+
+        let client = builder.build().map_err(|err| {
+            LlmError::Configuration(format!("构建 Anthropic SDK 客户端失败：{err}"))
+        })?;
+
+        Ok(Self {
+            client,
+            http_client,
+            base_url,
+            api_key: config.api_key.clone(),
+            api_version,
+            beta: config.beta.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl AnthropicTransport for AsyncAnthropicTransport {
+    async fn create(
+        &self,
+        request: async_anthropic::types::CreateMessagesRequest,
+    ) -> Result<async_anthropic::types::CreateMessagesResponse, LlmError> {
+        self.client
+            .messages()
+            .create(request)
+            .await
+            .map_err(map_anthropic_error)
+    }
+
+    async fn create_stream(
+        &self,
+        request: async_anthropic::types::CreateMessagesRequest,
+    ) -> Result<AnthropicSdkStream, LlmError> {
+        Ok(self.client.messages().create_stream(request).await)
+    }
+
+    async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
+        let url = format!("{}/v1/models", self.base_url.trim_end_matches('/'));
+        let mut request = self
+            .http_client
+            .get(url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", &self.api_version)
+            .header(reqwest::header::ACCEPT, "application/json");
+        if let Some(beta) = &self.beta {
+            request = request.header("anthropic-beta", beta);
+        }
+
+        let response = request.send().await.map_err(|err| {
+            if err.is_timeout() {
+                LlmError::Timeout(0)
+            } else {
+                LlmError::Transport(err.to_string())
+            }
+        })?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|err| LlmError::Transport(format!("读取 Anthropic 响应体失败：{err}")))?;
+
+        if !status.is_success() {
+            return Err(map_list_models_http_error(status, &body));
+        }
+
+        parse_models_response(&body)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct AnthropicClient<T = AsyncAnthropicTransport> {
+    transport: T,
+    config: AnthropicConfig,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicModelsEnvelope {
+    #[serde(default)]
+    data: Vec<AnthropicModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicModelEntry {
+    id: String,
+    #[serde(default)]
+    display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicDirectModelEntry {
+    id: String,
+    #[serde(default)]
+    display_name: Option<String>,
+}
+
+fn parse_models_response(body: &str) -> Result<Vec<ProviderModelInfo>, LlmError> {
+    if let Ok(response) = serde_json::from_str::<AnthropicModelsEnvelope>(body) {
+        return Ok(response
+            .data
+            .into_iter()
+            .map(|model| ProviderModelInfo {
+                display_name: model.display_name.or_else(|| Some(model.id.clone())),
+                id: model.id,
+            })
+            .collect());
+    }
+
+    if let Ok(response) = serde_json::from_str::<Vec<AnthropicDirectModelEntry>>(body) {
+        return Ok(response
+            .into_iter()
+            .map(|model| ProviderModelInfo {
+                display_name: model.display_name.or_else(|| Some(model.id.clone())),
+                id: model.id,
+            })
+            .collect());
+    }
+
+    Err(LlmError::Serialization(format!(
+        "解析 Anthropic 模型列表失败，响应体前 512 字节：{}",
+        body.chars().take(512).collect::<String>()
+    )))
+}
+
+fn map_list_models_http_error(status: reqwest::StatusCode, body: &str) -> LlmError {
+    let message = body.chars().take(512).collect::<String>();
+    match status {
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+            LlmError::Authentication(format!("请检查 Anthropic API Key：{message}"))
+        }
+        reqwest::StatusCode::TOO_MANY_REQUESTS => LlmError::RateLimited(message),
+        reqwest::StatusCode::BAD_REQUEST => LlmError::InvalidRequest(message),
+        _ if status.is_server_error() => LlmError::Transport(format!(
+            "Anthropic 模型列表请求失败，HTTP {}: {}",
+            status.as_u16(),
+            message
+        )),
+        _ => LlmError::Provider {
+            provider: "anthropic",
+            message: format!("模型列表请求失败，HTTP {}: {}", status.as_u16(), message),
+        },
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::parse_models_response;
+
+    #[test]
+    fn parse_official_models_response() {
+        let models = parse_models_response(
+            r#"{
+                "data":[
+                    {
+                        "type":"model",
+                        "id":"claude-sonnet-4-20250514",
+                        "display_name":"Claude Sonnet 4",
+                        "created_at":"2025-05-14T00:00:00Z"
+                    }
+                ],
+                "has_more":false,
+                "first_id":"claude-sonnet-4-20250514",
+                "last_id":"claude-sonnet-4-20250514"
+            }"#,
+        )
+        .expect("parse official response");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "claude-sonnet-4-20250514");
+        assert_eq!(models[0].display_name.as_deref(), Some("Claude Sonnet 4"));
+    }
+
+    #[test]
+    fn parse_proxy_models_response_without_display_name() {
+        let models = parse_models_response(
+            r#"{
+                "data":[
+                    {"id":"claude-3-5-sonnet-latest","object":"model"}
+                ]
+            }"#,
+        )
+        .expect("parse proxy response");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "claude-3-5-sonnet-latest");
+        assert_eq!(
+            models[0].display_name.as_deref(),
+            Some("claude-3-5-sonnet-latest")
+        );
+    }
+}
+
+impl AnthropicClient<AsyncAnthropicTransport> {
+    pub fn from_config(config: AnthropicConfig) -> Result<Self, LlmError> {
+        let transport = AsyncAnthropicTransport::new(&config)?;
+        Ok(Self { transport, config })
+    }
+}
+
+impl<T> AnthropicClient<T>
+where
+    T: AnthropicTransport,
+{
+    #[cfg(test)]
+    pub fn new(transport: T, config: AnthropicConfig) -> Self {
+        Self { transport, config }
+    }
+
+    pub async fn create(
+        &self,
+        request: async_anthropic::types::CreateMessagesRequest,
+    ) -> Result<async_anthropic::types::CreateMessagesResponse, LlmError> {
+        let model = request.model.clone();
+        self.run_with_retry("anthropic_complete", "anthropic", &model, false, || {
+            let request = request.clone();
+            async move { self.transport.create(request).await }
+        })
+        .await
+    }
+
+    pub async fn create_stream(
+        &self,
+        request: async_anthropic::types::CreateMessagesRequest,
+    ) -> Result<AnthropicSdkStream, LlmError> {
+        let model = request.model.clone();
+        self.run_with_retry("anthropic_stream", "anthropic", &model, true, || {
+            let request = request.clone();
+            async move { self.transport.create_stream(request).await }
+        })
+        .await
+    }
+
+    pub async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
+        self.run_with_retry(
+            "anthropic_list_models",
+            "anthropic",
+            "<list_models>",
+            false,
+            || async { self.transport.list_models().await },
+        )
+        .await
+    }
+
+    async fn run_with_retry<F, Fut, R>(
+        &self,
+        operation: &'static str,
+        provider: &'static str,
+        model: &str,
+        stream: bool,
+        mut f: F,
+    ) -> Result<R, LlmError>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<R, LlmError>>,
+    {
+        let mut attempt = 0u32;
+        let mut delay_ms = 1000u64;
+
+        loop {
+            let start = std::time::Instant::now();
+            tracing::info!(
+                operation,
+                provider,
+                model,
+                stream,
+                attempt,
+                "开始 Anthropic 请求"
+            );
+            match f().await {
+                Ok(result) => {
+                    tracing::info!(
+                        operation,
+                        provider,
+                        model,
+                        stream,
+                        attempt,
+                        latency_ms = start.elapsed().as_millis() as u64,
+                        "Anthropic 请求完成"
+                    );
+                    return Ok(result);
+                }
+                Err(err) if err.is_retryable() && attempt < self.config.max_retries => {
+                    attempt += 1;
+                    tracing::warn!(
+                        operation,
+                        provider,
+                        model,
+                        stream,
+                        attempt,
+                        delay_ms,
+                        error = %err,
+                        "Anthropic 请求失败，准备重试"
+                    );
+                    if let Some(notifier) = &self.config.retry_notifier {
+                        notifier(attempt, self.config.max_retries, delay_ms, &err.to_string());
+                    }
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                    delay_ms *= 2;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        operation,
+                        provider,
+                        model,
+                        stream,
+                        attempt,
+                        latency_ms = start.elapsed().as_millis() as u64,
+                        error = %err,
+                        "Anthropic 请求失败"
+                    );
+                    return Err(err);
+                }
+            }
+        }
+    }
+}

--- a/crates/tiangong-llm/src/providers/anthropic/config.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/config.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::error::LlmError;
+
+pub type RetryNotifier = Arc<dyn Fn(u32, u32, u64, &str) + Send + Sync>;
+
+const DEFAULT_API_VERSION: &str = "2023-06-01";
+
+/// Anthropic provider 配置。
+#[derive(Clone)]
+pub struct AnthropicConfig {
+    pub api_key: String,
+    pub base_url: Option<String>,
+    pub timeout: Duration,
+    pub max_retries: u32,
+    pub api_version: Option<String>,
+    pub beta: Option<String>,
+    pub retry_notifier: Option<RetryNotifier>,
+}
+
+impl std::fmt::Debug for AnthropicConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnthropicConfig")
+            .field("api_key", &(!self.api_key.is_empty()))
+            .field("base_url", &self.base_url)
+            .field("timeout", &self.timeout)
+            .field("max_retries", &self.max_retries)
+            .field("api_version", &self.api_version)
+            .field("beta", &self.beta)
+            .field("retry_notifier", &self.retry_notifier.is_some())
+            .finish()
+    }
+}
+
+impl AnthropicConfig {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            base_url: None,
+            timeout: Duration::from_secs(60),
+            max_retries: 3,
+            api_version: Some(DEFAULT_API_VERSION.to_string()),
+            beta: None,
+            retry_notifier: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn from_env() -> Result<Self, LlmError> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY")
+            .map_err(|_| LlmError::Configuration("缺少环境变量 ANTHROPIC_API_KEY".to_string()))?;
+        let mut config = Self::new(api_key);
+        config.base_url = std::env::var("ANTHROPIC_BASE_URL").ok();
+        config.api_version = std::env::var("ANTHROPIC_API_VERSION").ok();
+        Ok(config)
+    }
+
+    pub fn normalized_base_url(&self) -> Option<String> {
+        self.base_url.as_ref().map(|base_url| {
+            let trimmed = base_url.trim().trim_end_matches('/').to_string();
+            trimmed.strip_suffix("/v1").unwrap_or(&trimmed).to_string()
+        })
+    }
+
+    pub fn resolve_api_version(&self) -> String {
+        self.api_version
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(DEFAULT_API_VERSION)
+            .to_string()
+    }
+}

--- a/crates/tiangong-llm/src/providers/anthropic/error.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/error.rs
@@ -1,0 +1,30 @@
+use async_anthropic::errors::AnthropicError;
+
+use crate::error::LlmError;
+
+pub fn map_anthropic_error(error: AnthropicError) -> LlmError {
+    match error {
+        AnthropicError::NetworkError(err) => {
+            if err.is_timeout() {
+                LlmError::Timeout(0)
+            } else {
+                LlmError::Transport(err.to_string())
+            }
+        }
+        AnthropicError::BadRequest(message) => LlmError::InvalidRequest(message),
+        AnthropicError::ApiError(message) => LlmError::RateLimited(message),
+        AnthropicError::Unauthorized => {
+            LlmError::Authentication("请检查 Anthropic API Key".to_string())
+        }
+        AnthropicError::DeserializationError(err) => LlmError::Serialization(err.to_string()),
+        AnthropicError::Unknown(message) => LlmError::Provider {
+            provider: "anthropic",
+            message,
+        },
+        AnthropicError::UnexpectedError => LlmError::Provider {
+            provider: "anthropic",
+            message: "unexpected error".to_string(),
+        },
+        AnthropicError::StreamError(err) => LlmError::Stream(err.to_string()),
+    }
+}

--- a/crates/tiangong-llm/src/providers/anthropic/error.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/error.rs
@@ -1,30 +1,19 @@
-use async_anthropic::errors::AnthropicError;
+use tiangong_anthropic::AnthropicError;
 
 use crate::error::LlmError;
 
 pub fn map_anthropic_error(error: AnthropicError) -> LlmError {
     match error {
-        AnthropicError::NetworkError(err) => {
-            if err.is_timeout() {
-                LlmError::Timeout(0)
-            } else {
-                LlmError::Transport(err.to_string())
-            }
-        }
-        AnthropicError::BadRequest(message) => LlmError::InvalidRequest(message),
-        AnthropicError::ApiError(message) => LlmError::RateLimited(message),
-        AnthropicError::Unauthorized => {
-            LlmError::Authentication("请检查 Anthropic API Key".to_string())
-        }
-        AnthropicError::DeserializationError(err) => LlmError::Serialization(err.to_string()),
-        AnthropicError::Unknown(message) => LlmError::Provider {
+        AnthropicError::Config(err) => LlmError::Configuration(err),
+        AnthropicError::Transport(err) => LlmError::Transport(err),
+        AnthropicError::Authentication(err) => LlmError::Authentication(err),
+        AnthropicError::InvalidRequest(err) => LlmError::InvalidRequest(err),
+        AnthropicError::RateLimited(err) => LlmError::RateLimited(err),
+        AnthropicError::Serialization(err) => LlmError::Serialization(err),
+        AnthropicError::Stream(err) => LlmError::Stream(err),
+        AnthropicError::Api(err) => LlmError::Provider {
             provider: "anthropic",
-            message,
+            message: err,
         },
-        AnthropicError::UnexpectedError => LlmError::Provider {
-            provider: "anthropic",
-            message: "unexpected error".to_string(),
-        },
-        AnthropicError::StreamError(err) => LlmError::Stream(err.to_string()),
     }
 }

--- a/crates/tiangong-llm/src/providers/anthropic/mapping.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/mapping.rs
@@ -283,7 +283,7 @@ pub(super) fn map_stream_event(
         }
         StreamEvent::MessageStop => Ok(vec![ProviderStreamEvent::MessageEnd]),
         StreamEvent::Error { message } => Ok(vec![ProviderStreamEvent::Error(message)]),
-        StreamEvent::Ping => Ok(Vec::new()),
+        StreamEvent::Ping | StreamEvent::Unknown => Ok(Vec::new()),
     }
 }
 

--- a/crates/tiangong-llm/src/providers/anthropic/mapping.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/mapping.rs
@@ -1,10 +1,16 @@
 use std::collections::BTreeMap;
 
-use serde_json::{Map, Value};
+use serde_json::Value;
+use tiangong_anthropic::types::{
+    ContentBlock, ContentBlockDeltaData, ContentBlockParam, ContentBlockStartData,
+    Message as AnthropicMessage, MessageRole as AnthropicMessageRole, MessagesCreateRequest,
+    MessagesCreateResponse, StreamEvent, ThinkingConfig, Tool as AnthropicTool,
+    ToolChoice as AnthropicToolChoice, Usage,
+};
 
 use crate::error::LlmError;
 use crate::message::{ChatMessage, MessageContent, MessageRole};
-use crate::request::ProviderRequest;
+use crate::request::{ProviderRequest, ThinkingConfig as ProviderThinkingConfig};
 use crate::response::{ProviderResponse, StopReason};
 use crate::stream::ProviderStreamEvent;
 use crate::tool::{ToolCall, ToolChoice, ToolResult, ToolResultContent};
@@ -12,84 +18,71 @@ use crate::usage::TokenUsageData;
 
 pub(super) fn to_anthropic_request(
     request: &ProviderRequest,
-) -> Result<async_anthropic::types::CreateMessagesRequest, LlmError> {
+) -> Result<MessagesCreateRequest, LlmError> {
     let messages = request
         .messages
         .iter()
         .filter_map(map_message)
         .collect::<Result<Vec<_>, _>>()?;
 
-    let tools: Option<Vec<Map<String, Value>>> = if request.tools.is_empty() {
+    let tools = if request.tools.is_empty() {
         None
     } else {
         Some(
             request
                 .tools
                 .iter()
-                .map(|tool| {
-                    let mut item = Map::new();
-                    item.insert("name".to_string(), Value::String(tool.name.clone()));
-                    item.insert(
-                        "description".to_string(),
-                        Value::String(tool.description.clone()),
-                    );
-                    item.insert("input_schema".to_string(), tool.input_schema.clone());
-                    item
+                .map(|tool| AnthropicTool {
+                    name: tool.name.clone(),
+                    description: Some(tool.description.clone()),
+                    input_schema: tool.input_schema.clone(),
                 })
                 .collect(),
         )
     };
 
     let tool_choice = request.tool_choice.as_ref().map(|choice| match choice {
-        ToolChoice::Auto => async_anthropic::types::ToolChoice::Auto,
-        ToolChoice::Any => async_anthropic::types::ToolChoice::Any,
-        ToolChoice::Tool(name) => async_anthropic::types::ToolChoice::Tool(name.clone()),
+        ToolChoice::Auto => AnthropicToolChoice::Auto,
+        ToolChoice::Any => AnthropicToolChoice::Any,
+        ToolChoice::Tool(name) => AnthropicToolChoice::Tool {
+            name: name.clone(),
+            disable_parallel_tool_use: None,
+        },
     });
 
-    let mut builder = async_anthropic::types::CreateMessagesRequestBuilder::default();
-    builder
-        .model(request.model.clone())
-        .messages(messages)
-        .max_tokens(request.max_tokens.unwrap_or(4096) as i32);
-
-    if let Some(system) = request
-        .system
-        .as_ref()
-        .filter(|value| !value.trim().is_empty())
-    {
-        builder.system(system.clone());
-    }
-    if let Some(temperature) = request.temperature {
-        builder.temperature(temperature);
-    }
-    if let Some(top_p) = request.top_p {
-        builder.top_p(top_p);
-    }
-    if !request.stop_sequences.is_empty() {
-        builder.stop_sequences(request.stop_sequences.clone());
-    }
-    if let Some(metadata) = request.metadata.clone() {
-        builder.metadata(metadata);
-    }
-    if let Some(tools) = tools {
-        builder.tools(tools);
-    }
-    if let Some(tool_choice) = tool_choice {
-        builder.tool_choice(tool_choice);
-    }
-
-    builder
-        .build()
-        .map_err(|err| LlmError::InvalidRequest(format!("构建 Anthropic 请求失败：{err}")))
+    Ok(MessagesCreateRequest {
+        model: request.model.clone(),
+        max_tokens: request.max_tokens.unwrap_or(4096),
+        system: request
+            .system
+            .clone()
+            .filter(|value| !value.trim().is_empty()),
+        messages,
+        temperature: request.temperature,
+        stop_sequences: (!request.stop_sequences.is_empty())
+            .then(|| request.stop_sequences.clone()),
+        top_p: request.top_p,
+        metadata: request.metadata.clone(),
+        tools,
+        tool_choice,
+        stream: None,
+        thinking: map_thinking_config(request.thinking.as_ref()),
+    })
 }
 
-fn map_message(message: &ChatMessage) -> Option<Result<async_anthropic::types::Message, LlmError>> {
+fn map_thinking_config(thinking: Option<&ProviderThinkingConfig>) -> Option<ThinkingConfig> {
+    thinking.map(|thinking| ThinkingConfig::Enabled {
+        budget_tokens: thinking.budget_tokens,
+    })
+}
+
+fn map_message(message: &ChatMessage) -> Option<Result<AnthropicMessage, LlmError>> {
     match message.role {
         MessageRole::System => None,
         MessageRole::User | MessageRole::Assistant | MessageRole::Tool => {
             let role = match message.role {
-                MessageRole::Assistant => async_anthropic::types::MessageRole::Assistant,
-                _ => async_anthropic::types::MessageRole::User,
+                MessageRole::Assistant => AnthropicMessageRole::Assistant,
+                _ => AnthropicMessageRole::User,
             };
 
             let content = message
@@ -97,34 +90,27 @@ fn map_message(message: &ChatMessage) -> Option<Result<async_anthropic::types::M
                 .iter()
                 .map(map_content)
                 .collect::<Result<Vec<_>, _>>();
-            Some(content.map(|content| async_anthropic::types::Message {
-                role,
-                content: async_anthropic::types::MessageContentList(content),
-            }))
+            Some(content.map(|content| AnthropicMessage { role, content }))
         }
     }
 }
 
-fn map_content(
-    content: &MessageContent,
-) -> Result<async_anthropic::types::MessageContent, LlmError> {
+fn map_content(content: &MessageContent) -> Result<ContentBlockParam, LlmError> {
     match content {
-        MessageContent::Text(text) => Ok(async_anthropic::types::Text::from(text).into()),
-        MessageContent::ToolCall(tool_call) => Ok(async_anthropic::types::ToolUse {
+        MessageContent::Text(text) => Ok(ContentBlockParam::Text { text: text.clone() }),
+        MessageContent::ToolCall(tool_call) => Ok(ContentBlockParam::ToolUse {
             id: tool_call.id.clone(),
             name: tool_call.name.clone(),
             input: tool_call.arguments.clone(),
-        }
-        .into()),
-        MessageContent::ToolResult(tool_result) => Ok(async_anthropic::types::ToolResult {
+        }),
+        MessageContent::ToolResult(tool_result) => Ok(ContentBlockParam::ToolResult {
             tool_use_id: tool_result.tool_call_id.clone(),
             content: Some(match &tool_result.content {
-                ToolResultContent::Text(text) => text.clone(),
-                ToolResultContent::Json(value) => value.to_string(),
+                ToolResultContent::Text(text) => Value::String(text.clone()),
+                ToolResultContent::Json(value) => value.clone(),
             }),
-            is_error: tool_result.is_error,
-        }
-        .into()),
+            is_error: Some(tool_result.is_error),
+        }),
         MessageContent::Image(_) => Err(LlmError::UnsupportedFeature(
             "Anthropic 图片输入映射暂未实现".to_string(),
         )),
@@ -132,62 +118,69 @@ fn map_content(
 }
 
 pub(super) fn from_anthropic_response(
-    response: async_anthropic::types::CreateMessagesResponse,
+    response: MessagesCreateResponse,
 ) -> Result<ProviderResponse, LlmError> {
     let raw = serde_json::to_value(&response)
         .map(Some)
         .map_err(|err| LlmError::Serialization(err.to_string()))?;
 
-    let content = response.content.unwrap_or_default();
-    let assistant_message = ChatMessage {
-        role: MessageRole::Assistant,
-        content: content
-            .into_iter()
-            .map(from_content)
-            .collect::<Result<Vec<_>, _>>()?,
-    };
-
-    let usage = response.usage.map(|usage| {
-        TokenUsageData::new(
-            usage.input_tokens.unwrap_or(0) as usize,
-            usage.output_tokens.unwrap_or(0) as usize,
+    let mut reasoning_chunks = Vec::new();
+    let assistant_content = response
+        .content
+        .into_iter()
+        .filter_map(
+            |content| match from_content(content, &mut reasoning_chunks) {
+                Ok(Some(item)) => Some(Ok(item)),
+                Ok(None) => None,
+                Err(err) => Some(Err(err)),
+            },
         )
-    });
+        .collect::<Result<Vec<_>, _>>()?;
 
     Ok(ProviderResponse {
-        id: response.id,
-        model: response.model,
-        assistant_message,
-        reasoning_content: None,
+        id: Some(response.id),
+        model: Some(response.model),
+        assistant_message: ChatMessage {
+            role: MessageRole::Assistant,
+            content: assistant_content,
+        },
+        reasoning_content: (!reasoning_chunks.is_empty()).then(|| reasoning_chunks.join("")),
         stop_reason: response.stop_reason.as_deref().map(map_stop_reason),
-        usage,
+        usage: response.usage.map(map_usage),
         raw,
     })
 }
 
 fn from_content(
-    content: async_anthropic::types::MessageContent,
-) -> Result<MessageContent, LlmError> {
+    content: ContentBlock,
+    reasoning_chunks: &mut Vec<String>,
+) -> Result<Option<MessageContent>, LlmError> {
     match content {
-        async_anthropic::types::MessageContent::Text(text) => Ok(MessageContent::Text(text.text)),
-        async_anthropic::types::MessageContent::ToolUse(tool_use) => {
-            Ok(MessageContent::ToolCall(ToolCall {
-                id: tool_use.id,
-                name: tool_use.name,
-                arguments: tool_use.input,
-            }))
+        ContentBlock::Text { text } => Ok(Some(MessageContent::Text(text))),
+        ContentBlock::ToolUse { id, name, input } => Ok(Some(MessageContent::ToolCall(ToolCall {
+            id,
+            name,
+            arguments: input,
+        }))),
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        } => Ok(Some(MessageContent::ToolResult(ToolResult {
+            tool_call_id: tool_use_id,
+            content: match content {
+                Some(Value::String(text)) => ToolResultContent::Text(text),
+                Some(value) => ToolResultContent::Json(value),
+                None => ToolResultContent::Text(String::new()),
+            },
+            is_error: is_error.unwrap_or(false),
+        }))),
+        ContentBlock::Thinking { thinking, .. } => {
+            reasoning_chunks.push(thinking);
+            Ok(None)
         }
-        async_anthropic::types::MessageContent::ToolResult(tool_result) => {
-            let content = tool_result
-                .content
-                .map(ToolResultContent::Text)
-                .unwrap_or_else(|| ToolResultContent::Text(String::new()));
-            Ok(MessageContent::ToolResult(ToolResult {
-                tool_call_id: tool_result.tool_use_id,
-                content,
-                is_error: tool_result.is_error,
-            }))
-        }
+        ContentBlock::RedactedThinking { .. } => Ok(None),
+        ContentBlock::Unknown => Ok(None),
     }
 }
 
@@ -199,6 +192,13 @@ fn map_stop_reason(reason: &str) -> StopReason {
         "stop_sequence" => StopReason::StopSequence,
         other => StopReason::Other(other.to_string()),
     }
+}
+
+fn map_usage(usage: Usage) -> TokenUsageData {
+    TokenUsageData::new(
+        usage.input_tokens.unwrap_or(0) as usize,
+        usage.output_tokens.unwrap_or(0) as usize,
+    )
 }
 
 #[derive(Default)]
@@ -213,75 +213,77 @@ struct ToolCallAccumulator {
 
 pub(super) fn map_stream_event(
     state: &mut AnthropicStreamState,
-    event: async_anthropic::types::MessagesStreamEvent,
+    event: StreamEvent,
 ) -> Result<Vec<ProviderStreamEvent>, LlmError> {
     match event {
-        async_anthropic::types::MessagesStreamEvent::MessageStart { usage, .. } => {
+        StreamEvent::MessageStart { message } => {
             let mut events = vec![ProviderStreamEvent::MessageStart];
-            if let Some(usage) = usage {
-                events.push(ProviderStreamEvent::Usage(TokenUsageData::new(
-                    usage.input_tokens.unwrap_or(0) as usize,
-                    usage.output_tokens.unwrap_or(0) as usize,
-                )));
+            if let Some(usage) = message.usage {
+                events.push(ProviderStreamEvent::Usage(map_usage(usage)));
             }
             Ok(events)
         }
-        async_anthropic::types::MessagesStreamEvent::ContentBlockStart {
+        StreamEvent::ContentBlockStart {
             index,
             content_block,
         } => match content_block {
-            async_anthropic::types::MessageContent::ToolUse(tool_use) => {
-                state.tool_calls.insert(
-                    index,
-                    ToolCallAccumulator {
-                        id: tool_use.id.clone(),
-                    },
-                );
+            ContentBlockStartData::ToolUse { id, name, input } => {
+                state
+                    .tool_calls
+                    .insert(index, ToolCallAccumulator { id: id.clone() });
                 Ok(vec![ProviderStreamEvent::ToolCallStart(ToolCall {
-                    id: tool_use.id,
-                    name: tool_use.name,
-                    arguments: tool_use.input,
+                    id,
+                    name,
+                    arguments: input,
                 })])
+            }
+            ContentBlockStartData::Thinking { thinking, .. } if !thinking.is_empty() => {
+                Ok(vec![ProviderStreamEvent::ReasoningDelta(thinking)])
+            }
+            ContentBlockStartData::Text { text } if !text.is_empty() => {
+                Ok(vec![ProviderStreamEvent::TextDelta(text)])
             }
             _ => Ok(Vec::new()),
         },
-        async_anthropic::types::MessagesStreamEvent::ContentBlockDelta { index, delta } => {
-            match delta {
-                async_anthropic::types::ContentBlockDelta::TextDelta { text } => {
-                    Ok(vec![ProviderStreamEvent::TextDelta(text)])
-                }
-                async_anthropic::types::ContentBlockDelta::InputJsonDelta { partial_json } => {
-                    let call_id = state
-                        .tool_calls
-                        .get(&index)
-                        .map(|call| call.id.clone())
-                        .unwrap_or_else(|| format!("tool_call_{index}"));
-                    Ok(vec![ProviderStreamEvent::ToolCallDelta {
-                        call_id,
-                        partial_json,
-                    }])
-                }
+        StreamEvent::ContentBlockDelta { index, delta } => match delta {
+            ContentBlockDeltaData::TextDelta { text } => {
+                Ok(vec![ProviderStreamEvent::TextDelta(text)])
             }
-        }
-        async_anthropic::types::MessagesStreamEvent::ContentBlockStop { index } => {
+            ContentBlockDeltaData::InputJsonDelta { partial_json } => {
+                let call_id = state
+                    .tool_calls
+                    .get(&index)
+                    .map(|call| call.id.clone())
+                    .unwrap_or_else(|| format!("tool_call_{index}"));
+                Ok(vec![ProviderStreamEvent::ToolCallDelta {
+                    call_id,
+                    partial_json,
+                }])
+            }
+            ContentBlockDeltaData::ThinkingDelta { thinking } => {
+                Ok(vec![ProviderStreamEvent::ReasoningDelta(thinking)])
+            }
+            ContentBlockDeltaData::SignatureDelta { .. } | ContentBlockDeltaData::Unknown => {
+                Ok(Vec::new())
+            }
+        },
+        StreamEvent::ContentBlockStop { index } => {
             if let Some(call) = state.tool_calls.remove(&index) {
                 Ok(vec![ProviderStreamEvent::ToolCallEnd { call_id: call.id }])
             } else {
                 Ok(Vec::new())
             }
         }
-        async_anthropic::types::MessagesStreamEvent::MessageDelta { usage, .. } => {
+        StreamEvent::MessageDelta { usage, .. } => {
             if let Some(usage) = usage {
-                return Ok(vec![ProviderStreamEvent::Usage(TokenUsageData::new(
-                    usage.input_tokens.unwrap_or(0) as usize,
-                    usage.output_tokens.unwrap_or(0) as usize,
-                ))]);
+                Ok(vec![ProviderStreamEvent::Usage(map_usage(usage))])
+            } else {
+                Ok(Vec::new())
             }
-            Ok(Vec::new())
         }
-        async_anthropic::types::MessagesStreamEvent::MessageStop => {
-            Ok(vec![ProviderStreamEvent::MessageEnd])
-        }
+        StreamEvent::MessageStop => Ok(vec![ProviderStreamEvent::MessageEnd]),
+        StreamEvent::Error { message } => Ok(vec![ProviderStreamEvent::Error(message)]),
+        StreamEvent::Ping => Ok(Vec::new()),
     }
 }
 

--- a/crates/tiangong-llm/src/providers/anthropic/mapping.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/mapping.rs
@@ -1,0 +1,292 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+
+use crate::error::LlmError;
+use crate::message::{ChatMessage, MessageContent, MessageRole};
+use crate::request::ProviderRequest;
+use crate::response::{ProviderResponse, StopReason};
+use crate::stream::ProviderStreamEvent;
+use crate::tool::{ToolCall, ToolChoice, ToolResult, ToolResultContent};
+use crate::usage::TokenUsageData;
+
+pub(super) fn to_anthropic_request(
+    request: &ProviderRequest,
+) -> Result<async_anthropic::types::CreateMessagesRequest, LlmError> {
+    let messages = request
+        .messages
+        .iter()
+        .filter_map(map_message)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let tools: Option<Vec<Map<String, Value>>> = if request.tools.is_empty() {
+        None
+    } else {
+        Some(
+            request
+                .tools
+                .iter()
+                .map(|tool| {
+                    let mut item = Map::new();
+                    item.insert("name".to_string(), Value::String(tool.name.clone()));
+                    item.insert(
+                        "description".to_string(),
+                        Value::String(tool.description.clone()),
+                    );
+                    item.insert("input_schema".to_string(), tool.input_schema.clone());
+                    item
+                })
+                .collect(),
+        )
+    };
+
+    let tool_choice = request.tool_choice.as_ref().map(|choice| match choice {
+        ToolChoice::Auto => async_anthropic::types::ToolChoice::Auto,
+        ToolChoice::Any => async_anthropic::types::ToolChoice::Any,
+        ToolChoice::Tool(name) => async_anthropic::types::ToolChoice::Tool(name.clone()),
+    });
+
+    let mut builder = async_anthropic::types::CreateMessagesRequestBuilder::default();
+    builder
+        .model(request.model.clone())
+        .messages(messages)
+        .max_tokens(request.max_tokens.unwrap_or(4096) as i32);
+
+    if let Some(system) = request
+        .system
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        builder.system(system.clone());
+    }
+    if let Some(temperature) = request.temperature {
+        builder.temperature(temperature);
+    }
+    if let Some(top_p) = request.top_p {
+        builder.top_p(top_p);
+    }
+    if !request.stop_sequences.is_empty() {
+        builder.stop_sequences(request.stop_sequences.clone());
+    }
+    if let Some(metadata) = request.metadata.clone() {
+        builder.metadata(metadata);
+    }
+    if let Some(tools) = tools {
+        builder.tools(tools);
+    }
+    if let Some(tool_choice) = tool_choice {
+        builder.tool_choice(tool_choice);
+    }
+
+    builder
+        .build()
+        .map_err(|err| LlmError::InvalidRequest(format!("构建 Anthropic 请求失败：{err}")))
+}
+
+fn map_message(message: &ChatMessage) -> Option<Result<async_anthropic::types::Message, LlmError>> {
+    match message.role {
+        MessageRole::System => None,
+        MessageRole::User | MessageRole::Assistant | MessageRole::Tool => {
+            let role = match message.role {
+                MessageRole::Assistant => async_anthropic::types::MessageRole::Assistant,
+                _ => async_anthropic::types::MessageRole::User,
+            };
+
+            let content = message
+                .content
+                .iter()
+                .map(map_content)
+                .collect::<Result<Vec<_>, _>>();
+            Some(content.map(|content| async_anthropic::types::Message {
+                role,
+                content: async_anthropic::types::MessageContentList(content),
+            }))
+        }
+    }
+}
+
+fn map_content(
+    content: &MessageContent,
+) -> Result<async_anthropic::types::MessageContent, LlmError> {
+    match content {
+        MessageContent::Text(text) => Ok(async_anthropic::types::Text::from(text).into()),
+        MessageContent::ToolCall(tool_call) => Ok(async_anthropic::types::ToolUse {
+            id: tool_call.id.clone(),
+            name: tool_call.name.clone(),
+            input: tool_call.arguments.clone(),
+        }
+        .into()),
+        MessageContent::ToolResult(tool_result) => Ok(async_anthropic::types::ToolResult {
+            tool_use_id: tool_result.tool_call_id.clone(),
+            content: Some(match &tool_result.content {
+                ToolResultContent::Text(text) => text.clone(),
+                ToolResultContent::Json(value) => value.to_string(),
+            }),
+            is_error: tool_result.is_error,
+        }
+        .into()),
+        MessageContent::Image(_) => Err(LlmError::UnsupportedFeature(
+            "Anthropic 图片输入映射暂未实现".to_string(),
+        )),
+    }
+}
+
+pub(super) fn from_anthropic_response(
+    response: async_anthropic::types::CreateMessagesResponse,
+) -> Result<ProviderResponse, LlmError> {
+    let raw = serde_json::to_value(&response)
+        .map(Some)
+        .map_err(|err| LlmError::Serialization(err.to_string()))?;
+
+    let content = response.content.unwrap_or_default();
+    let assistant_message = ChatMessage {
+        role: MessageRole::Assistant,
+        content: content
+            .into_iter()
+            .map(from_content)
+            .collect::<Result<Vec<_>, _>>()?,
+    };
+
+    let usage = response.usage.map(|usage| {
+        TokenUsageData::new(
+            usage.input_tokens.unwrap_or(0) as usize,
+            usage.output_tokens.unwrap_or(0) as usize,
+        )
+    });
+
+    Ok(ProviderResponse {
+        id: response.id,
+        model: response.model,
+        assistant_message,
+        reasoning_content: None,
+        stop_reason: response.stop_reason.as_deref().map(map_stop_reason),
+        usage,
+        raw,
+    })
+}
+
+fn from_content(
+    content: async_anthropic::types::MessageContent,
+) -> Result<MessageContent, LlmError> {
+    match content {
+        async_anthropic::types::MessageContent::Text(text) => Ok(MessageContent::Text(text.text)),
+        async_anthropic::types::MessageContent::ToolUse(tool_use) => {
+            Ok(MessageContent::ToolCall(ToolCall {
+                id: tool_use.id,
+                name: tool_use.name,
+                arguments: tool_use.input,
+            }))
+        }
+        async_anthropic::types::MessageContent::ToolResult(tool_result) => {
+            let content = tool_result
+                .content
+                .map(ToolResultContent::Text)
+                .unwrap_or_else(|| ToolResultContent::Text(String::new()));
+            Ok(MessageContent::ToolResult(ToolResult {
+                tool_call_id: tool_result.tool_use_id,
+                content,
+                is_error: tool_result.is_error,
+            }))
+        }
+    }
+}
+
+fn map_stop_reason(reason: &str) -> StopReason {
+    match reason {
+        "end_turn" => StopReason::EndTurn,
+        "tool_use" => StopReason::ToolUse,
+        "max_tokens" => StopReason::MaxTokens,
+        "stop_sequence" => StopReason::StopSequence,
+        other => StopReason::Other(other.to_string()),
+    }
+}
+
+#[derive(Default)]
+pub(super) struct AnthropicStreamState {
+    tool_calls: BTreeMap<usize, ToolCallAccumulator>,
+}
+
+#[derive(Default)]
+struct ToolCallAccumulator {
+    id: String,
+}
+
+pub(super) fn map_stream_event(
+    state: &mut AnthropicStreamState,
+    event: async_anthropic::types::MessagesStreamEvent,
+) -> Result<Vec<ProviderStreamEvent>, LlmError> {
+    match event {
+        async_anthropic::types::MessagesStreamEvent::MessageStart { usage, .. } => {
+            let mut events = vec![ProviderStreamEvent::MessageStart];
+            if let Some(usage) = usage {
+                events.push(ProviderStreamEvent::Usage(TokenUsageData::new(
+                    usage.input_tokens.unwrap_or(0) as usize,
+                    usage.output_tokens.unwrap_or(0) as usize,
+                )));
+            }
+            Ok(events)
+        }
+        async_anthropic::types::MessagesStreamEvent::ContentBlockStart {
+            index,
+            content_block,
+        } => match content_block {
+            async_anthropic::types::MessageContent::ToolUse(tool_use) => {
+                state.tool_calls.insert(
+                    index,
+                    ToolCallAccumulator {
+                        id: tool_use.id.clone(),
+                    },
+                );
+                Ok(vec![ProviderStreamEvent::ToolCallStart(ToolCall {
+                    id: tool_use.id,
+                    name: tool_use.name,
+                    arguments: tool_use.input,
+                })])
+            }
+            _ => Ok(Vec::new()),
+        },
+        async_anthropic::types::MessagesStreamEvent::ContentBlockDelta { index, delta } => {
+            match delta {
+                async_anthropic::types::ContentBlockDelta::TextDelta { text } => {
+                    Ok(vec![ProviderStreamEvent::TextDelta(text)])
+                }
+                async_anthropic::types::ContentBlockDelta::InputJsonDelta { partial_json } => {
+                    let call_id = state
+                        .tool_calls
+                        .get(&index)
+                        .map(|call| call.id.clone())
+                        .unwrap_or_else(|| format!("tool_call_{index}"));
+                    Ok(vec![ProviderStreamEvent::ToolCallDelta {
+                        call_id,
+                        partial_json,
+                    }])
+                }
+            }
+        }
+        async_anthropic::types::MessagesStreamEvent::ContentBlockStop { index } => {
+            if let Some(call) = state.tool_calls.remove(&index) {
+                Ok(vec![ProviderStreamEvent::ToolCallEnd { call_id: call.id }])
+            } else {
+                Ok(Vec::new())
+            }
+        }
+        async_anthropic::types::MessagesStreamEvent::MessageDelta { usage, .. } => {
+            if let Some(usage) = usage {
+                return Ok(vec![ProviderStreamEvent::Usage(TokenUsageData::new(
+                    usage.input_tokens.unwrap_or(0) as usize,
+                    usage.output_tokens.unwrap_or(0) as usize,
+                ))]);
+            }
+            Ok(Vec::new())
+        }
+        async_anthropic::types::MessagesStreamEvent::MessageStop => {
+            Ok(vec![ProviderStreamEvent::MessageEnd])
+        }
+    }
+}
+
+pub(super) fn map_stream_error(
+    error: crate::error::LlmError,
+) -> Vec<Result<ProviderStreamEvent, LlmError>> {
+    vec![Err(error)]
+}

--- a/crates/tiangong-llm/src/providers/anthropic/mod.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/mod.rs
@@ -1,0 +1,12 @@
+mod client;
+mod config;
+mod error;
+mod mapping;
+mod provider;
+mod stream;
+
+#[cfg(test)]
+mod tests;
+
+pub use config::AnthropicConfig;
+pub use provider::AnthropicProvider;

--- a/crates/tiangong-llm/src/providers/anthropic/provider.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/provider.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::error::LlmError;
 use crate::model::ProviderModelInfo;
 use crate::provider::{LlmProvider, ProviderCapabilities};
-use crate::providers::anthropic::client::{AnthropicClient, AsyncAnthropicTransport};
+use crate::providers::anthropic::client::{AnthropicClient, NativeAnthropicTransport};
 use crate::providers::anthropic::config::AnthropicConfig;
 use crate::providers::anthropic::mapping::{from_anthropic_response, to_anthropic_request};
 use crate::providers::anthropic::stream::map_anthropic_stream;
@@ -12,11 +12,11 @@ use crate::response::ProviderResponse;
 use crate::stream::ProviderStream;
 
 #[derive(Clone)]
-pub struct AnthropicProvider<T = AsyncAnthropicTransport> {
+pub struct AnthropicProvider<T = NativeAnthropicTransport> {
     client: AnthropicClient<T>,
 }
 
-impl AnthropicProvider<AsyncAnthropicTransport> {
+impl AnthropicProvider<NativeAnthropicTransport> {
     pub fn from_config(config: AnthropicConfig) -> Result<Self, LlmError> {
         Ok(Self {
             client: AnthropicClient::from_config(config)?,

--- a/crates/tiangong-llm/src/providers/anthropic/provider.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/provider.rs
@@ -1,0 +1,63 @@
+use async_trait::async_trait;
+
+use crate::error::LlmError;
+use crate::model::ProviderModelInfo;
+use crate::provider::{LlmProvider, ProviderCapabilities};
+use crate::providers::anthropic::client::{AnthropicClient, AsyncAnthropicTransport};
+use crate::providers::anthropic::config::AnthropicConfig;
+use crate::providers::anthropic::mapping::{from_anthropic_response, to_anthropic_request};
+use crate::providers::anthropic::stream::map_anthropic_stream;
+use crate::request::ProviderRequest;
+use crate::response::ProviderResponse;
+use crate::stream::ProviderStream;
+
+#[derive(Clone)]
+pub struct AnthropicProvider<T = AsyncAnthropicTransport> {
+    client: AnthropicClient<T>,
+}
+
+impl AnthropicProvider<AsyncAnthropicTransport> {
+    pub fn from_config(config: AnthropicConfig) -> Result<Self, LlmError> {
+        Ok(Self {
+            client: AnthropicClient::from_config(config)?,
+        })
+    }
+}
+
+impl<T> AnthropicProvider<T> {
+    #[cfg(test)]
+    pub(crate) fn new(client: AnthropicClient<T>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl<T> LlmProvider for AnthropicProvider<T>
+where
+    T: super::client::AnthropicTransport,
+{
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            streaming: true,
+            tool_calling: true,
+            system_prompt: true,
+            list_models: true,
+        }
+    }
+
+    async fn complete(&self, req: ProviderRequest) -> Result<ProviderResponse, LlmError> {
+        let request = to_anthropic_request(&req)?;
+        let response = self.client.create(request).await?;
+        from_anthropic_response(response)
+    }
+
+    async fn stream(&self, req: ProviderRequest) -> Result<ProviderStream, LlmError> {
+        let request = to_anthropic_request(&req)?;
+        let stream = self.client.create_stream(request).await?;
+        Ok(map_anthropic_stream(stream))
+    }
+
+    async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
+        self.client.list_models().await
+    }
+}

--- a/crates/tiangong-llm/src/providers/anthropic/stream.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/stream.rs
@@ -1,0 +1,25 @@
+use futures_util::{StreamExt, stream};
+
+use crate::error::LlmError;
+use crate::stream::{ProviderStream, ProviderStreamEvent};
+
+use super::mapping::{AnthropicStreamState, map_stream_error, map_stream_event};
+
+pub(crate) type AnthropicSdkStream = async_anthropic::types::CreateMessagesResponseStream;
+
+pub(super) fn map_anthropic_stream(stream_in: AnthropicSdkStream) -> ProviderStream {
+    let mut state = AnthropicStreamState::default();
+    let stream = stream_in
+        .map(move |event| match event {
+            Ok(event) => match map_stream_event(&mut state, event) {
+                Ok(events) => events
+                    .into_iter()
+                    .map(Ok)
+                    .collect::<Vec<Result<ProviderStreamEvent, LlmError>>>(),
+                Err(err) => map_stream_error(err),
+            },
+            Err(err) => map_stream_error(super::error::map_anthropic_error(err)),
+        })
+        .flat_map(stream::iter);
+    Box::pin(stream)
+}

--- a/crates/tiangong-llm/src/providers/anthropic/stream.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/stream.rs
@@ -1,13 +1,12 @@
 use futures_util::{StreamExt, stream};
+use tiangong_anthropic::types::EventStream;
 
 use crate::error::LlmError;
 use crate::stream::{ProviderStream, ProviderStreamEvent};
 
 use super::mapping::{AnthropicStreamState, map_stream_error, map_stream_event};
 
-pub(crate) type AnthropicSdkStream = async_anthropic::types::CreateMessagesResponseStream;
-
-pub(super) fn map_anthropic_stream(stream_in: AnthropicSdkStream) -> ProviderStream {
+pub(super) fn map_anthropic_stream(stream_in: EventStream) -> ProviderStream {
     let mut state = AnthropicStreamState::default();
     let stream = stream_in
         .map(move |event| match event {

--- a/crates/tiangong-llm/src/providers/anthropic/tests.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/tests.rs
@@ -1,0 +1,220 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures_util::stream;
+use serde_json::json;
+
+use crate::message::{ChatMessage, MessageContent, MessageRole};
+use crate::provider::LlmProvider;
+use crate::providers::anthropic::client::{AnthropicClient, AnthropicTransport};
+use crate::providers::anthropic::config::AnthropicConfig;
+use crate::providers::anthropic::provider::AnthropicProvider;
+use crate::request::ProviderRequest;
+use crate::stream::ProviderStreamEvent;
+use crate::tool::{ToolChoice, ToolResult, ToolResultContent, ToolSpec};
+
+#[derive(Clone, Default)]
+struct MockAnthropicTransport {
+    response: Option<async_anthropic::types::CreateMessagesResponse>,
+    stream_events: Vec<Result<async_anthropic::types::MessagesStreamEvent, crate::error::LlmError>>,
+}
+
+#[async_trait]
+impl AnthropicTransport for MockAnthropicTransport {
+    async fn create(
+        &self,
+        _request: async_anthropic::types::CreateMessagesRequest,
+    ) -> Result<async_anthropic::types::CreateMessagesResponse, crate::error::LlmError> {
+        Ok(self.response.clone().expect("mock response"))
+    }
+
+    async fn create_stream(
+        &self,
+        _request: async_anthropic::types::CreateMessagesRequest,
+    ) -> Result<super::stream::AnthropicSdkStream, crate::error::LlmError> {
+        let items = self
+            .stream_events
+            .clone()
+            .into_iter()
+            .map(|event| match event {
+                Ok(event) => Ok(event),
+                Err(err) => Err(async_anthropic::errors::AnthropicError::Unknown(
+                    err.to_string(),
+                )),
+            });
+        Ok(Box::pin(stream::iter(items)))
+    }
+
+    async fn list_models(
+        &self,
+    ) -> Result<Vec<crate::model::ProviderModelInfo>, crate::error::LlmError> {
+        Ok(vec![crate::model::ProviderModelInfo {
+            id: "claude-3-7-sonnet".to_string(),
+            display_name: Some("Claude 3.7 Sonnet".to_string()),
+        }])
+    }
+}
+
+fn sample_request() -> ProviderRequest {
+    ProviderRequest {
+        model: "claude-3-7-sonnet".to_string(),
+        system: Some("你是测试助手".to_string()),
+        messages: vec![
+            ChatMessage::text(MessageRole::User, "你好"),
+            ChatMessage {
+                role: MessageRole::Assistant,
+                content: vec![MessageContent::ToolCall(crate::tool::ToolCall {
+                    id: "call_1".to_string(),
+                    name: "search_web".to_string(),
+                    arguments: json!({"q": "rust"}),
+                })],
+            },
+            ChatMessage {
+                role: MessageRole::Tool,
+                content: vec![MessageContent::ToolResult(ToolResult {
+                    tool_call_id: "call_1".to_string(),
+                    content: ToolResultContent::Json(json!({"answer": "ok"})),
+                    is_error: false,
+                })],
+            },
+        ],
+        tools: vec![ToolSpec {
+            name: "search_web".to_string(),
+            description: "搜索网页".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "q": { "type": "string" }
+                },
+                "required": ["q"]
+            }),
+        }],
+        tool_choice: Some(ToolChoice::Auto),
+        max_tokens: Some(1024),
+        temperature: Some(0.2),
+        top_p: None,
+        stop_sequences: vec!["STOP".to_string()],
+        metadata: None,
+    }
+}
+
+#[test]
+fn test_request_mapping_with_system_and_tools() {
+    let mapped = super::mapping::to_anthropic_request(&sample_request()).expect("mapped request");
+    assert_eq!(mapped.model, "claude-3-7-sonnet");
+    assert_eq!(mapped.system.as_deref(), Some("你是测试助手"));
+    assert_eq!(mapped.messages.len(), 3);
+    assert_eq!(mapped.tools.as_ref().map(Vec::len), Some(1));
+    assert!(matches!(
+        mapped.tool_choice,
+        Some(async_anthropic::types::ToolChoice::Auto)
+    ));
+}
+
+#[test]
+fn test_tool_result_mapping_back_to_message_content() {
+    let response = async_anthropic::types::CreateMessagesResponse {
+        id: Some("msg_1".to_string()),
+        content: Some(vec![async_anthropic::types::MessageContent::ToolUse(
+            async_anthropic::types::ToolUse {
+                id: "call_1".to_string(),
+                name: "search_web".to_string(),
+                input: json!({"q": "rust"}),
+            },
+        )]),
+        model: Some("claude-3-7-sonnet".to_string()),
+        stop_reason: Some("tool_use".to_string()),
+        stop_sequence: None,
+        usage: Some(async_anthropic::types::Usage {
+            input_tokens: Some(12),
+            output_tokens: Some(7),
+        }),
+    };
+
+    let mapped = super::mapping::from_anthropic_response(response).expect("mapped response");
+    assert_eq!(
+        mapped.usage.as_ref().map(|usage| usage.total_tokens),
+        Some(19)
+    );
+    assert!(matches!(
+        mapped.assistant_message.content.first(),
+        Some(MessageContent::ToolCall(_))
+    ));
+}
+
+#[tokio::test]
+async fn test_provider_complete_and_stream_behavior() {
+    let response = async_anthropic::types::CreateMessagesResponse {
+        id: Some("msg_1".to_string()),
+        content: Some(vec![async_anthropic::types::MessageContent::Text(
+            async_anthropic::types::Text {
+                text: "你好，世界".to_string(),
+            },
+        )]),
+        model: Some("claude-3-7-sonnet".to_string()),
+        stop_reason: Some("end_turn".to_string()),
+        stop_sequence: None,
+        usage: Some(async_anthropic::types::Usage {
+            input_tokens: Some(10),
+            output_tokens: Some(4),
+        }),
+    };
+
+    let stream_events = vec![
+        Ok(async_anthropic::types::MessagesStreamEvent::MessageStart {
+            message: async_anthropic::types::MessageStart {
+                id: "msg_1".to_string(),
+                model: "claude-3-7-sonnet".to_string(),
+                role: "assistant".to_string(),
+                content: vec![],
+                stop_reason: None,
+                stop_sequence: None,
+                usage: None,
+            },
+            usage: Some(async_anthropic::types::Usage {
+                input_tokens: Some(10),
+                output_tokens: Some(0),
+            }),
+        }),
+        Ok(
+            async_anthropic::types::MessagesStreamEvent::ContentBlockDelta {
+                index: 0,
+                delta: async_anthropic::types::ContentBlockDelta::TextDelta {
+                    text: "你好".to_string(),
+                },
+            },
+        ),
+        Ok(async_anthropic::types::MessagesStreamEvent::MessageStop),
+    ];
+
+    let transport = MockAnthropicTransport {
+        response: Some(response),
+        stream_events,
+    };
+    let provider = AnthropicProvider::new(AnthropicClient::new(
+        transport,
+        AnthropicConfig {
+            api_key: "test".to_string(),
+            base_url: None,
+            timeout: std::time::Duration::from_secs(30),
+            max_retries: 0,
+            api_version: None,
+            beta: None,
+            retry_notifier: Some(Arc::new(|_, _, _, _| {})),
+        },
+    ));
+
+    let complete = provider.complete(sample_request()).await.expect("complete");
+    assert_eq!(complete.assistant_message.content.len(), 1);
+
+    let mut stream = provider.stream(sample_request()).await.expect("stream");
+    let mut seen = Vec::new();
+    use futures_util::StreamExt;
+    while let Some(event) = stream.next().await {
+        seen.push(event.expect("stream event"));
+    }
+
+    assert!(seen.contains(&ProviderStreamEvent::MessageStart));
+    assert!(seen.contains(&ProviderStreamEvent::TextDelta("你好".to_string())));
+    assert!(seen.contains(&ProviderStreamEvent::MessageEnd));
+}

--- a/crates/tiangong-llm/src/providers/anthropic/tests.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/tests.rs
@@ -131,7 +131,7 @@ fn test_tool_and_thinking_mapping_back_to_message_content() {
         content: vec![
             ContentBlock::Thinking {
                 thinking: "先搜索一下".to_string(),
-                signature: "sig".to_string(),
+                signature: Some("sig".to_string()),
             },
             ContentBlock::ToolUse {
                 id: "call_1".to_string(),

--- a/crates/tiangong-llm/src/providers/anthropic/tests.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/tests.rs
@@ -3,44 +3,46 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures_util::stream;
 use serde_json::json;
+use tiangong_anthropic::types::{
+    ContentBlock, ContentBlockDeltaData, ContentBlockStartData, EventStream, MessageStartData,
+    MessagesCreateRequest, MessagesCreateResponse, StreamEvent, Usage,
+};
 
 use crate::message::{ChatMessage, MessageContent, MessageRole};
 use crate::provider::LlmProvider;
 use crate::providers::anthropic::client::{AnthropicClient, AnthropicTransport};
 use crate::providers::anthropic::config::AnthropicConfig;
 use crate::providers::anthropic::provider::AnthropicProvider;
-use crate::request::ProviderRequest;
+use crate::request::{ProviderRequest, ThinkingConfig};
 use crate::stream::ProviderStreamEvent;
 use crate::tool::{ToolChoice, ToolResult, ToolResultContent, ToolSpec};
 
 #[derive(Clone, Default)]
 struct MockAnthropicTransport {
-    response: Option<async_anthropic::types::CreateMessagesResponse>,
-    stream_events: Vec<Result<async_anthropic::types::MessagesStreamEvent, crate::error::LlmError>>,
+    response: Option<MessagesCreateResponse>,
+    stream_events: Vec<Result<StreamEvent, crate::error::LlmError>>,
 }
 
 #[async_trait]
 impl AnthropicTransport for MockAnthropicTransport {
     async fn create(
         &self,
-        _request: async_anthropic::types::CreateMessagesRequest,
-    ) -> Result<async_anthropic::types::CreateMessagesResponse, crate::error::LlmError> {
+        _request: MessagesCreateRequest,
+    ) -> Result<MessagesCreateResponse, crate::error::LlmError> {
         Ok(self.response.clone().expect("mock response"))
     }
 
     async fn create_stream(
         &self,
-        _request: async_anthropic::types::CreateMessagesRequest,
-    ) -> Result<super::stream::AnthropicSdkStream, crate::error::LlmError> {
+        _request: MessagesCreateRequest,
+    ) -> Result<EventStream, crate::error::LlmError> {
         let items = self
             .stream_events
             .clone()
             .into_iter()
-            .map(|event| match event {
+            .map(|item| match item {
                 Ok(event) => Ok(event),
-                Err(err) => Err(async_anthropic::errors::AnthropicError::Unknown(
-                    err.to_string(),
-                )),
+                Err(err) => Err(tiangong_anthropic::AnthropicError::Stream(err.to_string())),
             });
         Ok(Box::pin(stream::iter(items)))
     }
@@ -95,6 +97,9 @@ fn sample_request() -> ProviderRequest {
         top_p: None,
         stop_sequences: vec!["STOP".to_string()],
         metadata: None,
+        thinking: Some(ThinkingConfig {
+            budget_tokens: 4096,
+        }),
     }
 }
 
@@ -106,32 +111,45 @@ fn test_request_mapping_with_system_and_tools() {
     assert_eq!(mapped.messages.len(), 3);
     assert_eq!(mapped.tools.as_ref().map(Vec::len), Some(1));
     assert!(matches!(
+        mapped.thinking,
+        Some(tiangong_anthropic::types::ThinkingConfig::Enabled {
+            budget_tokens: 4096
+        })
+    ));
+    assert!(matches!(
         mapped.tool_choice,
-        Some(async_anthropic::types::ToolChoice::Auto)
+        Some(tiangong_anthropic::types::ToolChoice::Auto)
     ));
 }
 
 #[test]
-fn test_tool_result_mapping_back_to_message_content() {
-    let response = async_anthropic::types::CreateMessagesResponse {
-        id: Some("msg_1".to_string()),
-        content: Some(vec![async_anthropic::types::MessageContent::ToolUse(
-            async_anthropic::types::ToolUse {
+fn test_tool_and_thinking_mapping_back_to_message_content() {
+    let response = MessagesCreateResponse {
+        id: "msg_1".to_string(),
+        kind: "message".to_string(),
+        role: tiangong_anthropic::types::MessageRole::Assistant,
+        content: vec![
+            ContentBlock::Thinking {
+                thinking: "先搜索一下".to_string(),
+                signature: "sig".to_string(),
+            },
+            ContentBlock::ToolUse {
                 id: "call_1".to_string(),
                 name: "search_web".to_string(),
                 input: json!({"q": "rust"}),
             },
-        )]),
-        model: Some("claude-3-7-sonnet".to_string()),
+        ],
+        model: "claude-3-7-sonnet".to_string(),
         stop_reason: Some("tool_use".to_string()),
         stop_sequence: None,
-        usage: Some(async_anthropic::types::Usage {
+        usage: Some(Usage {
             input_tokens: Some(12),
             output_tokens: Some(7),
         }),
     };
 
     let mapped = super::mapping::from_anthropic_response(response).expect("mapped response");
+    assert_eq!(mapped.reasoning_content.as_deref(), Some("先搜索一下"));
     assert_eq!(
         mapped.usage.as_ref().map(|usage| usage.total_tokens),
         Some(19)
@@ -144,47 +162,51 @@ fn test_tool_result_mapping_back_to_message_content() {
 
 #[tokio::test]
 async fn test_provider_complete_and_stream_behavior() {
-    let response = async_anthropic::types::CreateMessagesResponse {
-        id: Some("msg_1".to_string()),
-        content: Some(vec![async_anthropic::types::MessageContent::Text(
-            async_anthropic::types::Text {
-                text: "你好，世界".to_string(),
-            },
-        )]),
-        model: Some("claude-3-7-sonnet".to_string()),
+    let response = MessagesCreateResponse {
+        id: "msg_1".to_string(),
+        kind: "message".to_string(),
+        role: tiangong_anthropic::types::MessageRole::Assistant,
+        content: vec![ContentBlock::Text {
+            text: "你好，世界".to_string(),
+        }],
+        model: "claude-3-7-sonnet".to_string(),
         stop_reason: Some("end_turn".to_string()),
         stop_sequence: None,
-        usage: Some(async_anthropic::types::Usage {
+        usage: Some(Usage {
             input_tokens: Some(10),
             output_tokens: Some(4),
         }),
     };
 
     let stream_events = vec![
-        Ok(async_anthropic::types::MessagesStreamEvent::MessageStart {
-            message: async_anthropic::types::MessageStart {
+        Ok(StreamEvent::MessageStart {
+            message: MessageStartData {
                 id: "msg_1".to_string(),
                 model: "claude-3-7-sonnet".to_string(),
-                role: "assistant".to_string(),
+                role: tiangong_anthropic::types::MessageRole::Assistant,
                 content: vec![],
                 stop_reason: None,
                 stop_sequence: None,
-                usage: None,
+                usage: Some(Usage {
+                    input_tokens: Some(10),
+                    output_tokens: Some(0),
+                }),
             },
-            usage: Some(async_anthropic::types::Usage {
-                input_tokens: Some(10),
-                output_tokens: Some(0),
-            }),
         }),
-        Ok(
-            async_anthropic::types::MessagesStreamEvent::ContentBlockDelta {
-                index: 0,
-                delta: async_anthropic::types::ContentBlockDelta::TextDelta {
-                    text: "你好".to_string(),
-                },
+        Ok(StreamEvent::ContentBlockStart {
+            index: 0,
+            content_block: ContentBlockStartData::Thinking {
+                thinking: "先想一下".to_string(),
+                signature: String::new(),
             },
-        ),
-        Ok(async_anthropic::types::MessagesStreamEvent::MessageStop),
+        }),
+        Ok(StreamEvent::ContentBlockDelta {
+            index: 1,
+            delta: ContentBlockDeltaData::TextDelta {
+                text: "你好".to_string(),
+            },
+        }),
+        Ok(StreamEvent::MessageStop),
     ];
 
     let transport = MockAnthropicTransport {
@@ -215,6 +237,19 @@ async fn test_provider_complete_and_stream_behavior() {
     }
 
     assert!(seen.contains(&ProviderStreamEvent::MessageStart));
+    assert!(seen.contains(&ProviderStreamEvent::ReasoningDelta("先想一下".to_string())));
     assert!(seen.contains(&ProviderStreamEvent::TextDelta("你好".to_string())));
     assert!(seen.contains(&ProviderStreamEvent::MessageEnd));
+}
+
+#[tokio::test]
+async fn test_provider_list_models() {
+    let provider = AnthropicProvider::new(AnthropicClient::new(
+        MockAnthropicTransport::default(),
+        AnthropicConfig::new("test"),
+    ));
+
+    let models = provider.list_models().await.expect("list models");
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].id, "claude-3-7-sonnet");
 }

--- a/crates/tiangong-llm/src/providers/mod.rs
+++ b/crates/tiangong-llm/src/providers/mod.rs
@@ -1,0 +1,2 @@
+pub mod anthropic;
+pub mod openai;

--- a/crates/tiangong-llm/src/providers/openai/config.rs
+++ b/crates/tiangong-llm/src/providers/openai/config.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+pub type RetryNotifier = Arc<dyn Fn(u32, u32, u64, &str) + Send + Sync>;
+
+#[derive(Clone)]
+pub struct OpenAiCompatibleConfig {
+    pub api_key: String,
+    pub base_url: String,
+    pub timeout: Duration,
+    pub max_retries: u32,
+    pub retry_notifier: Option<RetryNotifier>,
+}
+
+impl OpenAiCompatibleConfig {
+    pub fn new(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            base_url: base_url.into(),
+            timeout: Duration::from_secs(60),
+            max_retries: 3,
+            retry_notifier: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for OpenAiCompatibleConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAiCompatibleConfig")
+            .field("api_key", &(!self.api_key.is_empty()))
+            .field("base_url", &self.base_url)
+            .field("timeout", &self.timeout)
+            .field("max_retries", &self.max_retries)
+            .field("retry_notifier", &self.retry_notifier.is_some())
+            .finish()
+    }
+}

--- a/crates/tiangong-llm/src/providers/openai/error.rs
+++ b/crates/tiangong-llm/src/providers/openai/error.rs
@@ -1,0 +1,30 @@
+use crate::error::LlmError;
+
+pub fn map_openai_error(error: &async_openai::error::OpenAIError) -> LlmError {
+    let text = error.to_string();
+    if text.contains("401") {
+        return LlmError::Authentication(text);
+    }
+    if text.contains("429") || text.to_ascii_lowercase().contains("rate limit") {
+        return LlmError::RateLimited(text);
+    }
+    if text.contains("400") {
+        return LlmError::InvalidRequest(text);
+    }
+    if text.contains("timeout") {
+        return LlmError::Timeout(0);
+    }
+    LlmError::Transport(text)
+}
+
+pub fn is_retryable_openai_error(err: &async_openai::error::OpenAIError) -> bool {
+    let text = err.to_string();
+    text.contains("429")
+        || text.contains("500 Internal Server Error")
+        || text.contains("502 Bad Gateway")
+        || text.contains("503 Service Unavailable")
+        || text.contains("504 Gateway Timeout")
+        || text.contains("connection reset")
+        || text.contains("connection refused")
+        || text.to_ascii_lowercase().contains("rate limit")
+}

--- a/crates/tiangong-llm/src/providers/openai/error.rs
+++ b/crates/tiangong-llm/src/providers/openai/error.rs
@@ -5,7 +5,7 @@ pub fn map_openai_error(error: &async_openai::error::OpenAIError) -> LlmError {
     if text.contains("401") {
         return LlmError::Authentication(text);
     }
-    if text.contains("429") || text.to_ascii_lowercase().contains("rate limit") {
+    if is_rate_limited_text(&text) {
         return LlmError::RateLimited(text);
     }
     if text.contains("400") {
@@ -19,12 +19,20 @@ pub fn map_openai_error(error: &async_openai::error::OpenAIError) -> LlmError {
 
 pub fn is_retryable_openai_error(err: &async_openai::error::OpenAIError) -> bool {
     let text = err.to_string();
-    text.contains("429")
+    is_rate_limited_text(&text)
         || text.contains("500 Internal Server Error")
         || text.contains("502 Bad Gateway")
         || text.contains("503 Service Unavailable")
         || text.contains("504 Gateway Timeout")
         || text.contains("connection reset")
         || text.contains("connection refused")
-        || text.to_ascii_lowercase().contains("rate limit")
+}
+
+fn is_rate_limited_text(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    text.contains("429")
+        || text.contains("529")
+        || lower.contains("rate limit")
+        || lower.contains("too many requests")
+        || lower.contains("overloaded_error")
 }

--- a/crates/tiangong-llm/src/providers/openai/mapping.rs
+++ b/crates/tiangong-llm/src/providers/openai/mapping.rs
@@ -1,0 +1,274 @@
+use anyhow::{Context, Result, anyhow};
+use async_openai::types::chat::{
+    ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
+    ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
+    CreateChatCompletionRequestArgs,
+};
+use serde_json::{Value, json};
+
+use crate::message::{ChatMessage, MessageContent, MessageRole};
+use crate::request::ProviderRequest;
+use crate::response::{ProviderResponse, StopReason};
+use crate::tool::ToolSpec;
+use crate::usage::TokenUsageData;
+
+pub fn normalize_api_base(base_url: &str) -> Result<String> {
+    let trimmed = base_url.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("API_BASE_URL 不能为空"));
+    }
+    let cleaned = trimmed.trim_end_matches('/');
+    let cleaned = cleaned.strip_suffix("/chat/completions").unwrap_or(cleaned);
+    Ok(cleaned.to_string())
+}
+
+pub fn build_request_json(req: &ProviderRequest, stream: bool) -> Result<Value> {
+    let messages = build_openai_messages(req)?;
+    let mut request_args_binding = CreateChatCompletionRequestArgs::default();
+    let mut request_args = request_args_binding
+        .model(req.model.clone())
+        .messages(messages)
+        .stream(stream);
+    if let Some(max_tokens) = req.max_tokens.map(|value| value as u16) {
+        request_args = request_args.max_tokens(max_tokens);
+    }
+    if let Some(temperature) = req.temperature {
+        request_args = request_args.temperature(temperature);
+    }
+    let request = request_args.build().context("构建 OpenAI 请求失败")?;
+
+    let mut payload = serde_json::to_value(request).context("序列化 OpenAI 请求失败")?;
+    if stream {
+        inject_stream_usage_option(&mut payload);
+    }
+    if let Some(temperature) = req.temperature {
+        inject_temperature_config(&mut payload, temperature)?;
+    }
+    if !req.tools.is_empty() {
+        inject_function_tools(&mut payload, &req.tools);
+    }
+    Ok(payload)
+}
+
+fn build_openai_messages(req: &ProviderRequest) -> Result<Vec<ChatCompletionRequestMessage>> {
+    let mut messages = Vec::new();
+    if let Some(system) = req.system.as_ref().filter(|value| !value.trim().is_empty()) {
+        messages.push(
+            ChatCompletionRequestSystemMessageArgs::default()
+                .content(system.clone())
+                .build()
+                .context("构建 system 消息失败")?
+                .into(),
+        );
+    }
+
+    for message in &req.messages {
+        match message.role {
+            MessageRole::System => {}
+            MessageRole::User | MessageRole::Tool => {
+                let text = extract_message_text(message);
+                if !text.is_empty() {
+                    messages.push(
+                        ChatCompletionRequestUserMessageArgs::default()
+                            .content(text)
+                            .build()
+                            .context("构建 user 消息失败")?
+                            .into(),
+                    );
+                }
+            }
+            MessageRole::Assistant => {
+                let text = extract_message_text(message);
+                if !text.is_empty() {
+                    messages.push(
+                        ChatCompletionRequestAssistantMessageArgs::default()
+                            .content(text)
+                            .build()
+                            .context("构建 assistant 消息失败")?
+                            .into(),
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(messages)
+}
+
+fn extract_message_text(message: &ChatMessage) -> String {
+    message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            MessageContent::Text(text) => Some(text.clone()),
+            MessageContent::ToolResult(result) => Some(match &result.content {
+                crate::tool::ToolResultContent::Text(text) => text.clone(),
+                crate::tool::ToolResultContent::Json(value) => value.to_string(),
+            }),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn parse_complete_response(payload: &Value) -> Result<ProviderResponse> {
+    let choice = payload
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|choices| choices.first())
+        .ok_or_else(|| anyhow!("OpenAI 响应缺少 choices"))?;
+
+    let text = choice
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let reasoning_content = choice
+        .get("message")
+        .and_then(|message| message.get("reasoning_content"))
+        .and_then(Value::as_str)
+        .map(|value| value.to_string());
+
+    let tool_calls = choice
+        .get("message")
+        .and_then(|message| message.get("tool_calls"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut content = Vec::new();
+    if !text.trim().is_empty() {
+        content.push(MessageContent::Text(strip_think_tags(text.trim())));
+    }
+    for tool_call in tool_calls {
+        let id = tool_call
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let name = tool_call
+            .get("function")
+            .and_then(|v| v.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let arguments = tool_call
+            .get("function")
+            .and_then(|v| v.get("arguments"))
+            .and_then(Value::as_str)
+            .and_then(|raw| serde_json::from_str(raw).ok())
+            .unwrap_or_else(|| json!({}));
+        if !name.is_empty() {
+            content.push(MessageContent::ToolCall(crate::tool::ToolCall {
+                id: id.to_string(),
+                name: name.to_string(),
+                arguments,
+            }));
+        }
+    }
+
+    let usage = payload.get("usage").map(parse_usage);
+
+    Ok(ProviderResponse {
+        id: payload
+            .get("id")
+            .and_then(Value::as_str)
+            .map(|v| v.to_string()),
+        model: payload
+            .get("model")
+            .and_then(Value::as_str)
+            .map(|v| v.to_string()),
+        assistant_message: ChatMessage {
+            role: MessageRole::Assistant,
+            content,
+        },
+        reasoning_content,
+        stop_reason: choice
+            .get("finish_reason")
+            .and_then(Value::as_str)
+            .map(map_stop_reason),
+        usage,
+        raw: Some(payload.clone()),
+    })
+}
+
+fn map_stop_reason(reason: &str) -> StopReason {
+    match reason {
+        "stop" => StopReason::EndTurn,
+        "tool_calls" => StopReason::ToolUse,
+        "length" => StopReason::MaxTokens,
+        other => StopReason::Other(other.to_string()),
+    }
+}
+
+pub fn parse_usage(usage: &Value) -> TokenUsageData {
+    let prompt = usage
+        .get("prompt_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let completion = usage
+        .get("completion_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let total = usage
+        .get("total_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or((prompt + completion) as u64) as usize;
+    TokenUsageData {
+        prompt_tokens: prompt,
+        completion_tokens: completion,
+        total_tokens: total,
+    }
+}
+
+fn inject_stream_usage_option(payload: &mut Value) {
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    obj.insert("stream_options".to_string(), json!({"include_usage": true}));
+}
+
+fn inject_temperature_config(payload: &mut Value, temperature: f32) -> Result<()> {
+    let Some(obj) = payload.as_object_mut() else {
+        return Ok(());
+    };
+    let number = serde_json::Number::from_f64(temperature as f64)
+        .ok_or_else(|| anyhow!("temperature 无效"))?;
+    obj.insert("temperature".to_string(), Value::Number(number));
+    Ok(())
+}
+
+fn inject_function_tools(payload: &mut Value, functions: &[ToolSpec]) {
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    let tools = functions
+        .iter()
+        .map(|spec| {
+            json!({
+                "type": "function",
+                "function": {
+                    "name": spec.name,
+                    "description": spec.description,
+                    "parameters": spec.input_schema,
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    obj.insert("tools".to_string(), Value::Array(tools));
+    obj.insert("tool_choice".to_string(), Value::String("auto".to_string()));
+}
+
+pub fn strip_think_tags(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut remaining = text;
+    while let Some(start) = remaining.find("<think>") {
+        result.push_str(&remaining[..start]);
+        if let Some(end) = remaining[start..].find("</think>") {
+            remaining = &remaining[start + end + 8..];
+        } else {
+            return result;
+        }
+    }
+    result.push_str(remaining);
+    result
+}

--- a/crates/tiangong-llm/src/providers/openai/mod.rs
+++ b/crates/tiangong-llm/src/providers/openai/mod.rs
@@ -1,0 +1,8 @@
+mod config;
+mod error;
+mod mapping;
+mod provider;
+mod stream;
+
+pub use config::OpenAiCompatibleConfig;
+pub use provider::OpenAiCompatibleProvider;

--- a/crates/tiangong-llm/src/providers/openai/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai/provider.rs
@@ -210,9 +210,18 @@ impl LlmProvider for OpenAiCompatibleProvider {
                 status = status.as_u16(),
                 "OpenAI 兼容请求失败"
             );
+            let message = format!("获取模型列表失败：HTTP {status}，响应：{body}");
+            if status.as_u16() == 429
+                || status.as_u16() == 529
+                || body.to_ascii_lowercase().contains("rate limit")
+                || body.to_ascii_lowercase().contains("too many requests")
+                || body.to_ascii_lowercase().contains("overloaded_error")
+            {
+                return Err(LlmError::RateLimited(message));
+            }
             return Err(LlmError::Provider {
                 provider: "openai_compatible",
-                message: format!("获取模型列表失败：HTTP {status}，响应：{body}"),
+                message,
             });
         }
         #[derive(serde::Deserialize)]

--- a/crates/tiangong-llm/src/providers/openai/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai/provider.rs
@@ -1,0 +1,253 @@
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use futures_util::{StreamExt, stream};
+use serde_json::Value;
+use tokio::time::timeout;
+
+use crate::error::LlmError;
+use crate::model::ProviderModelInfo;
+use crate::provider::{LlmProvider, ProviderCapabilities};
+use crate::providers::openai::config::OpenAiCompatibleConfig;
+use crate::providers::openai::error::{is_retryable_openai_error, map_openai_error};
+use crate::providers::openai::mapping::{
+    build_request_json, normalize_api_base, parse_complete_response,
+};
+use crate::request::ProviderRequest;
+use crate::response::ProviderResponse;
+use crate::stream::ProviderStream;
+
+const MAX_RETRIES: u32 = 3;
+const INITIAL_RETRY_DELAY_MS: u64 = 1000;
+
+#[derive(Clone)]
+pub struct OpenAiCompatibleProvider {
+    config: OpenAiCompatibleConfig,
+}
+
+impl OpenAiCompatibleProvider {
+    pub fn new(config: OpenAiCompatibleConfig) -> Self {
+        Self { config }
+    }
+
+    fn build_client(&self) -> async_openai::Client<async_openai::config::OpenAIConfig> {
+        let config = async_openai::config::OpenAIConfig::new()
+            .with_api_key(self.config.api_key.clone())
+            .with_api_base(
+                normalize_api_base(&self.config.base_url)
+                    .unwrap_or_else(|_| self.config.base_url.clone()),
+            );
+        let no_retry = backoff::ExponentialBackoff {
+            max_elapsed_time: Some(Duration::from_nanos(1)),
+            ..Default::default()
+        };
+        async_openai::Client::build(reqwest::Client::new(), config, no_retry)
+    }
+
+    async fn with_retry<F, Fut, T>(
+        &self,
+        operation: &'static str,
+        model: &str,
+        stream: bool,
+        mut f: F,
+    ) -> Result<T, LlmError>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<T, async_openai::error::OpenAIError>>,
+    {
+        let mut attempt = 0u32;
+        let mut delay_ms = INITIAL_RETRY_DELAY_MS;
+        let max_retries = self.config.max_retries.max(MAX_RETRIES);
+        loop {
+            let start = std::time::Instant::now();
+            tracing::info!(
+                operation,
+                provider = "openai_compatible",
+                model,
+                stream,
+                attempt,
+                "开始 OpenAI 兼容请求"
+            );
+            match f().await {
+                Ok(value) => {
+                    tracing::info!(
+                        operation,
+                        provider = "openai_compatible",
+                        model,
+                        stream,
+                        attempt,
+                        latency_ms = start.elapsed().as_millis() as u64,
+                        "OpenAI 兼容请求完成"
+                    );
+                    return Ok(value);
+                }
+                Err(err) if attempt < max_retries && is_retryable_openai_error(&err) => {
+                    attempt += 1;
+                    if let Some(notifier) = &self.config.retry_notifier {
+                        notifier(attempt, max_retries, delay_ms, &err.to_string());
+                    }
+                    tracing::warn!(
+                        operation,
+                        provider = "openai_compatible",
+                        model,
+                        stream,
+                        attempt,
+                        delay_ms,
+                        error = %err,
+                        "OpenAI 兼容请求失败，准备重试"
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                    delay_ms *= 2;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        operation,
+                        provider = "openai_compatible",
+                        model,
+                        stream,
+                        attempt,
+                        latency_ms = start.elapsed().as_millis() as u64,
+                        error = %err,
+                        "OpenAI 兼容请求失败"
+                    );
+                    return Err(map_openai_error(&err));
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenAiCompatibleProvider {
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            streaming: true,
+            tool_calling: true,
+            system_prompt: true,
+            list_models: true,
+        }
+    }
+
+    async fn complete(&self, req: ProviderRequest) -> Result<ProviderResponse, LlmError> {
+        let model = req.model.clone();
+        let client = self.build_client();
+        let payload = build_request_json(&req, false)
+            .map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
+        let chat = client.chat();
+        let response: Value = timeout(
+            self.config.timeout,
+            self.with_retry("openai_complete", &model, false, || {
+                chat.create_byot::<_, Value>(payload.clone())
+            }),
+        )
+        .await
+        .map_err(|_| LlmError::Timeout(self.config.timeout.as_millis() as u64))??;
+        parse_complete_response(&response).map_err(|err| LlmError::Provider {
+            provider: "openai_compatible",
+            message: err.to_string(),
+        })
+    }
+
+    async fn stream(&self, req: ProviderRequest) -> Result<ProviderStream, LlmError> {
+        let model = req.model.clone();
+        let client = self.build_client();
+        let payload = build_request_json(&req, true)
+            .map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
+        let chat = client.chat();
+        let stream = timeout(
+            self.config.timeout,
+            self.with_retry("openai_stream", &model, true, || {
+                chat.create_stream_byot::<_, Value>(payload.clone())
+            }),
+        )
+        .await
+        .map_err(|_| LlmError::Timeout(self.config.timeout.as_millis() as u64))??;
+
+        let mapped = stream
+            .map(|item| match item {
+                Ok(payload) => super::stream::parse_stream_payload(&payload),
+                Err(err) => vec![Err(map_openai_error(&err))],
+            })
+            .flat_map(stream::iter);
+        Ok(Box::pin(mapped))
+    }
+
+    async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
+        let start = std::time::Instant::now();
+        tracing::info!(
+            operation = "openai_list_models",
+            provider = "openai_compatible",
+            model = "<list_models>",
+            stream = false,
+            attempt = 0,
+            "开始 OpenAI 兼容请求"
+        );
+        let base = normalize_api_base(&self.config.base_url)
+            .map_err(|err| LlmError::Configuration(err.to_string()))?;
+        let url = format!("{base}/models");
+        let client = reqwest::Client::builder()
+            .timeout(self.config.timeout)
+            .build()
+            .map_err(|err| LlmError::Transport(err.to_string()))?;
+        let response = client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .send()
+            .await
+            .with_context(|| format!("请求模型列表失败：{url}"))
+            .map_err(|err| LlmError::Transport(err.to_string()))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            tracing::warn!(
+                operation = "openai_list_models",
+                provider = "openai_compatible",
+                model = "<list_models>",
+                stream = false,
+                attempt = 0,
+                latency_ms = start.elapsed().as_millis() as u64,
+                status = status.as_u16(),
+                "OpenAI 兼容请求失败"
+            );
+            return Err(LlmError::Provider {
+                provider: "openai_compatible",
+                message: format!("获取模型列表失败：HTTP {status}，响应：{body}"),
+            });
+        }
+        #[derive(serde::Deserialize)]
+        struct ModelEntry {
+            id: String,
+        }
+        #[derive(serde::Deserialize)]
+        struct ModelsResponse {
+            data: Vec<ModelEntry>,
+        }
+        let body = response
+            .text()
+            .await
+            .map_err(|err| LlmError::Transport(err.to_string()))?;
+        let parsed: ModelsResponse =
+            serde_json::from_str(&body).map_err(|err| LlmError::Provider {
+                provider: "openai_compatible",
+                message: format!("failed to deserialize api response: {err}: {body}"),
+            })?;
+        tracing::info!(
+            operation = "openai_list_models",
+            provider = "openai_compatible",
+            model = "<list_models>",
+            stream = false,
+            attempt = 0,
+            latency_ms = start.elapsed().as_millis() as u64,
+            "OpenAI 兼容请求完成"
+        );
+        Ok(parsed
+            .data
+            .into_iter()
+            .map(|entry| ProviderModelInfo {
+                id: entry.id,
+                display_name: None,
+            })
+            .collect())
+    }
+}

--- a/crates/tiangong-llm/src/providers/openai/stream.rs
+++ b/crates/tiangong-llm/src/providers/openai/stream.rs
@@ -1,0 +1,60 @@
+use serde_json::Value;
+
+use crate::stream::ProviderStreamEvent;
+
+pub fn parse_stream_payload(
+    payload: &Value,
+) -> Vec<Result<ProviderStreamEvent, crate::error::LlmError>> {
+    let mut events = Vec::new();
+    if let Some(usage) = payload.get("usage") {
+        events.push(Ok(ProviderStreamEvent::Usage(super::mapping::parse_usage(
+            usage,
+        ))));
+    }
+    if let Some(choices) = payload.get("choices").and_then(Value::as_array) {
+        for choice in choices {
+            let delta = choice.get("delta").unwrap_or(&Value::Null);
+            if let Some(reasoning) = delta.get("reasoning_content").and_then(Value::as_str)
+                && !reasoning.is_empty()
+            {
+                events.push(Ok(ProviderStreamEvent::ReasoningDelta(
+                    reasoning.to_string(),
+                )));
+            }
+            if let Some(content) = delta.get("content").and_then(Value::as_str)
+                && !content.is_empty()
+            {
+                events.push(Ok(ProviderStreamEvent::TextDelta(content.to_string())));
+            }
+            if let Some(tool_calls) = delta.get("tool_calls").and_then(Value::as_array) {
+                for tool_call in tool_calls {
+                    let id = tool_call
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    if let Some(function) = tool_call.get("function") {
+                        if let Some(name) = function.get("name").and_then(Value::as_str) {
+                            events.push(Ok(ProviderStreamEvent::ToolCallStart(
+                                crate::tool::ToolCall {
+                                    id: id.clone(),
+                                    name: name.to_string(),
+                                    arguments: serde_json::json!({}),
+                                },
+                            )));
+                        }
+                        if let Some(arguments) = function.get("arguments").and_then(Value::as_str)
+                            && !arguments.is_empty()
+                        {
+                            events.push(Ok(ProviderStreamEvent::ToolCallDelta {
+                                call_id: id.clone(),
+                                partial_json: arguments.to_string(),
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    events
+}

--- a/crates/tiangong-llm/src/request.rs
+++ b/crates/tiangong-llm/src/request.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::message::ChatMessage;
+use crate::tool::{ToolChoice, ToolSpec};
+
+/// 统一 provider 请求。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRequest {
+    pub model: String,
+    pub system: Option<String>,
+    pub messages: Vec<ChatMessage>,
+    #[serde(default)]
+    pub tools: Vec<ToolSpec>,
+    #[serde(default)]
+    pub tool_choice: Option<ToolChoice>,
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    #[serde(default)]
+    pub top_p: Option<f32>,
+    #[serde(default)]
+    pub stop_sequences: Vec<String>,
+    #[serde(default)]
+    pub metadata: Option<Map<String, Value>>,
+}

--- a/crates/tiangong-llm/src/request.rs
+++ b/crates/tiangong-llm/src/request.rs
@@ -4,6 +4,16 @@ use serde_json::{Map, Value};
 use crate::message::ChatMessage;
 use crate::tool::{ToolChoice, ToolSpec};
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThinkingConfig {
+    #[serde(default = "default_thinking_budget_tokens")]
+    pub budget_tokens: u32,
+}
+
+fn default_thinking_budget_tokens() -> u32 {
+    2048
+}
+
 /// 统一 provider 请求。
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProviderRequest {
@@ -24,4 +34,6 @@ pub struct ProviderRequest {
     pub stop_sequences: Vec<String>,
     #[serde(default)]
     pub metadata: Option<Map<String, Value>>,
+    #[serde(default)]
+    pub thinking: Option<ThinkingConfig>,
 }

--- a/crates/tiangong-llm/src/response.rs
+++ b/crates/tiangong-llm/src/response.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::message::ChatMessage;
+use crate::usage::TokenUsageData;
+
+/// 统一停止原因。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopReason {
+    EndTurn,
+    ToolUse,
+    MaxTokens,
+    StopSequence,
+    Other(String),
+}
+
+/// 统一 provider 响应。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderResponse {
+    pub id: Option<String>,
+    pub model: Option<String>,
+    pub assistant_message: ChatMessage,
+    #[serde(default)]
+    pub reasoning_content: Option<String>,
+    pub stop_reason: Option<StopReason>,
+    pub usage: Option<TokenUsageData>,
+    #[serde(default)]
+    pub raw: Option<Value>,
+}

--- a/crates/tiangong-llm/src/stream.rs
+++ b/crates/tiangong-llm/src/stream.rs
@@ -1,0 +1,29 @@
+use std::pin::Pin;
+
+use futures_util::Stream;
+use serde::{Deserialize, Serialize};
+
+use crate::error::LlmError;
+use crate::tool::ToolCall;
+use crate::usage::TokenUsageData;
+
+/// 统一流式事件。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ProviderStreamEvent {
+    MessageStart,
+    ReasoningDelta(String),
+    TextDelta(String),
+    ToolCallStart(ToolCall),
+    ToolCallDelta {
+        call_id: String,
+        partial_json: String,
+    },
+    ToolCallEnd {
+        call_id: String,
+    },
+    MessageEnd,
+    Usage(TokenUsageData),
+    Error(String),
+}
+
+pub type ProviderStream = Pin<Box<dyn Stream<Item = Result<ProviderStreamEvent, LlmError>> + Send>>;

--- a/crates/tiangong-llm/src/tool.rs
+++ b/crates/tiangong-llm/src/tool.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// 统一工具定义。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolSpec {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+/// 统一工具选择策略。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolChoice {
+    Auto,
+    Any,
+    Tool(String),
+}
+
+/// 统一工具调用。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: Value,
+}
+
+/// 工具结果内容。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolResultContent {
+    Text(String),
+    Json(Value),
+}
+
+/// 统一工具结果。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolResult {
+    pub tool_call_id: String,
+    pub content: ToolResultContent,
+    #[serde(default)]
+    pub is_error: bool,
+}

--- a/crates/tiangong-llm/src/usage.rs
+++ b/crates/tiangong-llm/src/usage.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+/// 统一 token 用量模型。
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsageData {
+    pub prompt_tokens: usize,
+    pub completion_tokens: usize,
+    pub total_tokens: usize,
+}
+
+impl TokenUsageData {
+    pub fn new(prompt_tokens: usize, completion_tokens: usize) -> Self {
+        Self {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens: prompt_tokens + completion_tokens,
+        }
+    }
+}
+
+impl From<TokenUsageData> for tiangong_types::TokenUsage {
+    fn from(value: TokenUsageData) -> Self {
+        Self {
+            prompt_tokens: value.prompt_tokens,
+            completion_tokens: value.completion_tokens,
+            total_tokens: value.total_tokens,
+        }
+    }
+}

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -28,6 +28,7 @@
 #### 模型配置
 - 模型配置必须独立为 `models.json`，采用 Provider 与 Model 分离设计。
 - Provider 层只定义连接信息（`base_url`、`api_key`、`timeout_ms`），可被多个模型共享。
+- Provider 层必须支持声明请求协议类型，至少包含 `openai_compatible` 与 `anthropic` 两种协议；未显式配置时默认按 `openai_compatible` 处理。
 - Model 层引用 Provider，声明实际模型 ID 和能力列表（`capabilities`），携带专属参数（`options`）。
 - 能力类型包括：`chat`（常规对话/推理）、`multimodal`（多模态理解）、`image_generation`（图片生成）、`video_generation`（视频生成）、`stt`（语音识别）、`tts`（语音合成）。
 - 一个模型可声明多种能力（如 gpt-4o 同时支持 chat 和 multimodal）。
@@ -35,6 +36,8 @@
 - `chat` 为基础必选能力，routing 中未配置 `chat` 时程序必须在所有模式（GUI/CLI/Server）下持续提示用户完成模型设置，在设置完成前不执行对话任务。
 - 其余能力（multimodal/image_generation/video_generation/stt/tts）未在 routing 中配置时视为关闭，对应功能不可用但不影响其他功能正常运行。
 - `api_key` 必须支持环境变量引用（`${ENV_VAR}` 语法），避免明文存储。
+- 核心对话链路必须按 Provider 协议动态构建请求，不允许将所有聊天模型强制视为 OpenAI 兼容接口。
+- 当 `chat` 或 `lite` routing 指向 `anthropic` Provider 时，必须支持 Anthropic Messages 请求格式的同步、流式、工具调用与轻量模型调用，并保持 CLI/GUI/Server 行为一致。
 
 #### Server 模式
 - 必须新增 `tiangong server` 命令，启动 HTTP REST + WebSocket 服务。

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -39,6 +39,7 @@
 - 核心对话链路必须按 Provider 协议动态构建请求，不允许将所有聊天模型强制视为 OpenAI 兼容接口。
 - 当 `chat` 或 `lite` routing 指向 `anthropic` Provider 时，必须支持 Anthropic Messages 请求格式的同步、流式、工具调用与轻量模型调用，并保持 CLI/GUI/Server 行为一致。
 - Rust 侧 LLM 协议层必须沉淀为独立库（当前为 `tiangong-llm`），由该库统一维护 Provider 抽象、领域模型与错误边界；Anthropic 适配层必须拆分为独立 crate `tiangong-anthropic`，由该 crate 内部使用 `reqwest + serde` 原生实现 Anthropic Messages 与 SSE 解析，并通过 `tiangong-llm` 接入上层；OpenAI 兼容适配层内部可接入 `async-openai`，但第三方 SDK 类型不允许泄漏到上层业务。
+- 必须维护 `tiangong-llm` 的架构约束文档，明确其职责仅限统一抽象、Provider 封装、请求/响应映射、错误边界与流事件边界；新增协议或修复兼容问题时不得继续将 transport、业务规则和上层策略堆叠进该 crate，后续若需拆分 transport 或共享执行器，必须以该文档为准。
 
 #### Server 模式
 - 必须新增 `tiangong server` 命令，启动 HTTP REST + WebSocket 服务。

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -38,6 +38,7 @@
 - `api_key` 必须支持环境变量引用（`${ENV_VAR}` 语法），避免明文存储。
 - 核心对话链路必须按 Provider 协议动态构建请求，不允许将所有聊天模型强制视为 OpenAI 兼容接口。
 - 当 `chat` 或 `lite` routing 指向 `anthropic` Provider 时，必须支持 Anthropic Messages 请求格式的同步、流式、工具调用与轻量模型调用，并保持 CLI/GUI/Server 行为一致。
+- Rust 侧 LLM 协议层必须沉淀为独立库（当前为 `tiangong-llm`），由该库统一维护 Provider 抽象、领域模型与错误边界；Anthropic 适配层当前可内部接入 `async-anthropic`，OpenAI 兼容适配层内部可接入 `async-openai`，但第三方 SDK 类型不允许泄漏到上层业务，也不允许长期保留手写 HTTP 请求作为主实现路径。
 
 #### Server 模式
 - 必须新增 `tiangong server` 命令，启动 HTTP REST + WebSocket 服务。

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -38,7 +38,7 @@
 - `api_key` 必须支持环境变量引用（`${ENV_VAR}` 语法），避免明文存储。
 - 核心对话链路必须按 Provider 协议动态构建请求，不允许将所有聊天模型强制视为 OpenAI 兼容接口。
 - 当 `chat` 或 `lite` routing 指向 `anthropic` Provider 时，必须支持 Anthropic Messages 请求格式的同步、流式、工具调用与轻量模型调用，并保持 CLI/GUI/Server 行为一致。
-- Rust 侧 LLM 协议层必须沉淀为独立库（当前为 `tiangong-llm`），由该库统一维护 Provider 抽象、领域模型与错误边界；Anthropic 适配层当前可内部接入 `async-anthropic`，OpenAI 兼容适配层内部可接入 `async-openai`，但第三方 SDK 类型不允许泄漏到上层业务，也不允许长期保留手写 HTTP 请求作为主实现路径。
+- Rust 侧 LLM 协议层必须沉淀为独立库（当前为 `tiangong-llm`），由该库统一维护 Provider 抽象、领域模型与错误边界；Anthropic 适配层必须拆分为独立 crate `tiangong-anthropic`，由该 crate 内部使用 `reqwest + serde` 原生实现 Anthropic Messages 与 SSE 解析，并通过 `tiangong-llm` 接入上层；OpenAI 兼容适配层内部可接入 `async-openai`，但第三方 SDK 类型不允许泄漏到上层业务。
 
 #### Server 模式
 - 必须新增 `tiangong server` 命令，启动 HTTP REST + WebSocket 服务。

--- a/docs/tiangong-core-integration.md
+++ b/docs/tiangong-core-integration.md
@@ -23,8 +23,8 @@
 
 代码入口见：
 
-- [core/mod.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-core/src/core/mod.rs)
-- [core_config.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-core/src/core_config.rs)
+- `crates/tiangong-core/src/core/mod.rs`
+- `crates/tiangong-core/src/core_config.rs`
 
 `TiangongCore` 不负责：
 
@@ -52,7 +52,7 @@
 
 ### `TiangongCore`
 
-主要接口位于 [core/mod.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-core/src/core/mod.rs)：
+主要接口位于 `crates/tiangong-core/src/core/mod.rs`：
 
 ```rust
 pub struct TiangongCore;
@@ -80,7 +80,7 @@ impl TiangongCore {
 
 ### `CoreConfig`
 
-定义位于 [core_config.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-core/src/core_config.rs)。
+定义位于 `crates/tiangong-core/src/core_config.rs`。
 
 当前运行所需最小配置包括：
 
@@ -122,7 +122,7 @@ impl TiangongCore {
 
 仓库内现成示例见：
 
-- [test_core.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-core/examples/test_core.rs)
+- `crates/tiangong-core/examples/test_core.rs`
 
 一个最小接入示例如下：
 
@@ -194,8 +194,8 @@ let provider = CoreConfigProvider::new(CoreConfig {
 
 相关代码：
 
-- [crates/tiangong-config/src/lib.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-config/src/lib.rs)
-- [crates/tiangong-config/src/config.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-config/src/config.rs)
+- `crates/tiangong-config/src/lib.rs`
+- `crates/tiangong-config/src/config.rs`
 
 示例：
 
@@ -375,8 +375,8 @@ Core 应负责：
 
 ## 参考材料
 
-- [docs/rfc/0006-core-config-provider.md](/Users/hubertshelley/Documents/silent/tiangong/docs/rfc/0006-core-config-provider.md)
-- [crates/tiangong-core/examples/test_core.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-core/examples/test_core.rs)
-- [crates/tiangong-core/src/core/mod.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-core/src/core/mod.rs)
-- [crates/tiangong-core/src/core_config.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-core/src/core_config.rs)
-- [crates/tiangong-config/src/lib.rs](/Users/hubertshelley/Documents/silent/tiangong/crates/tiangong-config/src/lib.rs)
+- `docs/rfc/0006-core-config-provider.md`
+- `crates/tiangong-core/examples/test_core.rs`
+- `crates/tiangong-core/src/core/mod.rs`
+- `crates/tiangong-core/src/core_config.rs`
+- `crates/tiangong-config/src/lib.rs`

--- a/docs/tiangong-llm-architecture.md
+++ b/docs/tiangong-llm-architecture.md
@@ -1,0 +1,116 @@
+# tiangong-llm 架构约束
+
+## 目的
+
+本文档用于约束 `crates/tiangong-llm` 的职责边界，避免其从“统一 LLM 适配层”继续演化成“大而杂的协议实现仓库”。
+
+当前原则是：
+
+- `tiangong-llm` 负责统一抽象
+- 各协议 provider 负责协议级映射与 provider 封装
+- 具体 transport 尽量下沉到独立 crate
+- 上层业务不得依赖第三方 SDK 类型
+
+## 当前定位
+
+`tiangong-llm` 是上层业务与具体 LLM 协议实现之间的稳定边界层，当前主要承担以下职责：
+
+- 定义统一领域模型：
+  - `crates/tiangong-llm/src/request.rs`
+  - `crates/tiangong-llm/src/response.rs`
+  - `crates/tiangong-llm/src/message.rs`
+  - `crates/tiangong-llm/src/tool.rs`
+  - `crates/tiangong-llm/src/stream.rs`
+  - `crates/tiangong-llm/src/error.rs`
+- 定义统一 provider trait：
+  - `crates/tiangong-llm/src/provider.rs`
+- 维护 provider 适配入口：
+  - `crates/tiangong-llm/src/providers/anthropic`
+  - `crates/tiangong-llm/src/providers/openai`
+- 在 provider 内完成统一模型与协议模型之间的映射
+- 在 provider 内完成统一错误模型与协议错误之间的映射
+
+它不应直接承载上层业务决策，也不应成为 transport 细节、重试策略、产品规则的堆积点。
+
+## 明确边界
+
+### 可以放在 tiangong-llm 内的内容
+
+- 与供应商无关的统一请求、响应、消息、工具、流事件、usage 和错误模型
+- `LlmProvider` trait 与 provider capability 描述
+- provider 入口对象与最薄一层 provider facade
+- 请求映射、响应映射、流事件映射
+- 供应商错误向统一错误的转换
+- 与协议强相关、但仍然属于 provider 适配一部分的轻量兼容逻辑
+
+### 不应继续放在 tiangong-llm 内的内容
+
+- 供应商专属的底层 HTTP/SSE transport 细节
+- 大量 `reqwest`/SDK client 构建代码
+- 长段重试执行器、退避策略和日志模板的重复实现
+- 与业务场景绑定的提示词策略、模型选择策略、thinking 开关策略
+- `tiangong-core` 的运行时逻辑、消息拼装逻辑、任务编排逻辑
+- 面向 GUI/CLI/Server 的展示层兼容逻辑
+
+## 推荐结构
+
+理想结构应保持为三层：
+
+1. 上层调用层
+   - `tiangong-core`
+   - 只使用统一接口和统一领域模型
+2. 统一适配层
+   - `tiangong-llm`
+   - 只负责抽象、映射、错误边界和 provider facade
+3. 协议 transport 层
+   - 例如 `crates/tiangong-anthropic`
+   - 负责底层 HTTP、SSE、原始响应解析、协议模型
+
+## 当前状态判断
+
+当前实现中：
+
+- Anthropic 链路相对符合目标结构
+  - `crates/tiangong-anthropic` 承担了原生 transport
+  - `tiangong-llm` 中 Anthropic provider 主要负责映射和封装
+- OpenAI 兼容链路仍处于过渡态
+  - `crates/tiangong-llm/src/providers/openai/provider.rs` 目前同时承担了 client 构建、重试、timeout、list models、错误分类等职责
+  - 这部分后续应拆出独立 transport 或共享执行层，但当前不作为阻塞其他功能开发的前置任务
+
+结论：
+
+- `tiangong-llm` 当前可继续承载新增 provider 能力
+- 但不得再复制 OpenAI 兼容当前这种“provider 内堆 transport 细节”的模式
+
+## 新增 Provider 的规则
+
+新增 provider 时必须遵循以下顺序：
+
+1. 先定义统一边界是否已足够
+2. 如需协议专属 transport，优先新建独立 crate
+3. 在 `tiangong-llm` 中仅新增：
+   - provider facade
+   - mapping
+   - error adapter
+   - stream adapter
+4. 不允许将第三方 SDK 类型暴露到 `tiangong-core`
+
+## 后续重构优先级
+
+以下事项属于后续收敛方向，但当前不阻塞其他主功能开发：
+
+- 将 OpenAI 兼容 transport 从 `crates/tiangong-llm/src/providers/openai/provider.rs` 中拆出
+- 抽取 provider 共用的 retry/logging 执行器
+- 统一 `list_models` 的 transport 承载方式
+- 继续缩减 provider 文件中的 HTTP 直连细节
+
+## 变更准则
+
+后续修改 `tiangong-llm` 时，优先遵循以下判断：
+
+- 这是统一抽象问题，还是某个协议的 transport 问题
+- 这是 provider 映射问题，还是 `tiangong-core` 的业务问题
+- 这段逻辑是否会被多个 provider 复用
+- 这段逻辑是否会让 `tiangong-llm` 对上层行为产生不必要的产品耦合
+
+如果答案偏向 transport、业务策略或上层产品行为，则不应继续塞进 `tiangong-llm`。

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -118,6 +118,7 @@ export interface ProviderConfigView {
   base_url: string;
   api_key: string;
   timeout_ms: number;
+  protocol: string;
 }
 
 export interface ModelEntryView {
@@ -285,8 +286,13 @@ export const api = {
   getModelList: (): Promise<string[]> =>
     invoke('get_model_list'),
 
-  fetchProviderModels: (baseUrl: string, apiKey: string, timeoutMs?: number): Promise<string[]> =>
-    invoke('fetch_provider_models', { baseUrl, apiKey, timeoutMs }),
+  fetchProviderModels: (
+    baseUrl: string,
+    apiKey: string,
+    timeoutMs?: number,
+    protocol?: string,
+  ): Promise<string[]> =>
+    invoke('fetch_provider_models', { baseUrl, apiKey, timeoutMs, protocol }),
 
   // ----------------------------------------------------------------
   // @提及补全

--- a/frontend/src/components/SettingsButton.tsx
+++ b/frontend/src/components/SettingsButton.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { Settings, Eye, EyeOff } from 'lucide-react';
 import { api } from '@/api/tauri';
 import type { ModelsConfigView, ProviderConfigView } from '@/api/tauri';
@@ -61,6 +62,7 @@ export function SettingsButton() {
     base_url: '',
     api_key: '',
     timeout_ms: 60000,
+    protocol: 'openai_compatible',
   };
 
   const updateProvider = (updates: Partial<ProviderConfigView>) => {
@@ -121,6 +123,22 @@ export function SettingsButton() {
                 className="bg-[#1E1E1E] border-[#3C3C3C] text-white"
                 placeholder="https://api.openai.com/v1"
               />
+            </div>
+
+            <div className="space-y-2">
+              <Label>协议类型</Label>
+              <Select
+                value={firstProvider.protocol || 'openai_compatible'}
+                onValueChange={(value) => updateProvider({ protocol: value })}
+              >
+                <SelectTrigger className="bg-[#1E1E1E] border-[#3C3C3C] text-white">
+                  <SelectValue placeholder="选择协议" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="openai_compatible">OpenAI 兼容</SelectItem>
+                  <SelectItem value="anthropic">Anthropic</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="space-y-2">

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -820,6 +820,11 @@ function RoutingSection({
   capabilities: ModelCapabilityInfo[];
 }) {
   const modelKeys = Object.keys(config.models);
+  const modelLabel = (modelKey: string) => {
+    const model = config.models[modelKey];
+    if (!model) return modelKey;
+    return `${model.provider} / ${model.model}`;
+  };
 
   const setRoute = (capKey: string, modelName: string) => {
     const next = { ...config };
@@ -870,7 +875,7 @@ function RoutingSection({
                         return false;
                       })
                       .map((mk) => (
-                        <SelectItem key={mk} value={mk}>{mk}</SelectItem>
+                        <SelectItem key={mk} value={mk}>{modelLabel(mk)}</SelectItem>
                       ))}
                   </SelectContent>
                 </Select>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -227,14 +227,22 @@ function ProvidersSection({
     base_url: '',
     api_key: '',
     timeout_ms: 60000,
+    protocol: 'openai_compatible',
   });
   const [showApiKey, setShowApiKey] = useState(false);
 
   const providerKeys = Object.keys(config.providers);
+  const protocolLabel = (protocol?: string) =>
+    protocol === 'anthropic' ? 'Anthropic' : 'OpenAI 兼容';
 
   const openAdd = () => {
     setModalMode('add');
-    setDraft({ base_url: '', api_key: '', timeout_ms: 60000 });
+    setDraft({
+      base_url: '',
+      api_key: '',
+      timeout_ms: 60000,
+      protocol: 'openai_compatible',
+    });
     setNewKey('');
     setShowApiKey(false);
   };
@@ -303,10 +311,18 @@ function ProvidersSection({
           <Card key={key}>
             <CardContent className="p-3">
               <div className="flex items-center justify-between">
-                <div>
-                  <span className="font-medium text-sm">{key}</span>
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm">{key}</span>
+                    <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-5">
+                      {protocolLabel(config.providers[key].protocol)}
+                    </Badge>
+                  </div>
                   <div className="text-xs text-muted-foreground mt-1">
                     {config.providers[key].base_url || '(未设置 URL)'}
+                  </div>
+                  <div className="text-[11px] text-muted-foreground mt-1">
+                    超时 {config.providers[key].timeout_ms} ms
                   </div>
                 </div>
                 <div className="flex items-center gap-1">
@@ -413,6 +429,21 @@ function ProviderForm({
           placeholder="60000"
         />
       </div>
+      <div>
+        <Label className="text-xs">协议类型</Label>
+        <Select
+          value={draft.protocol || 'openai_compatible'}
+          onValueChange={(value) => setDraft({ ...draft, protocol: value })}
+        >
+          <SelectTrigger className="text-sm h-8">
+            <SelectValue placeholder="选择协议" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="openai_compatible">OpenAI 兼容</SelectItem>
+            <SelectItem value="anthropic">Anthropic</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
       <div className="flex justify-end gap-2 pt-1">
         <Button variant="ghost" size="sm" onClick={onCancel}>
           取消
@@ -467,6 +498,7 @@ function ModelsSection({
         provider.base_url,
         provider.api_key,
         provider.timeout_ms,
+        provider.protocol,
       );
       if (models.length === 0) {
         showError('无可用模型', '该 Provider 未返回任何模型，请检查 API 配置');

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -122,6 +122,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-anthropic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55f84bfda9889ff5e5052bbe16e681e90142eeb28e4c61cf380b1fed104dc73"
+dependencies = [
+ "backoff",
+ "derive_builder",
+ "reqwest 0.12.28",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5328,6 +5347,7 @@ dependencies = [
  "scru128",
  "serde",
  "serde_json",
+ "tiangong-llm",
  "tiangong-media",
  "tiangong-types",
  "tokio",
@@ -5362,6 +5382,25 @@ dependencies = [
  "serde_json",
  "tiangong-core",
  "tiangong-media",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tiangong-llm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-anthropic",
+ "async-openai",
+ "async-trait",
+ "backoff",
+ "futures-util",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tiangong-types",
  "tokio",
  "tracing",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5243,9 +5243,9 @@ dependencies = [
 name = "tiangong-anthropic"
 version = "0.1.0"
 dependencies = [
+ "eventsource-stream",
  "futures-util",
  "reqwest 0.12.28",
- "reqwest-eventsource",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -122,25 +122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-anthropic"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55f84bfda9889ff5e5052bbe16e681e90142eeb28e4c61cf380b1fed104dc73"
-dependencies = [
- "backoff",
- "derive_builder",
- "reqwest 0.12.28",
- "reqwest-eventsource",
- "secrecy",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5259,6 +5240,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiangong-anthropic"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "reqwest 0.12.28",
+ "reqwest-eventsource",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tiangong-app"
 version = "0.1.0"
 dependencies = [
@@ -5391,7 +5384,6 @@ name = "tiangong-llm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-anthropic",
  "async-openai",
  "async-trait",
  "backoff",
@@ -5400,6 +5392,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tiangong-anthropic",
  "tiangong-types",
  "tokio",
  "tracing",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1292,8 +1292,9 @@ pub fn fetch_provider_models(
     base_url: String,
     api_key: String,
     timeout_ms: Option<u64>,
+    protocol: Option<String>,
 ) -> Result<Vec<String>, String> {
-    use tiangong_core::model::{ModelProviderConfig, SingleProviderClient};
+    use tiangong_core::model::{ModelProviderConfig, ProviderProtocol, SingleProviderClient};
     use tiangong_core::models_config::ModelsConfig;
 
     let resolved_key = ModelsConfig::resolve_api_key(&api_key);
@@ -1301,6 +1302,10 @@ pub fn fetch_provider_models(
         api_auth_token: resolved_key,
         api_base_url: base_url,
         api_timeout_ms: timeout_ms.unwrap_or(60_000).to_string(),
+        api_protocol: protocol
+            .as_deref()
+            .and_then(|value| value.parse::<ProviderProtocol>().ok())
+            .unwrap_or_default(),
         api_model: String::new(),
         api_lite_model: String::new(),
     };

--- a/src-tauri/src/view.rs
+++ b/src-tauri/src/view.rs
@@ -266,6 +266,7 @@ pub struct ProviderConfigView {
     pub base_url: String,
     pub api_key: String,
     pub timeout_ms: u64,
+    pub protocol: String,
 }
 
 /// 单个模型配置（前端使用）
@@ -297,6 +298,7 @@ impl ModelsConfigView {
                         base_url: v.base_url.clone(),
                         api_key: v.api_key.clone(),
                         timeout_ms: v.timeout_ms,
+                        protocol: v.protocol.as_str().to_string(),
                     },
                 )
             })
@@ -354,6 +356,7 @@ impl ModelsConfigView {
                         base_url: v.base_url.clone(),
                         api_key: v.api_key.clone(),
                         timeout_ms: v.timeout_ms,
+                        protocol: v.protocol.parse().unwrap_or_default(),
                     },
                 )
             })


### PR DESCRIPTION
## 概要
- 引入独立的 `tiangong-llm` 协议抽象层与 `tiangong-anthropic` transport crate
- 为模型配置增加 `anthropic` 协议支持，并打通 GUI/CLI/Core 的协议透传
- 收敛 Anthropic provider 的请求、SSE、thinking、错误分类与兼容性处理
- 补充 `tiangong-llm` 架构约束文档，明确后续演进边界

## 主要改动
- 新增独立 crate：`crates/tiangong-llm`
- 新增独立 crate：`crates/tiangong-anthropic`
- 将 Anthropic / OpenAI 兼容 provider 统一收口到 `tiangong-llm`
- 将 Anthropic messages 与 SSE 改为原生 `reqwest + serde` 实现
- 修复协议透传、流式运行时边界、thinking 解析、兼容供应商缺失字段与扩展事件
- 将 `429/529/overloaded_error` 统一归类为可重试的限流/拥挤错误
- GUI 的 Providers/Routing 显示补充协议与 provider 区分
- 新增 `docs/tiangong-llm-architecture.md`

## 验证
- `cargo check --workspace`
- `cargo clippy -p tiangong-anthropic -p tiangong-llm -p tiangong-core --all-targets --tests -- -D warnings`
- `cargo test -p tiangong-llm anthropic -- --nocapture`
- `yarn --cwd frontend build`

## 备注
- 当前 `TODO.md` 中与 Anthropic 协议抽象相关的主链路任务已基本落地
- OpenAI 兼容 transport 的进一步拆分保留到后续阶段处理，不阻塞当前功能开发
