### PR TITLE
fix(core): 使用 lite 模型检测 React 循环端回复

### DIFF
--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -101,6 +101,62 @@ pub(crate) fn select_client_for_request<'a>(
     engine.client()
 }
 
+const COMPLETION_CHECK_SYSTEM_PROMPT: &str = "\
+你是一个任务完成度判断器。你需要判断 AI 助手是否已经充分完成了用户的请求。
+
+判断标准（偏向判定为已完成）：
+- 助手是否给出了实质性的回复内容（代码改动说明、执行结果、分析结论等）
+- 如果助手回复了具体的操作结果（如编译通过、文件已修改、命令已执行），应判定为已完成
+- 只有当回复明显空洞（如只有\"好的\"\"让我来\"等过渡语）或用户请求明显需要操作但助手未执行任何工具时，才判定为未完成
+
+回复规则：
+- 已完成：COMPLETE
+- 未完成：INCOMPLETE
+- 只回复一个词，不要添加任何其他文字";
+
+/// 使用 lite 模型判断当前回复是否真正完成了任务。
+/// 返回 `true` 表示任务已完成，`false` 表示需要继续 react 循环。
+/// 如果 lite 模型调用失败，降级返回 `true`（直接结束，不影响原有流程）。
+pub(crate) async fn check_completion_with_lite_model(
+    engine: &RuntimeEngine,
+    user_input: &str,
+    assistant_response: &str,
+) -> bool {
+    if assistant_response.trim().is_empty() {
+        return false;
+    }
+
+    let lite = engine.lite_client().clone();
+    let system_prompt = COMPLETION_CHECK_SYSTEM_PROMPT.to_string();
+    let user_prompt = format_completion_check_prompt(user_input, assistant_response);
+
+    let result = tokio::task::spawn_blocking(move || {
+        lite.complete_lite_with_system(&system_prompt, &user_prompt)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(response_text)) => parse_completion_response(&response_text),
+        _ => {
+            tracing::warn!("lite 模型完成度检测失败，降级为直接结束");
+            true
+        }
+    }
+}
+
+fn format_completion_check_prompt(user_input: &str, assistant_response: &str) -> String {
+    format!(
+        "用户原始请求：\n{user_input}\n\n\
+         AI 助手的最新回复：\n{assistant_response}\n\n\
+         请判断：AI 助手是否已经充分完成了用户的请求？"
+    )
+}
+
+fn parse_completion_response(response: &str) -> bool {
+    let trimmed = response.trim().to_uppercase();
+    trimmed.contains("COMPLETE") && !trimmed.contains("INCOMPLETE")
+}
+
 pub(crate) fn loop_context_with_memory(
     loop_context: &[Message],
     memory_context: Option<&str>,

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -22,8 +22,8 @@ use crate::permission::{
 };
 use crate::prompt::PromptAssembler;
 use crate::react::context::{
-    emit_token_usage, force_final_response, loop_context_with_memory, maybe_update_context_summary,
-    select_client_for_request,
+    check_completion_with_lite_model, emit_token_usage, force_final_response,
+    loop_context_with_memory, maybe_update_context_summary, select_client_for_request,
 };
 use crate::react::message::*;
 use crate::runtime::LlmOutputRecord;
@@ -351,7 +351,7 @@ impl ReactEngine {
     pub(crate) async fn execute_turn(
         &mut self,
         session: &mut Session,
-        _user_input: &str,
+        user_input: &str,
         stream_tx: &StdSender<StreamEvent>,
         cmd_rx: &mut tokio_mpsc::UnboundedReceiver<Command>,
         memory_handle: Option<&tiangong_memory::MemoryHandle>,
@@ -366,6 +366,7 @@ impl ReactEngine {
         let mut failed_tool_call_keys = HashSet::new();
         let mut failed_tool_names = HashSet::new();
         let mut memory_candidate_count = 0usize;
+        let mut completion_check_count: u32 = 0;
 
         if self.agent_id == "main" {
             let routed = self
@@ -374,9 +375,7 @@ impl ReactEngine {
                 .and_then(|team| {
                     team.lock().ok().map(|mut team| {
                         crate::agent_team::lifecycle::route_user_mentions(
-                            &mut team,
-                            _user_input,
-                            stream_tx,
+                            &mut team, user_input, stream_tx,
                         )
                     })
                 })
@@ -563,25 +562,39 @@ impl ReactEngine {
                     continue;
                 }
 
-                // 有 reasoning 但无 tool_calls 且回复为空或简短时，明确提醒模型补全决策。
-                // 若确实不需要工具，下一轮应直接给出最终回复；若需要操作，应返回 tool_calls。
-                if !response.reasoning_content.trim().is_empty()
-                    && response.text.trim().chars().count() <= 100
-                    && round < self.max_rounds
-                {
-                    let previous_text = response.text.trim();
-                    let previous_text_block = if previous_text.is_empty() {
-                        "上一轮 assistant 回复为空。".to_string()
-                    } else {
-                        format!("上一轮 assistant 短回复：\n{previous_text}")
-                    };
-                    loop_context.push(Message::new(
-                        MessageRole::Tool,
-                        format!(
-                            "<system-reminder>\n{previous_text_block}\n上一轮包含 thinking，但没有返回可执行 tool_calls。请重新判断：如果仍需要执行操作，直接返回正确的 tool_calls；如果不需要执行操作，直接给出最终回复。\n</system-reminder>"
-                        ),
-                    ));
-                    continue 'react_loop;
+                // lite 模型完成度检测：判断回复是否真正完成了任务
+                if round < self.max_rounds && completion_check_count < 2 {
+                    completion_check_count += 1;
+                    let is_complete =
+                        check_completion_with_lite_model(&self.engine, user_input, &response.text)
+                            .await;
+
+                    if !is_complete {
+                        // 将已流式输出的回复保存到 session，避免上下文丢失
+                        session.append_message_with_id_and_media(
+                            pending_msg_id.clone(),
+                            MessageRole::Assistant,
+                            response.text.clone(),
+                            response.reasoning_content.clone(),
+                            std::mem::take(&mut pending_media_assets),
+                        );
+                        if let Some(message) = session.messages.last_mut() {
+                            message.reasoning_signature = response.reasoning_signature.clone();
+                        }
+                        // 加入 loop_context 使下一轮模型看到已输出内容
+                        loop_context
+                            .push(Message::new(MessageRole::Assistant, response.text.clone()));
+                        loop_context.push(Message::new(
+                            MessageRole::Tool,
+                            format!(
+                                "<system-reminder>\n上方回复被判定为未完成任务。\
+                                不要重复上方已说过的内容。\
+                                如果需要执行操作，直接返回 tool_calls；\
+                                如果确实无需更多操作，简要补充未覆盖的要点即可。\n</system-reminder>"
+                            ),
+                        ));
+                        continue 'react_loop;
+                    }
                 }
 
                 session.append_message_with_id_and_media(

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -586,12 +586,11 @@ impl ReactEngine {
                             .push(Message::new(MessageRole::Assistant, response.text.clone()));
                         loop_context.push(Message::new(
                             MessageRole::Tool,
-                            format!(
-                                "<system-reminder>\n上方回复被判定为未完成任务。\
+                            "<system-reminder>\n上方回复被判定为未完成任务。\
                                 不要重复上方已说过的内容。\
                                 如果需要执行操作，直接返回 tool_calls；\
                                 如果确实无需更多操作，简要补充未覆盖的要点即可。\n</system-reminder>"
-                            ),
+                                .to_string(),
                         ));
                         continue 'react_loop;
                     }


### PR DESCRIPTION
## Summary
- 去除基于 reasoning + 短文本判断的简易修复（无效）
- 改为在模型返回无 tool_calls 的回复时，使用 lite 模型判断任务是否真正完成
- 未完成时保存当前回复到 session 并注入提醒继续循环，已完成则正常结束
- 最多检测 2 次，防止无限弹跳

## Test plan
- [x] 测试需要多步骤的任务（如"分析 react 模块代码结构"），确认不会出现端回复
- [x] 测试简单问答（如"你好"），确认不会误判为未完成导致重复输出
- [x] 验证 lite 模型调用失败时降级正常