### PR TITLE
fix(server): 多模态媒体管道修复与会话文件丢失问题

### DIFF
--- a/crates/tiangong-core/src/app_state/repository/persist.rs
+++ b/crates/tiangong-core/src/app_state/repository/persist.rs
@@ -58,17 +58,9 @@ impl AppRepository {
             session_ids_set.insert(session.id.clone());
         }
 
-        for session_id in self.list_session_ids_from_dir()? {
-            if session_ids_set.contains(&session_id) {
-                continue;
-            }
-
-            let stale_path = session_storage_path(&self.paths.sessions_dir_path, &session_id);
-            if stale_path.exists() {
-                fs::remove_file(&stale_path)
-                    .with_context(|| format!("删除废弃会话文件失败：{}", stale_path.display()))?;
-            }
-        }
+        // 不再删除不在内存中的会话文件：多进程（桌面端 / server）共享同一数据目录，
+        // 每个进程只持有自己加载到内存的会话子集，删除"未知"文件会导致其他进程创建的会话丢失。
+        // 会话文件的清理由 delete_active_session 显式执行。
 
         let mut app_agent_config = store.agent.agent_config.clone();
         app_agent_config.skills.installed.clear();

--- a/crates/tiangong-core/src/app_state/tests/repository.rs
+++ b/crates/tiangong-core/src/app_state/tests/repository.rs
@@ -85,6 +85,14 @@ fn load_from_disk_prefers_most_recent_session_when_app_storage_missing() -> Resu
     with_isolated_state(
         "tiangong-repository-recover-latest-without-app",
         |paths, state| {
+            // 清除 load_or_default 创建的默认会话文件
+            let sessions_dir = paths.fake_home.join(".tiangong").join("sessions");
+            if sessions_dir.exists() {
+                for entry in fs::read_dir(&sessions_dir)? {
+                    fs::remove_file(entry?.path())?;
+                }
+            }
+
             state.store.session.sessions.clear();
 
             let mut older = Session::new("较早会话");
@@ -119,6 +127,14 @@ fn load_from_disk_prefers_most_recent_session_when_active_session_is_invalid() -
     with_isolated_state(
         "tiangong-repository-recover-latest-invalid-active",
         |paths, state| {
+            // 清除 load_or_default 创建的默认会话文件
+            let sessions_dir = paths.fake_home.join(".tiangong").join("sessions");
+            if sessions_dir.exists() {
+                for entry in fs::read_dir(&sessions_dir)? {
+                    fs::remove_file(entry?.path())?;
+                }
+            }
+
             state.store.session.sessions.clear();
 
             let mut older = Session::new("较早会话");
@@ -157,7 +173,15 @@ fn load_from_disk_prefers_most_recent_session_when_active_session_is_invalid() -
 fn load_from_disk_filters_child_sessions_from_session_list_state() -> Result<()> {
     with_isolated_state(
         "tiangong-repository-filter-child-sessions",
-        |_paths, state| {
+        |paths, state| {
+            // 清除 load_or_default 创建的默认会话文件
+            let sessions_dir = paths.fake_home.join(".tiangong").join("sessions");
+            if sessions_dir.exists() {
+                for entry in fs::read_dir(&sessions_dir)? {
+                    fs::remove_file(entry?.path())?;
+                }
+            }
+
             state.store.session.sessions.clear();
 
             let mut parent = Session::new("主会话");

--- a/crates/tiangong-server/src/api/chat.rs
+++ b/crates/tiangong-server/src/api/chat.rs
@@ -38,6 +38,7 @@ pub async fn chat(mut req: Request) -> Result<Response> {
             sender_id: "http-client".to_string(),
             sender_role: access.role,
             content: MessageContent::Text(body.message),
+            media: Vec::new(),
             reply_to: None,
             timestamp: now_text(),
         })

--- a/crates/tiangong-server/src/api/messages.rs
+++ b/crates/tiangong-server/src/api/messages.rs
@@ -32,6 +32,7 @@ pub async fn post_message(mut req: Request) -> Result<Response> {
     }
 
     let content = resolve_content(body.message, body.content)?;
+    let media = body.media;
     let (session_id, outgoing) = app
         .router
         .handle_incoming_with_session(IncomingMessage {
@@ -47,6 +48,7 @@ pub async fn post_message(mut req: Request) -> Result<Response> {
                 .unwrap_or_else(|| "external-user".to_string()),
             sender_role: access.role,
             content: content.into(),
+            media,
             reply_to: body.reply_to,
             timestamp: now_text(),
         })

--- a/crates/tiangong-server/src/api/types.rs
+++ b/crates/tiangong-server/src/api/types.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tiangong_types::MessageContent;
+use tiangong_types::{MediaAsset, MessageContent};
 
 /// POST /api/v1/chat 请求体
 #[derive(Debug, Deserialize)]
@@ -37,6 +37,9 @@ pub struct ConnectorMessageRequest {
     /// 结构化消息内容
     #[serde(default)]
     pub content: Option<ApiMessageContent>,
+    /// 附加媒体资源（图片、视频等）
+    #[serde(default)]
+    pub media: Vec<MediaAsset>,
     #[serde(default)]
     pub reply_to: Option<String>,
 }

--- a/crates/tiangong-server/src/api/ws.rs
+++ b/crates/tiangong-server/src/api/ws.rs
@@ -153,6 +153,7 @@ async fn on_receive(msg: Message, parts: Arc<RwLock<WebSocketParts>>) -> Result<
                 sender_id: "ws-client".to_string(),
                 sender_role: access.role,
                 content: MessageContent::Text(request.message),
+                media: Vec::new(),
                 reply_to: None,
                 timestamp: now_text(),
             };

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -40,17 +40,22 @@ impl ServerCoreManager {
         connector: &str,
         channel_id: &str,
         content: String,
+        message_id: Option<String>,
+        media: Vec<MediaAsset>,
     ) -> Result<(String, OutgoingMessage)> {
         let session_id = self
             .resolve_connector_session_id(connector, channel_id)
             .await?;
-        self.send_message_and_wait(&session_id, content).await
+        self.send_message_and_wait(&session_id, content, message_id, media)
+            .await
     }
 
     pub async fn send_message_and_wait(
         &self,
         requested_session_id: &str,
         content: String,
+        message_id: Option<String>,
+        media: Vec<MediaAsset>,
     ) -> Result<(String, OutgoingMessage)> {
         let (session_id, session, created) = self.ensure_core(requested_session_id).await?;
         if created {
@@ -65,7 +70,8 @@ impl ServerCoreManager {
             let Some(core) = cores.get(&session_id) else {
                 return Err(anyhow!("会话 core 不存在：{session_id}"));
             };
-            core.send_message(content);
+            let msg_id = message_id.unwrap_or_else(|| scru128::new().to_string());
+            core.send_message_with_id(content, msg_id, media);
         }
 
         let tracker_for_wait = tracker.clone();

--- a/crates/tiangong-server/src/remote/router.rs
+++ b/crates/tiangong-server/src/remote/router.rs
@@ -7,7 +7,7 @@ use tiangong_core::session::MessageRole;
 use tiangong_core::task::TaskNotification;
 use tiangong_media::agent::MediaAgent;
 use tiangong_media::stt::TranscribeRequest;
-use tiangong_types::{IncomingMessage, MessageContent, OutgoingMessage};
+use tiangong_types::{IncomingMessage, MediaAsset, MediaKind, MessageContent, OutgoingMessage};
 use tokio::sync::Mutex;
 
 use super::core::ServerCoreManager;
@@ -66,6 +66,7 @@ impl MessageRouter {
             .publish(TiangongEvent::MessageReceived(msg.clone()));
 
         let text = self.extract_text(&msg).await;
+        let media = extract_media(&msg);
         let channel_id = if msg.channel_id.trim().is_empty() {
             let state = self.state.lock().await;
             state.active_session_id().to_string()
@@ -85,7 +86,12 @@ impl MessageRouter {
         );
 
         let Some(outgoing) = self
-            .handle_runtime_event_with_reply(event, Some(msg.id.clone()))
+            .handle_runtime_event_with_reply(
+                event,
+                Some(msg.id.clone()),
+                Some(msg.id.clone()),
+                media,
+            )
             .await?
         else {
             return Ok((
@@ -105,7 +111,7 @@ impl MessageRouter {
         event: RuntimeEvent,
     ) -> Result<Option<OutgoingMessage>> {
         Ok(self
-            .handle_runtime_event_with_reply(event, None)
+            .handle_runtime_event_with_reply(event, None, None, Vec::new())
             .await?
             .map(|(_, outgoing)| outgoing))
     }
@@ -209,6 +215,8 @@ impl MessageRouter {
         &self,
         event: RuntimeEvent,
         reply_to: Option<String>,
+        message_id: Option<String>,
+        media: Vec<MediaAsset>,
     ) -> Result<Option<(String, OutgoingMessage)>> {
         match event.event_type {
             RuntimeEventType::UserMessage => {
@@ -225,13 +233,19 @@ impl MessageRouter {
                     .map(str::trim)
                     .unwrap_or_default()
                     .to_string();
-                if text.is_empty() {
+                if text.is_empty() && media.is_empty() {
                     return Ok(None);
                 }
 
                 let (actual_session_id, mut outgoing) = self
                     .core_manager
-                    .send_connector_message_and_wait(connector, &requested_session_id, text)
+                    .send_connector_message_and_wait(
+                        connector,
+                        &requested_session_id,
+                        text,
+                        message_id,
+                        media,
+                    )
                     .await?;
                 outgoing.reply_to = reply_to;
                 self.event_bus.publish(TiangongEvent::MessageSent {
@@ -316,4 +330,46 @@ async fn download_url(url: &str) -> Result<Vec<u8>> {
     let response = reqwest::get(url).await?;
     let bytes = response.bytes().await?;
     Ok(bytes.to_vec())
+}
+
+fn extract_media(msg: &IncomingMessage) -> Vec<MediaAsset> {
+    let mut media = msg.media.clone();
+    if media.is_empty() {
+        media = content_to_media(&msg.content);
+    }
+    media
+}
+
+fn content_to_media(content: &MessageContent) -> Vec<MediaAsset> {
+    match content {
+        MessageContent::Image { url, caption } => vec![MediaAsset {
+            kind: MediaKind::Image,
+            url: url.clone(),
+            mime_type: None,
+            title: caption.clone(),
+            capability: None,
+        }],
+        MessageContent::Video { url, caption } => vec![MediaAsset {
+            kind: MediaKind::Video,
+            url: url.clone(),
+            mime_type: None,
+            title: caption.clone(),
+            capability: None,
+        }],
+        MessageContent::Audio { url, .. } => vec![MediaAsset {
+            kind: MediaKind::Audio,
+            url: url.clone(),
+            mime_type: None,
+            title: None,
+            capability: None,
+        }],
+        MessageContent::File { url, name } => vec![MediaAsset {
+            kind: MediaKind::File,
+            url: url.clone(),
+            mime_type: None,
+            title: Some(name.clone()),
+            capability: None,
+        }],
+        MessageContent::Text(_) => Vec::new(),
+    }
 }

--- a/crates/tiangong-types/src/remote.rs
+++ b/crates/tiangong-types/src/remote.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::message::MediaAsset;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RemoteRole {
@@ -48,6 +50,8 @@ pub struct IncomingMessage {
     #[serde(default)]
     pub sender_role: RemoteRole,
     pub content: MessageContent,
+    #[serde(default)]
+    pub media: Vec<MediaAsset>,
     pub reply_to: Option<String>,
     pub timestamp: String,
 }

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -1,0 +1,626 @@
+# 天工 Server API 对接文档
+
+## 概述
+
+天工 Server 提供基于 HTTP + WebSocket 的 API，支持外部 Bot / Connector 接入，实现消息收发、会话管理、事件订阅等能力。
+
+- **基础路径**: `/api/v1`
+- **默认监听**: `127.0.0.1:8080`
+- **认证方式**: Bearer Token（通过 `Authorization` 请求头）
+- **数据格式**: JSON
+
+## 快速开始
+
+### 启动 Server
+
+```bash
+tiangong server --host 127.0.0.1 --port 8080 --token your_secret_token
+```
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--host` | 监听地址 | `127.0.0.1` |
+| `--port` | 监听端口 | `8080` |
+| `--token` | API 认证 Token | 无（不鉴权） |
+| `-d` | 后台守护进程运行 | 否 |
+
+### 认证
+
+所有接口（除健康检查外）均需在请求头中携带 Token：
+
+```
+Authorization: Bearer your_secret_token
+```
+
+### 角色与权限
+
+通过请求头 `x-tiangong-role` 指定角色，支持两种角色：
+
+| 角色 | 权限 |
+|------|------|
+| `controller`（默认） | 发送消息、管理会话、观察数据 |
+| `observer` | 仅观察（只读） |
+
+可通过 `x-tiangong-session-id` 请求头限定 observer 仅可访问指定会话。
+
+---
+
+## HTTP API
+
+### 健康检查
+
+```
+GET /api/v1/health
+```
+
+**无需认证**
+
+**响应**：
+
+```json
+{ "status": "ok" }
+```
+
+### 发送消息（简易）
+
+```
+POST /api/v1/chat
+```
+
+向当前活跃会话或指定会话发送文本消息，同步等待 AI 回复。
+
+**请求体**：
+
+```json
+{
+  "session_id": "可选，指定会话 ID",
+  "message": "用户消息文本"
+}
+```
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| session_id | string | 否 | 为空时使用当前活跃会话 |
+| message | string | 是 | 用户消息内容 |
+
+**响应**：
+
+```json
+{
+  "session_id": "会话 ID",
+  "response": "AI 回复文本"
+}
+```
+
+### 发送消息（Connector 完整接口）
+
+```
+POST /api/v1/messages
+```
+
+外部 Bot / Connector 统一消息入口，支持多模态内容和媒体资源。
+
+**请求体**：
+
+```json
+{
+  "connector": "feishu-bot",
+  "channel_id": "oc_xxxxxx",
+  "sender_id": "user_001",
+  "message_id": "可选，外部消息 ID",
+  "message": "文本消息",
+  "content": { "type": "text", "text": "或使用结构化内容" },
+  "media": [
+    {
+      "kind": "image",
+      "url": "https://example.com/photo.jpg",
+      "mime_type": "image/jpeg",
+      "title": "图片描述",
+      "capability": "multimodal"
+    }
+  ],
+  "reply_to": "可选，回复的消息 ID"
+}
+```
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| connector | string | 否 | Connector 名称，默认 `external-bot` |
+| channel_id | string | 是 | 外部通道 ID（如飞书 chat_id） |
+| sender_id | string | 否 | 外部发送者 ID，默认 `external-user` |
+| message_id | string | 否 | 外部消息 ID，不传时自动生成 |
+| message | string | 否 | 文本消息快捷字段 |
+| content | object | 否 | 结构化消息内容（与 message 二选一） |
+| media | array | 否 | 附加媒体资源列表 |
+| reply_to | string | 否 | 回复的消息 ID |
+
+> `message` 和 `content` 至少提供一个。`message` 优先级更高。
+
+**响应**：
+
+```json
+{
+  "session_id": "会话 ID",
+  "connector": "feishu-bot",
+  "channel_id": "oc_xxxxxx",
+  "reply_to": "回复的消息 ID",
+  "message": "AI 回复文本",
+  "content": { "type": "text", "text": "AI 回复文本" }
+}
+```
+
+### 消息内容类型
+
+`content` 字段支持以下类型：
+
+#### 文本消息
+
+```json
+{ "type": "text", "text": "消息内容" }
+```
+
+#### 图片消息
+
+```json
+{ "type": "image", "url": "https://example.com/photo.jpg", "caption": "图片描述" }
+```
+
+#### 音频消息
+
+```json
+{ "type": "audio", "url": "https://example.com/voice.ogg", "duration": 30 }
+```
+
+#### 视频消息
+
+```json
+{ "type": "video", "url": "https://example.com/clip.mp4", "caption": "视频描述" }
+```
+
+#### 文件消息
+
+```json
+{ "type": "file", "url": "https://example.com/doc.pdf", "name": "文档.pdf" }
+```
+
+### 媒体资源
+
+`media` 数组中的每个元素：
+
+```json
+{
+  "kind": "image",
+  "url": "资源 URL",
+  "mime_type": "可选，MIME 类型",
+  "title": "可选，标题或描述",
+  "capability": "可选，能力标识（如 multimodal）"
+}
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| kind | string | `image`、`video`、`audio`、`file` |
+| url | string | 资源 URL（支持 http/https/data URL） |
+| mime_type | string | MIME 类型（可选） |
+| title | string | 标题或描述（可选） |
+| capability | string | 能力标识（可选，如 `multimodal`） |
+
+### 会话管理
+
+#### 列出会话
+
+```
+GET /api/v1/sessions?limit=20&offset=0
+```
+
+**响应**：
+
+```json
+[
+  {
+    "id": "会话 ID",
+    "title": "会话标题",
+    "message_count": 12,
+    "created_at": "2026-05-20T10:00:00",
+    "updated_at": "2026-05-20T11:30:00"
+  }
+]
+```
+
+#### 创建会话
+
+```
+POST /api/v1/sessions
+```
+
+**请求体**：
+
+```json
+{ "title": "可选，会话标题" }
+```
+
+**响应**（201）：
+
+```json
+{ "session_id": "新会话 ID" }
+```
+
+#### 获取会话详情
+
+```
+GET /api/v1/sessions/{id}
+```
+
+**响应**：
+
+```json
+{
+  "id": "会话 ID",
+  "title": "会话标题",
+  "messages": [
+    {
+      "id": "消息 ID",
+      "role": "user",
+      "content": "消息内容",
+      "created_at": "2026-05-20T10:00:00"
+    }
+  ],
+  "created_at": "2026-05-20T10:00:00",
+  "updated_at": "2026-05-20T11:30:00"
+}
+```
+
+#### 获取会话费用
+
+```
+GET /api/v1/sessions/{id}/cost
+```
+
+#### 删除会话
+
+```
+DELETE /api/v1/sessions/{id}
+```
+
+**响应**：
+
+```json
+{ "status": "deleted", "id": "会话 ID" }
+```
+
+### MCP 服务列表
+
+```
+GET /api/v1/mcp
+```
+
+列出已配置的 MCP 服务。
+
+### Skill 列表
+
+```
+GET /api/v1/skills
+```
+
+列出已配置的 Skill。
+
+**响应**：
+
+```json
+{
+  "total": 10,
+  "items": [
+    { "id": "skill_id", "name": "skill 名称", "enabled": true }
+  ]
+}
+```
+
+### 关闭 Server
+
+```
+POST /api/v1/server/shutdown
+```
+
+优雅关闭 Server。
+
+**响应**：
+
+```json
+{ "status": "shutting_down" }
+```
+
+---
+
+## WebSocket API
+
+### 连接
+
+```
+WS /api/v1/ws
+```
+
+**连接时需在请求头中携带认证 Token**（与 HTTP 相同方式）。
+
+**可选请求头**：
+
+| 请求头 | 说明 |
+|--------|------|
+| `x-tiangong-role` | 角色：`controller` 或 `observer` |
+| `x-tiangong-session-id` | 限定会话范围（observer 角色适用） |
+
+### 发送消息
+
+向 Server 发送 JSON 文本消息：
+
+```json
+{
+  "message": "用户消息文本",
+  "session_id": "可选，指定会话 ID"
+}
+```
+
+如果未指定 `session_id`，将使用当前活跃会话。
+
+### 接收事件
+
+Server 会持续推送以下类型的事件：
+
+#### 消息接收
+
+```json
+{
+  "type": "message_received",
+  "data": {
+    "id": "消息 ID",
+    "connector": "来源 Connector",
+    "channel_id": "通道 ID",
+    "sender_id": "发送者 ID"
+  }
+}
+```
+
+#### 消息发送
+
+```json
+{
+  "type": "message_sent",
+  "data": {
+    "session_id": "会话 ID",
+    "content": "AI 回复内容",
+    "reply_to": "回复的消息 ID"
+  }
+}
+```
+
+#### 会话创建
+
+```json
+{
+  "type": "session_created",
+  "data": { "session_id": "会话 ID" }
+}
+```
+
+#### 回合完成
+
+```json
+{
+  "type": "turn_completed",
+  "data": {
+    "session_id": "会话 ID",
+    "success": true
+  }
+}
+```
+
+#### 配置变更
+
+```json
+{ "type": "config_changed" }
+```
+
+#### Server 关闭
+
+```json
+{ "type": "shutdown" }
+```
+
+---
+
+## 对接示例
+
+### cURL 示例
+
+**发送文本消息**：
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your_secret_token" \
+  -d '{
+    "connector": "my-bot",
+    "channel_id": "channel_001",
+    "message": "你好，请帮我分析一下这段代码"
+  }'
+```
+
+**发送图片消息**：
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your_secret_token" \
+  -d '{
+    "connector": "my-bot",
+    "channel_id": "channel_001",
+    "message": "请描述这张图片",
+    "media": [
+      {
+        "kind": "image",
+        "url": "https://example.com/photo.jpg",
+        "capability": "multimodal"
+      }
+    ]
+  }'
+```
+
+**发送图文混合消息**：
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your_secret_token" \
+  -d '{
+    "connector": "my-bot",
+    "channel_id": "channel_001",
+    "message": "请分析这张截图中的错误",
+    "media": [
+      {
+        "kind": "image",
+        "url": "data:image/png;base64,iVBOR...",
+        "mime_type": "image/png",
+        "capability": "multimodal"
+      }
+    ]
+  }'
+```
+
+### Python 示例
+
+```python
+import requests
+
+BASE_URL = "http://127.0.0.1:8080/api/v1"
+TOKEN = "your_secret_token"
+HEADERS = {
+    "Authorization": f"Bearer {TOKEN}",
+    "Content-Type": "application/json",
+}
+
+# 发送文本消息
+def send_text(channel_id: str, message: str):
+    resp = requests.post(
+        f"{BASE_URL}/messages",
+        headers=HEADERS,
+        json={
+            "connector": "python-bot",
+            "channel_id": channel_id,
+            "message": message,
+        },
+    )
+    return resp.json()
+
+# 发送图片消息
+def send_image(channel_id: str, text: str, image_url: str):
+    resp = requests.post(
+        f"{BASE_URL}/messages",
+        headers=HEADERS,
+        json={
+            "connector": "python-bot",
+            "channel_id": channel_id,
+            "message": text,
+            "media": [
+                {
+                    "kind": "image",
+                    "url": image_url,
+                    "capability": "multimodal",
+                }
+            ],
+        },
+    )
+    return resp.json()
+
+# 列出会话
+def list_sessions():
+    resp = requests.get(f"{BASE_URL}/sessions", headers=HEADERS)
+    return resp.json()
+
+# 使用示例
+result = send_text("channel_001", "你好")
+print(result)
+```
+
+### WebSocket 示例（JavaScript）
+
+```javascript
+const ws = new WebSocket("ws://127.0.0.1:8080/api/v1/ws", {
+  headers: {
+    Authorization: "Bearer your_secret_token",
+    "x-tiangong-role": "controller",
+  },
+});
+
+// 发送消息
+ws.send(JSON.stringify({
+  message: "你好",
+  session_id: "可选的会话 ID",
+}));
+
+// 接收事件
+ws.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+  switch (data.type) {
+    case "message_sent":
+      console.log("AI 回复:", data.data.content);
+      break;
+    case "turn_completed":
+      console.log("回合完成:", data.data.success);
+      break;
+    case "message_received":
+      console.log("收到消息:", data.data);
+      break;
+  }
+};
+```
+
+---
+
+## 错误处理
+
+所有错误响应格式统一：
+
+```json
+{
+  "code": 400,
+  "msg": "错误描述",
+  "data": null
+}
+```
+
+常见 HTTP 状态码：
+
+| 状态码 | 说明 |
+|--------|------|
+| 400 | 请求参数错误 |
+| 401 | 未认证或 Token 无效 |
+| 403 | 权限不足 |
+| 404 | 资源不存在 |
+| 500 | 服务端内部错误 |
+
+---
+
+## 数据流
+
+### 消息处理流程
+
+```
+外部 Bot → POST /api/v1/messages
+  → 认证校验 + 权限校验
+  → MessageRouter.handle_incoming_with_session
+    → 提取文本 + 提取媒体资源
+    → ServerCoreManager.send_connector_message_and_wait
+      → TiangongCore.send_message_with_id(text, id, media)
+        → React Engine 执行
+  → 返回 AI 回复
+```
+
+### 媒体资源传递
+
+```
+外部 Bot 发送图片:
+  → content: Image { url, caption }
+  → media: [MediaAsset { kind: Image, url, ... }]
+  → Router: extract_text("[图片消息]") + extract_media([MediaAsset])
+  → CoreManager: send_message_with_id(text, id, media)
+  → TiangongCore: 媒体归档到本地 → session 消息包含完整媒体数据
+```

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -912,7 +912,6 @@ function ProviderModelsView({
               onClick={() => setSelectedProvider(key)}
             >
               <span>{key}</span>
-              <span className="text-[10px] px-1 py-0.5 rounded bg-primary/10 text-primary">默认</span>
             </button>
           ))}
           {/* 自定义供应商 */}


### PR DESCRIPTION
## Summary
- 修复多模态媒体数据在 server 消息处理管道中丢失的问题，图片/视频等媒体资源可正确传递到 TiangongCore
- 移除 `persist_to_disk` 中自动删除"未知"会话文件的逻辑，防止桌面端和 server 共享数据目录时互相删除对方的会话文件
- 添加 Server API 对接文档

## Changes

### 多模态媒体管道修复
- `IncomingMessage` 添加 `media` 字段，支持携带媒体资源
- `ConnectorMessageRequest` 添加 `media` 字段，外部 Bot 可通过 API 发送图片等媒体
- `MessageRouter` 新增 `extract_media` / `content_to_media` 将 `MessageContent` 转换为 `MediaAsset`
- `ServerCoreManager` 调用 `send_message_with_id` 传递媒体数据到 TiangongCore
- `chat.rs` 和 `ws.rs` 补充 `media` 字段

### 会话文件丢失修复
- `persist_to_disk` 不再删除不在当前进程内存中的会话文件
- 会话文件只能通过用户主动操作（`delete_active_session`）删除
- 适配相关测试用例

### 文档
- 新增 `docs/server-api.md`，涵盖 HTTP API、WebSocket 事件、多模态消息格式、认证机制及对接示例

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets --tests --benches -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `yarn build` (frontend)
- [x] 通过飞书 Bot 发送图片消息，验证媒体数据端到端传递