### PR TITLE
fix(core): 修复会话恢复和入口通道异常问题

### DIFF
--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -197,7 +197,9 @@ impl ResponseState {
                 }
             }
 
-            StreamEvent::ToolResult { name, ok, output } => {
+            StreamEvent::ToolResult {
+                name, ok, output, ..
+            } => {
                 self.end_active_stream();
                 output::tool_result(name, *ok, output);
             }

--- a/crates/tiangong-core/Cargo.toml
+++ b/crates/tiangong-core/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-openai = { git = "https://github.com/silent-rs/async-openai", branch = "main", package = "async-openai", features = ["byot", "chat-completion", "model"] }
 backoff = "0.4"
-tokio = { version = "1", features = ["rt", "time", "process", "io-util"] }
+tokio = { version = "1", features = ["rt", "time", "process", "io-util", "sync"] }
 rmcp = { version = "0.17.0", default-features = false, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 futures-util = "0.3"

--- a/crates/tiangong-core/src/agents/execution_tool_agent.rs
+++ b/crates/tiangong-core/src/agents/execution_tool_agent.rs
@@ -161,6 +161,14 @@ pub(crate) fn basic_file_function_tools() -> Vec<FunctionToolSpec> {
 }
 
 pub(crate) fn build_tool_call_from_function(call: &ModelFunctionCall) -> Result<ToolCall> {
+    if let Some(parse_error) = call
+        .arguments
+        .get("__parse_error")
+        .and_then(serde_json::Value::as_str)
+    {
+        return Err(anyhow::anyhow!("{parse_error}"));
+    }
+
     let mut args = Vec::new();
     let tool_call = match call.name.as_str() {
         "list_dir" => {

--- a/crates/tiangong-core/src/app_state/facade/sessions/ingress.rs
+++ b/crates/tiangong-core/src/app_state/facade/sessions/ingress.rs
@@ -5,14 +5,25 @@ impl TiangongState {
     ///
     /// 统一处理：
     /// - 解析活动会话
+    /// - 固定用户消息并立即持久化
     /// - 清空输入草稿
     /// - 更新运行状态
     /// - 返回用于创建/复用 TiangongCore 的会话快照
     pub fn prepare_active_user_message_ingress(
         &mut self,
-        _content: impl Into<String>,
-    ) -> Result<(String, Session)> {
+        content: impl Into<String>,
+    ) -> Result<(String, String, Session)> {
+        let content = content.into();
         let idx = self.ensure_active_session_index();
+        let message_id = scru128::new().to_string();
+        let session_id = self.store.session.sessions[idx].id.clone();
+        self.store.session.sessions[idx].append_message_with_id(
+            message_id.clone(),
+            MessageRole::User,
+            content,
+            String::new(),
+        );
+        self.persist_session_and_app(&session_id)?;
         let session = self.store.session.sessions[idx].clone();
         self.store.session.input_draft.clear();
         self.store.runtime.run.status = crate::runtime::RunStatus::Executing;
@@ -21,7 +32,7 @@ impl TiangongState {
         let usage = session.total_usage();
         self.store.runtime.run.last_usage = (usage.total_tokens > 0).then_some(usage);
         self.store.runtime.run.updated_at = now_text();
-        Ok((session.id.clone(), session))
+        Ok((session.id.clone(), message_id, session))
     }
 
     /// 向指定会话注入外部事件消息，并立即持久化。

--- a/crates/tiangong-core/src/app_state/formatting.rs
+++ b/crates/tiangong-core/src/app_state/formatting.rs
@@ -109,18 +109,16 @@ pub(crate) fn format_tool_trace_message(result: &ToolResult) -> String {
     let Some(record) = result.execution.as_ref() else {
         let mut lines = vec!["工具执行 [unknown]".to_string()];
         lines.push(format!("summary: {}", result.summary));
-        let stdout_text = clip_tool_output_lines(result.stdout.as_str(), 5);
-        let stderr_text = clip_tool_output_lines(result.stderr.as_str(), 5);
-        if !stdout_text.trim().is_empty() {
+        if !result.stdout.trim().is_empty() {
             lines.push("stdout:".to_string());
             lines.push("```text".to_string());
-            lines.push(stdout_text);
+            lines.push(result.stdout.clone());
             lines.push("```".to_string());
         }
-        if !stderr_text.trim().is_empty() {
+        if !result.stderr.trim().is_empty() {
             lines.push("stderr:".to_string());
             lines.push("```text".to_string());
-            lines.push(stderr_text);
+            lines.push(result.stderr.clone());
             lines.push("```".to_string());
         }
         return lines.join("\n");
@@ -135,35 +133,19 @@ pub(crate) fn format_tool_trace_message(result: &ToolResult) -> String {
         result.ok, result.exit_code, record.duration_ms
     ));
     lines.push(format!("summary: {}", result.summary));
-    let stdout_text = clip_tool_output_lines(result.stdout.as_str(), 5);
-    let stderr_text = clip_tool_output_lines(result.stderr.as_str(), 5);
-    if !stdout_text.trim().is_empty() {
+    if !result.stdout.trim().is_empty() {
         lines.push("stdout:".to_string());
         lines.push("```text".to_string());
-        lines.push(stdout_text);
+        lines.push(result.stdout.clone());
         lines.push("```".to_string());
     }
-    if !stderr_text.trim().is_empty() {
+    if !result.stderr.trim().is_empty() {
         lines.push("stderr:".to_string());
         lines.push("```text".to_string());
-        lines.push(stderr_text);
+        lines.push(result.stderr.clone());
         lines.push("```".to_string());
     }
     lines.join("\n")
-}
-
-fn clip_tool_output_lines(text: &str, max_lines: usize) -> String {
-    let lines = text.lines().collect::<Vec<_>>();
-    if lines.len() <= max_lines {
-        return text.to_string();
-    }
-    let kept = lines
-        .iter()
-        .take(max_lines)
-        .copied()
-        .collect::<Vec<_>>()
-        .join("\n");
-    format!("{kept}\n...(省略 {} 行)", lines.len() - max_lines)
 }
 
 fn format_tool_command(record: &ToolExecutionRecord) -> Option<String> {

--- a/crates/tiangong-core/src/app_state/repository/load.rs
+++ b/crates/tiangong-core/src/app_state/repository/load.rs
@@ -16,9 +16,11 @@ impl AppRepository {
                 }
             }
 
+            let active_session_id = resolve_active_session_id(&sessions, None);
+
             return Ok(Some(LoadedState {
                 sessions,
-                active_session_id: session_ids.first().cloned().unwrap_or_default(),
+                active_session_id,
                 model_list: Vec::new(),
                 agent_config,
             }));
@@ -39,14 +41,8 @@ impl AppRepository {
                 sessions.push(session);
             }
         }
-        let active_session_id = if session_ids
-            .iter()
-            .any(|session_id| session_id == &persisted.active_session_id)
-        {
-            persisted.active_session_id
-        } else {
-            session_ids.first().cloned().unwrap_or_default()
-        };
+        let active_session_id =
+            resolve_active_session_id(&sessions, Some(&persisted.active_session_id));
         let agent_config = self.load_agent_config_with_fallback(persisted.agent_config)?;
 
         Ok(Some(LoadedState {
@@ -197,4 +193,23 @@ impl AppRepository {
         session_ids.dedup();
         Ok(session_ids)
     }
+}
+
+fn resolve_active_session_id(sessions: &[Session], persisted_active_id: Option<&str>) -> String {
+    if let Some(active_id) = persisted_active_id
+        && sessions.iter().any(|session| session.id == active_id)
+    {
+        return active_id.to_string();
+    }
+
+    sessions
+        .iter()
+        .max_by(|left, right| {
+            left.updated_at
+                .cmp(&right.updated_at)
+                .then_with(|| left.created_at.cmp(&right.created_at))
+                .then_with(|| left.id.cmp(&right.id))
+        })
+        .map(|session| session.id.clone())
+        .unwrap_or_default()
 }

--- a/crates/tiangong-core/src/app_state/tests/repository.rs
+++ b/crates/tiangong-core/src/app_state/tests/repository.rs
@@ -81,6 +81,79 @@ fn repository_persist_to_disk_round_trips_split_configs_and_sessions() -> Result
 }
 
 #[test]
+fn load_from_disk_prefers_most_recent_session_when_app_storage_missing() -> Result<()> {
+    with_isolated_state(
+        "tiangong-repository-recover-latest-without-app",
+        |paths, state| {
+            state.store.session.sessions.clear();
+
+            let mut older = Session::new("较早会话");
+            older.created_at = "2026-04-22 09:00:00.000000".to_string();
+            older.updated_at = "2026-04-22 09:05:00.000000".to_string();
+
+            let mut newer = Session::new("最近会话");
+            newer.created_at = "2026-04-23 10:00:00.000000".to_string();
+            newer.updated_at = "2026-04-23 10:20:00.000000".to_string();
+
+            state.store.session.active_session_id = older.id.clone();
+            state.store.session.sessions = vec![older.clone(), newer.clone()];
+            state.persist_to_disk()?;
+
+            fs::remove_file(paths.fake_home.join(".tiangong").join("app.json"))?;
+
+            let loaded = state
+                .services
+                .repository
+                .load_from_disk()?
+                .expect("应能从 session 文件恢复状态");
+
+            assert_eq!(loaded.active_session_id, newer.id);
+            assert_eq!(loaded.sessions.len(), 2);
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn load_from_disk_prefers_most_recent_session_when_active_session_is_invalid() -> Result<()> {
+    with_isolated_state(
+        "tiangong-repository-recover-latest-invalid-active",
+        |paths, state| {
+            state.store.session.sessions.clear();
+
+            let mut older = Session::new("较早会话");
+            older.created_at = "2026-04-22 09:00:00.000000".to_string();
+            older.updated_at = "2026-04-22 09:05:00.000000".to_string();
+
+            let mut newer = Session::new("最近会话");
+            newer.created_at = "2026-04-23 10:00:00.000000".to_string();
+            newer.updated_at = "2026-04-23 10:20:00.000000".to_string();
+
+            state.store.session.sessions = vec![older, newer.clone()];
+            state.store.session.active_session_id = newer.id.clone();
+            state.persist_to_disk()?;
+
+            let app_path = paths.fake_home.join(".tiangong").join("app.json");
+            let mut app_json: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&app_path)?)?;
+            app_json["active_session_id"] =
+                serde_json::Value::String("missing-session-id".to_string());
+            fs::write(&app_path, serde_json::to_string_pretty(&app_json)?)?;
+
+            let loaded = state
+                .services
+                .repository
+                .load_from_disk()?
+                .expect("应能在 active_session_id 失效时恢复状态");
+
+            assert_eq!(loaded.active_session_id, newer.id);
+            assert_eq!(loaded.sessions.len(), 2);
+            Ok(())
+        },
+    )
+}
+
+#[test]
 fn sync_mcp_dependency_lock_writes_expected_ref_counts() -> Result<()> {
     with_isolated_state("tiangong-mcp-dependency-lock", |paths, state| {
         state.store.agent.agent_config.skills.installed = vec![

--- a/crates/tiangong-core/src/app_state/tests/state.rs
+++ b/crates/tiangong-core/src/app_state/tests/state.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::fs;
 
 use super::super::repository::canonical_scru128_id;
 use super::super::*;
@@ -21,6 +22,34 @@ fn normalize_sessions_repairs_invalid_ids_and_active_session() -> Result<()> {
         assert_eq!(canonical_scru128_id(&second_id), Some(second_id.clone()));
         assert_ne!(first_id, second_id);
         assert_eq!(state.store.session.active_session_id, first_id);
+        Ok(())
+    })
+}
+
+#[test]
+fn prepare_active_user_message_ingress_persists_message_immediately() -> Result<()> {
+    with_isolated_state("tiangong-state-ingress-persist", |paths, state| {
+        state.create_session();
+
+        let (session_id, message_id, session) =
+            state.prepare_active_user_message_ingress("立即固定这条消息")?;
+
+        assert_eq!(state.active_session_id(), session_id);
+        assert_eq!(session.messages.len(), 1);
+        assert_eq!(session.messages[0].id, message_id);
+        assert_eq!(session.messages[0].content, "立即固定这条消息");
+
+        let session_path = paths
+            .fake_home
+            .join(".tiangong")
+            .join("sessions")
+            .join(format!("{session_id}.json"));
+        assert!(session_path.exists());
+
+        let persisted: Session = serde_json::from_str(&fs::read_to_string(session_path)?)?;
+        assert_eq!(persisted.messages.len(), 1);
+        assert_eq!(persisted.messages[0].id, message_id);
+        assert_eq!(persisted.messages[0].content, "立即固定这条消息");
         Ok(())
     })
 }

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -15,7 +15,9 @@ use crate::app_state::formatting::{format_llm_output_message, format_tool_trace_
 use crate::coordinator::TaskCoordinator;
 use crate::coordinator::types::CoordinatorTask;
 use crate::core_config::{CoreConfig, CoreConfigProvider};
-use crate::model::{FunctionToolSpec, ModelClient, ModelRequest, SingleProviderClient, TokenUsage};
+use crate::model::{
+    FunctionToolSpec, ModelClient, ModelRequest, ModelToolChoice, SingleProviderClient, TokenUsage,
+};
 use crate::observe::{audit_permission_with_context, audit_tool_execution};
 use crate::prompt::PromptAssembler;
 use crate::runtime::{LlmOutputRecord, RuntimeEngine, inject_enhanced_tools, use_stream_mode};
@@ -27,8 +29,10 @@ use tiangong_types::{SessionStreamEvent, StreamEvent};
 use std::sync::mpsc::Receiver;
 
 const MAX_ROUNDS: usize = 20;
+const MAX_REQUIRED_TOOL_REPROMPTS: usize = 2;
 const MEMORY_LOOP_FEEDBACK_MAX_CHARS: usize = 12_000;
 const TOOL_RESULT_STREAM_MAX_CHARS: usize = 8_000;
+const FINISH_TASK_TOOL_NAME: &str = "finish_task";
 
 type MemoryRecallToolOutput = (crate::tool::ToolResult, tiangong_types::TokenUsage, bool);
 
@@ -330,39 +334,47 @@ impl TiangongCore {
         }
     }
 
-    fn send_cmd(&self, cmd: Command) {
-        if let Some(ref tx) = self.cmd_tx {
-            let _ = tx.send(cmd);
-        }
+    fn send_cmd(&self, cmd: Command) -> bool {
+        let Some(ref tx) = self.cmd_tx else {
+            return false;
+        };
+        tx.send(cmd).is_ok()
     }
 
-    pub fn send_message(&self, content: String) {
+    pub fn send_message(&self, content: String) -> bool {
         self.send_cmd(Command::Message {
             content,
             message_id: None,
-        });
+        })
     }
 
-    pub fn send_message_with_id(&self, content: String, message_id: String) {
+    pub fn send_message_with_id(&self, content: String, message_id: String) -> bool {
         self.send_cmd(Command::Message {
             content,
             message_id: Some(message_id),
-        });
+        })
     }
 
-    pub fn cancel(&self) {
-        self.send_cmd(Command::Cancel);
+    pub fn cancel(&self) -> bool {
+        self.send_cmd(Command::Cancel)
     }
 
-    pub fn respond_approval(&self, request_id: String, approved: bool) {
+    pub fn respond_approval(&self, request_id: String, approved: bool) -> bool {
         self.send_cmd(Command::Approval {
             request_id,
             approved,
-        });
+        })
     }
 
     pub fn session_id(&self) -> &str {
         &self.session_id
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.worker
+            .as_ref()
+            .map(|worker| !worker.is_finished())
+            .unwrap_or(false)
     }
 
     /// 设置信任模式（实时生效，当前对话下一次工具调用立即感知）
@@ -374,7 +386,7 @@ impl TiangongCore {
 
     /// 关闭并获取最终 session
     pub fn into_session(mut self) -> Session {
-        self.send_cmd(Command::Shutdown);
+        let _ = self.send_cmd(Command::Shutdown);
         self.cmd_tx = None;
         if let Some(w) = self.worker.take() {
             match w.join() {
@@ -730,6 +742,7 @@ async fn execute_turn_inner_async(
     let mut pending_media_assets: Vec<tiangong_types::MediaAsset> = Vec::new();
     let mut memory_context: Option<String> = None;
     let mut memory_recall_attempted = false;
+    let mut required_tool_reprompts = 0;
 
     'react_loop: loop {
         match drain_pending_commands_async(session, &mut loop_context, stream_tx, cmd_rx) {
@@ -748,12 +761,16 @@ async fn execute_turn_inner_async(
             break;
         }
 
+        let structured_action_required = round > 0;
+        let request_tools = tools_for_round(tools, structured_action_required);
+        let tool_choice = structured_action_required.then_some(ModelToolChoice::Any);
+
         let mut prompt_loop_context = loop_context.clone();
         if round > 0 {
             prompt_loop_context.push(Message {
                 id: scru128::new().to_string(),
                 role: MessageRole::System,
-                content: "内部调度提示：根据上面的工具执行结果继续完成用户原始目标。若目标尚未实际完成，继续调用必要工具；只有确认目标已完成时，才给出最终回复。".to_string(),
+                content: "内部调度提示：根据上面的工具执行结果继续完成用户原始目标。本轮必须调用一个工具：若仍需读取、写入、执行命令或验证文件，请调用真实工具；若目标已经完成，请调用 finish_task 并提供完成依据。不要用普通文本声称已经执行工具。".to_string(),
                 reasoning_content: String::new(),
                 worker_id: None,
                 media: Vec::new(),
@@ -765,7 +782,7 @@ async fn execute_turn_inner_async(
         let assembled = assembler.assemble(
             session,
             "",
-            tools.to_vec(),
+            request_tools.clone(),
             engine.models_config(),
             engine.agent_config(),
             &prompt_loop_context,
@@ -798,10 +815,15 @@ async fn execute_turn_inner_async(
             tokio_mpsc::unbounded_channel::<crate::model::ModelStreamChunk>();
         let client = engine.client().clone();
         let req_clone = req.clone();
-        let tools_clone = tools.to_vec();
+        let tools_clone = request_tools.clone();
         let llm_fut = tokio::task::spawn(async move {
             client
-                .stream_function_calls(req_clone, tools_clone, chunk_tx)
+                .stream_function_calls_with_tool_choice(
+                    req_clone,
+                    tools_clone,
+                    tool_choice,
+                    chunk_tx,
+                )
                 .await
         });
 
@@ -882,6 +904,17 @@ async fn execute_turn_inner_async(
                 continue;
             }
 
+            if structured_action_required && required_tool_reprompts < MAX_REQUIRED_TOOL_REPROMPTS {
+                required_tool_reprompts += 1;
+                push_required_tool_reprompt(
+                    &mut loop_context,
+                    &response.text,
+                    &response.reasoning_content,
+                    "上一轮没有返回 tool_calls。请调用真实工具继续执行，或调用 finish_task 结构化结束。",
+                );
+                continue;
+            }
+
             session.append_message_with_id_and_media(
                 pending_msg_id,
                 MessageRole::Assistant,
@@ -917,7 +950,79 @@ async fn execute_turn_inner_async(
         }
 
         // 工具调用
-        let tool_names: Vec<String> = response.tool_calls.iter().map(|c| c.name.clone()).collect();
+        if let Some(finish_call) = only_finish_task_call(&response.tool_calls) {
+            match build_finish_task_final_text(finish_call) {
+                Ok(final_text) => {
+                    let output = LlmOutputRecord {
+                        stage: format!("react-round-{round}"),
+                        content: response.text.clone(),
+                        reasoning_content: response.reasoning_content.clone(),
+                        tool_calls: vec![FINISH_TASK_TOOL_NAME.to_string()],
+                        usage: response.usage.clone(),
+                    };
+                    session.append_message_with_reasoning(
+                        MessageRole::System,
+                        format_llm_output_message(&output),
+                        response.reasoning_content.clone(),
+                    );
+                    let _ = stream_tx.send(StreamEvent::Delta {
+                        message_id: pending_msg_id.clone(),
+                        content: final_text.clone(),
+                    });
+                    session.append_message_with_id_and_media(
+                        pending_msg_id,
+                        MessageRole::Assistant,
+                        final_text,
+                        response.reasoning_content.clone(),
+                        std::mem::take(&mut pending_media_assets),
+                    );
+                    session.persist_to_disk();
+                    let _ = stream_tx.send(StreamEvent::Done {
+                        usage: Some(tiangong_types::TokenUsage {
+                            prompt_tokens: accumulated_usage.prompt_tokens,
+                            completion_tokens: accumulated_usage.completion_tokens,
+                            total_tokens: accumulated_usage.total_tokens,
+                        }),
+                    });
+                    return accumulated_usage;
+                }
+                Err(err) if required_tool_reprompts < MAX_REQUIRED_TOOL_REPROMPTS => {
+                    required_tool_reprompts += 1;
+                    push_required_tool_reprompt(
+                        &mut loop_context,
+                        &response.text,
+                        &response.reasoning_content,
+                        &format!("finish_task 参数无效：{err}"),
+                    );
+                    continue;
+                }
+                Err(_) => {}
+            }
+        }
+
+        let executable_calls = response
+            .tool_calls
+            .iter()
+            .filter(|call| call.name != FINISH_TASK_TOOL_NAME)
+            .collect::<Vec<_>>();
+        if executable_calls.is_empty() {
+            if required_tool_reprompts < MAX_REQUIRED_TOOL_REPROMPTS {
+                required_tool_reprompts += 1;
+                push_required_tool_reprompt(
+                    &mut loop_context,
+                    &response.text,
+                    &response.reasoning_content,
+                    "模型没有返回可执行工具调用。",
+                );
+                continue;
+            }
+            let _ = stream_tx.send(StreamEvent::Error {
+                message: "模型没有返回可执行工具调用，任务已停止".to_string(),
+            });
+            return accumulated_usage;
+        }
+        required_tool_reprompts = 0;
+        let tool_names: Vec<String> = executable_calls.iter().map(|c| c.name.clone()).collect();
         let output = LlmOutputRecord {
             stage: format!("react-round-{round}"),
             content: response.text.clone(),
@@ -951,7 +1056,7 @@ async fn execute_turn_inner_async(
         }
 
         // 执行工具
-        for call in &response.tool_calls {
+        for call in executable_calls {
             match drain_pending_commands_async(session, &mut loop_context, stream_tx, cmd_rx) {
                 PendingCommandEffect::Terminate => return accumulated_usage,
                 PendingCommandEffect::MessageInjected => {
@@ -1145,8 +1250,8 @@ async fn execute_turn_inner_async(
             let _ = stream_tx.send(StreamEvent::ToolResult {
                 name: call.name.clone(),
                 ok: result.ok,
-                output: tool_result_stream_output(&result.stdout),
-                full_output: Some(result.stdout.clone()),
+                output: tool_result_stream_output(&result),
+                full_output: Some(tool_result_full_output(&result)),
             });
             session.append_message(MessageRole::System, format_tool_trace_message(&result));
 
@@ -1240,6 +1345,7 @@ fn execute_turn_inner(
     let mut pending_media_assets: Vec<tiangong_types::MediaAsset> = Vec::new();
     let mut memory_context: Option<String> = None;
     let mut memory_recall_attempted = false;
+    let mut required_tool_reprompts = 0;
 
     'react_loop: loop {
         match drain_pending_commands(session, &mut loop_context, stream_tx, cmd_rx) {
@@ -1260,12 +1366,16 @@ fn execute_turn_inner(
         // 构建 prompt
         // 用户输入统一通过 session.messages 传递，不使用独立的 user_input 通道。
         // 工具调用后的续写提示只在本轮 prompt 中临时注入，避免重复累积到 loop_context。
+        let structured_action_required = round > 0;
+        let request_tools = tools_for_round(tools, structured_action_required);
+        let tool_choice = structured_action_required.then_some(ModelToolChoice::Any);
+
         let mut prompt_loop_context = loop_context.clone();
         if round > 0 {
             prompt_loop_context.push(Message {
                 id: scru128::new().to_string(),
                 role: MessageRole::System,
-                content: "内部调度提示：根据上面的工具执行结果继续完成用户原始目标。若目标尚未实际完成，继续调用必要工具；只有确认目标已完成时，才给出最终回复。".to_string(),
+                content: "内部调度提示：根据上面的工具执行结果继续完成用户原始目标。本轮必须调用一个工具：若仍需读取、写入、执行命令或验证文件，请调用真实工具；若目标已经完成，请调用 finish_task 并提供完成依据。不要用普通文本声称已经执行工具。".to_string(),
                 reasoning_content: String::new(),
                 worker_id: None,
                 media: Vec::new(),
@@ -1277,7 +1387,7 @@ fn execute_turn_inner(
         let assembled = assembler.assemble(
             session,
             "",
-            tools.to_vec(),
+            request_tools.clone(),
             engine.models_config(),
             engine.agent_config(),
             &prompt_loop_context,
@@ -1314,10 +1424,13 @@ fn execute_turn_inner(
         let stream_cancel_c = stream_cancel.clone();
         let cmds_during_stream: Arc<Mutex<Vec<Command>>> = Arc::new(Mutex::new(Vec::new()));
         let cmds_during_stream_c = cmds_during_stream.clone();
-        let response_result =
-            engine
-                .client()
-                .complete_with_functions_stream(&req, tools, &mut |delta| {
+        let response_result = engine
+            .client()
+            .complete_with_functions_stream_with_tool_choice(
+                &req,
+                &request_tools,
+                tool_choice,
+                &mut |delta| {
                     // 每个 chunk 回调时顺带排空命令队列，实现任意时刻响应
                     while let Ok(cmd) = cmd_rx.try_recv() {
                         match cmd {
@@ -1337,7 +1450,8 @@ fn execute_turn_inner(
                     if !stream_cancel_c.load(Ordering::Acquire) {
                         sink.push_chunk(delta);
                     }
-                });
+                },
+            );
         sink.finish();
         // Cancel/Shutdown 在流期间被触发
         if stream_cancel.load(Ordering::Acquire) {
@@ -1393,6 +1507,17 @@ fn execute_turn_inner(
                 continue;
             }
 
+            if structured_action_required && required_tool_reprompts < MAX_REQUIRED_TOOL_REPROMPTS {
+                required_tool_reprompts += 1;
+                push_required_tool_reprompt(
+                    &mut loop_context,
+                    &response.text,
+                    &response.reasoning_content,
+                    "上一轮没有返回 tool_calls。请调用真实工具继续执行，或调用 finish_task 结构化结束。",
+                );
+                continue;
+            }
+
             // 最终回复：使用预生成的 ID 记录到 session
             session.append_message_with_id_and_media(
                 pending_msg_id,
@@ -1425,7 +1550,79 @@ fn execute_turn_inner(
         }
 
         // 工具调用
-        let tool_names: Vec<String> = response.tool_calls.iter().map(|c| c.name.clone()).collect();
+        if let Some(finish_call) = only_finish_task_call(&response.tool_calls) {
+            match build_finish_task_final_text(finish_call) {
+                Ok(final_text) => {
+                    let output = LlmOutputRecord {
+                        stage: format!("react-round-{round}"),
+                        content: response.text.clone(),
+                        reasoning_content: response.reasoning_content.clone(),
+                        tool_calls: vec![FINISH_TASK_TOOL_NAME.to_string()],
+                        usage: response.usage.clone(),
+                    };
+                    session.append_message_with_reasoning(
+                        MessageRole::System,
+                        format_llm_output_message(&output),
+                        response.reasoning_content.clone(),
+                    );
+                    let _ = stream_tx.send(StreamEvent::Delta {
+                        message_id: pending_msg_id.clone(),
+                        content: final_text.clone(),
+                    });
+                    session.append_message_with_id_and_media(
+                        pending_msg_id,
+                        MessageRole::Assistant,
+                        final_text,
+                        response.reasoning_content.clone(),
+                        std::mem::take(&mut pending_media_assets),
+                    );
+                    session.persist_to_disk();
+                    let _ = stream_tx.send(StreamEvent::Done {
+                        usage: Some(tiangong_types::TokenUsage {
+                            prompt_tokens: accumulated_usage.prompt_tokens,
+                            completion_tokens: accumulated_usage.completion_tokens,
+                            total_tokens: accumulated_usage.total_tokens,
+                        }),
+                    });
+                    return accumulated_usage;
+                }
+                Err(err) if required_tool_reprompts < MAX_REQUIRED_TOOL_REPROMPTS => {
+                    required_tool_reprompts += 1;
+                    push_required_tool_reprompt(
+                        &mut loop_context,
+                        &response.text,
+                        &response.reasoning_content,
+                        &format!("finish_task 参数无效：{err}"),
+                    );
+                    continue;
+                }
+                Err(_) => {}
+            }
+        }
+
+        let executable_calls = response
+            .tool_calls
+            .iter()
+            .filter(|call| call.name != FINISH_TASK_TOOL_NAME)
+            .collect::<Vec<_>>();
+        if executable_calls.is_empty() {
+            if required_tool_reprompts < MAX_REQUIRED_TOOL_REPROMPTS {
+                required_tool_reprompts += 1;
+                push_required_tool_reprompt(
+                    &mut loop_context,
+                    &response.text,
+                    &response.reasoning_content,
+                    "模型没有返回可执行工具调用。",
+                );
+                continue;
+            }
+            let _ = stream_tx.send(StreamEvent::Error {
+                message: "模型没有返回可执行工具调用，任务已停止".to_string(),
+            });
+            return accumulated_usage;
+        }
+        required_tool_reprompts = 0;
+        let tool_names: Vec<String> = executable_calls.iter().map(|c| c.name.clone()).collect();
 
         // 记录 LLM 输出到 session
         let output = LlmOutputRecord {
@@ -1465,7 +1662,7 @@ fn execute_turn_inner(
         }
 
         // 执行工具
-        for call in &response.tool_calls {
+        for call in executable_calls {
             match drain_pending_commands(session, &mut loop_context, stream_tx, cmd_rx) {
                 PendingCommandEffect::Terminate => return accumulated_usage,
                 PendingCommandEffect::MessageInjected => {
@@ -1667,8 +1864,8 @@ fn execute_turn_inner(
             let _ = stream_tx.send(StreamEvent::ToolResult {
                 name: call.name.clone(),
                 ok: result.ok,
-                output: tool_result_stream_output(&result.stdout),
-                full_output: Some(result.stdout.clone()),
+                output: tool_result_stream_output(&result),
+                full_output: Some(tool_result_full_output(&result)),
             });
 
             // 记录到 session
@@ -1889,6 +2086,123 @@ fn append_or_reuse_user_message(
 fn is_synthetic_tool_call_placeholder(text: &str) -> bool {
     let trimmed = text.trim();
     trimmed.starts_with("[调用工具:") && trimmed.ends_with(']')
+}
+
+fn tools_for_round(tools: &[FunctionToolSpec], include_finish_task: bool) -> Vec<FunctionToolSpec> {
+    let mut request_tools = tools.to_vec();
+    if include_finish_task
+        && !request_tools
+            .iter()
+            .any(|tool| tool.name == FINISH_TASK_TOOL_NAME)
+    {
+        request_tools.push(finish_task_tool_spec());
+    }
+    request_tools
+}
+
+fn finish_task_tool_spec() -> FunctionToolSpec {
+    FunctionToolSpec {
+        name: FINISH_TASK_TOOL_NAME.to_string(),
+        description:
+            "结构化结束当前任务。仅当已经通过工具结果确认目标完成、或确认无法继续推进时调用。"
+                .to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["completed", "blocked"],
+                    "description": "completed 表示任务已完成；blocked 表示已尽力但被外部条件阻塞"
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "给用户的最终简明结论"
+                },
+                "evidence": {
+                    "type": "string",
+                    "description": "完成或阻塞依据，必须引用最近工具结果中的实际观察"
+                }
+            },
+            "required": ["status", "summary", "evidence"]
+        }),
+    }
+}
+
+fn only_finish_task_call(
+    calls: &[crate::model::ModelFunctionCall],
+) -> Option<&crate::model::ModelFunctionCall> {
+    if calls.len() == 1 && calls[0].name == FINISH_TASK_TOOL_NAME {
+        Some(&calls[0])
+    } else {
+        None
+    }
+}
+
+fn build_finish_task_final_text(call: &crate::model::ModelFunctionCall) -> anyhow::Result<String> {
+    let status = call
+        .arguments
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim();
+    let summary = call
+        .arguments
+        .get("summary")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim();
+    let evidence = call
+        .arguments
+        .get("evidence")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim();
+
+    if !matches!(status, "completed" | "blocked") {
+        return Err(anyhow::anyhow!("status 必须是 completed 或 blocked"));
+    }
+    if summary.is_empty() {
+        return Err(anyhow::anyhow!("summary 不能为空"));
+    }
+    if evidence.is_empty() {
+        return Err(anyhow::anyhow!("evidence 不能为空"));
+    }
+
+    if status == "blocked" {
+        Ok(format!("{summary}\n\n依据：{evidence}"))
+    } else {
+        Ok(summary.to_string())
+    }
+}
+
+fn push_required_tool_reprompt(
+    loop_context: &mut Vec<Message>,
+    text: &str,
+    reasoning_content: &str,
+    reason: &str,
+) {
+    if !text.trim().is_empty() || !reasoning_content.trim().is_empty() {
+        loop_context.push(Message {
+            id: scru128::new().to_string(),
+            role: MessageRole::Assistant,
+            content: text.trim().to_string(),
+            reasoning_content: reasoning_content.trim().to_string(),
+            worker_id: None,
+            media: Vec::new(),
+            created_at: now_text(),
+        });
+    }
+    loop_context.push(Message {
+        id: scru128::new().to_string(),
+        role: MessageRole::System,
+        content: format!(
+            "内部调度提示：{reason} 本轮被强制要求使用工具。若仍需读取、写入、执行命令或验证文件，必须直接调用真实工具；若目标已经完成，必须调用 finish_task 并提供 status、summary、evidence。"
+        ),
+        reasoning_content: String::new(),
+        worker_id: None,
+        media: Vec::new(),
+        created_at: now_text(),
+    });
 }
 
 /// 超限时强制最终回复
@@ -2278,9 +2592,36 @@ fn build_memory_recall_feedback(stdout: &str, allow_memory_context: bool) -> Str
     }
 }
 
-fn tool_result_stream_output(output: &str) -> String {
+fn tool_result_full_output(result: &crate::tool::ToolResult) -> String {
+    if result.ok {
+        return if result.stdout.trim().is_empty() {
+            result.summary.clone()
+        } else {
+            result.stdout.clone()
+        };
+    }
+
+    let mut lines = Vec::new();
+    if !result.summary.trim().is_empty() {
+        lines.push(format!("summary: {}", result.summary));
+    }
+    if !result.stderr.trim().is_empty() {
+        lines.push(format!("stderr:\n{}", result.stderr));
+    }
+    if !result.stdout.trim().is_empty() {
+        lines.push(format!("stdout:\n{}", result.stdout));
+    }
+    if lines.is_empty() {
+        "工具执行失败，但没有返回详细错误".to_string()
+    } else {
+        lines.join("\n")
+    }
+}
+
+fn tool_result_stream_output(result: &crate::tool::ToolResult) -> String {
+    let output = tool_result_full_output(result);
     truncate_chars_with_notice(
-        output,
+        &output,
         TOOL_RESULT_STREAM_MAX_CHARS,
         "\n...(已截断，完整工具输出已记录到会话数据)",
     )

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -250,7 +250,10 @@ fn resolve_memory_workspace_id(session_cwd: &str) -> Option<String> {
 /// 用户命令
 pub(crate) enum Command {
     /// 发送消息
-    Message(String),
+    Message {
+        content: String,
+        message_id: Option<String>,
+    },
     /// 取消当前执行
     Cancel,
     /// 审批响应
@@ -325,7 +328,17 @@ impl TiangongCore {
     }
 
     pub fn send_message(&self, content: String) {
-        self.send_cmd(Command::Message(content));
+        self.send_cmd(Command::Message {
+            content,
+            message_id: None,
+        });
+    }
+
+    pub fn send_message_with_id(&self, content: String, message_id: String) {
+        self.send_cmd(Command::Message {
+            content,
+            message_id: Some(message_id),
+        });
     }
 
     pub fn cancel(&self) {
@@ -459,18 +472,16 @@ fn worker_loop(
         }
 
         match cmd {
-            Command::Message(content) => {
+            Command::Message {
+                content,
+                message_id,
+            } => {
                 let turn_start_idx = session.messages.len();
                 // 记录用户消息
-                session.append_message(MessageRole::User, content.clone());
+                let user_msg_id = append_or_reuse_user_message(&mut session, &content, message_id);
                 // 通知消费端：用户消息已记录（携带 session 中的 message_id）
-                let user_msg_id = session
-                    .messages
-                    .last()
-                    .map(|m| m.id.clone())
-                    .unwrap_or_default();
                 let _ = stream_tx.send(StreamEvent::UserMessage {
-                    message_id: user_msg_id,
+                    message_id: user_msg_id.clone(),
                     content: content.clone(),
                 });
 
@@ -918,10 +929,14 @@ fn execute_turn_inner(
                                 });
                                 return accumulated_usage;
                             }
-                            Ok(Command::Message(content)) => {
-                                session.append_message(MessageRole::User, content.clone());
+                            Ok(Command::Message {
+                                content,
+                                message_id,
+                            }) => {
+                                let loop_message_id =
+                                    append_or_reuse_user_message(session, &content, message_id);
                                 loop_context.push(Message {
-                                    id: scru128::new().to_string(),
+                                    id: loop_message_id,
                                     role: MessageRole::User,
                                     content,
                                     reasoning_content: String::new(),
@@ -1083,11 +1098,15 @@ fn execute_turn_inner(
                     });
                     return accumulated_usage;
                 }
-                Command::Message(content) => {
+                Command::Message {
+                    content,
+                    message_id,
+                } => {
                     // 用户追加消息：注入 loop_context，下一轮 LLM 会看到
-                    session.append_message(MessageRole::User, content.clone());
+                    let loop_message_id =
+                        append_or_reuse_user_message(session, &content, message_id);
                     loop_context.push(Message {
-                        id: scru128::new().to_string(),
+                        id: loop_message_id,
                         role: MessageRole::User,
                         content,
                         reasoning_content: String::new(),
@@ -1105,6 +1124,31 @@ fn execute_turn_inner(
     }
 
     accumulated_usage
+}
+
+fn append_or_reuse_user_message(
+    session: &mut Session,
+    content: &str,
+    message_id: Option<String>,
+) -> String {
+    if let Some(message_id) = message_id {
+        if !session.messages.iter().any(|msg| msg.id == message_id) {
+            session.append_message_with_id(
+                message_id.clone(),
+                MessageRole::User,
+                content.to_string(),
+                String::new(),
+            );
+        }
+        return message_id;
+    }
+
+    session.append_message(MessageRole::User, content.to_string());
+    session
+        .messages
+        .last()
+        .map(|m| m.id.clone())
+        .unwrap_or_default()
 }
 
 /// 超限时强制最终回复

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -27,6 +27,10 @@ use tiangong_types::{SessionStreamEvent, StreamEvent};
 use std::sync::mpsc::Receiver;
 
 const MAX_ROUNDS: usize = 20;
+const MEMORY_LOOP_FEEDBACK_MAX_CHARS: usize = 12_000;
+const TOOL_RESULT_STREAM_MAX_CHARS: usize = 8_000;
+
+type MemoryRecallToolOutput = (crate::tool::ToolResult, tiangong_types::TokenUsage, bool);
 
 /// 进程级 Memory Handle 注册表。
 ///
@@ -725,11 +729,16 @@ async fn execute_turn_inner_async(
     let mut accumulated_usage = TokenUsage::default();
     let mut pending_media_assets: Vec<tiangong_types::MediaAsset> = Vec::new();
     let mut memory_context: Option<String> = None;
+    let mut memory_recall_attempted = false;
 
     'react_loop: loop {
         match drain_pending_commands_async(session, &mut loop_context, stream_tx, cmd_rx) {
             PendingCommandEffect::Terminate => return accumulated_usage,
-            PendingCommandEffect::MessageInjected | PendingCommandEffect::None => {}
+            PendingCommandEffect::MessageInjected => {
+                memory_context = None;
+                memory_recall_attempted = false;
+            }
+            PendingCommandEffect::None => {}
         }
 
         if round >= max_rounds {
@@ -893,6 +902,7 @@ async fn execute_turn_inner_async(
             if user_message_injected_during_stream {
                 // 新输入到来后，旧的 recall_memory 注入上下文可能不再相关，避免污染下一轮 prompt
                 memory_context = None;
+                memory_recall_attempted = false;
                 continue 'react_loop;
             }
 
@@ -945,6 +955,8 @@ async fn execute_turn_inner_async(
             match drain_pending_commands_async(session, &mut loop_context, stream_tx, cmd_rx) {
                 PendingCommandEffect::Terminate => return accumulated_usage,
                 PendingCommandEffect::MessageInjected => {
+                    memory_context = None;
+                    memory_recall_attempted = false;
                     session.persist_to_disk();
                     continue 'react_loop;
                 }
@@ -993,6 +1005,7 @@ async fn execute_turn_inner_async(
                         name: call.name.clone(),
                         ok: false,
                         output: format!("权限拒绝：{reason}"),
+                        full_output: None,
                     });
                     loop_context.push(Message {
                         id: scru128::new().to_string(),
@@ -1082,6 +1095,7 @@ async fn execute_turn_inner_async(
                             name: call.name.clone(),
                             ok: false,
                             output: "用户拒绝执行".to_string(),
+                            full_output: None,
                         });
                         let _ = stream_tx.send(StreamEvent::Done {
                             usage: Some(tiangong_types::TokenUsage {
@@ -1103,7 +1117,12 @@ async fn execute_turn_inner_async(
             let (result, memory_tool_usage, allow_memory_context) =
                 tokio::task::block_in_place(|| {
                     if call.name == "recall_memory" {
-                        execute_memory_recall_tool(call, memory_handle, session)
+                        if memory_recall_attempted {
+                            duplicate_memory_recall_tool_result()
+                        } else {
+                            memory_recall_attempted = true;
+                            execute_memory_recall_tool(call, memory_handle, session)
+                        }
                     } else {
                         (
                             engine.execute_tool_call(call, mcp_targets, &engine.agent_config().mcp),
@@ -1126,7 +1145,8 @@ async fn execute_turn_inner_async(
             let _ = stream_tx.send(StreamEvent::ToolResult {
                 name: call.name.clone(),
                 ok: result.ok,
-                output: result.stdout.clone(),
+                output: tool_result_stream_output(&result.stdout),
+                full_output: Some(result.stdout.clone()),
             });
             session.append_message(MessageRole::System, format_tool_trace_message(&result));
 
@@ -1162,15 +1182,10 @@ async fn execute_turn_inner_async(
                 if allow_memory_context && !result.stdout.trim().is_empty() {
                     memory_context = Some(result.stdout.clone());
                 }
-                let notice = if !allow_memory_context || result.stdout.trim().is_empty() {
-                    "recall_memory 执行完成：未找到增量历史记忆。".to_string()
-                } else {
-                    "recall_memory 执行完成：历史上下文已注入 system prompt，请直接参考使用，无需再次调用此工具。".to_string()
-                };
                 loop_context.push(Message {
                     id: scru128::new().to_string(),
-                    role: MessageRole::System,
-                    content: notice,
+                    role: MessageRole::User,
+                    content: build_memory_recall_feedback(&result.stdout, allow_memory_context),
                     reasoning_content: String::new(),
                     worker_id: None,
                     media: Vec::new(),
@@ -1191,6 +1206,8 @@ async fn execute_turn_inner_async(
             match drain_pending_commands_async(session, &mut loop_context, stream_tx, cmd_rx) {
                 PendingCommandEffect::Terminate => return accumulated_usage,
                 PendingCommandEffect::MessageInjected => {
+                    memory_context = None;
+                    memory_recall_attempted = false;
                     session.persist_to_disk();
                     continue 'react_loop;
                 }
@@ -1222,11 +1239,16 @@ fn execute_turn_inner(
     let mut accumulated_usage = TokenUsage::default();
     let mut pending_media_assets: Vec<tiangong_types::MediaAsset> = Vec::new();
     let mut memory_context: Option<String> = None;
+    let mut memory_recall_attempted = false;
 
     'react_loop: loop {
         match drain_pending_commands(session, &mut loop_context, stream_tx, cmd_rx) {
             PendingCommandEffect::Terminate => return accumulated_usage,
-            PendingCommandEffect::MessageInjected | PendingCommandEffect::None => {}
+            PendingCommandEffect::MessageInjected => {
+                memory_context = None;
+                memory_recall_attempted = false;
+            }
+            PendingCommandEffect::None => {}
         }
 
         if round >= max_rounds {
@@ -1348,6 +1370,8 @@ fn execute_turn_inner(
                 false
             };
             if had_messages {
+                memory_context = None;
+                memory_recall_attempted = false;
                 continue 'react_loop;
             }
         }
@@ -1445,6 +1469,8 @@ fn execute_turn_inner(
             match drain_pending_commands(session, &mut loop_context, stream_tx, cmd_rx) {
                 PendingCommandEffect::Terminate => return accumulated_usage,
                 PendingCommandEffect::MessageInjected => {
+                    memory_context = None;
+                    memory_recall_attempted = false;
                     session.persist_to_disk();
                     continue 'react_loop;
                 }
@@ -1494,6 +1520,7 @@ fn execute_turn_inner(
                         name: call.name.clone(),
                         ok: false,
                         output: format!("权限拒绝：{reason}"),
+                        full_output: None,
                     });
                     loop_context.push(Message {
                         id: scru128::new().to_string(),
@@ -1589,6 +1616,7 @@ fn execute_turn_inner(
                             name: call.name.clone(),
                             ok: false,
                             output: "用户拒绝执行".to_string(),
+                            full_output: None,
                         });
                         // 拒绝后结束本轮，避免 LLM 再次调用同工具形成死循环
                         let _ = stream_tx.send(StreamEvent::Done {
@@ -1610,7 +1638,12 @@ fn execute_turn_inner(
 
             let (result, memory_tool_usage, allow_memory_context) = if call.name == "recall_memory"
             {
-                execute_memory_recall_tool(call, memory_handle, session)
+                if memory_recall_attempted {
+                    duplicate_memory_recall_tool_result()
+                } else {
+                    memory_recall_attempted = true;
+                    execute_memory_recall_tool(call, memory_handle, session)
+                }
             } else {
                 (
                     engine.execute_tool_call(call, mcp_targets, &engine.agent_config().mcp),
@@ -1634,7 +1667,8 @@ fn execute_turn_inner(
             let _ = stream_tx.send(StreamEvent::ToolResult {
                 name: call.name.clone(),
                 ok: result.ok,
-                output: result.stdout.clone(),
+                output: tool_result_stream_output(&result.stdout),
+                full_output: Some(result.stdout.clone()),
             });
 
             // 记录到 session
@@ -1670,20 +1704,14 @@ fn execute_turn_inner(
                     }
                 )
             };
-            // recall_memory 的检索内容注入 system prompt，loop_context 只记录简短通知
             if call.name == "recall_memory" && result.ok {
                 if allow_memory_context && !result.stdout.trim().is_empty() {
                     memory_context = Some(result.stdout.clone());
                 }
-                let notice = if !allow_memory_context || result.stdout.trim().is_empty() {
-                    "recall_memory 执行完成：未找到增量历史记忆。".to_string()
-                } else {
-                    "recall_memory 执行完成：历史上下文已注入 system prompt，请直接参考使用，无需再次调用此工具。".to_string()
-                };
                 loop_context.push(Message {
                     id: scru128::new().to_string(),
-                    role: MessageRole::System,
-                    content: notice,
+                    role: MessageRole::User,
+                    content: build_memory_recall_feedback(&result.stdout, allow_memory_context),
                     reasoning_content: String::new(),
                     worker_id: None,
                     media: Vec::new(),
@@ -1704,6 +1732,8 @@ fn execute_turn_inner(
             match drain_pending_commands(session, &mut loop_context, stream_tx, cmd_rx) {
                 PendingCommandEffect::Terminate => return accumulated_usage,
                 PendingCommandEffect::MessageInjected => {
+                    memory_context = None;
+                    memory_recall_attempted = false;
                     session.persist_to_disk();
                     continue 'react_loop;
                 }
@@ -2061,7 +2091,7 @@ fn execute_memory_recall_tool(
     call: &crate::model::ModelFunctionCall,
     memory_handle: Option<&tiangong_memory::MemoryHandle>,
     session: &Session,
-) -> (crate::tool::ToolResult, tiangong_types::TokenUsage, bool) {
+) -> MemoryRecallToolOutput {
     let started = std::time::Instant::now();
     let Some(handle) = memory_handle else {
         return (
@@ -2207,6 +2237,62 @@ fn memory_recall_tool_result(
             exit_code,
             summary,
         }),
+    }
+}
+
+fn duplicate_memory_recall_tool_result() -> MemoryRecallToolOutput {
+    let started = std::time::Instant::now();
+    (
+        memory_recall_tool_result(
+            true,
+            "本轮已完成回忆，跳过重复调用",
+            "recall_memory 本轮已经执行过，回忆结果已经注入当前上下文。请直接基于已有回忆结果完成用户原始目标，不要再次调用 recall_memory。"
+                .to_string(),
+            String::new(),
+            0,
+            vec!["duplicate-recall".to_string()],
+            started,
+        ),
+        tiangong_types::TokenUsage::default(),
+        false,
+    )
+}
+
+fn build_memory_recall_feedback(stdout: &str, allow_memory_context: bool) -> String {
+    let header = if allow_memory_context && !stdout.trim().is_empty() {
+        "recall_memory 已完成。以下是可直接使用的回忆结果，请基于这些内容继续完成用户原始目标；不要再次调用 recall_memory，除非用户提出新的历史查询。"
+    } else if stdout.trim().is_empty() {
+        "recall_memory 已完成，但没有可用的增量历史记忆。请基于当前上下文继续完成用户原始目标；不要再次调用 recall_memory。"
+    } else {
+        "recall_memory 已完成，结果如下。请基于当前上下文继续完成用户原始目标；不要再次调用 recall_memory。"
+    };
+    let body = truncate_chars_with_notice(
+        stdout.trim(),
+        MEMORY_LOOP_FEEDBACK_MAX_CHARS,
+        "\n...(已截断，完整回忆结果已记录在工具执行消息中)",
+    );
+    if body.trim().is_empty() {
+        header.to_string()
+    } else {
+        format!("{header}\n\n{body}")
+    }
+}
+
+fn tool_result_stream_output(output: &str) -> String {
+    truncate_chars_with_notice(
+        output,
+        TOOL_RESULT_STREAM_MAX_CHARS,
+        "\n...(已截断，完整工具输出已记录到会话数据)",
+    )
+}
+
+fn truncate_chars_with_notice(text: &str, max_chars: usize, notice: &str) -> String {
+    let mut chars = text.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}{notice}")
+    } else {
+        truncated
     }
 }
 

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -4,9 +4,11 @@
 //! CLI / GUI / Server / Connector 统一通过 TiangongCore 运行。
 
 use std::collections::HashMap;
-use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Sender, Sender as StdSender};
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
 use std::thread::{self, JoinHandle};
+use tokio::sync::mpsc as tokio_mpsc;
 
 use crate::agents::execution_mcp_agent::{McpFunctionTarget, execution_function_tools};
 use crate::app_state::formatting::{format_llm_output_message, format_tool_trace_message};
@@ -20,6 +22,9 @@ use crate::runtime::{LlmOutputRecord, RuntimeEngine, inject_enhanced_tools, use_
 use crate::session::{Message, MessageRole, Session, now_text};
 use crate::stream_throttle::ThrottledStreamSink;
 use tiangong_types::{SessionStreamEvent, StreamEvent};
+
+// 为了让 drain_pending_commands / execute_turn_standalone 继续使用 std Receiver
+use std::sync::mpsc::Receiver;
 
 const MAX_ROUNDS: usize = 20;
 
@@ -265,8 +270,8 @@ pub(crate) enum Command {
 
 /// 天工智能体核心
 pub struct TiangongCore {
-    /// 用户命令发送端
-    cmd_tx: Option<Sender<Command>>,
+    /// 用户命令发送端（tokio unbounded，send 不需要 await）
+    cmd_tx: Option<tokio_mpsc::UnboundedSender<Command>>,
     /// 工作线程
     worker: Option<JoinHandle<Session>>,
     /// 会话 ID
@@ -298,7 +303,7 @@ impl TiangongCore {
         let initial_trust_mode = config_snapshot.trust_mode;
         let shared_trust_mode = Arc::new(RwLock::new(initial_trust_mode));
         let session_id = session.id.clone();
-        let (cmd_tx, cmd_rx) = mpsc::channel::<Command>();
+        let (cmd_tx, cmd_rx) = tokio_mpsc::unbounded_channel::<Command>();
 
         let worker_trust_mode = shared_trust_mode.clone();
         let worker = thread::spawn(move || {
@@ -391,9 +396,40 @@ impl Drop for TiangongCore {
 /// 工作线程：接收用户命令，执行 LLM + 工具，推送 StreamEvent
 fn worker_loop(
     config: CoreConfigProvider,
+    session: Session,
+    external_tx: StdSender<SessionStreamEvent>,
+    cmd_rx: tokio_mpsc::UnboundedReceiver<Command>,
+    shared_trust_mode: Arc<RwLock<crate::permission::TrustMode>>,
+    memory_handle: Option<tiangong_memory::MemoryHandle>,
+    memory_workspace_id: Option<String>,
+) -> Session {
+    // 在专用的 tokio runtime 上运行 async 工作循环，
+    // 使 execute_turn_inner 可以用 select! + stream_function_calls 实现真正取消。
+    //
+    // 注意：execute_turn_inner_async 内部使用了 tokio::task::block_in_place，
+    // 该 API 仅在 multi-thread runtime 可用，因此这里使用 1 worker 的 multi-thread runtime。
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .expect("创建 TiangongCore tokio runtime 失败");
+    rt.block_on(worker_loop_async(
+        config,
+        session,
+        external_tx,
+        cmd_rx,
+        shared_trust_mode,
+        memory_handle,
+        memory_workspace_id,
+    ))
+}
+
+/// 真正的 async 工作循环
+async fn worker_loop_async(
+    config: CoreConfigProvider,
     mut session: Session,
-    external_tx: Sender<SessionStreamEvent>,
-    cmd_rx: Receiver<Command>,
+    external_tx: StdSender<SessionStreamEvent>,
+    mut cmd_rx: tokio_mpsc::UnboundedReceiver<Command>,
     shared_trust_mode: Arc<RwLock<crate::permission::TrustMode>>,
     mut memory_handle: Option<tiangong_memory::MemoryHandle>,
     memory_workspace_id: Option<String>,
@@ -407,6 +443,7 @@ fn worker_loop(
     let mut turn_count: u32 = 0;
 
     // 内部 StreamEvent 通道 —— 转发线程负责包装 session_id
+    // stream_tx 保持 std::sync::mpsc（工具执行等同步代码可直接使用）
     let (stream_tx, stream_rx) = mpsc::channel::<StreamEvent>();
     let fwd_session_id = session_id.clone();
     let fwd_tx = external_tx.clone();
@@ -445,7 +482,7 @@ fn worker_loop(
         }
     }
 
-    while let Ok(cmd) = cmd_rx.recv() {
+    while let Some(cmd) = cmd_rx.recv().await {
         // 配置变更检测：仅在 generation 变化时重建 engine 和工具列表
         let cfg_gen = config.generation();
         if engine.is_none() || cfg_gen != last_cfg_gen {
@@ -486,16 +523,17 @@ fn worker_loop(
                 });
 
                 // 执行对话轮次
-                execute_turn(
+                execute_turn_async(
                     &mut session,
                     &content,
                     engine.as_ref().unwrap(),
                     &tools,
                     &mcp_targets,
                     &stream_tx,
-                    &cmd_rx,
+                    &mut cmd_rx,
                     memory_handle.as_ref(),
-                );
+                )
+                .await;
 
                 // turn 完成后触发 Micro 反刍（fire-and-forget）
                 if let Some(handle) = memory_handle.as_ref() {
@@ -544,6 +582,7 @@ fn worker_loop(
 
     // 关闭内部通道，等待转发线程结束
     drop(stream_tx);
+    tokio::task::spawn_blocking(|| ()).await.ok(); // yield，让 forward_handle 有机会 drain
     let _ = forward_handle.join();
 
     // 会话结束 → 触发 Meso 反刍（提炼 Entity/Decision，更新 Workspace Injection）
@@ -569,7 +608,7 @@ pub(crate) fn execute_turn_standalone(
     engine: &RuntimeEngine,
     tools: &[FunctionToolSpec],
     mcp_targets: &HashMap<String, McpFunctionTarget>,
-    stream_tx: &Sender<StreamEvent>,
+    stream_tx: &StdSender<StreamEvent>,
     cmd_rx: &Receiver<Command>,
     max_rounds: usize,
 ) -> TokenUsage {
@@ -586,36 +625,45 @@ pub(crate) fn execute_turn_standalone(
     )
 }
 
-/// 执行一个完整的对话轮次（可能多轮工具调用）
+/// 执行一个完整的对话轮次（可能多轮工具调用），async 版
 ///
 /// 首先判断是否需要多代理并行执行，如需要则拆分并行；
 /// 否则走标准的 ReAct 循环。
 /// 每轮之间检查 cmd_rx：新消息注入上下文，cancel 立即生效。
 #[allow(clippy::too_many_arguments)]
-fn execute_turn(
+async fn execute_turn_async(
     session: &mut Session,
     user_input: &str,
     engine: &RuntimeEngine,
     tools: &[FunctionToolSpec],
     mcp_targets: &HashMap<String, McpFunctionTarget>,
-    stream_tx: &Sender<StreamEvent>,
-    cmd_rx: &Receiver<Command>,
+    stream_tx: &StdSender<StreamEvent>,
+    cmd_rx: &mut tokio_mpsc::UnboundedReceiver<Command>,
     memory_handle: Option<&tiangong_memory::MemoryHandle>,
 ) {
-    // 判断是否需要多代理并行执行
-    let coordinator = TaskCoordinator::new(engine.clone());
-    let task = CoordinatorTask {
-        id: scru128::new().to_string(),
-        objective: user_input.to_string(),
-        user_input: user_input.to_string(),
-        context: Vec::new(),
+    // 判断是否需要多代理并行执行（同步 LLM 调用，用 block_in_place 保护）
+    let should_split = {
+        let coordinator = TaskCoordinator::new(engine.clone());
+        let task = CoordinatorTask {
+            id: scru128::new().to_string(),
+            objective: user_input.to_string(),
+            user_input: user_input.to_string(),
+            context: Vec::new(),
+        };
+        tokio::task::block_in_place(|| coordinator.should_split(&task))
     };
 
-    if coordinator.should_split(&task) {
+    if should_split {
         tracing::info!("任务需要拆分，启动多代理并行执行");
-        match coordinator.coordinate(task, session, stream_tx) {
+        let coordinator = TaskCoordinator::new(engine.clone());
+        let task = CoordinatorTask {
+            id: scru128::new().to_string(),
+            objective: user_input.to_string(),
+            user_input: user_input.to_string(),
+            context: Vec::new(),
+        };
+        match tokio::task::block_in_place(|| coordinator.coordinate(task, session, stream_tx)) {
             Ok(result) => {
-                // 记录合并结果到 session
                 session.append_message(MessageRole::Assistant, result.final_response);
                 let _ = stream_tx.send(StreamEvent::Done {
                     usage: Some(tiangong_types::TokenUsage {
@@ -627,8 +675,7 @@ fn execute_turn(
             }
             Err(err) => {
                 tracing::warn!("多代理并行执行失败，回退单代理: {err}");
-                // 回退到单代理执行
-                execute_turn_inner(
+                execute_turn_inner_async(
                     session,
                     user_input,
                     engine,
@@ -638,13 +685,14 @@ fn execute_turn(
                     cmd_rx,
                     MAX_ROUNDS,
                     memory_handle,
-                );
+                )
+                .await;
             }
         }
         return;
     }
 
-    execute_turn_inner(
+    execute_turn_inner_async(
         session,
         user_input,
         engine,
@@ -654,10 +702,509 @@ fn execute_turn(
         cmd_rx,
         MAX_ROUNDS,
         memory_handle,
-    );
+    )
+    .await;
 }
 
-/// 内部执行：标准 ReAct 循环
+/// 内部执行：标准 ReAct 循环（async 版，由 TiangongCore 主路径使用）
+/// LLM 流式调用使用真正的 async stream，通过 tokio::select! 实现任意时刻取消。
+#[allow(clippy::too_many_arguments)]
+async fn execute_turn_inner_async(
+    session: &mut Session,
+    _user_input: &str,
+    engine: &RuntimeEngine,
+    tools: &[FunctionToolSpec],
+    mcp_targets: &HashMap<String, McpFunctionTarget>,
+    stream_tx: &StdSender<StreamEvent>,
+    cmd_rx: &mut tokio_mpsc::UnboundedReceiver<Command>,
+    max_rounds: usize,
+    memory_handle: Option<&tiangong_memory::MemoryHandle>,
+) -> TokenUsage {
+    let mut loop_context: Vec<Message> = Vec::new();
+    let mut round = 0;
+    let mut accumulated_usage = TokenUsage::default();
+    let mut pending_media_assets: Vec<tiangong_types::MediaAsset> = Vec::new();
+    let mut memory_context: Option<String> = None;
+
+    'react_loop: loop {
+        match drain_pending_commands_async(session, &mut loop_context, stream_tx, cmd_rx) {
+            PendingCommandEffect::Terminate => return accumulated_usage,
+            PendingCommandEffect::MessageInjected | PendingCommandEffect::None => {}
+        }
+
+        if round >= max_rounds {
+            tokio::task::block_in_place(|| {
+                force_final_response(session, &loop_context, engine, stream_tx);
+            });
+            break;
+        }
+
+        let mut prompt_loop_context = loop_context.clone();
+        if round > 0 {
+            prompt_loop_context.push(Message {
+                id: scru128::new().to_string(),
+                role: MessageRole::System,
+                content: "内部调度提示：根据上面的工具执行结果继续完成用户原始目标。若目标尚未实际完成，继续调用必要工具；只有确认目标已完成时，才给出最终回复。".to_string(),
+                reasoning_content: String::new(),
+                worker_id: None,
+                media: Vec::new(),
+                created_at: now_text(),
+            });
+        }
+
+        let assembler = PromptAssembler::new(engine.context_limit);
+        let assembled = assembler.assemble(
+            session,
+            "",
+            tools.to_vec(),
+            engine.models_config(),
+            engine.agent_config(),
+            &prompt_loop_context,
+        );
+
+        let mut system_prompt = assembled.final_system_prompt();
+        if let Some(ctx) = memory_context.as_deref() {
+            system_prompt.push_str(
+                "\n\n---\n## 历史上下文（回忆系统注入）\n\
+以下内容来自 recall_memory 工具的检索结果，仅供当前回复参考，\
+请勿重复回忆，除非用户有新的回忆需求：\n",
+            );
+            system_prompt.push_str(ctx);
+        }
+        let req = ModelRequest {
+            session_title: session.title.clone(),
+            user_input: assembled.user_input.clone(),
+            context: assembled.build_messages(),
+            assembled_system_prompt: Some(system_prompt),
+            thinking: Some(crate::model::ModelThinkingConfig {
+                budget_tokens: 4096,
+            }),
+        };
+
+        let pending_msg_id = scru128::new().to_string();
+        let sink = ThrottledStreamSink::new(pending_msg_id.clone(), stream_tx.clone());
+
+        // ── 真正的 async 流式调用 + select! 取消 ──
+        let (chunk_tx, mut chunk_rx) =
+            tokio_mpsc::unbounded_channel::<crate::model::ModelStreamChunk>();
+        let client = engine.client().clone();
+        let req_clone = req.clone();
+        let tools_clone = tools.to_vec();
+        let llm_fut = tokio::task::spawn(async move {
+            client
+                .stream_function_calls(req_clone, tools_clone, chunk_tx)
+                .await
+        });
+
+        // 同时驱动 LLM 流和命令队列，直到 LLM 完成或收到取消指令。
+        // 用户新消息在流式阶段立即落盘并回显，但不打断当前生成；
+        // 本次输出完成后再进入下一轮规划处理新消息。
+        let mut user_message_injected_during_stream = false;
+        let response_result: anyhow::Result<crate::model::ModelFunctionResponse> = loop {
+            tokio::select! {
+                biased;
+                // 优先处理用户命令
+                cmd_opt = cmd_rx.recv() => {
+                    match cmd_opt {
+                        Some(Command::Cancel) | Some(Command::Shutdown) | None => {
+                            llm_fut.abort();
+                            sink.finish();
+                            let _ = stream_tx.send(StreamEvent::Error {
+                                message: "已取消".into(),
+                            });
+                            return accumulated_usage;
+                        }
+                        // 用户输入到来时不打断当前生成：立即落盘并回显给前端，
+                        // 当前 assistant 继续输出；输出完成后马上进入下一轮规划处理新消息。
+                        Some(Command::Message { content, message_id }) => {
+                            append_user_message_to_loop_context(
+                                session,
+                                &mut loop_context,
+                                stream_tx,
+                                content,
+                                message_id,
+                            );
+                            user_message_injected_during_stream = true;
+                        }
+                        // Approval 在非等待阶段无语义，忽略
+                        Some(Command::Approval { .. }) => {}
+                    }
+                }
+                // 处理 LLM chunk
+                chunk_opt = chunk_rx.recv() => {
+                    match chunk_opt {
+                        Some(chunk) => sink.push_chunk(&chunk),
+                        None => {
+                            // chunk_tx 已关闭，LLM future 即将完成，等待结果
+                            let response_result = match llm_fut.await {
+                                Ok(r) => r,
+                                Err(e) if e.is_cancelled() => {
+                                    sink.finish();
+                                    let _ = stream_tx.send(StreamEvent::Error {
+                                        message: "已取消".into(),
+                                    });
+                                    return accumulated_usage;
+                                }
+                                Err(e) => Err(anyhow::anyhow!(e.to_string())),
+                            };
+                            break response_result;
+                        }
+                    }
+                }
+            }
+        };
+        sink.finish();
+
+        let response = match response_result {
+            Ok(r) => r,
+            Err(err) => {
+                let _ = stream_tx.send(StreamEvent::Error {
+                    message: err.to_string(),
+                });
+                return accumulated_usage;
+            }
+        };
+
+        accumulated_usage.accumulate(&response.usage);
+        round += 1;
+
+        if response.tool_calls.is_empty() {
+            if is_synthetic_tool_call_placeholder(&response.text) {
+                continue;
+            }
+
+            session.append_message_with_id_and_media(
+                pending_msg_id,
+                MessageRole::Assistant,
+                response.text.clone(),
+                response.reasoning_content.clone(),
+                std::mem::take(&mut pending_media_assets),
+            );
+            let output = LlmOutputRecord {
+                stage: format!("react-round-{round}"),
+                content: String::new(),
+                reasoning_content: String::new(),
+                tool_calls: Vec::new(),
+                usage: response.usage.clone(),
+            };
+            session.append_message(MessageRole::System, format_llm_output_message(&output));
+            session.persist_to_disk();
+
+            if user_message_injected_during_stream {
+                // 新输入到来后，旧的 recall_memory 注入上下文可能不再相关，避免污染下一轮 prompt
+                memory_context = None;
+                continue 'react_loop;
+            }
+
+            let _ = stream_tx.send(StreamEvent::Done {
+                usage: Some(tiangong_types::TokenUsage {
+                    prompt_tokens: accumulated_usage.prompt_tokens,
+                    completion_tokens: accumulated_usage.completion_tokens,
+                    total_tokens: accumulated_usage.total_tokens,
+                }),
+            });
+            return accumulated_usage;
+        }
+
+        // 工具调用
+        let tool_names: Vec<String> = response.tool_calls.iter().map(|c| c.name.clone()).collect();
+        let output = LlmOutputRecord {
+            stage: format!("react-round-{round}"),
+            content: response.text.clone(),
+            reasoning_content: response.reasoning_content.clone(),
+            tool_calls: tool_names.clone(),
+            usage: response.usage.clone(),
+        };
+        session.append_message_with_reasoning(
+            MessageRole::System,
+            format_llm_output_message(&output),
+            response.reasoning_content.clone(),
+        );
+        let _ = stream_tx.send(StreamEvent::ToolCalls {
+            names: tool_names.clone(),
+            usage: Some(tiangong_types::TokenUsage {
+                prompt_tokens: response.usage.prompt_tokens,
+                completion_tokens: response.usage.completion_tokens,
+                total_tokens: response.usage.total_tokens,
+            }),
+        });
+        if !response.text.is_empty() || !response.reasoning_content.is_empty() {
+            loop_context.push(Message {
+                id: scru128::new().to_string(),
+                role: MessageRole::Assistant,
+                content: response.text.clone(),
+                reasoning_content: response.reasoning_content.clone(),
+                worker_id: None,
+                media: Vec::new(),
+                created_at: now_text(),
+            });
+        }
+
+        // 执行工具
+        for call in &response.tool_calls {
+            match drain_pending_commands_async(session, &mut loop_context, stream_tx, cmd_rx) {
+                PendingCommandEffect::Terminate => return accumulated_usage,
+                PendingCommandEffect::MessageInjected => {
+                    session.persist_to_disk();
+                    continue 'react_loop;
+                }
+                PendingCommandEffect::None => {}
+            }
+
+            let args_summary = format_call_args_summary(call);
+            let (target_scope, target_summary) = infer_audit_target(call);
+            let normalized_target = normalize_permission_target(
+                session,
+                target_scope.as_deref(),
+                target_summary.as_deref(),
+            );
+
+            use crate::permission::PermissionDecision;
+            let decision = evaluate_tool_permission(
+                engine,
+                &call.name,
+                target_scope.as_deref(),
+                normalized_target.as_deref(),
+            );
+            let trust_mode = format!("{:?}", engine.permission_gate().trust_mode());
+            match decision {
+                PermissionDecision::Approved => {
+                    audit_permission_with_context(
+                        &session.id,
+                        &call.name,
+                        "approved",
+                        &trust_mode,
+                        (!args_summary.is_empty()).then_some(args_summary.as_str()),
+                        target_scope.as_deref(),
+                        normalized_target.as_deref().or(target_summary.as_deref()),
+                    );
+                }
+                PermissionDecision::Denied { reason } => {
+                    audit_permission_with_context(
+                        &session.id,
+                        &call.name,
+                        "denied",
+                        &trust_mode,
+                        (!args_summary.is_empty()).then_some(args_summary.as_str()),
+                        target_scope.as_deref(),
+                        normalized_target.as_deref().or(target_summary.as_deref()),
+                    );
+                    let _ = stream_tx.send(StreamEvent::ToolResult {
+                        name: call.name.clone(),
+                        ok: false,
+                        output: format!("权限拒绝：{reason}"),
+                    });
+                    loop_context.push(Message {
+                        id: scru128::new().to_string(),
+                        role: MessageRole::User,
+                        content: format!("工具 {} 执行失败：权限拒绝 - {reason}", call.name),
+                        reasoning_content: String::new(),
+                        worker_id: None,
+                        media: Vec::new(),
+                        created_at: now_text(),
+                    });
+                    continue;
+                }
+                PermissionDecision::NeedsApproval { request_id } => {
+                    audit_permission_with_context(
+                        &session.id,
+                        &call.name,
+                        "needs_approval",
+                        &trust_mode,
+                        (!args_summary.is_empty()).then_some(args_summary.as_str()),
+                        target_scope.as_deref(),
+                        normalized_target.as_deref().or(target_summary.as_deref()),
+                    );
+                    crate::approval_store::add_pending(
+                        &session.id,
+                        crate::session::PendingApproval {
+                            request_id: request_id.clone(),
+                            tool_name: call.name.clone(),
+                            tool_args_summary: args_summary.clone(),
+                            created_at: now_text(),
+                        },
+                    );
+                    let _ = stream_tx.send(StreamEvent::ApprovalNeeded {
+                        request_id: request_id.clone(),
+                        tool_name: call.name.clone(),
+                        args_summary: args_summary.clone(),
+                    });
+
+                    // async 等待用户审批
+                    let approved = loop {
+                        match cmd_rx.recv().await {
+                            Some(Command::Approval {
+                                request_id: rid,
+                                approved,
+                            }) if rid == request_id => {
+                                break approved;
+                            }
+                            Some(Command::Cancel) | Some(Command::Shutdown) | None => {
+                                let _ = stream_tx.send(StreamEvent::Error {
+                                    message: "已取消".into(),
+                                });
+                                return accumulated_usage;
+                            }
+                            Some(Command::Message {
+                                content,
+                                message_id,
+                            }) => {
+                                append_user_message_to_loop_context(
+                                    session,
+                                    &mut loop_context,
+                                    stream_tx,
+                                    content,
+                                    message_id,
+                                );
+                            }
+                            Some(Command::Approval { .. }) => {}
+                        }
+                    };
+
+                    crate::approval_store::remove_pending(&session.id, &request_id);
+
+                    if !approved {
+                        audit_tool_execution(
+                            &session.id,
+                            &call.name,
+                            false,
+                            (!args_summary.is_empty()).then_some(args_summary.as_str()),
+                            target_scope.as_deref(),
+                            normalized_target.as_deref().or(target_summary.as_deref()),
+                            "用户拒绝执行",
+                        );
+                        session.append_message(
+                            MessageRole::System,
+                            format!("工具 {} 被用户拒绝执行", call.name),
+                        );
+                        session.persist_to_disk();
+                        let _ = stream_tx.send(StreamEvent::ToolResult {
+                            name: call.name.clone(),
+                            ok: false,
+                            output: "用户拒绝执行".to_string(),
+                        });
+                        let _ = stream_tx.send(StreamEvent::Done {
+                            usage: Some(tiangong_types::TokenUsage {
+                                prompt_tokens: accumulated_usage.prompt_tokens,
+                                completion_tokens: accumulated_usage.completion_tokens,
+                                total_tokens: accumulated_usage.total_tokens,
+                            }),
+                        });
+                        return accumulated_usage;
+                    }
+                }
+            }
+
+            let _ = stream_tx.send(StreamEvent::ToolStart {
+                name: call.name.clone(),
+                args_summary: args_summary.clone(),
+            });
+
+            let (result, memory_tool_usage, allow_memory_context) =
+                tokio::task::block_in_place(|| {
+                    if call.name == "recall_memory" {
+                        execute_memory_recall_tool(call, memory_handle, session)
+                    } else {
+                        (
+                            engine.execute_tool_call(call, mcp_targets, &engine.agent_config().mcp),
+                            tiangong_types::TokenUsage::default(),
+                            false,
+                        )
+                    }
+                });
+            accumulated_usage.accumulate(&memory_tool_usage);
+
+            audit_tool_execution(
+                &session.id,
+                &call.name,
+                result.ok,
+                (!args_summary.is_empty()).then_some(args_summary.as_str()),
+                target_scope.as_deref(),
+                normalized_target.as_deref().or(target_summary.as_deref()),
+                &result.summary,
+            );
+            let _ = stream_tx.send(StreamEvent::ToolResult {
+                name: call.name.clone(),
+                ok: result.ok,
+                output: result.stdout.clone(),
+            });
+            session.append_message(MessageRole::System, format_tool_trace_message(&result));
+
+            let is_media_tool = matches!(
+                call.name.as_str(),
+                "generate_image" | "generate_video" | "text_to_speech" | "speech_to_text"
+            );
+            if result.ok {
+                pending_media_assets.extend(parse_media_assets_from_tool_result(
+                    &call.name,
+                    &result.stdout,
+                    &result.summary,
+                ));
+            }
+            let feedback = if is_media_tool && result.ok {
+                format!(
+                    "工具 {} 执行成功：{}。媒体内容已生成并交付给用户，不要再次调用该工具。请直接给出文本回复。",
+                    call.name, result.summary
+                )
+            } else {
+                format!(
+                    "工具 {} 执行{}：{}",
+                    call.name,
+                    if result.ok { "成功" } else { "失败" },
+                    if result.stdout.is_empty() {
+                        result.summary.clone()
+                    } else {
+                        result.stdout.clone()
+                    }
+                )
+            };
+            if call.name == "recall_memory" && result.ok {
+                if allow_memory_context && !result.stdout.trim().is_empty() {
+                    memory_context = Some(result.stdout.clone());
+                }
+                let notice = if !allow_memory_context || result.stdout.trim().is_empty() {
+                    "recall_memory 执行完成：未找到增量历史记忆。".to_string()
+                } else {
+                    "recall_memory 执行完成：历史上下文已注入 system prompt，请直接参考使用，无需再次调用此工具。".to_string()
+                };
+                loop_context.push(Message {
+                    id: scru128::new().to_string(),
+                    role: MessageRole::System,
+                    content: notice,
+                    reasoning_content: String::new(),
+                    worker_id: None,
+                    media: Vec::new(),
+                    created_at: now_text(),
+                });
+            } else {
+                loop_context.push(Message {
+                    id: scru128::new().to_string(),
+                    role: MessageRole::User,
+                    content: feedback,
+                    reasoning_content: String::new(),
+                    worker_id: None,
+                    media: Vec::new(),
+                    created_at: now_text(),
+                });
+            }
+
+            match drain_pending_commands_async(session, &mut loop_context, stream_tx, cmd_rx) {
+                PendingCommandEffect::Terminate => return accumulated_usage,
+                PendingCommandEffect::MessageInjected => {
+                    session.persist_to_disk();
+                    continue 'react_loop;
+                }
+                PendingCommandEffect::None => {}
+            }
+        }
+
+        session.persist_to_disk();
+    }
+
+    accumulated_usage
+}
+
+/// 内部执行：标准 ReAct 循环（同步版，由 execute_turn_standalone / Worker 使用）
 #[allow(clippy::too_many_arguments)]
 fn execute_turn_inner(
     session: &mut Session,
@@ -665,7 +1212,7 @@ fn execute_turn_inner(
     engine: &RuntimeEngine,
     tools: &[FunctionToolSpec],
     mcp_targets: &HashMap<String, McpFunctionTarget>,
-    stream_tx: &Sender<StreamEvent>,
+    stream_tx: &StdSender<StreamEvent>,
     cmd_rx: &Receiver<Command>,
     max_rounds: usize,
     memory_handle: Option<&tiangong_memory::MemoryHandle>,
@@ -676,7 +1223,12 @@ fn execute_turn_inner(
     let mut pending_media_assets: Vec<tiangong_types::MediaAsset> = Vec::new();
     let mut memory_context: Option<String> = None;
 
-    loop {
+    'react_loop: loop {
+        match drain_pending_commands(session, &mut loop_context, stream_tx, cmd_rx) {
+            PendingCommandEffect::Terminate => return accumulated_usage,
+            PendingCommandEffect::MessageInjected | PendingCommandEffect::None => {}
+        }
+
         if round >= max_rounds {
             // 超限：强制最终回复
             force_final_response(session, &loop_context, engine, stream_tx);
@@ -733,14 +1285,72 @@ fn execute_turn_inner(
         let pending_msg_id = scru128::new().to_string();
 
         // LLM 流式调用
+        // stream_cancel：流期间收到 Cancel/Shutdown 时设为 true，后续 chunk 不再入 sink
+        // cmds_during_stream：流期间截获的非终止命令（如 Message），LLM 完成后统一处理
         let sink = ThrottledStreamSink::new(pending_msg_id.clone(), stream_tx.clone());
+        let stream_cancel = Arc::new(AtomicBool::new(false));
+        let stream_cancel_c = stream_cancel.clone();
+        let cmds_during_stream: Arc<Mutex<Vec<Command>>> = Arc::new(Mutex::new(Vec::new()));
+        let cmds_during_stream_c = cmds_during_stream.clone();
         let response_result =
             engine
                 .client()
                 .complete_with_functions_stream(&req, tools, &mut |delta| {
-                    sink.push_chunk(delta);
+                    // 每个 chunk 回调时顺带排空命令队列，实现任意时刻响应
+                    while let Ok(cmd) = cmd_rx.try_recv() {
+                        match cmd {
+                            Command::Cancel => {
+                                stream_cancel_c.store(true, Ordering::Release);
+                            }
+                            Command::Shutdown => {
+                                stream_cancel_c.store(true, Ordering::Release);
+                            }
+                            other => {
+                                if let Ok(mut q) = cmds_during_stream_c.lock() {
+                                    q.push(other);
+                                }
+                            }
+                        }
+                    }
+                    if !stream_cancel_c.load(Ordering::Acquire) {
+                        sink.push_chunk(delta);
+                    }
                 });
         sink.finish();
+        // Cancel/Shutdown 在流期间被触发
+        if stream_cancel.load(Ordering::Acquire) {
+            let _ = stream_tx.send(StreamEvent::Error {
+                message: "已取消".into(),
+            });
+            return accumulated_usage;
+        }
+        // 处理流期间截获的用户消息，有新消息则立即重新规划
+        {
+            let had_messages = if let Ok(mut q) = cmds_during_stream.lock() {
+                let has = !q.is_empty();
+                for cmd in q.drain(..) {
+                    if let Command::Message {
+                        content,
+                        message_id,
+                    } = cmd
+                    {
+                        append_user_message_to_loop_context(
+                            session,
+                            &mut loop_context,
+                            stream_tx,
+                            content,
+                            message_id,
+                        );
+                    }
+                }
+                has
+            } else {
+                false
+            };
+            if had_messages {
+                continue 'react_loop;
+            }
+        }
         let response = match response_result {
             Ok(r) => r,
             Err(err) => {
@@ -755,6 +1365,10 @@ fn execute_turn_inner(
         round += 1;
 
         if response.tool_calls.is_empty() {
+            if is_synthetic_tool_call_placeholder(&response.text) {
+                continue;
+            }
+
             // 最终回复：使用预生成的 ID 记录到 session
             session.append_message_with_id_and_media(
                 pending_msg_id,
@@ -813,24 +1427,30 @@ fn execute_turn_inner(
             }),
         });
 
-        // 记录 assistant 意图到 loop_context
-        let assistant_text = if response.text.is_empty() {
-            format!("[调用工具: {}]", tool_names.join(", "))
-        } else {
-            response.text.clone()
-        };
-        loop_context.push(Message {
-            id: scru128::new().to_string(),
-            role: MessageRole::Assistant,
-            content: assistant_text,
-            reasoning_content: response.reasoning_content.clone(),
-            worker_id: None,
-            media: Vec::new(),
-            created_at: now_text(),
-        });
+        // 仅保留模型真实输出，避免把内部工具占位文本再次喂回上下文。
+        if !response.text.is_empty() || !response.reasoning_content.is_empty() {
+            loop_context.push(Message {
+                id: scru128::new().to_string(),
+                role: MessageRole::Assistant,
+                content: response.text.clone(),
+                reasoning_content: response.reasoning_content.clone(),
+                worker_id: None,
+                media: Vec::new(),
+                created_at: now_text(),
+            });
+        }
 
         // 执行工具
         for call in &response.tool_calls {
+            match drain_pending_commands(session, &mut loop_context, stream_tx, cmd_rx) {
+                PendingCommandEffect::Terminate => return accumulated_usage,
+                PendingCommandEffect::MessageInjected => {
+                    session.persist_to_disk();
+                    continue 'react_loop;
+                }
+                PendingCommandEffect::None => {}
+            }
+
             let args_summary = format_call_args_summary(call);
             let (target_scope, target_summary) = infer_audit_target(call);
             let normalized_target = normalize_permission_target(
@@ -933,17 +1553,13 @@ fn execute_turn_inner(
                                 content,
                                 message_id,
                             }) => {
-                                let loop_message_id =
-                                    append_or_reuse_user_message(session, &content, message_id);
-                                loop_context.push(Message {
-                                    id: loop_message_id,
-                                    role: MessageRole::User,
+                                append_user_message_to_loop_context(
+                                    session,
+                                    &mut loop_context,
+                                    stream_tx,
                                     content,
-                                    reasoning_content: String::new(),
-                                    worker_id: None,
-                                    media: Vec::new(),
-                                    created_at: now_text(),
-                                });
+                                    message_id,
+                                );
                             }
                             Ok(Command::Shutdown) => return accumulated_usage,
                             _ => {}
@@ -1084,46 +1700,135 @@ fn execute_turn_inner(
                     created_at: now_text(),
                 });
             }
+
+            match drain_pending_commands(session, &mut loop_context, stream_tx, cmd_rx) {
+                PendingCommandEffect::Terminate => return accumulated_usage,
+                PendingCommandEffect::MessageInjected => {
+                    session.persist_to_disk();
+                    continue 'react_loop;
+                }
+                PendingCommandEffect::None => {}
+            }
         }
 
         // 工具调用完成后增量持久化（防止崩溃丢失中间数据）
         session.persist_to_disk();
 
-        // 每轮之间检查用户命令（非阻塞）
-        while let Ok(cmd) = cmd_rx.try_recv() {
-            match cmd {
-                Command::Cancel => {
-                    let _ = stream_tx.send(StreamEvent::Error {
-                        message: "已取消".into(),
-                    });
-                    return accumulated_usage;
-                }
-                Command::Message {
-                    content,
-                    message_id,
-                } => {
-                    // 用户追加消息：注入 loop_context，下一轮 LLM 会看到
-                    let loop_message_id =
-                        append_or_reuse_user_message(session, &content, message_id);
-                    loop_context.push(Message {
-                        id: loop_message_id,
-                        role: MessageRole::User,
-                        content,
-                        reasoning_content: String::new(),
-                        worker_id: None,
-                        media: Vec::new(),
-                        created_at: now_text(),
-                    });
-                }
-                Command::Shutdown => return accumulated_usage,
-                _ => {}
-            }
-        }
-
         // 继续下一轮
     }
 
     accumulated_usage
+}
+
+enum PendingCommandEffect {
+    None,
+    MessageInjected,
+    Terminate,
+}
+
+fn drain_pending_commands_async(
+    session: &mut Session,
+    loop_context: &mut Vec<Message>,
+    stream_tx: &StdSender<StreamEvent>,
+    cmd_rx: &mut tokio_mpsc::UnboundedReceiver<Command>,
+) -> PendingCommandEffect {
+    let mut injected_message = false;
+
+    while let Ok(cmd) = cmd_rx.try_recv() {
+        match cmd {
+            Command::Cancel => {
+                let _ = stream_tx.send(StreamEvent::Error {
+                    message: "已取消".into(),
+                });
+                return PendingCommandEffect::Terminate;
+            }
+            Command::Shutdown => return PendingCommandEffect::Terminate,
+            Command::Message {
+                content,
+                message_id,
+            } => {
+                append_user_message_to_loop_context(
+                    session,
+                    loop_context,
+                    stream_tx,
+                    content,
+                    message_id,
+                );
+                injected_message = true;
+            }
+            Command::Approval { .. } => {}
+        }
+    }
+
+    if injected_message {
+        PendingCommandEffect::MessageInjected
+    } else {
+        PendingCommandEffect::None
+    }
+}
+
+fn drain_pending_commands(
+    session: &mut Session,
+    loop_context: &mut Vec<Message>,
+    stream_tx: &StdSender<StreamEvent>,
+    cmd_rx: &Receiver<Command>,
+) -> PendingCommandEffect {
+    let mut injected_message = false;
+
+    while let Ok(cmd) = cmd_rx.try_recv() {
+        match cmd {
+            Command::Cancel => {
+                let _ = stream_tx.send(StreamEvent::Error {
+                    message: "已取消".into(),
+                });
+                return PendingCommandEffect::Terminate;
+            }
+            Command::Shutdown => return PendingCommandEffect::Terminate,
+            Command::Message {
+                content,
+                message_id,
+            } => {
+                append_user_message_to_loop_context(
+                    session,
+                    loop_context,
+                    stream_tx,
+                    content,
+                    message_id,
+                );
+                injected_message = true;
+            }
+            Command::Approval { .. } => {}
+        }
+    }
+
+    if injected_message {
+        PendingCommandEffect::MessageInjected
+    } else {
+        PendingCommandEffect::None
+    }
+}
+
+fn append_user_message_to_loop_context(
+    session: &mut Session,
+    loop_context: &mut Vec<Message>,
+    stream_tx: &StdSender<StreamEvent>,
+    content: String,
+    message_id: Option<String>,
+) {
+    let loop_message_id = append_or_reuse_user_message(session, &content, message_id);
+    let _ = stream_tx.send(StreamEvent::UserMessage {
+        message_id: loop_message_id.clone(),
+        content: content.clone(),
+    });
+    loop_context.push(Message {
+        id: loop_message_id,
+        role: MessageRole::User,
+        content,
+        reasoning_content: String::new(),
+        worker_id: None,
+        media: Vec::new(),
+        created_at: now_text(),
+    });
 }
 
 fn append_or_reuse_user_message(
@@ -1151,12 +1856,17 @@ fn append_or_reuse_user_message(
         .unwrap_or_default()
 }
 
+fn is_synthetic_tool_call_placeholder(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed.starts_with("[调用工具:") && trimmed.ends_with(']')
+}
+
 /// 超限时强制最终回复
 fn force_final_response(
     session: &mut Session,
     loop_context: &[Message],
     engine: &RuntimeEngine,
-    stream_tx: &Sender<StreamEvent>,
+    stream_tx: &StdSender<StreamEvent>,
 ) {
     // 将强制回复提示作为 System 消息注入上下文
     let mut final_context = loop_context.to_vec();
@@ -1259,7 +1969,7 @@ fn force_final_response(
 /// `shared_trust_mode` 是 TiangongCore 持有的独立信任模式，RuntimeEngine 共享此引用。
 fn build_engine_from_config(
     config: &crate::core_config::CoreConfig,
-    stream_tx: &Sender<StreamEvent>,
+    stream_tx: &StdSender<StreamEvent>,
     shared_trust_mode: Arc<RwLock<crate::permission::TrustMode>>,
 ) -> RuntimeEngine {
     use crate::agent_config::AgentConfig;

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -487,6 +487,122 @@ impl SingleProviderClient {
         let response = self.block_on_llm(provider.complete(request))?;
         Ok(collect_provider_text(&response).trim().to_string())
     }
+    /// 真正的 async 流式函数调用。
+    ///
+    /// 通过 `chunk_tx` 实时发送每个 token chunk，完成后返回 `ModelFunctionResponse`。
+    /// 该方法持有 `self`（owned），可直接在 `tokio::spawn` 里使用，future 是 `Send + 'static`。
+    /// 取消 JoinHandle 后 HTTP 流会随 future drop 而断开。
+    pub async fn stream_function_calls(
+        self,
+        req: ModelRequest,
+        functions: Vec<FunctionToolSpec>,
+        chunk_tx: tokio::sync::mpsc::UnboundedSender<ModelStreamChunk>,
+    ) -> Result<ModelFunctionResponse> {
+        fn looks_like_complete_json(raw: &str) -> bool {
+            let trimmed = raw.trim();
+            (trimmed.starts_with('{') && trimmed.ends_with('}'))
+                || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+        }
+
+        let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
+        let model = self.cfg.api_model.trim().to_string();
+        if model.is_empty() {
+            return Err(anyhow!(
+                "API_MODEL 不能为空，无法发起 async 流式工具模型请求"
+            ));
+        }
+        let request = build_provider_request(&req, &model, anthropic_max_tokens(), &functions);
+        let provider = self.build_provider_dispatch(timeout_ms)?;
+
+        let mut text = String::new();
+        let mut reasoning_content = String::new();
+        let mut usage = TokenUsageData::default();
+        let mut tool_calls: std::collections::BTreeMap<String, (String, String)> =
+            std::collections::BTreeMap::new();
+
+        let mut stream = provider.stream(request).await.map_err(map_llm_error)?;
+        while let Some(event) = stream.next().await {
+            match event.map_err(map_llm_error)? {
+                ProviderStreamEvent::ReasoningDelta(delta) => {
+                    if !delta.is_empty() {
+                        reasoning_content.push_str(&delta);
+                        let _ = chunk_tx.send(ModelStreamChunk {
+                            content: String::new(),
+                            reasoning_content: delta,
+                        });
+                    }
+                }
+                ProviderStreamEvent::TextDelta(delta) => {
+                    if !delta.is_empty() {
+                        text.push_str(&delta);
+                        let _ = chunk_tx.send(ModelStreamChunk {
+                            content: delta,
+                            reasoning_content: String::new(),
+                        });
+                    }
+                }
+                ProviderStreamEvent::ToolCallStart(call) => {
+                    let args = if call.arguments.is_null() || call.arguments == json!({}) {
+                        String::new()
+                    } else {
+                        call.arguments.to_string()
+                    };
+                    tool_calls.insert(call.id.clone(), (call.name, args));
+                }
+                ProviderStreamEvent::ToolCallDelta {
+                    call_id,
+                    partial_json,
+                } => {
+                    let entry = tool_calls
+                        .entry(call_id)
+                        .or_insert_with(|| (String::new(), String::new()));
+                    // 某些 provider 会在 ToolCallStart 里直接给出完整 arguments，
+                    // 也可能在 delta 中再发送一遍；这里尽量避免重复拼接导致 JSON 无法解析。
+                    if entry.1.trim().is_empty() || !looks_like_complete_json(&entry.1) {
+                        entry.1.push_str(&partial_json);
+                    }
+                }
+                ProviderStreamEvent::Usage(stream_usage) => usage = stream_usage,
+                ProviderStreamEvent::Error(message) => return Err(anyhow!(message)),
+                ProviderStreamEvent::MessageStart
+                | ProviderStreamEvent::ToolCallEnd { .. }
+                | ProviderStreamEvent::MessageEnd => {}
+            }
+        }
+
+        let mut tool_calls_vec = Vec::new();
+        for (id, (name, raw_args)) in tool_calls.into_iter() {
+            if name.trim().is_empty() {
+                continue;
+            }
+            let arguments = if raw_args.trim().is_empty() {
+                json!({})
+            } else {
+                serde_json::from_str(&raw_args).with_context(|| {
+                    format!("解析工具调用参数失败：tool={name} id={id} raw={raw_args}")
+                })?
+            };
+            tool_calls_vec.push(ModelFunctionCall {
+                id,
+                name,
+                arguments,
+            });
+        }
+
+        if text.trim().is_empty()
+            && reasoning_content.trim().is_empty()
+            && tool_calls_vec.is_empty()
+        {
+            return Err(anyhow!("async 流式响应缺少文本、思考内容和工具调用"));
+        }
+
+        Ok(ModelFunctionResponse {
+            text: text.trim().to_string(),
+            reasoning_content: reasoning_content.trim().to_string(),
+            usage: usage.into(),
+            tool_calls: tool_calls_vec,
+        })
+    }
 }
 
 impl ModelClient for SingleProviderClient {

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -21,6 +21,7 @@ use tiangong_llm::usage::TokenUsageData;
 use tokio::runtime::Builder as TokioRuntimeBuilder;
 
 pub use tiangong_llm::ProviderProtocol;
+pub use tiangong_llm::tool::ToolChoice as ModelToolChoice;
 pub use tiangong_types::TokenUsage;
 
 #[derive(Debug, Clone)]
@@ -333,6 +334,15 @@ impl SingleProviderClient {
         req: &ModelRequest,
         functions: &[FunctionToolSpec],
     ) -> Result<ModelFunctionResponse> {
+        self.complete_with_functions_anthropic_with_tool_choice(req, functions, None)
+    }
+
+    fn complete_with_functions_anthropic_with_tool_choice(
+        &self,
+        req: &ModelRequest,
+        functions: &[FunctionToolSpec],
+        tool_choice: Option<ModelToolChoice>,
+    ) -> Result<ModelFunctionResponse> {
         let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
         let model = self.cfg.api_model.trim();
         if model.is_empty() {
@@ -340,7 +350,8 @@ impl SingleProviderClient {
         }
 
         let provider = self.build_anthropic_provider(timeout_ms)?;
-        let request = build_provider_request(req, model, anthropic_max_tokens(), functions);
+        let request =
+            build_provider_request(req, model, anthropic_max_tokens(), functions, tool_choice);
         let response = self.block_on_llm(provider.complete(request))?;
         convert_provider_response_to_function_response(response)
     }
@@ -394,7 +405,7 @@ impl SingleProviderClient {
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起流式模型请求"));
         }
-        let request = build_provider_request(req, model, anthropic_max_tokens(), &[]);
+        let request = build_provider_request(req, model, anthropic_max_tokens(), &[], None);
         let provider = self.build_provider_dispatch(timeout_ms)?;
         consume_provider_stream(provider, request, &mut on_delta)
     }
@@ -406,12 +417,23 @@ impl SingleProviderClient {
         functions: &[FunctionToolSpec],
         on_delta: &mut dyn FnMut(&ModelStreamChunk),
     ) -> Result<ModelFunctionResponse> {
+        self.complete_with_functions_stream_impl_with_tool_choice(req, functions, None, on_delta)
+    }
+
+    pub fn complete_with_functions_stream_impl_with_tool_choice(
+        &self,
+        req: &ModelRequest,
+        functions: &[FunctionToolSpec],
+        tool_choice: Option<ModelToolChoice>,
+        on_delta: &mut dyn FnMut(&ModelStreamChunk),
+    ) -> Result<ModelFunctionResponse> {
         let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
         let model = self.cfg.api_model.trim();
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起流式工具模型请求"));
         }
-        let request = build_provider_request(req, model, anthropic_max_tokens(), functions);
+        let request =
+            build_provider_request(req, model, anthropic_max_tokens(), functions, tool_choice);
         let provider = self.build_provider_dispatch(timeout_ms)?;
         convert_stream_to_function_response(provider, request, on_delta)
     }
@@ -498,6 +520,65 @@ impl SingleProviderClient {
         functions: Vec<FunctionToolSpec>,
         chunk_tx: tokio::sync::mpsc::UnboundedSender<ModelStreamChunk>,
     ) -> Result<ModelFunctionResponse> {
+        self.stream_function_calls_with_tool_choice(req, functions, None, chunk_tx)
+            .await
+    }
+
+    pub async fn stream_function_calls_with_tool_choice(
+        self,
+        req: ModelRequest,
+        functions: Vec<FunctionToolSpec>,
+        tool_choice: Option<ModelToolChoice>,
+        chunk_tx: tokio::sync::mpsc::UnboundedSender<ModelStreamChunk>,
+    ) -> Result<ModelFunctionResponse> {
+        let fallback_client = self.clone();
+        let fallback_req = req.clone();
+        let fallback_functions = functions.clone();
+        let fallback_tool_choice = tool_choice.clone();
+        let fallback_tx = chunk_tx.clone();
+
+        match self
+            .stream_function_calls_streaming(req, functions, tool_choice, chunk_tx)
+            .await
+        {
+            Ok(response) => Ok(response),
+            Err(err) => {
+                if let Some(on_retry) = &fallback_client.on_retry {
+                    on_retry(1, MAX_RETRIES, 0, &err.to_string());
+                }
+                let response = tokio::task::spawn_blocking(move || {
+                    fallback_client.complete_with_functions_with_tool_choice(
+                        &fallback_req,
+                        &fallback_functions,
+                        fallback_tool_choice,
+                    )
+                })
+                .await
+                .context("流式失败后回退非流式调用失败")??;
+                if !response.reasoning_content.is_empty() {
+                    let _ = fallback_tx.send(ModelStreamChunk {
+                        content: String::new(),
+                        reasoning_content: response.reasoning_content.clone(),
+                    });
+                }
+                if !response.text.is_empty() {
+                    let _ = fallback_tx.send(ModelStreamChunk {
+                        content: response.text.clone(),
+                        reasoning_content: String::new(),
+                    });
+                }
+                Ok(response)
+            }
+        }
+    }
+
+    async fn stream_function_calls_streaming(
+        self,
+        req: ModelRequest,
+        functions: Vec<FunctionToolSpec>,
+        tool_choice: Option<ModelToolChoice>,
+        chunk_tx: tokio::sync::mpsc::UnboundedSender<ModelStreamChunk>,
+    ) -> Result<ModelFunctionResponse> {
         fn looks_like_complete_json(raw: &str) -> bool {
             let trimmed = raw.trim();
             (trimmed.starts_with('{') && trimmed.ends_with('}'))
@@ -511,7 +592,13 @@ impl SingleProviderClient {
                 "API_MODEL 不能为空，无法发起 async 流式工具模型请求"
             ));
         }
-        let request = build_provider_request(&req, &model, anthropic_max_tokens(), &functions);
+        let request = build_provider_request(
+            &req,
+            &model,
+            anthropic_max_tokens(),
+            &functions,
+            tool_choice,
+        );
         let provider = self.build_provider_dispatch(timeout_ms)?;
 
         let mut text = String::new();
@@ -575,13 +662,7 @@ impl SingleProviderClient {
             if name.trim().is_empty() {
                 continue;
             }
-            let arguments = if raw_args.trim().is_empty() {
-                json!({})
-            } else {
-                serde_json::from_str(&raw_args).with_context(|| {
-                    format!("解析工具调用参数失败：tool={name} id={id} raw={raw_args}")
-                })?
-            };
+            let arguments = parse_tool_arguments_or_error(&name, &id, &raw_args);
             tool_calls_vec.push(ModelFunctionCall {
                 id,
                 name,
@@ -602,6 +683,86 @@ impl SingleProviderClient {
             usage: usage.into(),
             tool_calls: tool_calls_vec,
         })
+    }
+
+    pub fn complete_with_functions_with_tool_choice(
+        &self,
+        req: &ModelRequest,
+        functions: &[FunctionToolSpec],
+        tool_choice: Option<ModelToolChoice>,
+    ) -> Result<ModelFunctionResponse> {
+        if self.protocol() == ProviderProtocol::Anthropic {
+            return self.complete_with_functions_anthropic_with_tool_choice(
+                req,
+                functions,
+                tool_choice,
+            );
+        }
+
+        let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
+        let model = self.cfg.api_model.trim();
+        if model.is_empty() {
+            return Err(anyhow!("API_MODEL 不能为空，无法发起工具模型请求"));
+        }
+        let provider =
+            build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?;
+        let request =
+            build_provider_request(req, model, anthropic_max_tokens(), functions, tool_choice);
+        let response = self.block_on_llm(provider.complete(request))?;
+        convert_provider_response_to_function_response(response)
+    }
+
+    pub fn complete_with_functions_stream_with_tool_choice(
+        &self,
+        req: &ModelRequest,
+        functions: &[FunctionToolSpec],
+        tool_choice: Option<ModelToolChoice>,
+        on_delta: &mut dyn FnMut(&ModelStreamChunk),
+    ) -> Result<ModelFunctionResponse> {
+        if use_stream_mode() {
+            match self.complete_with_functions_stream_impl_with_tool_choice(
+                req,
+                functions,
+                tool_choice.clone(),
+                on_delta,
+            ) {
+                Ok(resp) => Ok(resp),
+                Err(_) => {
+                    // 流式失败，回退到非流式，一次性推送 reasoning + content
+                    let resp =
+                        self.complete_with_functions_with_tool_choice(req, functions, tool_choice)?;
+                    if !resp.reasoning_content.is_empty() {
+                        on_delta(&ModelStreamChunk {
+                            content: String::new(),
+                            reasoning_content: resp.reasoning_content.clone(),
+                        });
+                    }
+                    if !resp.text.is_empty() {
+                        on_delta(&ModelStreamChunk {
+                            content: resp.text.clone(),
+                            reasoning_content: String::new(),
+                        });
+                    }
+                    Ok(resp)
+                }
+            }
+        } else {
+            let resp =
+                self.complete_with_functions_with_tool_choice(req, functions, tool_choice)?;
+            if !resp.reasoning_content.is_empty() {
+                on_delta(&ModelStreamChunk {
+                    content: String::new(),
+                    reasoning_content: resp.reasoning_content.clone(),
+                });
+            }
+            if !resp.text.is_empty() {
+                on_delta(&ModelStreamChunk {
+                    content: resp.text.clone(),
+                    reasoning_content: String::new(),
+                });
+            }
+            Ok(resp)
+        }
     }
 }
 
@@ -638,7 +799,7 @@ impl ModelClient for SingleProviderClient {
         }
         let provider =
             build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?;
-        let request = build_provider_request(req, model, anthropic_max_tokens(), &[]);
+        let request = build_provider_request(req, model, anthropic_max_tokens(), &[], None);
         let response = self.block_on_llm(provider.complete(request))?;
         Ok(ModelResponse {
             text: collect_provider_text(&response).trim().to_string(),
@@ -654,20 +815,7 @@ impl ModelClient for SingleProviderClient {
         req: &ModelRequest,
         functions: &[FunctionToolSpec],
     ) -> Result<ModelFunctionResponse> {
-        if self.protocol() == ProviderProtocol::Anthropic {
-            return self.complete_with_functions_anthropic(req, functions);
-        }
-
-        let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
-        let model = self.cfg.api_model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("API_MODEL 不能为空，无法发起工具模型请求"));
-        }
-        let provider =
-            build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?;
-        let request = build_provider_request(req, model, anthropic_max_tokens(), functions);
-        let response = self.block_on_llm(provider.complete(request))?;
-        convert_provider_response_to_function_response(response)
+        SingleProviderClient::complete_with_functions_with_tool_choice(self, req, functions, None)
     }
 
     fn complete_with_functions_stream(
@@ -676,43 +824,9 @@ impl ModelClient for SingleProviderClient {
         functions: &[FunctionToolSpec],
         on_delta: &mut dyn FnMut(&ModelStreamChunk),
     ) -> Result<ModelFunctionResponse> {
-        if use_stream_mode() {
-            match self.complete_with_functions_stream_impl(req, functions, on_delta) {
-                Ok(resp) => Ok(resp),
-                Err(_) => {
-                    // 流式失败，回退到非流式，一次性推送 reasoning + content
-                    let resp = self.complete_with_functions(req, functions)?;
-                    if !resp.reasoning_content.is_empty() {
-                        on_delta(&ModelStreamChunk {
-                            content: String::new(),
-                            reasoning_content: resp.reasoning_content.clone(),
-                        });
-                    }
-                    if !resp.text.is_empty() {
-                        on_delta(&ModelStreamChunk {
-                            content: resp.text.clone(),
-                            reasoning_content: String::new(),
-                        });
-                    }
-                    Ok(resp)
-                }
-            }
-        } else {
-            let resp = self.complete_with_functions(req, functions)?;
-            if !resp.reasoning_content.is_empty() {
-                on_delta(&ModelStreamChunk {
-                    content: String::new(),
-                    reasoning_content: resp.reasoning_content.clone(),
-                });
-            }
-            if !resp.text.is_empty() {
-                on_delta(&ModelStreamChunk {
-                    content: resp.text.clone(),
-                    reasoning_content: String::new(),
-                });
-            }
-            Ok(resp)
-        }
+        SingleProviderClient::complete_with_functions_stream_with_tool_choice(
+            self, req, functions, None, on_delta,
+        )
     }
 }
 
@@ -758,6 +872,7 @@ fn build_provider_request(
     model: &str,
     max_tokens: u32,
     functions: &[FunctionToolSpec],
+    tool_choice: Option<ModelToolChoice>,
 ) -> ProviderRequest {
     let (system, messages) = build_provider_messages(req);
     ProviderRequest {
@@ -772,7 +887,7 @@ fn build_provider_request(
                 input_schema: tool.parameters.clone(),
             })
             .collect(),
-        tool_choice: (!functions.is_empty()).then_some(LlmToolChoice::Auto),
+        tool_choice: tool_choice.or_else(|| (!functions.is_empty()).then_some(LlmToolChoice::Auto)),
         max_tokens: Some(max_tokens),
         temperature: configured_temperature_f32(),
         top_p: None,
@@ -952,6 +1067,23 @@ fn convert_provider_response_to_function_response(
     })
 }
 
+fn parse_tool_arguments_or_error(tool_name: &str, call_id: &str, raw_args: &str) -> Value {
+    if raw_args.trim().is_empty() {
+        return json!({});
+    }
+
+    serde_json::from_str(raw_args).unwrap_or_else(|err| {
+        let raw_preview: String = raw_args.chars().take(512).collect();
+        json!({
+            "__parse_error": format!(
+                "工具参数 JSON 无效：tool={tool_name} id={call_id} error={err}。\
+        长内容写入请分段调用 write_file，第一次 append=false，后续 append=true。"
+            ),
+            "__raw_args_preview": raw_preview,
+        })
+    })
+}
+
 fn collect_provider_text(response: &ProviderResponse) -> String {
     response
         .assistant_message
@@ -1024,13 +1156,9 @@ async fn consume_provider_stream_events_async(
         .into_iter()
         .filter(|(_, (name, _))| !name.is_empty())
         .map(|(id, (name, raw_args))| ModelFunctionCall {
+            arguments: parse_tool_arguments_or_error(&name, &id, &raw_args),
             id,
             name,
-            arguments: if raw_args.trim().is_empty() {
-                json!({})
-            } else {
-                serde_json::from_str(&raw_args).unwrap_or_else(|_| json!({}))
-            },
         })
         .collect::<Vec<_>>();
 

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -833,6 +833,16 @@ fn build_provider_messages(req: &ModelRequest) -> (String, Vec<ChatMessage>) {
         ));
     }
 
+    let mut messages = sanitize_provider_messages(messages);
+    if messages.is_empty() {
+        let fallback = if req.user_input.trim().is_empty() {
+            "请继续处理当前任务。".to_string()
+        } else {
+            req.user_input.trim().to_string()
+        };
+        messages.push(ChatMessage::text(LlmMessageRole::User, fallback));
+    }
+
     (system_texts.join("\n"), messages)
 }
 
@@ -847,9 +857,6 @@ fn provider_message_from_session(msg: &Message) -> Option<ChatMessage> {
     if !msg.content.trim().is_empty() {
         parts.push(msg.content.trim().to_string());
     }
-    if !msg.reasoning_content.trim().is_empty() {
-        parts.push(format!("[思考]\n{}", msg.reasoning_content.trim()));
-    }
     if parts.is_empty() {
         return None;
     }
@@ -858,6 +865,56 @@ fn provider_message_from_session(msg: &Message) -> Option<ChatMessage> {
         role,
         vec![LlmMessageContent::Text(parts.join("\n\n"))],
     ))
+}
+
+fn sanitize_provider_messages(messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
+    let mut sanitized: Vec<ChatMessage> = Vec::new();
+    let mut seen_user = false;
+
+    for message in messages {
+        if message.role == LlmMessageRole::System || is_empty_provider_message(&message) {
+            continue;
+        }
+        if !seen_user {
+            if message.role != LlmMessageRole::User {
+                continue;
+            }
+            seen_user = true;
+        }
+
+        if let Some(last) = sanitized.last_mut()
+            && last.role == message.role
+        {
+            merge_provider_message_content(last, message);
+            continue;
+        }
+        sanitized.push(message);
+    }
+
+    sanitized
+}
+
+fn is_empty_provider_message(message: &ChatMessage) -> bool {
+    message.content.iter().all(|content| match content {
+        LlmMessageContent::Text(text) => text.trim().is_empty(),
+        _ => false,
+    })
+}
+
+fn merge_provider_message_content(target: &mut ChatMessage, source: ChatMessage) {
+    for content in source.content {
+        match (target.content.last_mut(), content) {
+            (Some(LlmMessageContent::Text(current)), LlmMessageContent::Text(next)) => {
+                if !next.trim().is_empty() {
+                    if !current.trim().is_empty() {
+                        current.push_str("\n\n");
+                    }
+                    current.push_str(next.trim());
+                }
+            }
+            (_, content) => target.content.push(content),
+        }
+    }
 }
 
 fn convert_provider_response_to_function_response(

--- a/crates/tiangong-llm/src/error.rs
+++ b/crates/tiangong-llm/src/error.rs
@@ -41,7 +41,7 @@ impl LlmError {
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,
-            Self::Transport(_) | Self::Timeout(_) | Self::RateLimited(_)
+            Self::Transport(_) | Self::Timeout(_) | Self::RateLimited(_) | Self::Stream(_)
         )
     }
 }

--- a/crates/tiangong-llm/src/providers/openai/mapping.rs
+++ b/crates/tiangong-llm/src/providers/openai/mapping.rs
@@ -9,7 +9,7 @@ use serde_json::{Value, json};
 use crate::message::{ChatMessage, MessageContent, MessageRole};
 use crate::request::ProviderRequest;
 use crate::response::{ProviderResponse, StopReason};
-use crate::tool::ToolSpec;
+use crate::tool::{ToolChoice, ToolSpec};
 use crate::usage::TokenUsageData;
 
 pub fn normalize_api_base(base_url: &str) -> Result<String> {
@@ -45,7 +45,7 @@ pub fn build_request_json(req: &ProviderRequest, stream: bool) -> Result<Value> 
         inject_temperature_config(&mut payload, temperature)?;
     }
     if !req.tools.is_empty() {
-        inject_function_tools(&mut payload, &req.tools);
+        inject_function_tools(&mut payload, &req.tools, req.tool_choice.as_ref());
     }
     Ok(payload)
 }
@@ -237,7 +237,11 @@ fn inject_temperature_config(payload: &mut Value, temperature: f32) -> Result<()
     Ok(())
 }
 
-fn inject_function_tools(payload: &mut Value, functions: &[ToolSpec]) {
+fn inject_function_tools(
+    payload: &mut Value,
+    functions: &[ToolSpec],
+    tool_choice: Option<&ToolChoice>,
+) {
     let Some(obj) = payload.as_object_mut() else {
         return;
     };
@@ -255,7 +259,15 @@ fn inject_function_tools(payload: &mut Value, functions: &[ToolSpec]) {
         })
         .collect::<Vec<_>>();
     obj.insert("tools".to_string(), Value::Array(tools));
-    obj.insert("tool_choice".to_string(), Value::String("auto".to_string()));
+    let tool_choice = match tool_choice {
+        Some(ToolChoice::Any) => Value::String("required".to_string()),
+        Some(ToolChoice::Tool(name)) => json!({
+            "type": "function",
+            "function": { "name": name },
+        }),
+        Some(ToolChoice::Auto) | None => Value::String("auto".to_string()),
+    };
+    obj.insert("tool_choice".to_string(), tool_choice);
 }
 
 pub fn strip_think_tags(text: &str) -> String {

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -328,17 +328,23 @@ fn sync_stream_event_to_state(
             };
             session.append_message(MessageRole::System, summary);
         }
-        StreamEvent::ToolResult { name, ok, output } => {
+        StreamEvent::ToolResult {
+            name,
+            ok,
+            output,
+            full_output,
+        } => {
+            let persisted_output = full_output.as_deref().unwrap_or(output);
             let status = if *ok { "成功" } else { "失败" };
             if *ok {
-                let media = parse_tool_media_assets(name, output);
+                let media = parse_tool_media_assets(name, persisted_output);
                 if !media.is_empty() {
                     session.append_message_with_media(MessageRole::Assistant, String::new(), media);
                 }
             }
             session.append_message(
                 MessageRole::System,
-                format!("工具 {name} 执行{status}\n{output}"),
+                format!("工具 {name} 执行{status}\n{persisted_output}"),
             );
         }
         StreamEvent::ApprovalNeeded { .. } => {

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -315,6 +315,7 @@ fn sync_stream_event_to_state(
             content,
         } => append_assistant_reasoning(session, message_id, content),
         StreamEvent::ToolCalls { names, .. } => {
+            cleanup_latest_assistant_before_tool_calls(session);
             session.append_message(
                 MessageRole::System,
                 format!("LLM 输出\ntool_calls: {}", names.join(", ")),
@@ -391,12 +392,23 @@ fn sync_stream_event_to_state(
 }
 
 fn append_assistant_delta(session: &mut Session, message_id: &str, content: &str) {
+    if content.trim().is_empty()
+        && !session
+            .messages
+            .iter()
+            .any(|message| message.id == message_id)
+    {
+        return;
+    }
     ensure_assistant_message(session, message_id);
     if let Some(message) = session
         .messages
         .iter_mut()
         .find(|message| message.id == message_id)
     {
+        if message.content.trim().is_empty() && content.trim().is_empty() {
+            return;
+        }
         message.content.push_str(content);
     }
 }
@@ -409,6 +421,25 @@ fn append_assistant_reasoning(session: &mut Session, message_id: &str, content: 
         .find(|message| message.id == message_id)
     {
         message.reasoning_content.push_str(content);
+    }
+}
+
+fn cleanup_latest_assistant_before_tool_calls(session: &mut Session) {
+    let Some(index) = session
+        .messages
+        .iter()
+        .rposition(|message| message.role == MessageRole::Assistant)
+    else {
+        return;
+    };
+
+    let message = &mut session.messages[index];
+    if !message.content.trim().is_empty() {
+        return;
+    }
+    message.content.clear();
+    if message.reasoning_content.trim().is_empty() && message.media.is_empty() {
+        session.messages.remove(index);
     }
 }
 

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -304,6 +304,7 @@ fn sync_stream_event_to_state(
                 content.clone(),
                 String::new(),
             );
+            should_persist = true;
         }
         StreamEvent::Delta {
             message_id,

--- a/crates/tiangong-types/src/stream.rs
+++ b/crates/tiangong-types/src/stream.rs
@@ -27,7 +27,11 @@ pub enum StreamEvent {
     ToolResult {
         name: String,
         ok: bool,
+        /// 给 UI/外部消费者展示的输出，可能被截断。
         output: String,
+        /// Rust 内部落盘使用的完整输出，不序列化给前端或远端消费者。
+        #[serde(default, skip)]
+        full_output: Option<String>,
     },
     /// LLM 决定调用工具
     ToolCalls {

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -225,8 +225,8 @@ export const api = {
   cancelTurn: (): Promise<boolean> =>
     invoke('cancel_turn'),
 
-  appendMessage: (content: string): Promise<boolean> =>
-    invoke('append_message', { content }),
+  appendMessage: (sessionId: string, content: string): Promise<boolean> =>
+    invoke('append_message', { sessionId, content }),
 
   respondApproval: (requestId: string, approved: boolean): Promise<boolean> =>
     invoke('respond_approval', { requestId, approved }),

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -159,8 +159,9 @@ export function MessageInput() {
       sendMessage(inputContent);
     } else {
       // 执行中：追加消息到正在执行的 turn
+      if (!activeSessionId) return;
       try {
-        await api.appendMessage(inputContent);
+        await api.appendMessage(activeSessionId, inputContent);
         setInputContent('');
       } catch (e) {
         console.error('追加消息失败:', e);

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -161,8 +161,12 @@ export function MessageInput() {
       // 执行中：追加消息到正在执行的 turn
       if (!activeSessionId) return;
       try {
-        await api.appendMessage(activeSessionId, inputContent);
-        setInputContent('');
+        const appended = await api.appendMessage(activeSessionId, inputContent);
+        if (appended) {
+          setInputContent('');
+        } else {
+          console.warn('当前会话没有正在执行的任务，追加消息未发送');
+        }
       } catch (e) {
         console.error('追加消息失败:', e);
       }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -85,9 +85,23 @@ impl TiangongApp {
 
     /// 向指定会话的 core 发送消息
     pub fn send_to_core(&self, session_id: &str, content: String) -> bool {
+        self.send_to_core_with_id(session_id, content, None)
+    }
+
+    /// 向指定会话的 core 发送带固定消息 ID 的消息
+    pub fn send_to_core_with_id(
+        &self,
+        session_id: &str,
+        content: String,
+        message_id: Option<String>,
+    ) -> bool {
         let cores = self.cores.lock().unwrap();
         if let Some(core) = cores.get(session_id) {
-            core.send_message(content);
+            if let Some(message_id) = message_id {
+                core.send_message_with_id(content, message_id);
+            } else {
+                core.send_message(content);
+            }
             true
         } else {
             false

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -74,8 +74,12 @@ impl TiangongApp {
         stream_tx: std::sync::mpsc::Sender<tiangong_types::SessionStreamEvent>,
     ) -> (String, bool) {
         let mut cores = self.cores.lock().unwrap();
-        if cores.contains_key(session_id) {
-            return (session_id.to_string(), false); // 已存在，复用
+        if let Some(core) = cores.get(session_id) {
+            if core.is_running() {
+                return (session_id.to_string(), false); // 已存在，复用
+            }
+            eprintln!("移除已停止的 TiangongCore：{session_id}");
+            cores.remove(session_id);
         }
         let core = TiangongCore::with_session(self.config.clone(), session, stream_tx);
         let id = core.session_id().to_string();
@@ -95,14 +99,18 @@ impl TiangongApp {
         content: String,
         message_id: Option<String>,
     ) -> bool {
-        let cores = self.cores.lock().unwrap();
+        let mut cores = self.cores.lock().unwrap();
         if let Some(core) = cores.get(session_id) {
-            if let Some(message_id) = message_id {
-                core.send_message_with_id(content, message_id);
+            let sent = if let Some(message_id) = message_id {
+                core.send_message_with_id(content, message_id)
             } else {
-                core.send_message(content);
+                core.send_message(content)
+            };
+            if !sent {
+                eprintln!("TiangongCore 命令通道已关闭，移除僵尸 core：{session_id}");
+                cores.remove(session_id);
             }
-            true
+            sent
         } else {
             false
         }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -84,10 +84,13 @@ impl TiangongApp {
     }
 
     /// 向指定会话的 core 发送消息
-    pub fn send_to_core(&self, session_id: &str, content: String) {
+    pub fn send_to_core(&self, session_id: &str, content: String) -> bool {
         let cores = self.cores.lock().unwrap();
         if let Some(core) = cores.get(session_id) {
             core.send_message(content);
+            true
+        } else {
+            false
         }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -27,8 +27,16 @@ fn append_assistant_delta(
     message_id: &str,
     content: &str,
 ) {
+    if content.trim().is_empty()
+        && !session.messages.iter().any(|msg| msg.id == message_id)
+    {
+        return;
+    }
     ensure_assistant_message(session, assistant_msg_id, message_id);
     if let Some(msg) = session.messages.iter_mut().find(|msg| msg.id == message_id) {
+        if msg.content.trim().is_empty() && content.trim().is_empty() {
+            return;
+        }
         msg.content.push_str(content);
     }
 }
@@ -42,6 +50,29 @@ fn append_assistant_reasoning(
     ensure_assistant_message(session, assistant_msg_id, message_id);
     if let Some(msg) = session.messages.iter_mut().find(|msg| msg.id == message_id) {
         msg.reasoning_content.push_str(content);
+    }
+}
+
+fn cleanup_assistant_before_tool_calls(
+    session: &mut tiangong_core::session::Session,
+    assistant_msg_id: &mut Option<String>,
+) {
+    let Some(message_id) = assistant_msg_id.take() else {
+        return;
+    };
+    let Some(index) = session.messages.iter().position(|msg| {
+        msg.id == message_id && msg.role == tiangong_core::session::MessageRole::Assistant
+    }) else {
+        return;
+    };
+
+    let message = &mut session.messages[index];
+    if !message.content.trim().is_empty() {
+        return;
+    }
+    message.content.clear();
+    if message.reasoning_content.trim().is_empty() && message.media.is_empty() {
+        session.messages.remove(index);
     }
 }
 
@@ -412,6 +443,7 @@ pub fn send_message(
                             );
                         }
                         StreamEvent::ToolCalls { names, usage } => {
+                            cleanup_assistant_before_tool_calls(session, &mut assistant_msg_id);
                             session.append_message(
                                 tiangong_core::session::MessageRole::System,
                                 format!("LLM 输出\ntool_calls: {}", names.join(", ")),
@@ -420,7 +452,6 @@ pub fn send_message(
                                 add_session_usage(session, usage);
                                 recorded_turn_usage.accumulate(usage);
                             }
-                            assistant_msg_id = None;
                         }
                         StreamEvent::ToolStart {
                             ref args_summary, ..
@@ -744,8 +775,16 @@ pub fn cancel_turn(state: State<TiangongApp>) -> Result<bool, String> {
 
 /// 向正在执行的 turn 追加用户消息
 #[tauri::command]
-pub fn append_message(content: String, state: State<TiangongApp>) -> Result<bool, String> {
-    state.with_state(|core_state| core_state.append_user_message_to_running_turn(&content))
+pub fn append_message(
+    session_id: String,
+    content: String,
+    state: State<TiangongApp>,
+) -> Result<bool, String> {
+    if session_id.trim().is_empty() {
+        return Err("当前会话 ID 不能为空".to_string());
+    }
+
+    Ok(state.send_to_core(&session_id, content))
 }
 
 /// 响应工具审批请求

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -335,14 +335,19 @@ pub fn send_message(
     use tiangong_types::{SessionStreamEvent, StreamEvent};
 
     // 准备 session
-    let (session_id, session_snapshot) = state
+    let (session_id, user_message_id, session_snapshot) = state
         .with_state(|core_state| core_state.prepare_active_user_message_ingress(content.clone()))?;
 
     // 获取或创建 TiangongCore
     let (stream_tx, stream_rx) = mpsc::channel::<SessionStreamEvent>();
     let (sid, is_new_core) = state.ensure_core(&session_id, session_snapshot, stream_tx);
     // 发送消息（core 内部会 append 到 core session 并推送 UserMessage 事件）
-    state.send_to_core(&sid, content.clone());
+    {
+        let cores = state.cores.lock().map_err(|e| e.to_string())?;
+        if let Some(core) = cores.get(&sid) {
+            core.send_message_with_id(content.clone(), user_message_id);
+        }
+    }
 
     // 只在新创建 core 时启动消费线程（复用 core 时旧消费线程仍在运行）
     if !is_new_core {
@@ -375,12 +380,14 @@ pub fn send_message(
                         } => {
                             recorded_turn_usage = tiangong_types::TokenUsage::default();
                             // Core 已记录用户消息，同步到 TiangongState session
-                            session.append_message_with_id(
-                                message_id.clone(),
-                                tiangong_core::session::MessageRole::User,
-                                content.clone(),
-                                String::new(),
-                            );
+                            if !session.messages.iter().any(|msg| msg.id == *message_id) {
+                                session.append_message_with_id(
+                                    message_id.clone(),
+                                    tiangong_core::session::MessageRole::User,
+                                    content.clone(),
+                                    String::new(),
+                                );
+                            }
                         }
                         StreamEvent::Delta {
                             message_id,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -432,15 +432,17 @@ pub fn send_message(
                             ref name,
                             ok,
                             ref output,
+                            ref full_output,
                         } => {
+                            let persisted_output = full_output.as_deref().unwrap_or(output);
                             let status = if *ok { "ok=true" } else { "ok=false" };
                             let media_assets = if *ok
                                 && name == "generate_image"
-                                && looks_like_pure_image_markdown(output)
+                                && looks_like_pure_image_markdown(persisted_output)
                             {
-                                parse_image_markdown_assets(output)
+                                parse_image_markdown_assets(persisted_output)
                             } else if *ok && is_video_tool(name) {
-                                parse_video_url_assets(output)
+                                parse_video_url_assets(persisted_output)
                             } else {
                                 Vec::new()
                             };
@@ -467,13 +469,8 @@ pub fn send_message(
                                 pending_final_media
                                     .get_or_insert_with(Vec::new)
                                     .extend(media_assets);
-                            } else if !output.trim().is_empty() {
-                                let preview = if output.chars().count() > 200 {
-                                    format!("{}...", output.chars().take(200).collect::<String>())
-                                } else {
-                                    output.clone()
-                                };
-                                lines.push(format!("stdout:\n{preview}"));
+                            } else if !persisted_output.trim().is_empty() {
+                                lines.push(format!("stdout:\n{persisted_output}"));
                             }
                             session.append_message(
                                 tiangong_core::session::MessageRole::System,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -778,13 +778,55 @@ pub fn cancel_turn(state: State<TiangongApp>) -> Result<bool, String> {
 pub fn append_message(
     session_id: String,
     content: String,
+    app: AppHandle,
     state: State<TiangongApp>,
 ) -> Result<bool, String> {
     if session_id.trim().is_empty() {
         return Err("当前会话 ID 不能为空".to_string());
     }
 
-    Ok(state.send_to_core(&session_id, content))
+    let message_id = scru128::new().to_string();
+    if !state.send_to_core_with_id(&session_id, content.clone(), Some(message_id.clone())) {
+        return Ok(false);
+    }
+
+    let snapshot = state.with_state(|core_state| {
+        {
+            let Some(session) = core_state
+                .sessions_mut()
+                .iter_mut()
+                .find(|session| session.id == session_id)
+            else {
+                return Err(anyhow::anyhow!("当前会话不存在"));
+            };
+            if !session.messages.iter().any(|msg| msg.id == message_id) {
+                session.append_message_with_id(
+                    message_id,
+                    tiangong_core::session::MessageRole::User,
+                    content,
+                    String::new(),
+                );
+            }
+        }
+
+        let usage = core_state
+            .sessions()
+            .iter()
+            .find(|session| session.id == session_id)
+            .map(|session| session.total_usage())
+            .unwrap_or_default();
+        core_state.store.session.input_draft.clear();
+        core_state.store.runtime.run.status = tiangong_core::runtime::RunStatus::Executing;
+        core_state.store.runtime.run.summary = "正在处理".to_string();
+        core_state.store.runtime.run.last_session_id = Some(session_id.clone());
+        core_state.store.runtime.run.last_usage = (usage.total_tokens > 0).then_some(usage);
+        core_state.store.runtime.run.updated_at = tiangong_core::session::now_text();
+        core_state.persist_session_and_app(&session_id)?;
+        Ok(build_session_snapshot(core_state, &session_id, true))
+    })?;
+    let _ = app.emit("run_snapshot", &snapshot);
+
+    Ok(true)
 }
 
 /// 响应工具审批请求

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -376,7 +376,9 @@ pub fn send_message(
     {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(&sid) {
-            core.send_message_with_id(content.clone(), user_message_id);
+            if !core.send_message_with_id(content.clone(), user_message_id) {
+                return Err("会话 core 已停止，请重试发送".to_string());
+            }
         }
     }
 
@@ -528,10 +530,7 @@ pub fn send_message(
                             attempt,
                             max_attempts,
                         } => {
-                            session.append_message(
-                                tiangong_core::session::MessageRole::System,
-                                format!("[重试] ({attempt}/{max_attempts}) {message}"),
-                            );
+                            let _ = (message, attempt, max_attempts);
                         }
                         StreamEvent::Done { usage } => {
                             if let Some(usage) = usage {
@@ -787,6 +786,11 @@ pub fn append_message(
 
     let message_id = scru128::new().to_string();
     if !state.send_to_core_with_id(&session_id, content.clone(), Some(message_id.clone())) {
+        let snapshot = state.with_state(|core_state| {
+            core_state.report_run_idle("当前会话任务已结束，请重新发送");
+            Ok(build_session_snapshot(core_state, &session_id, false))
+        })?;
+        let _ = app.emit("run_snapshot", &snapshot);
         return Ok(false);
     }
 


### PR DESCRIPTION
## 问题描述

会话任务结束后，TiangongCore 的 worker 线程已停止，但 core 仍留在 map 中，导致后续发送消息失败或会话无法恢复。

## 变更内容

- 为 `TiangongCore` 添加 `is_running()` 方法，通过检测 worker 线程状态判断 core 是否存活
- `send_cmd` / `send_message` / `cancel` / `respond_approval` 返回 `bool` 表示发送结果
- `app.rs`：检测已停止的 core 并自动移除，支持会话恢复时重建 core
- `commands.rs`：发送失败时返回错误，并通知前端 `run_idle` 状态
- 添加 `ModelToolChoice` 支持及 `FINISH_TASK_TOOL_NAME` 常量
