### PR TITLE
fix(core): 改进 loop 失败恢复策略

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 全功能可扩展的 GUI + CLI + Server 个人智能终端平台
 
-Silent-Tiangong 是一个实现"可对话、可规划、可执行、可扩展、可治理、可远程"的 Agent 能力闭环的个人 AI 中枢。支持多智能体团队协作、通过 Connector 接入各类 IM 通道远程调度，并具备图片/视频等多媒体生成能力。
+Silent-Tiangong 是一个实现"可对话、可规划、可执行、可扩展、可治理、可远程"的 Agent 能力闭环的个人 AI 中枢。支持多智能体团队协作、通过 Server API 对接各类 IM 通道远程调度，并具备图片/视频等多媒体生成能力。
 
 ## 核心能力
 
@@ -14,7 +14,7 @@ Silent-Tiangong 是一个实现"可对话、可规划、可执行、可扩展、
 - **Skill 管理** — Skill 安装、启停、卸载，按任务意图自动匹配
 - **长期记忆** — 基于 SQLite + Tantivy + 向量索引的持久化记忆系统，支持跨会话回忆
 - **多媒体生成** — 图片生成（DALL-E）、视频生成（火山方舟）、语音合成/识别（TTS/STT）
-- **多通道接入** — Telegram、Discord、飞书/Lark、Webhook Connector
+- **多通道接入** — 通过 Server API + 外部适配程序对接 Telegram、Discord、飞书/Lark 等 IM 通道
 - **权限管理** — 监督模式（高风险操作审批）/ 信任模式（全自动执行），实时切换
 
 ## 多智能体协作
@@ -61,7 +61,6 @@ crates/
   tiangong-cli/         CLI/TUI 前端（ratatui）
   tiangong-entry/       统一入口与命令路由
   tiangong-server/      HTTP REST + WebSocket Server
-  tiangong-connector/   IM 通道适配（Telegram/Discord/Lark/Webhook）
   tiangong-media/       多媒体生成（图片/视频/语音）
 frontend/               桌面 GUI（React + shadcn/ui）
 src-tauri/              Tauri 桌面壳
@@ -174,6 +173,7 @@ cargo run --release -- update --check
   skills.json           Skill 配置
   mcp.json              MCP 配置
   sessions/             会话持久化
+  logs/                 运行日志（含 Server 后台日志）
   media/                生成的媒体文件
   memory/               长期记忆数据（SQLite + Tantivy 索引）
 ```
@@ -192,8 +192,6 @@ cargo run --release -- update --check
 | LLM 协议 | async-openai（OpenAI 兼容）、tiangong-anthropic（Anthropic） |
 | MCP | rmcp |
 | 记忆存储 | rusqlite（SQLCipher）、tantivy（全文检索）、qdrant（向量索引） |
-| Telegram | teloxide |
-| Discord | serenity |
 | 序列化 | serde / serde_json |
 | ID 生成 | scru128 |
 

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -363,6 +363,8 @@ impl ReactEngine {
         let mut memory_context: Option<String> = None;
         let mut memory_recall_attempted = false;
         let mut successful_tool_call_keys = HashSet::new();
+        let mut failed_tool_call_keys = HashSet::new();
+        let mut failed_tool_names = HashSet::new();
         let mut memory_candidate_count = 0usize;
 
         if self.agent_id == "main" {
@@ -409,6 +411,8 @@ impl ReactEngine {
                     memory_context = None;
                     memory_recall_attempted = false;
                     successful_tool_call_keys.clear();
+                    failed_tool_call_keys.clear();
+                    failed_tool_names.clear();
                     memory_candidate_count = 0;
                 }
                 PendingCommandEffect::None => {}
@@ -559,6 +563,27 @@ impl ReactEngine {
                     continue;
                 }
 
+                // 有 reasoning 但无 tool_calls 且回复为空或简短时，明确提醒模型补全决策。
+                // 若确实不需要工具，下一轮应直接给出最终回复；若需要操作，应返回 tool_calls。
+                if !response.reasoning_content.trim().is_empty()
+                    && response.text.trim().chars().count() <= 100
+                    && round < self.max_rounds
+                {
+                    let previous_text = response.text.trim();
+                    let previous_text_block = if previous_text.is_empty() {
+                        "上一轮 assistant 回复为空。".to_string()
+                    } else {
+                        format!("上一轮 assistant 短回复：\n{previous_text}")
+                    };
+                    loop_context.push(Message::new(
+                        MessageRole::Tool,
+                        format!(
+                            "<system-reminder>\n{previous_text_block}\n上一轮包含 thinking，但没有返回可执行 tool_calls。请重新判断：如果仍需要执行操作，直接返回正确的 tool_calls；如果不需要执行操作，直接给出最终回复。\n</system-reminder>"
+                        ),
+                    ));
+                    continue 'react_loop;
+                }
+
                 session.append_message_with_id_and_media(
                     pending_msg_id,
                     MessageRole::Assistant,
@@ -593,6 +618,8 @@ impl ReactEngine {
                     memory_context = None;
                     memory_recall_attempted = false;
                     successful_tool_call_keys.clear();
+                    failed_tool_call_keys.clear();
+                    failed_tool_names.clear();
                     memory_candidate_count = 0;
                     continue 'react_loop;
                 }
@@ -648,6 +675,7 @@ impl ReactEngine {
             );
 
             // 执行工具
+            let mut need_failure_recovery_prompt = false;
             for call in executable_calls {
                 match drain_pending_commands_async(
                     session,
@@ -661,6 +689,8 @@ impl ReactEngine {
                         memory_context = None;
                         memory_recall_attempted = false;
                         successful_tool_call_keys.clear();
+                        failed_tool_call_keys.clear();
+                        failed_tool_names.clear();
                         session.persist_to_disk();
                         continue 'react_loop;
                     }
@@ -727,6 +757,12 @@ impl ReactEngine {
                 let tool_call_key = tool_call_dedupe_key(&call.name, &call.arguments);
                 if successful_tool_call_keys.contains(&tool_call_key) {
                     append_duplicate_tool_result(session, stream_tx, &call.id, &call.name);
+                    continue;
+                }
+                if failed_tool_call_keys.contains(&tool_call_key) {
+                    append_repeated_failed_tool_result(session, stream_tx, &call.id, &call.name);
+                    failed_tool_names.insert(call.name.clone());
+                    need_failure_recovery_prompt = true;
                     continue;
                 }
 
@@ -1018,6 +1054,8 @@ impl ReactEngine {
                 }
 
                 if result.ok {
+                    failed_tool_call_keys.remove(&tool_call_key);
+                    failed_tool_names.remove(&call.name);
                     successful_tool_call_keys.insert(tool_call_key);
                     pending_media_assets.extend(
                         crate::memory::turn_result::parse_media_assets_from_tool_result(
@@ -1026,6 +1064,10 @@ impl ReactEngine {
                             &result.summary,
                         ),
                     );
+                } else {
+                    failed_tool_call_keys.insert(tool_call_key);
+                    failed_tool_names.insert(call.name.clone());
+                    need_failure_recovery_prompt = true;
                 }
 
                 // 记忆候选评估
@@ -1080,12 +1122,48 @@ impl ReactEngine {
                         memory_context = None;
                         memory_recall_attempted = false;
                         successful_tool_call_keys.clear();
+                        failed_tool_call_keys.clear();
+                        failed_tool_names.clear();
                         memory_candidate_count = 0;
                         session.persist_to_disk();
                         continue 'react_loop;
                     }
                     PendingCommandEffect::None => {}
                 }
+            }
+
+            if need_failure_recovery_prompt {
+                let mut failed_tools = failed_tool_names.iter().cloned().collect::<Vec<_>>();
+                failed_tools.sort();
+                let collaboration_hint = if self.agent_id == "main"
+                    && request_tools.iter().any(|tool| tool.name == "create_agent")
+                {
+                    "如果问题适合并行排查或需要第二视角，请创建 temporary Sub Agent 协作处理，并把失败工具、失败原因、已尝试方案和用户目标一并分配给它。"
+                } else {
+                    "如果当前 Agent 无法继续独立推进，请向用户说明需要的外部条件、凭据、授权、环境调整或人工确认。"
+                };
+                let recall_hint = if request_tools
+                    .iter()
+                    .any(|tool| tool.name == "recall_memory")
+                {
+                    memory_recall_attempted = false;
+                    "优先调用 recall_memory，充分使用 Memory 系统查询这个工具以前成功调用时使用的参数、环境前置条件、配置方式、替代步骤和相关经验；只有回忆不足以解决时，再切换工具、创建子 Agent 或请求用户协作。"
+                } else {
+                    ""
+                };
+                let mut reminder = Message::new(
+                    MessageRole::Tool,
+                    format!(
+                        "<system-reminder>\n以下工具调用在本轮出现失败，暂时不要重复调用相同工具和相同参数：\n{}\n请重新规划：{}{}\n</system-reminder>",
+                        failed_tools.join("\n"),
+                        recall_hint,
+                        collaboration_hint
+                    ),
+                );
+                reminder.tool_name = Some("react_failed_tool_recovery".to_string());
+                loop_context.push(reminder);
+                session.persist_to_disk();
+                continue 'react_loop;
             }
 
             // 执行有待处理任务的 Sub Agent

--- a/crates/tiangong-core/src/react/message.rs
+++ b/crates/tiangong-core/src/react/message.rs
@@ -214,6 +214,30 @@ pub(crate) fn append_duplicate_tool_result(
     );
 }
 
+pub(crate) fn append_repeated_failed_tool_result(
+    session: &mut Session,
+    stream_tx: &StdSender<StreamEvent>,
+    tool_call_id: &str,
+    tool_name: &str,
+) {
+    let message = format!(
+        "本轮已经执行过完全相同的 {tool_name} 工具调用且执行失败，系统已跳过重复执行。请不要继续重复相同工具和参数；请切换到其他可行方式，或在缺少外部条件时请求用户协作。"
+    );
+    let _ = stream_tx.send(StreamEvent::ToolResult {
+        name: tool_name.to_string(),
+        tool_call_id: Some(tool_call_id.to_string()),
+        ok: false,
+        output: message.clone(),
+        full_output: Some(message.clone()),
+    });
+    append_tool_result_message(session, tool_call_id, tool_name, message.clone(), true);
+    append_runtime_tool_message(
+        session,
+        tool_name,
+        format!("跳过重复失败工具调用 [{tool_name}]\n{message}"),
+    );
+}
+
 pub(crate) fn is_media_tool_name(tool_name: &str) -> bool {
     matches!(
         tool_name,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2937,6 +2937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -3516,6 +3517,28 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"


### PR DESCRIPTION
## 变更内容
- 遇到有 thinking 但无 tool_calls 的短回复时，注入运行时提醒让模型重新决策。
- 工具调用失败后跳过完全相同的失败调用，避免原地重复执行。
- 失败恢复时优先引导模型使用 Memory 回忆历史成功调用方式，再考虑换方案、创建临时子 Agent 或请求用户协作。

## 验证
- cargo fmt -- --check
- cargo check --workspace
- push hooks: cargo check、cargo clippy、cargo nextest