### PR TITLE
feat(cli): 添加 tiangong update 在线更新命令

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4459,6 +4459,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "tiangong-cli",

--- a/README.md
+++ b/README.md
@@ -107,6 +107,44 @@ src-tauri/              Tauri 桌面壳
 📨 send_message → @test "认证模块开发完成，已提测"
 ```
 
+## 安装
+
+### 安装发布包
+
+在 GitHub Releases 下载当前系统对应的安装包：
+
+- macOS：下载 `.dmg` 安装包，打开后将「天工」拖入「应用程序」目录。
+- Windows：下载 `.msi` 或 `.exe` 安装包，按安装向导完成安装。
+- Linux：下载 `.AppImage`、`.deb` 或 `.rpm`，按发行版习惯安装或直接运行。
+
+安装后可直接启动桌面应用。macOS 构建暂未接入签名和公证，首次打开时如被系统拦截，需要在「系统设置 → 隐私与安全性」中允许打开。
+
+### 命令行入口
+
+桌面安装包内包含同一个 `tiangong` 入口，可用于 CLI、Server 和更新命令。
+
+macOS 可创建软链接：
+
+```bash
+ln -s /Applications/天工.app/Contents/MacOS/天工 /usr/local/bin/tiangong
+```
+
+Windows 安装后可将安装目录加入 `PATH`。Linux 安装包通常会直接提供可执行入口。
+
+### 在线更新
+
+桌面应用设置页提供版本显示、检查更新和安装更新按钮。也可以通过命令行检查和安装：
+
+```bash
+# 只检查是否有新版本
+tiangong update --check
+
+# 检查、下载并安装更新
+tiangong update
+```
+
+在线更新复用 GitHub Release 的更新元数据和签名校验。只有正式发布且上传了 updater 元数据后，才会检测到可用更新。
+
 ## 运行
 
 ```bash
@@ -120,6 +158,9 @@ cargo run --release -- cli
 cargo run --release -- server
 cargo run --release -- server -d    # 后台运行
 cargo run --release -- server stop  # 停止
+
+# 检查更新（源码运行时只做检查提示）
+cargo run --release -- update --check
 ```
 
 ## 配置

--- a/TODO.md
+++ b/TODO.md
@@ -76,6 +76,7 @@
 - [x] 接入 Tauri updater，通过 GitHub Release 检测和安装新版本
 - [x] 设置界面展示当前版本、检查更新和安装更新按钮
 - [x] 发布流水线注入 updater 签名私钥并生成更新元数据
+- [x] 新增 `tiangong update` 命令，复用 GitHub Release 在线更新链路
 
 ---
 

--- a/crates/tiangong-entry/Cargo.toml
+++ b/crates/tiangong-entry/Cargo.toml
@@ -12,3 +12,5 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+semver = "1"

--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -31,6 +31,18 @@ pub(crate) enum MainCommand {
     Mcp(McpArgs),
     #[command(about = "Skill 配置管理")]
     Skill(SkillArgs),
+    #[command(about = "检查并安装天工更新")]
+    Update(UpdateArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct UpdateArgs {
+    /// 只检查更新，不安装
+    #[arg(long, help = "只检查更新，不安装")]
+    pub(crate) check: bool,
+    /// 更新源地址，默认使用 GitHub Release updater JSON
+    #[arg(long, help = "覆盖更新源地址")]
+    pub(crate) endpoint: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/tiangong-entry/src/lib.rs
+++ b/crates/tiangong-entry/src/lib.rs
@@ -2,6 +2,7 @@ mod args;
 mod mcp;
 mod server;
 mod skill;
+mod update;
 
 use clap::Parser;
 use clap::error::ErrorKind;
@@ -27,6 +28,7 @@ pub fn run() -> anyhow::Result<()> {
         Some(MainCommand::Server(args)) => server::run_server_command(args),
         Some(MainCommand::Mcp(args)) => mcp::run_mcp_command(args),
         Some(MainCommand::Skill(args)) => skill::run_skill_command(args),
+        Some(MainCommand::Update(args)) => update::run_update_command(args),
         Some(MainCommand::Cli { trust_mode }) => {
             tiangong_cli::run_cli_with_trust_mode(trust_mode.map(|m| m.to_trust_mode()))
         }

--- a/crates/tiangong-entry/src/update.rs
+++ b/crates/tiangong-entry/src/update.rs
@@ -1,0 +1,129 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use anyhow::{Context, anyhow};
+use semver::Version;
+use serde::Deserialize;
+
+use crate::args::UpdateArgs;
+
+const DEFAULT_UPDATE_ENDPOINT: &str =
+    "https://github.com/silent-rs/silent-Tiangong/releases/latest/download/latest.json";
+
+#[derive(Debug, Deserialize)]
+struct ReleaseManifest {
+    #[serde(alias = "name")]
+    version: String,
+    #[serde(default)]
+    notes: Option<String>,
+    #[serde(default)]
+    platforms: BTreeMap<String, ReleasePlatform>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleasePlatform {
+    url: String,
+    #[allow(dead_code)]
+    signature: String,
+}
+
+pub(crate) fn run_update_command(args: UpdateArgs) -> anyhow::Result<()> {
+    let endpoint = args
+        .endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_UPDATE_ENDPOINT);
+
+    let Some(manifest) = fetch_release_manifest(endpoint)? else {
+        println!("当前没有可用的在线更新发布。");
+        return Ok(());
+    };
+    let current_version = parse_version(env!("CARGO_PKG_VERSION"))?;
+    let latest_version = parse_version(&manifest.version)?;
+
+    println!("当前版本：{}", current_version);
+    println!("最新版本：{}", latest_version);
+
+    if latest_version <= current_version {
+        println!("当前已是最新版本。");
+        return Ok(());
+    }
+
+    println!("发现新版本：{}", manifest.version.trim());
+    if let Some(notes) = manifest
+        .notes
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        println!("\n更新说明：\n{}", notes.trim());
+    }
+
+    if let Some(platform) = current_platform_key().and_then(|key| manifest.platforms.get(&key)) {
+        println!("\n更新包：{}", platform.url);
+    }
+
+    if args.check {
+        return Ok(());
+    }
+
+    println!("\n当前命令行入口已完成在线更新检查。");
+    println!(
+        "如需自动下载并安装，请使用已安装的桌面应用二进制运行 `tiangong update`，或在桌面应用设置中点击更新。"
+    );
+    Ok(())
+}
+
+fn fetch_release_manifest(endpoint: &str) -> anyhow::Result<Option<ReleaseManifest>> {
+    let response = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent("tiangong-cli-updater")
+        .build()
+        .context("初始化更新客户端失败")?
+        .get(endpoint)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .with_context(|| format!("请求更新源失败：{endpoint}"))?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !response.status().is_success() {
+        return Err(anyhow!("更新源返回异常状态：{}", response.status()));
+    }
+
+    response.json().map(Some).context("解析更新信息失败")
+}
+
+fn parse_version(raw: &str) -> anyhow::Result<Version> {
+    let value = raw.trim().trim_start_matches('v');
+    Version::parse(value).with_context(|| format!("版本号格式无效：{raw}"))
+}
+
+fn current_platform_key() -> Option<String> {
+    let os = if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "macos") {
+        "darwin"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        return None;
+    };
+
+    let arch = if cfg!(target_arch = "x86") {
+        "i686"
+    } else if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else if cfg!(target_arch = "arm") {
+        "armv7"
+    } else if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else if cfg!(target_arch = "riscv64") {
+        "riscv64"
+    } else {
+        return None;
+    };
+
+    Some(format!("{os}-{arch}"))
+}

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -32,6 +32,7 @@
 - 手动触发发布时必须默认创建草稿 Release，便于发布前检查安装包。
 - 应用必须通过 GitHub Release 的 updater JSON 检测新版本并执行应用内更新。
 - 设置界面必须展示当前应用版本，并提供检查更新与安装更新入口。
+- `tiangong update` 必须复用同一 GitHub Release 在线更新链路；桌面打包二进制应支持命令行触发检查、下载和安装更新。
 - 更新包必须使用 Tauri updater 签名校验，私钥只能通过 GitHub Secrets 注入发布流水线。
 
 #### 模型配置

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6369,6 +6369,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "tiangong-cli",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,6 +19,11 @@ fn init_logging(terminal_output: bool) -> anyhow::Result<tiangong_config::loggin
 }
 
 fn main() {
+    if should_run_cli_update() {
+        run_cli_update();
+        return;
+    }
+
     // 无参数 → GUI
     if std::env::args().len() <= 1 {
         run_gui();
@@ -33,6 +38,174 @@ fn main() {
         eprintln!("错误：{err}");
         std::process::exit(1);
     }
+}
+
+fn should_run_cli_update() -> bool {
+    let mut args = std::env::args().skip(1);
+    let Some(command) = args.next() else {
+        return false;
+    };
+    if command != "update" {
+        return false;
+    }
+    !args.any(|arg| arg == "-h" || arg == "--help")
+}
+
+fn run_cli_update() {
+    let _guard = init_logging(false).expect("failed to initialize logging");
+    let options = match parse_cli_update_options() {
+        Ok(options) => options,
+        Err(err) => {
+            eprintln!("错误：{err}");
+            std::process::exit(1);
+        }
+    };
+
+    tauri::Builder::default()
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .setup(move |app| {
+            use tauri::Manager;
+
+            for (_, window) in app.webview_windows() {
+                let _ = window.hide();
+            }
+
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                match run_cli_update_async(handle.clone(), options).await {
+                    Ok(CliUpdateOutcome::Done) => handle.exit(0),
+                    Ok(CliUpdateOutcome::RestartRequested) => {}
+                    Err(err) => {
+                        eprintln!("错误：{err}");
+                        handle.exit(1);
+                    }
+                }
+            });
+            Ok(())
+        })
+        .run(generate_tauri_context())
+        .expect("error while running updater");
+
+    drop(_guard);
+}
+
+#[derive(Debug)]
+struct CliUpdateOptions {
+    check_only: bool,
+    endpoint: Option<String>,
+}
+
+fn parse_cli_update_options() -> anyhow::Result<CliUpdateOptions> {
+    let mut check_only = false;
+    let mut endpoint = None;
+    let mut args = std::env::args().skip(2);
+    while let Some(arg) = args.next() {
+        if arg == "--check" {
+            check_only = true;
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--endpoint=") {
+            endpoint = Some(non_empty_update_endpoint(value)?);
+            continue;
+        }
+        if arg == "--endpoint" {
+            let value = args
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("--endpoint 缺少地址"))?;
+            endpoint = Some(non_empty_update_endpoint(&value)?);
+            continue;
+        }
+        return Err(anyhow::anyhow!("不支持的 update 参数：{arg}"));
+    }
+
+    Ok(CliUpdateOptions {
+        check_only,
+        endpoint,
+    })
+}
+
+fn non_empty_update_endpoint(value: &str) -> anyhow::Result<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(anyhow::anyhow!("--endpoint 不能为空"));
+    }
+    Ok(value.to_string())
+}
+
+enum CliUpdateOutcome {
+    Done,
+    RestartRequested,
+}
+
+async fn run_cli_update_async(
+    app: tauri::AppHandle,
+    options: CliUpdateOptions,
+) -> anyhow::Result<CliUpdateOutcome> {
+    use std::io::Write;
+
+    use tauri_plugin_updater::UpdaterExt;
+
+    let updater = if let Some(endpoint) = options.endpoint.as_deref() {
+        let endpoint = reqwest::Url::parse(endpoint)?;
+        app.updater_builder()
+            .endpoints(vec![endpoint])?
+            .build()?
+    } else {
+        app.updater()?
+    };
+    let update = match updater.check().await {
+        Ok(update) => update,
+        Err(tauri_plugin_updater::Error::ReleaseNotFound) => {
+            println!("当前没有可用的在线更新发布。");
+            return Ok(CliUpdateOutcome::Done);
+        }
+        Err(err) => return Err(err.into()),
+    };
+    let Some(update) = update else {
+        println!("当前已是最新版本。");
+        return Ok(CliUpdateOutcome::Done);
+    };
+
+    println!(
+        "发现新版本：{} -> {}",
+        update.current_version, update.version
+    );
+    if let Some(date) = update.date {
+        println!("发布时间：{date}");
+    }
+    if let Some(body) = update.body.as_deref().filter(|value| !value.trim().is_empty()) {
+        println!("\n更新说明：\n{}", body.trim());
+    }
+
+    if options.check_only {
+        return Ok(CliUpdateOutcome::Done);
+    }
+
+    println!("\n开始下载并安装更新...");
+    let mut downloaded = 0u64;
+    let mut last_percent = 0u64;
+    update
+        .download_and_install(
+            |chunk_len, content_len| {
+                downloaded = downloaded.saturating_add(chunk_len as u64);
+                if let Some(total) = content_len.filter(|value| *value > 0) {
+                    let percent = downloaded.saturating_mul(100) / total;
+                    if percent >= last_percent.saturating_add(10) || percent == 100 {
+                        last_percent = percent;
+                        print!("\r下载进度：{percent}%");
+                        let _ = std::io::stdout().flush();
+                    }
+                }
+            },
+            || {
+                println!("\n下载完成，正在安装...");
+            },
+        )
+        .await?;
+
+    println!("更新已安装，正在重启应用...");
+    app.request_restart();
+    Ok(CliUpdateOutcome::RestartRequested)
 }
 
 fn run_gui() {
@@ -127,8 +300,12 @@ fn run_gui() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .run(tauri::generate_context!())
+        .run(generate_tauri_context())
         .expect("error while running tauri application");
 
     drop(_guard);
+}
+
+fn generate_tauri_context() -> tauri::Context<tauri::Wry> {
+    tauri::generate_context!()
 }


### PR DESCRIPTION
## 变更内容
- 新增 `tiangong update` 命令，复用 GitHub Release updater JSON 检查版本。
- 桌面打包二进制运行 `tiangong update` 时，通过 Tauri updater 执行检查、下载、安装和重启。
- 支持 `--check` 只检查更新，支持 `--endpoint` 覆盖更新源。
- README 补充发布包安装、命令行入口和在线更新说明。

## 发布准备
- 当前应用版本为 `0.1.0`。
- 当前仓库尚无 `v*` 标签，PR 合并后可创建 `v0.1.0` 标签触发首个正式发布。
- 发布 workflow 会构建 macOS、Windows、Linux 安装包，并上传 updater 元数据。

## 验证
- `cargo fmt -- --check`
- `cargo check --workspace`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --workspace --all-targets --tests --benches -- -D warnings`
- `cargo run -p tiangong -- update --check`
- `cargo run --manifest-path src-tauri/Cargo.toml -- update --check`