### PR TITLE
fix(components): 优化 Windows 下 UI 交互体验

### DIFF
--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -158,7 +158,7 @@ export function MessageInput() {
   const tokenStats = useStore((state) => state.tokenStats);
   const agents = useStore((state) => state.agents);
   const selectedAgentTab = useStore((state) => state.selectedAgentTab);
-  const [isComposing, setIsComposing] = useState(false);
+  const isComposingRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputAreaRef = useRef<HTMLDivElement>(null);
   const lastNativeDropAtRef = useRef(0);
@@ -633,7 +633,7 @@ export function MessageInput() {
       if (e.key === 'Escape') { e.preventDefault(); setMentionOpen(false); return; }
       if (e.key === 'Tab') { e.preventDefault(); selectCandidate(filteredCandidates[mentionIndex]); return; }
     }
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !isComposing) {
+    if (e.key === 'Enter' && !e.shiftKey && !isComposingRef.current && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSend();
     }
@@ -1001,15 +1001,17 @@ export function MessageInput() {
                 onChange={(e) => handleInputChange(e.target.value)}
                 onKeyDown={handleKeyDown}
                 onPaste={handlePaste}
-                onCompositionStart={() => setIsComposing(true)}
-                onCompositionEnd={() => setIsComposing(false)}
+                onCompositionStart={() => { isComposingRef.current = true; }}
+                onCompositionEnd={() => {
+                  setTimeout(() => { isComposingRef.current = false; }, 0);
+                }}
                 onBlur={() => setTimeout(() => setMentionOpen(false), 150)}
                 placeholder={
                   isIdle
                     ? agents.length > 0
-                      ? '输入消息... (⌘+Enter 发送，@ 引用 Agent/Skill/MCP)'
-                      : '输入消息... (⌘+Enter 发送，@ 引用 Skill/MCP)'
-                    : '追加指示... (⌘+Enter 发送)'
+                      ? '输入消息... (Enter 发送，@ 引用 Agent/Skill/MCP)'
+                      : '输入消息... (Enter 发送，@ 引用 Skill/MCP)'
+                    : '追加指示... (Enter 发送)'
                 }
                 className="min-h-[60px] max-h-[200px] resize-none pr-32 bg-muted/50 focus-visible:ring-ring"
               />
@@ -1144,7 +1146,7 @@ export function MessageInput() {
                     <><ShieldOff className="w-3 h-3" /><span>信任</span></>
                   )}
                 </button>
-                <span>⌘+Enter 发送</span>
+                <span>Enter 发送 · Shift+Enter 换行</span>
               </div>
             </div>
           </div>

--- a/frontend/src/components/StatusPanel.tsx
+++ b/frontend/src/components/StatusPanel.tsx
@@ -93,10 +93,12 @@ export function StatusPanel() {
   };
 
 
+  const titlePaddingLeft = navigator.platform.includes('Mac') ? '80px' : '16px';
+
   return (
     <header
       className="flex h-12 shrink-0 items-center gap-2 border-b pr-4 select-none"
-      style={{ paddingLeft: '80px' }}
+      style={{ paddingLeft: titlePaddingLeft }}
       onMouseDown={(e) => {
         const tag = (e.target as HTMLElement).tagName;
         if (tag === 'INPUT' || tag === 'BUTTON') return;


### PR DESCRIPTION
## Summary
- 标题栏左侧内边距根据平台动态调整，macOS 保留红绿灯空间，Windows/Linux 左对齐
- 消息发送快捷键从 ⌘+Enter 改为 Enter 发送、Shift+Enter 换行
- 通过 ref + nativeEvent.isComposing 双重判断解决中文输入法选词时误发送的问题

## Test plan
- [x] macOS 下标题栏内容不被红绿灯遮挡
- [x] Windows 下标题栏内容左侧对齐、无多余空白
- [x] Enter 键正常发送消息
- [x] Shift+Enter 正常换行
- [x] 中文输入法选词过程中按 Enter 确认选词不会误触发发送