### PR TITLE
perf(ui): 优化长会话渲染和通知 CPU 占用

### DIFF
--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -15,7 +15,22 @@ interface MentionCandidate {
 }
 
 export function MessageInput() {
-  const { inputContent, setInputContent, sendMessage, cancelTurn, runStatus, runSummary, isDraft, activeSessionId, sessionRunStatuses, sessionCwd, setSessionCwd, addVoiceMessage, lastDurationMs, lastUsage } = useStore();
+  const inputContent = useStore((state) => state.inputContent);
+  const setInputContent = useStore((state) => state.setInputContent);
+  const sendMessage = useStore((state) => state.sendMessage);
+  const cancelTurn = useStore((state) => state.cancelTurn);
+  const runStatus = useStore((state) => state.runStatus);
+  const runSummary = useStore((state) => state.runSummary);
+  const isDraft = useStore((state) => state.isDraft);
+  const activeSessionId = useStore((state) => state.activeSessionId);
+  const currentSessionRunStatus = useStore((state) => (
+    state.activeSessionId ? state.sessionRunStatuses[state.activeSessionId] : undefined
+  ));
+  const sessionCwd = useStore((state) => state.sessionCwd);
+  const setSessionCwd = useStore((state) => state.setSessionCwd);
+  const addVoiceMessage = useStore((state) => state.addVoiceMessage);
+  const lastDurationMs = useStore((state) => state.lastDurationMs);
+  const lastUsage = useStore((state) => state.lastUsage);
   const [isComposing, setIsComposing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -32,7 +47,7 @@ export function MessageInput() {
 
   const currentRunStatus = isDraft
     ? 'idle'
-    : (activeSessionId && sessionRunStatuses[activeSessionId]) || runStatus;
+    : currentSessionRunStatus || runStatus;
   const sessionTotalTokens = lastUsage?.total_tokens ?? 0;
 
   useEffect(() => {
@@ -64,7 +79,7 @@ export function MessageInput() {
   // 当前会话是否空闲
   const currentSessionStatus = isDraft
     ? 'idle'
-    : (activeSessionId && sessionRunStatuses[activeSessionId]) || runStatus;
+    : currentSessionRunStatus || runStatus;
   const isIdle = currentSessionStatus === 'idle';
   const canSend = inputContent.trim().length > 0;  // 执行中也允许输入
 

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -28,7 +28,7 @@ import { TypingMessage } from "./TypingMessage";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { api } from "@/api/tauri";
 
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 /** 格式化消息时间（hover 显示） */
@@ -205,7 +205,7 @@ function VoiceBubble({ messageId, audioPath, duration, showText, content }: {
   );
 }
 
-function WorkerCard({ group, isActive, MarkdownComponents }: {
+function WorkerCardView({ group, isActive, MarkdownComponents }: {
   group: MessageGroup;
   isActive: boolean;
   MarkdownComponents: any;
@@ -310,6 +310,12 @@ function WorkerCard({ group, isActive, MarkdownComponents }: {
   );
 }
 
+const WorkerCard = memo(WorkerCardView, (prev, next) => (
+  prev.isActive === next.isActive
+  && prev.MarkdownComponents === next.MarkdownComponents
+  && sameMessageRefs(prev.group.messages, next.group.messages)
+));
+
 export function MessageList() {
   const {
     messages,
@@ -357,7 +363,7 @@ export function MessageList() {
 
   // 将本地文件路径转换为 Tauri asset URL
   // Markdown 渲染器（用于非流式消息）
-  const MarkdownComponents = {
+  const MarkdownComponents = useMemo(() => ({
     pre({ children, ...rest }: any) {
       return (
         <pre
@@ -528,7 +534,7 @@ export function MessageList() {
         </audio>
       );
     },
-  };
+  }), []);
 
   return (
     <ScrollArea className="h-full">
@@ -858,21 +864,23 @@ function summarizeToolGroup(tools: MessageItem[]): string {
 }
 
 /** 统一的智能体回合渲染 — 将系统消息（事件）和 assistant 消息（回复）合并展示 */
-function AgentTurn({
-  messages,
-  streamingMessageId,
-  streamingContent,
-  streamingReasoningContent: _streamingReasoningContent,
-  MarkdownComponents,
-  hasTts,
-}: {
+interface AgentTurnProps {
   messages: MessageItem[];
   streamingMessageId: string | null;
   streamingContent: string;
   streamingReasoningContent: string;
   MarkdownComponents: any;
   hasTts: boolean;
-}) {
+}
+
+function AgentTurnView({
+  messages,
+  streamingMessageId,
+  streamingContent,
+  streamingReasoningContent: _streamingReasoningContent,
+  MarkdownComponents,
+  hasTts,
+}: AgentTurnProps) {
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
   const [expandedToolGroups, setExpandedToolGroups] = useState<Set<string>>(new Set());
 
@@ -1167,6 +1175,39 @@ function AgentTurn({
     </div>
   );
 }
+
+function sameMessageRefs(left: MessageItem[], right: MessageItem[]): boolean {
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) return false;
+  }
+  return true;
+}
+
+function hasMessage(messages: MessageItem[], id: string | null): boolean {
+  return !!id && messages.some((message) => message.id === id);
+}
+
+const AgentTurn = memo(AgentTurnView, (prev, next) => {
+  if (
+    prev.hasTts !== next.hasTts
+    || prev.MarkdownComponents !== next.MarkdownComponents
+    || !sameMessageRefs(prev.messages, next.messages)
+  ) {
+    return false;
+  }
+
+  const touchesStreamingMessage =
+    hasMessage(prev.messages, prev.streamingMessageId)
+    || hasMessage(prev.messages, next.streamingMessageId);
+  if (!touchesStreamingMessage) {
+    return true;
+  }
+
+  return prev.streamingMessageId === next.streamingMessageId
+    && prev.streamingContent === next.streamingContent
+    && prev.streamingReasoningContent === next.streamingReasoningContent;
+});
 
 interface SystemMessageMeta {
   icon: React.ComponentType<{ className?: string }>;

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -2,6 +2,46 @@ import { create } from 'zustand';
 import { api, Session, Message, RunSnapshot, McpServer, Skill, TaskPlan } from '../api/tauri';
 import { notifyBackgroundSessionCompleted } from '../utils/desktopNotification';
 
+function sameJsonValue(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (left == null || right == null) return left == right;
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sameMessage(left: Message, right: Message): boolean {
+  return left.id === right.id
+    && left.role === right.role
+    && left.content === right.content
+    && left.reasoning_content === right.reasoning_content
+    && left.worker_id === right.worker_id
+    && left.tool_call_id === right.tool_call_id
+    && left.tool_name === right.tool_name
+    && left.tool_result_is_error === right.tool_result_is_error
+    && left.compact === right.compact
+    && left.created_at === right.created_at
+    && sameJsonValue(left.media, right.media)
+    && sameJsonValue(left.tool_calls, right.tool_calls);
+}
+
+function mergeSnapshotMessages(oldMessages: Message[], newMessages: Message[]): Message[] {
+  if (oldMessages.length === 0 || newMessages.length === 0) {
+    return newMessages;
+  }
+
+  const oldById = new Map(oldMessages.map((message) => [message.id, message]));
+  let changed = oldMessages.length !== newMessages.length;
+  const merged = newMessages.map((message) => {
+    const old = oldById.get(message.id);
+    if (old && sameMessage(old, message)) {
+      return old;
+    }
+    changed = true;
+    return message;
+  });
+
+  return changed ? merged : oldMessages;
+}
+
 interface AppState {
   // 状态
   sessions: Session[];
@@ -390,7 +430,7 @@ export const useStore = create<AppState>((set, get) => ({
     }
 
     const { messages: oldMessages, streamingMessageId: oldStreamingId } = get();
-    const newMessages = snapshot.messages;
+    const newMessages = mergeSnapshotMessages(oldMessages, snapshot.messages);
 
     // 检测最后一条消息是否是新的或内容在更新
     let streamingId: string | null = null;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6137,7 +6137,6 @@ dependencies = [
  "clap",
  "futures-util",
  "http",
- "mac-notification-sys",
  "reqwest 0.12.28",
  "rmcp",
  "scru128",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,9 +43,6 @@ tauri-plugin-notification = "2"
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-mac-notification-sys = "0.6"
-
 [features]
 default = []
 cli = []

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -29,130 +29,26 @@ pub fn send_desktop_notification(
         return Ok(false);
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        send_macos_interactive_notification(
-            app.clone(),
-            title,
-            body,
-            session_id,
-            MacNotificationKind::OpenSession,
-        );
-        return Ok(true);
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        app.notification()
-            .builder()
-            .title(title)
-            .body(body)
-            .group("tiangong-background-sessions")
-            .auto_cancel()
-            .show()
-            .map_err(|err| err.to_string())?;
-        Ok(true)
-    }
+    let _ = session_id;
+    show_desktop_notification(&app, title, body, "tiangong-background-sessions")?;
+    Ok(true)
 }
 
-#[cfg(target_os = "macos")]
-enum MacNotificationKind {
-    OpenSession,
-    Approval {
-        session_id: String,
-        request_id: String,
-    },
-}
-
-#[cfg(target_os = "macos")]
-fn send_macos_interactive_notification(
-    app: AppHandle,
+fn show_desktop_notification(
+    app: &AppHandle,
     title: String,
     body: String,
-    session_id: Option<String>,
-    kind: MacNotificationKind,
-) {
-    thread::spawn(move || {
-        let identifier = app.config().identifier.clone();
-        let _ = mac_notification_sys::set_application(&identifier);
-
-        let response = match &kind {
-            MacNotificationKind::OpenSession => {
-                let mut notification = mac_notification_sys::Notification::new();
-                notification
-                    .title(&title)
-                    .message(&body)
-                    .main_button(mac_notification_sys::MainButton::SingleAction("显示"))
-                    .close_button("关闭")
-                    .wait_for_click(true);
-                notification.send()
-            }
-            MacNotificationKind::Approval { .. } => {
-                let actions = ["同意", "拒绝"];
-                let mut notification = mac_notification_sys::Notification::new();
-                notification
-                    .title(&title)
-                    .message(&body)
-                    .main_button(mac_notification_sys::MainButton::DropdownActions(
-                        "处理",
-                        &actions,
-                    ))
-                    .close_button("稍后")
-                    .wait_for_click(true);
-                notification.send()
-            }
-        };
-
-        match response {
-            Ok(mac_notification_sys::NotificationResponse::Click)
-            | Ok(mac_notification_sys::NotificationResponse::ActionButton(_))
-                if matches!(kind, MacNotificationKind::OpenSession) =>
-            {
-                focus_main_window(&app);
-                if let Some(session_id) = session_id {
-                    let _ = app.emit("desktop_notification_open_session", session_id);
-                }
-            }
-            Ok(mac_notification_sys::NotificationResponse::ActionButton(action)) => {
-                if let MacNotificationKind::Approval {
-                    session_id,
-                    request_id,
-                } = kind
-                {
-                    let approved = action == "同意";
-                    app.state::<TiangongApp>().respond_approval_to_core(
-                        &session_id,
-                        request_id,
-                        approved,
-                    );
-                    focus_main_window(&app);
-                }
-            }
-            Ok(_) => {}
-            Err(err) => eprintln!("macOS 交互通知发送失败：{err}"),
-        }
-    });
+    group: &str,
+) -> Result<(), String> {
+    app.notification()
+        .builder()
+        .title(title)
+        .body(body)
+        .group(group)
+        .auto_cancel()
+        .show()
+        .map_err(|err| err.to_string())
 }
-
-fn focus_main_window(app: &AppHandle) {
-    activate_main_app(app);
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.show();
-        let _ = window.unminimize();
-        let _ = window.set_focus();
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn activate_main_app(app: &AppHandle) {
-    let _ = std::process::Command::new("open")
-        .arg("-b")
-        .arg(app.config().identifier.as_str())
-        .spawn();
-}
-
-#[cfg(not(target_os = "macos"))]
-fn activate_main_app(_app: &AppHandle) {}
 
 fn main_window_is_focused(app: &AppHandle) -> bool {
     app.get_webview_window("main")
@@ -187,24 +83,8 @@ fn send_approval_notification_if_background(
         format!("{tool_name}: {args_summary}")
     };
 
-    #[cfg(target_os = "macos")]
-    {
-        send_macos_interactive_notification(
-            app,
-            title,
-            body,
-            None,
-            MacNotificationKind::Approval {
-                session_id,
-                request_id,
-            },
-        );
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = send_desktop_notification(title, body, Some(session_id), app);
-    }
+    let _ = request_id;
+    let _ = show_desktop_notification(&app, title, body, "tiangong-approval-requests");
 }
 
 fn ensure_assistant_message(
@@ -230,9 +110,7 @@ fn append_assistant_delta(
     message_id: &str,
     content: &str,
 ) {
-    if content.trim().is_empty()
-        && !session.messages.iter().any(|msg| msg.id == message_id)
-    {
+    if content.trim().is_empty() && !session.messages.iter().any(|msg| msg.id == message_id) {
         return;
     }
     ensure_assistant_message(session, assistant_msg_id, message_id);


### PR DESCRIPTION
## 变更内容

- 优化长会话快照更新，复用未变化的消息对象，减少生成期间历史消息重复渲染。
- 调整消息输入框的 store 订阅粒度，避免流式快照刷新牵连输入输入框重渲染。
- 为消息列表中的回合和 Worker 卡片增加 memo 化，降低超长对话下的渲染压力。
- 移除 macOS 阻塞式交互通知路径，后台完成和审批通知改为普通 Tauri 通知，避免 `wait_for_click(true)` 线程导致 CPU 空转。
- 移除 `tiangong-app` 对 `mac-notification-sys` 的直接依赖。

## 验证

- `timeout 120 yarn build`
- `timeout 180 cargo check --manifest-path src-tauri/Cargo.toml`
- `timeout 60 cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- push hook 已通过 `cargo check --workspace`、`cargo clippy --workspace`、`cargo nextest run --workspace`、`yarn build (frontend)`