### PR TITLE
fix: 修复多模态数据丢失、会话记录丢失及多进程配置覆盖

### DIFF
--- a/crates/tiangong-core/src/app_state/facade/lifecycle.rs
+++ b/crates/tiangong-core/src/app_state/facade/lifecycle.rs
@@ -78,6 +78,7 @@ impl TiangongState {
         } else if let Ok(Some(legacy_loaded)) = state.load_from_legacy_disk() {
             state.apply_loaded_state(legacy_loaded);
             let _ = state.persist_to_disk();
+            let _ = state.persist_agent_configs_only();
         }
 
         state.migrate_legacy_skill_layout_if_needed();

--- a/crates/tiangong-core/src/app_state/facade/skills.rs
+++ b/crates/tiangong-core/src/app_state/facade/skills.rs
@@ -103,7 +103,7 @@ impl TiangongState {
         self.sync_installed_from_registry();
         validate_agent_config(&self.store.agent.agent_config)?;
         self.rebuild_runtime_for_agent_config();
-        self.sync_mcp_dependency_lock()?;
+        self.persist_agent_configs_only()?;
 
         let total = self.store.agent.agent_config.skills.installed.len();
         let enabled = self
@@ -140,7 +140,7 @@ impl TiangongState {
             validate_agent_config(&self.store.agent.agent_config)?;
             self.rebuild_runtime_for_agent_config();
             self.persist_app_only()?;
-            self.sync_mcp_dependency_lock()?;
+            self.persist_agent_configs_only()?;
             for backup in &gc_report.legacy_backups {
                 if backup.is_dir() {
                     let _ = fs::remove_dir_all(backup);

--- a/crates/tiangong-core/src/app_state/facade/storage.rs
+++ b/crates/tiangong-core/src/app_state/facade/storage.rs
@@ -22,6 +22,17 @@ impl TiangongState {
         self.services.repository.persist_app_only(&self.store)
     }
 
+    /// 仅持久化 agent 配置（skills.json、mcp.json）+ MCP 依赖锁。
+    /// 只应由显式修改 agent_config 的操作调用，避免多进程覆盖。
+    pub(in crate::app_state) fn persist_agent_configs_only(&self) -> Result<()> {
+        self.services
+            .repository
+            .persist_agent_configs(&self.store.agent.agent_config)?;
+        self.services
+            .repository
+            .sync_mcp_dependency_lock(&self.store.agent.agent_config)
+    }
+
     pub(in crate::app_state) fn persist_to_disk(&mut self) -> Result<()> {
         self.normalize_sessions_for_storage();
         self.services.repository.persist_to_disk(&self.store)

--- a/crates/tiangong-core/src/app_state/mod.rs
+++ b/crates/tiangong-core/src/app_state/mod.rs
@@ -141,12 +141,12 @@ impl TiangongState {
 
     pub fn set_default_trust_mode(&mut self, mode: crate::permission::TrustMode) -> Result<()> {
         self.store.agent.agent_config.default_trust_mode = mode;
-        self.persist_to_disk()
+        self.persist_app_only()
     }
 
     pub fn set_custom_system_prompt(&mut self, prompt: String) -> Result<()> {
         self.store.agent.agent_config.custom_system_prompt = prompt;
         self.rebuild_runtime_from_current_config();
-        self.persist_to_disk()
+        self.persist_app_only()
     }
 }

--- a/crates/tiangong-core/src/app_state/repository/persist.rs
+++ b/crates/tiangong-core/src/app_state/repository/persist.rs
@@ -40,22 +40,22 @@ impl AppRepository {
                 self.paths.app_storage_path.display()
             )
         })?;
-        self.persist_agent_configs(&store.agent.agent_config)?;
-        self.sync_mcp_dependency_lock(&store.agent.agent_config)
+        // 注意：不再调用 persist_agent_configs / sync_mcp_dependency_lock。
+        // agent 配置（skills.json、mcp.json）仅由显式修改它们的操作写入，
+        // 避免多进程共享数据目录时互相覆盖。
+        Ok(())
     }
 
     pub(in crate::app_state) fn persist_to_disk(&self, store: &AppStore) -> Result<()> {
         ensure_dir(&self.paths.sessions_dir_path)?;
         ensure_parent_dir(&self.paths.app_storage_path)?;
 
-        let mut session_ids_set = HashSet::new();
         for session in &store.session.sessions {
             let session_path = session_storage_path(&self.paths.sessions_dir_path, &session.id);
             let content = serde_json::to_string_pretty(session)
                 .with_context(|| format!("序列化会话失败：{}", session.id))?;
             fs::write(&session_path, content)
                 .with_context(|| format!("写入会话文件失败：{}", session_path.display()))?;
-            session_ids_set.insert(session.id.clone());
         }
 
         // 不再删除不在内存中的会话文件：多进程（桌面端 / server）共享同一数据目录，
@@ -77,8 +77,8 @@ impl AppRepository {
                 self.paths.app_storage_path.display()
             )
         })?;
-        self.persist_agent_configs(&store.agent.agent_config)?;
-        self.sync_mcp_dependency_lock(&store.agent.agent_config)
+        // 注意：不再调用 persist_agent_configs / sync_mcp_dependency_lock，理由同 persist_app_only。
+        Ok(())
     }
 
     pub(in crate::app_state) fn remove_session_file(&self, session_id: &str) -> Result<()> {
@@ -90,30 +90,133 @@ impl AppRepository {
         Ok(())
     }
 
-    fn persist_agent_configs(&self, agent_config: &AgentConfig) -> Result<()> {
+    /// 持久化 agent 配置（skills.json、mcp.json），写入前合并磁盘上的外部变更。
+    ///
+    /// 多进程（桌面端 / server）共享数据目录时，写入前先读取磁盘文件，
+    /// 将其他进程的变更合并进来，避免覆盖丢失。
+    /// 检测到外部变更时会记录 warn 日志。
+    pub(in crate::app_state) fn persist_agent_configs(
+        &self,
+        agent_config: &AgentConfig,
+    ) -> Result<()> {
         ensure_parent_dir(&self.paths.skills_config_path)?;
         ensure_parent_dir(&self.paths.mcp_config_path)?;
-        // skills.installed[] 现在由文件系统注册表（skills/<id>/）管理，不再写入 skills.json
-        let skills_without_installed = SkillsConfig {
+
+        // --- skills.json：合并磁盘上其他进程新增的 dirs ---
+        let merged_skills = self.merge_skills_with_disk(&agent_config.skills)?;
+        let skills_content = serde_json::to_string_pretty(&SkillsConfig {
             installed: Vec::new(),
-            ..agent_config.skills.clone()
-        };
-        let skills_content = serde_json::to_string_pretty(&skills_without_installed)
-            .context("序列化 skills 配置失败")?;
-        let mcp_content =
-            serde_json::to_string_pretty(&agent_config.mcp).context("序列化 mcp 配置失败")?;
+            ..merged_skills
+        })
+        .context("序列化 skills 配置失败")?;
         fs::write(&self.paths.skills_config_path, skills_content).with_context(|| {
             format!(
                 "写入 skills 配置失败：{}",
                 self.paths.skills_config_path.display()
             )
         })?;
+
+        // --- mcp.json：合并磁盘上其他进程新增的 server ---
+        let merged_mcp = self.merge_mcp_with_disk(&agent_config.mcp)?;
+        let mcp_content =
+            serde_json::to_string_pretty(&merged_mcp).context("序列化 mcp 配置失败")?;
         fs::write(&self.paths.mcp_config_path, mcp_content).with_context(|| {
             format!(
                 "写入 mcp 配置失败：{}",
                 self.paths.mcp_config_path.display()
             )
         })?;
+
         Ok(())
+    }
+
+    /// 读取磁盘上的 skills.json，合并其他进程新增的 dirs。
+    /// 合并策略：标量字段以内存为准，dirs 取并集。
+    fn merge_skills_with_disk(&self, memory_skills: &SkillsConfig) -> Result<SkillsConfig> {
+        if !self.paths.skills_config_path.exists() {
+            return Ok(memory_skills.clone());
+        }
+
+        let disk_content =
+            fs::read_to_string(&self.paths.skills_config_path).with_context(|| {
+                format!(
+                    "读取 skills 配置失败：{}",
+                    self.paths.skills_config_path.display()
+                )
+            })?;
+        let disk_skills: SkillsConfig = serde_json::from_str(&disk_content).with_context(|| {
+            format!(
+                "解析 skills 配置失败：{}",
+                self.paths.skills_config_path.display()
+            )
+        })?;
+
+        let mut merged_dirs: Vec<String> = memory_skills.dirs.clone();
+        for dir in &disk_skills.dirs {
+            if !merged_dirs.contains(dir) {
+                merged_dirs.push(dir.clone());
+            }
+        }
+
+        if disk_skills.enabled != memory_skills.enabled
+            || disk_skills.max_matches != memory_skills.max_matches
+            || merged_dirs.len() != memory_skills.dirs.len()
+        {
+            tracing::warn!(
+                "检测到 skills.json 被其他进程修改，已合并外部变更（dirs 并集，标量字段以当前进程为准）"
+            );
+        }
+
+        Ok(SkillsConfig {
+            enabled: memory_skills.enabled,
+            max_matches: memory_skills.max_matches,
+            dirs: merged_dirs,
+            installed: Vec::new(),
+        })
+    }
+
+    /// 读取磁盘上的 mcp.json，合并其他进程新增的 server。
+    /// 合并策略：同名 server 以内存（当前进程）为准，磁盘上独有的 server 保留。
+    fn merge_mcp_with_disk(&self, memory_mcp: &McpConfig) -> Result<McpConfig> {
+        if !self.paths.mcp_config_path.exists() {
+            return Ok(memory_mcp.clone());
+        }
+
+        let disk_content = fs::read_to_string(&self.paths.mcp_config_path).with_context(|| {
+            format!(
+                "读取 mcp 配置失败：{}",
+                self.paths.mcp_config_path.display()
+            )
+        })?;
+        let disk_mcp: McpConfig = serde_json::from_str(&disk_content).with_context(|| {
+            format!(
+                "解析 mcp 配置失败：{}",
+                self.paths.mcp_config_path.display()
+            )
+        })?;
+
+        let memory_names: Vec<&str> = memory_mcp.servers.iter().map(|s| s.name.as_str()).collect();
+        let mut external_added = Vec::new();
+
+        let mut merged_servers = memory_mcp.servers.clone();
+        for disk_server in &disk_mcp.servers {
+            if !memory_names.contains(&disk_server.name.as_str()) {
+                merged_servers.push(disk_server.clone());
+                external_added.push(disk_server.name.clone());
+            }
+        }
+
+        if !external_added.is_empty() {
+            tracing::warn!(
+                "检测到 mcp.json 被其他进程修改，已合并外部新增的 server：{}",
+                external_added.join(", ")
+            );
+        }
+
+        Ok(McpConfig {
+            enabled: memory_mcp.enabled,
+            timeout_ms: memory_mcp.timeout_ms,
+            servers: merged_servers,
+        })
     }
 }

--- a/crates/tiangong-core/src/app_state/services/mcp.rs
+++ b/crates/tiangong-core/src/app_state/services/mcp.rs
@@ -115,6 +115,7 @@ impl AppMcpService {
         validate_agent_config(&state.store.agent.agent_config)?;
         state.rebuild_runtime_for_agent_config();
         state.persist_app_only()?;
+        state.persist_agent_configs_only()?;
         audit::append_audit_log(&audit::AuditEntry::new(
             "mcp.register",
             name,
@@ -149,6 +150,7 @@ impl AppMcpService {
         validate_agent_config(&state.store.agent.agent_config)?;
         state.rebuild_runtime_for_agent_config();
         state.persist_app_only()?;
+        state.persist_agent_configs_only()?;
         audit::append_audit_log(&audit::AuditEntry::new(
             "mcp.remove",
             name,
@@ -185,6 +187,7 @@ impl AppMcpService {
         validate_agent_config(&state.store.agent.agent_config)?;
         state.rebuild_runtime_for_agent_config();
         state.persist_app_only()?;
+        state.persist_agent_configs_only()?;
         audit::append_audit_log(&audit::AuditEntry::new(
             "mcp.toggle",
             name,
@@ -257,6 +260,7 @@ impl AppMcpService {
         validate_agent_config(&state.store.agent.agent_config)?;
         state.rebuild_runtime_for_agent_config();
         state.persist_app_only()?;
+        state.persist_agent_configs_only()?;
 
         Ok(format!("配置已更新：{key}={updated_value}"))
     }

--- a/crates/tiangong-core/src/app_state/services/skill.rs
+++ b/crates/tiangong-core/src/app_state/services/skill.rs
@@ -247,7 +247,7 @@ impl AppSkillService {
         validate_agent_config(&state.store.agent.agent_config)?;
         state.rebuild_runtime_for_agent_config();
         state.persist_app_only()?;
-        state.sync_mcp_dependency_lock()?;
+        state.persist_agent_configs_only()?;
 
         let mut message = format!(
             "skill 已安装：{}@{} enabled={}",
@@ -341,7 +341,7 @@ impl AppSkillService {
         validate_agent_config(&state.store.agent.agent_config)?;
         state.rebuild_runtime_for_agent_config();
         state.persist_app_only()?;
-        state.sync_mcp_dependency_lock()?;
+        state.persist_agent_configs_only()?;
         audit::append_audit_log(&audit::AuditEntry::new(
             "skill.remove",
             id,
@@ -372,7 +372,7 @@ impl AppSkillService {
         state.sync_installed_from_registry();
         validate_agent_config(&state.store.agent.agent_config)?;
         state.rebuild_runtime_for_agent_config();
-        state.sync_mcp_dependency_lock()?;
+        state.persist_agent_configs_only()?;
         audit::append_audit_log(&audit::AuditEntry::new(
             "skill.toggle",
             id,

--- a/crates/tiangong-core/src/app_state/tests/repository.rs
+++ b/crates/tiangong-core/src/app_state/tests/repository.rs
@@ -38,6 +38,7 @@ fn repository_persist_to_disk_round_trips_split_configs_and_sessions() -> Result
         state.store.session.sessions.push(session.clone());
 
         state.persist_to_disk()?;
+        state.persist_agent_configs_only()?;
 
         let loaded = state
             .services

--- a/crates/tiangong-core/src/memory/gui_api.rs
+++ b/crates/tiangong-core/src/memory/gui_api.rs
@@ -3,7 +3,7 @@
 use crate::core_config::CoreConfigProvider;
 use crate::memory::registry::get_or_init_memory_handle_async;
 
-/// GUI Memory 管理：列出当前 workspace 的记忆节点。
+/// GUI Memory 管理：列出全部记忆节点（全局可见，不按 workspace 过滤）。
 pub async fn list_memory_nodes_for_gui(
     config_provider: &CoreConfigProvider,
     workspace_id: Option<String>,
@@ -13,12 +13,12 @@ pub async fn list_memory_nodes_for_gui(
     offset: Option<usize>,
 ) -> anyhow::Result<Vec<tiangong_memory::MemoryNode>> {
     let status = parse_memory_status(status.as_deref())?;
-    let handle = get_or_init_memory_handle_async(config_provider, workspace_id.clone())
+    let handle = get_or_init_memory_handle_async(config_provider, workspace_id)
         .await
         .ok_or_else(|| anyhow::anyhow!("Memory 未启动或初始化失败"))?;
     Ok(handle
         .list_nodes(tiangong_memory::MemoryListQuery {
-            workspace_id,
+            workspace_id: None,
             query,
             status,
             created_after: None,
@@ -28,7 +28,7 @@ pub async fn list_memory_nodes_for_gui(
         .await)
 }
 
-/// GUI Memory 管理：统计当前 workspace 的记忆节点真实总数。
+/// GUI Memory 管理：统计全部记忆节点真实总数（全局可见，不按 workspace 过滤）。
 pub async fn count_memory_nodes_for_gui(
     config_provider: &CoreConfigProvider,
     workspace_id: Option<String>,
@@ -37,12 +37,12 @@ pub async fn count_memory_nodes_for_gui(
     created_after: Option<String>,
 ) -> anyhow::Result<usize> {
     let status = parse_memory_status(status.as_deref())?;
-    let handle = get_or_init_memory_handle_async(config_provider, workspace_id.clone())
+    let handle = get_or_init_memory_handle_async(config_provider, workspace_id)
         .await
         .ok_or_else(|| anyhow::anyhow!("Memory 未启动或初始化失败"))?;
     Ok(handle
         .count_nodes(tiangong_memory::MemoryListQuery {
-            workspace_id,
+            workspace_id: None,
             query,
             status,
             created_after,


### PR DESCRIPTION
## Summary
- 修复 server 管道中图片/视频等多模态媒体数据丢失的问题
- 移除 `persist_to_disk` 中的会话文件删除逻辑，防止多进程共享数据目录时丢失对话记录
- 分离 agent 配置持久化（MCP/skills），写入前合并磁盘上的外部变更，避免多进程互相覆盖
- GUI 记忆面板改为全局查询，不按 workspace 过滤

## Test plan
- [x] cargo check --workspace
- [x] cargo clippy --workspace --all-targets --tests --benches -- -D warnings
- [x] cargo nextest run --workspace (250/250 通过)
- [x] 桌面端验证会话创建/切换不丢失 MCP/skills 配置
- [x] 桌面端验证记忆面板显示所有 workspace 的记忆