### PR TITLE
refactor(core): RFC 0013 Sub Agent 架构重构

### DIFF
--- a/crates/tiangong-core/src/agent_team/descriptor.rs
+++ b/crates/tiangong-core/src/agent_team/descriptor.rs
@@ -1,15 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-/// Agent 生命周期类型
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AgentLifecycle {
-    /// 持久存在，随会话生命周期
-    Persistent,
-    /// 单次任务完成后自动销毁
-    Temporary,
-}
-
 /// Agent 状态
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -37,8 +27,6 @@ pub struct AgentDescriptor {
     pub label: String,
     /// Agent 专属系统 prompt
     pub system_prompt: String,
-    /// 生命周期类型
-    pub lifecycle: AgentLifecycle,
     /// 可用工具列表（从主 Agent 工具集中选取）
     pub tools: Vec<String>,
     /// 当前状态

--- a/crates/tiangong-core/src/agent_team/lifecycle.rs
+++ b/crates/tiangong-core/src/agent_team/lifecycle.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender as StdSender;
 
-use crate::agent_team::descriptor::{AgentDescriptor, AgentLifecycle, AgentStatus};
+use crate::agent_team::descriptor::{AgentDescriptor, AgentStatus};
 use crate::agent_team::file_lock::FileLockManager;
 use crate::agent_team::message_bus::AgentMessage;
 use crate::agent_team::registry::AgentRegistry;
@@ -75,13 +75,18 @@ impl TeamContext {
         message: AgentMessage,
         media: Vec<tiangong_types::MediaAsset>,
     ) {
-        if let Some(tx) = self.active_agent_senders.get(agent_id) {
-            let _ = tx.send(Command::Message {
+        let dispatched = if let Some(tx) = self.active_agent_senders.get(agent_id) {
+            tx.send(Command::Message {
                 content: format_agent_message_for_prompt(&message),
                 message_id: Some(message.id.clone()),
                 media,
-            });
+            })
+            .is_ok()
         } else {
+            false
+        };
+
+        if !dispatched {
             self.registry.deliver_message(agent_id, message);
             if let Some(waker) = &self.dispatch_waker {
                 let _ = waker.send(());
@@ -112,7 +117,6 @@ struct RestoredAgent {
     agent_id: String,
     role: String,
     label: String,
-    lifecycle: AgentLifecycle,
     status: AgentStatus,
 }
 
@@ -171,11 +175,11 @@ pub fn restore_agents_from_session_history(
                 "你是从会话历史恢复的子 Agent，角色为 {}（{}）。请延续当前会话上下文，按该角色职责处理用户和主 Agent 分配的任务。",
                 agent.label, agent.role
             ),
-            lifecycle: agent.lifecycle,
             tools: tool_names.clone(),
             status: AgentStatus::Idle,
         };
-        let child_session = create_child_session(parent_session, &agent.label);
+        let child_session = load_child_session(parent_session, &agent.agent_id)
+            .unwrap_or_else(|| create_child_session(parent_session, &agent.label));
         team.registry
             .register_with_session(descriptor, child_session);
         count += 1;
@@ -196,17 +200,10 @@ fn parse_agent_created_message(content: &str) -> Option<RestoredAgent> {
         return None;
     }
 
-    let lifecycle = if after_role.contains("[temporary]") || after_role.contains("[临时]") {
-        AgentLifecycle::Temporary
-    } else {
-        AgentLifecycle::Persistent
-    };
-
     Some(RestoredAgent {
         agent_id,
         role: role.trim().to_string(),
         label: label.trim().to_string(),
-        lifecycle,
         status: AgentStatus::Idle,
     })
 }
@@ -265,12 +262,6 @@ pub fn execute_create_agent(
         .unwrap_or_default()
         .trim()
         .to_string();
-    let lifecycle_str = call
-        .arguments
-        .get("lifecycle")
-        .and_then(|v| v.as_str())
-        .unwrap_or("persistent")
-        .trim();
     let requested_tools: Vec<String> = call
         .arguments
         .get("tools")
@@ -302,12 +293,6 @@ pub fn execute_create_agent(
         );
     }
 
-    let lifecycle = if lifecycle_str == "temporary" {
-        AgentLifecycle::Temporary
-    } else {
-        AgentLifecycle::Persistent
-    };
-
     // 确定工具集：如果指定了 tools 则过滤，否则继承全部（排除团队管理工具）
     let tool_names = if requested_tools.is_empty() {
         let excluded = ["create_agent", "dismiss_agent"];
@@ -326,18 +311,11 @@ pub fn execute_create_agent(
 
     let agent_id = scru128::new().to_string();
 
-    let lifecycle_label = if lifecycle == AgentLifecycle::Temporary {
-        "临时"
-    } else {
-        "持久"
-    };
-
     let descriptor = AgentDescriptor {
         agent_id: agent_id.clone(),
         role: role.clone(),
         label: label.clone(),
         system_prompt,
-        lifecycle,
         tools: tool_names,
         status: AgentStatus::Idle,
     };
@@ -353,8 +331,31 @@ pub fn execute_create_agent(
         agent_id: agent_id.clone(),
         role: role.clone(),
         label: label.clone(),
-        lifecycle: lifecycle_str.to_string(),
     });
+
+    // 向所有已存在的 Agent 广播新成员通知
+    let notification = format!("[团队通知] 新成员 {label} (@{role}) 已加入团队");
+    let targets: Vec<String> = team
+        .registry
+        .alive_agents()
+        .iter()
+        .filter(|a| a.agent_id != agent_id)
+        .map(|a| a.agent_id.clone())
+        .collect();
+    for target_id in targets {
+        team.dispatch_agent_message(
+            &target_id,
+            AgentMessage {
+                id: scru128::new().to_string(),
+                from: "system".to_string(),
+                to: target_id.clone(),
+                content: notification.clone(),
+                priority: crate::agent_team::message_bus::MessagePriority::Normal,
+                created_at: now_text(),
+            },
+            Vec::new(),
+        );
+    }
 
     let tools_list = team
         .registry
@@ -364,7 +365,7 @@ pub fn execute_create_agent(
 
     ToolResult {
         ok: true,
-        summary: format!("{label} ({role}) 已加入团队 [{lifecycle_label}]"),
+        summary: format!("{label} ({role}) 已加入团队"),
         stdout: format!(
             "Agent '{label}' (role={role}, id={agent_id}) 已创建。\n可用工具: {tools_list}\n状态: 等待任务分配"
         ),
@@ -376,7 +377,7 @@ pub fn execute_create_agent(
             duration_ms: 0,
             ok: true,
             exit_code: 0,
-            summary: format!("Agent 已加入团队 [{lifecycle_label}]"),
+            summary: "Agent 已加入团队".to_string(),
         }),
     }
 }
@@ -1050,6 +1051,48 @@ fn create_child_session(parent: &Session, title: &str) -> Session {
     child
 }
 
+/// 持久化 child_session 到磁盘
+pub fn persist_child_session(parent_session: &Session, agent_id: &str, session: &Session) {
+    let home = std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let agents_dir = home
+        .join(".tiangong")
+        .join("sessions")
+        .join(&parent_session.id)
+        .join("agents");
+    if std::fs::create_dir_all(&agents_dir).is_err() {
+        tracing::warn!("创建 agents 目录失败");
+        return;
+    }
+    let path = agents_dir.join(format!("{agent_id}.json"));
+    match serde_json::to_string_pretty(session) {
+        Ok(content) => {
+            if let Err(err) = std::fs::write(&path, content) {
+                tracing::warn!(error = %err, "child session 持久化写入失败");
+            }
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "child session 序列化失败");
+        }
+    }
+}
+
+/// 从磁盘加载 child_session
+pub fn load_child_session(parent_session: &Session, agent_id: &str) -> Option<Session> {
+    let home = std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let path = home
+        .join(".tiangong")
+        .join("sessions")
+        .join(&parent_session.id)
+        .join("agents")
+        .join(format!("{agent_id}.json"));
+    let content = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::mpsc;
@@ -1088,8 +1131,7 @@ mod tests {
                 json!({
                     "role": "dev",
                     "label": "Developer",
-                    "system_prompt": "You are a developer",
-                    "lifecycle": "persistent"
+                    "system_prompt": "You are a developer"
                 }),
             ),
             &parent,
@@ -1239,6 +1281,12 @@ mod tests {
         let dev_id = team.registry.find_by_role("dev").unwrap().agent_id.clone();
         let test_id = team.registry.find_by_role("test").unwrap().agent_id.clone();
         let pm_id = team.registry.find_by_role("pm").unwrap().agent_id.clone();
+
+        // 先清空团队通知（创建 Agent 时自动广播的）
+        let _ = team.registry.drain_inbox(&dev_id);
+        let _ = team.registry.drain_inbox(&test_id);
+        let _ = team.registry.drain_inbox(&pm_id);
+
         let result = execute_broadcast_message(
             &mut team,
             &dev_id,
@@ -1396,11 +1444,11 @@ mod tests {
         let mut parent = Session::new("parent");
         parent.append_message(
             crate::session::MessageRole::System,
-            "[Agent] 开发者 (dev) 已加入团队 [persistent] id=agent-dev".to_string(),
+            "[Agent] 开发者 (dev) 已加入团队 id=agent-dev".to_string(),
         );
         parent.append_message(
             crate::session::MessageRole::System,
-            "[Agent] 项目经理 (pm) 已加入团队 [persistent] id=agent-pm".to_string(),
+            "[Agent] 项目经理 (pm) 已加入团队 id=agent-pm".to_string(),
         );
 
         let restored = restore_agents_from_session_history(
@@ -1432,7 +1480,7 @@ mod tests {
         let mut parent = Session::new("parent");
         parent.append_message(
             crate::session::MessageRole::System,
-            "[Agent] 开发者 (dev) 已加入团队 [persistent] id=agent-dev".to_string(),
+            "[Agent] 开发者 (dev) 已加入团队 id=agent-dev".to_string(),
         );
         parent.append_message(
             crate::session::MessageRole::System,

--- a/crates/tiangong-core/src/agent_team/tools.rs
+++ b/crates/tiangong-core/src/agent_team/tools.rs
@@ -31,7 +31,7 @@ pub fn inject_agent_team_tools(tools: &mut Vec<ToolSpec>) {
 fn create_agent_tool() -> ToolSpec {
     ToolSpec {
         name: "create_agent".to_string(),
-        description: "创建一个新的 Sub Agent 加入团队。Agent 将拥有独立的执行上下文和指定的角色。"
+        description: "创建一个 Sub Agent 加入团队。Agent 拥有独立的执行上下文和指定角色，持续存在直到被解散。"
             .to_string(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -48,15 +48,10 @@ fn create_agent_tool() -> ToolSpec {
                     "type": "string",
                     "description": "Agent 的角色系统提示，定义其职责和行为规范"
                 },
-                "lifecycle": {
-                    "type": "string",
-                    "enum": ["persistent", "temporary"],
-                    "description": "生命周期：persistent=持久存在，temporary=任务完成后自动销毁。默认 persistent"
-                },
                 "tools": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Agent 可用的工具列表。默认包含所有工具"
+                    "description": "Agent 可用的工具列表。不指定时继承你的全部工具（不含 create_agent/dismiss_agent）。建议根据任务需要精确授权。"
                 }
             },
             "required": ["role", "label", "system_prompt"]

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -303,6 +303,7 @@ async fn worker_loop_async(
 
     // IndexManager：Workspace 文件索引 + Session 对话索引
     let index_manager = crate::index::IndexManager::new()
+        .map(std::sync::Arc::new)
         .map_err(|e| {
             tracing::warn!("IndexManager 初始化失败: {e}");
             e
@@ -460,7 +461,7 @@ async fn worker_loop_async(
                     &stream_tx,
                     &mut cmd_rx,
                     memory.handle.as_ref(),
-                    index_manager.as_ref(),
+                    index_manager.clone(),
                     team_context.clone(),
                 )
                 .await;
@@ -669,7 +670,7 @@ async fn execute_turn_async(
     stream_tx: &StdSender<StreamEvent>,
     cmd_rx: &mut tokio_mpsc::UnboundedReceiver<Command>,
     memory_handle: Option<&tiangong_memory::MemoryHandle>,
-    index_manager: Option<&crate::index::IndexManager>,
+    index_manager: Option<std::sync::Arc<crate::index::IndexManager>>,
     team_context: Arc<Mutex<crate::agent_team::lifecycle::TeamContext>>,
 ) {
     let mut react = crate::react::engine::ReactEngine::new(

--- a/crates/tiangong-core/src/prompt/mod.rs
+++ b/crates/tiangong-core/src/prompt/mod.rs
@@ -5,4 +5,4 @@
 
 pub mod sections;
 
-pub use sections::SystemPromptConfig;
+pub use sections::{SubAgentPromptContext, SystemPromptConfig};

--- a/crates/tiangong-core/src/prompt/sections.rs
+++ b/crates/tiangong-core/src/prompt/sections.rs
@@ -119,12 +119,12 @@ fn build_agent_team_section() -> String {
     "团队协作能力（可选使用）：
 当任务复杂需要分工时，你可以创建团队来协作完成。以下是可用的团队工具：
 
-- create_agent(role, label, system_prompt, lifecycle, tools)：创建一个 Sub Agent
+- create_agent(role, label, system_prompt, tools)：创建一个 Sub Agent
   - role：角色标识（如 pm、dev、test），用于消息路由
   - label：显示名称（如「项目经理」「开发者」）
   - system_prompt：Agent 的专属指令
-  - lifecycle：persistent（持久，跨任务存在）或 temporary（单次任务后销毁）
-  - tools：可选，指定可用工具列表（默认继承你的工具集）
+  - tools：可选，指定可用工具列表（默认继承你的工具集，不含 create_agent/dismiss_agent）
+  - Agent 持续存在直到被解散
   - 最多同时 8 个 Agent
 
 - send_message(to, content)：向指定角色的 Agent 发送消息，Agent 会自动执行任务
@@ -192,6 +192,20 @@ pub fn build_full_system_prompt(session: &Session, config: &SystemPromptConfig) 
     }
 
     // 环境段
+    parts.extend(collect_environment_parts(session));
+
+    // 动态段
+    parts.extend(collect_dynamic_parts(config));
+
+    // 摘要段
+    parts.extend(collect_summary_part(session));
+
+    assemble_system_message(parts)
+}
+
+/// 收集环境段（工作目录、文件根）
+fn collect_environment_parts(session: &Session) -> Vec<String> {
+    let mut parts = Vec::new();
     let workspace = session_working_directory(session);
     parts.push(format!("当前会话：{}", session.title));
     parts.push(format!("当前工作目录：{}", workspace));
@@ -201,8 +215,12 @@ pub fn build_full_system_prompt(session: &Session, config: &SystemPromptConfig) 
         roots.push(format!("{home}/.tiangong/skills"));
     }
     parts.push(format!("允许文件操作目录：{}", roots.join(", ")));
+    parts
+}
 
-    // 动态段
+/// 收集动态段（多媒体、Skills、团队协作、用户上下文）
+fn collect_dynamic_parts(config: &SystemPromptConfig) -> Vec<String> {
+    let mut parts = Vec::new();
     if !config.media_text.is_empty() {
         parts.push(config.media_text.clone());
     }
@@ -218,17 +236,25 @@ pub fn build_full_system_prompt(session: &Session, config: &SystemPromptConfig) 
             config.user_context.join("\n")
         ));
     }
+    parts
+}
 
-    // 摘要段
+/// 收集摘要段
+fn collect_summary_part(session: &Session) -> Vec<String> {
     if let Some(summary) = session
         .context_summary
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
-        parts.push(format!("此前对话摘要：\n{summary}"));
+        vec![format!("此前对话摘要：\n{summary}")]
+    } else {
+        Vec::new()
     }
+}
 
+/// 组装最终的 System Message
+fn assemble_system_message(parts: Vec<String>) -> Message {
     Message {
         id: scru128::new().to_string(),
         role: MessageRole::System,
@@ -244,6 +270,58 @@ pub fn build_full_system_prompt(session: &Session, config: &SystemPromptConfig) 
         tool_result_is_error: false,
         compact: false,
         created_at: now_text(),
+    }
+}
+
+/// Sub Agent 的 system prompt 构建上下文
+///
+/// 将基础 SystemPromptConfig（纯配置快照）与运行时上下文
+/// （角色指令、团队成员列表）组合，构建 Sub Agent 专属的 system prompt。
+///
+/// 不修改 SystemPromptConfig，避免配置加载逻辑被运行时状态污染。
+pub struct SubAgentPromptContext<'a> {
+    /// 基础配置快照（引用，不持有）
+    base: &'a SystemPromptConfig,
+    /// Main Agent 生成的角色特化指令
+    role_prompt: &'a str,
+    /// 当前团队成员列表文本
+    team_roster: &'a str,
+}
+
+impl<'a> SubAgentPromptContext<'a> {
+    pub fn new(base: &'a SystemPromptConfig, role_prompt: &'a str, team_roster: &'a str) -> Self {
+        Self {
+            base,
+            role_prompt,
+            team_roster,
+        }
+    }
+
+    /// 构建 Sub Agent 的 system prompt
+    ///
+    /// 与 Main Agent 的区别：用角色特化指令替代通用身份块，附加团队成员列表。
+    pub fn build(&self, session: &Session) -> Message {
+        let mut parts = Vec::new();
+
+        // 角色特化指令替代通用身份块
+        parts.push(self.role_prompt.to_string());
+        parts.push(rules_block());
+
+        // 环境段
+        parts.extend(collect_environment_parts(session));
+
+        // 动态段
+        parts.extend(collect_dynamic_parts(self.base));
+
+        // 团队成员列表（Sub Agent 独有）
+        if !self.team_roster.is_empty() {
+            parts.push(format!("当前团队成员：\n{}", self.team_roster));
+        }
+
+        // 摘要段
+        parts.extend(collect_summary_part(session));
+
+        assemble_system_message(parts)
     }
 }
 

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -399,7 +399,7 @@ impl ReactEngine {
         stream_tx: &StdSender<StreamEvent>,
         cmd_rx: &mut tokio_mpsc::UnboundedReceiver<Command>,
         memory_handle: Option<&tiangong_memory::MemoryHandle>,
-        index_manager: Option<&crate::index::IndexManager>,
+        index_manager: Option<std::sync::Arc<crate::index::IndexManager>>,
     ) -> TokenUsage {
         let mut round = 0;
         let mut accumulated_usage = TokenUsage::default();
@@ -424,7 +424,13 @@ impl ReactEngine {
                 .unwrap_or(false);
             if routed {
                 let sub_result = self
-                    .drain_sub_agent_inboxes(session, stream_tx, cmd_rx)
+                    .drain_sub_agent_inboxes(
+                        session,
+                        stream_tx,
+                        cmd_rx,
+                        memory_handle,
+                        &index_manager,
+                    )
                     .await;
                 accumulated_usage.accumulate(&sub_result.usage);
                 if sub_result.cancelled {
@@ -1033,7 +1039,7 @@ impl ReactEngine {
                 let (result, tool_llm_usage, allow_memory_context, usage_source) = {
                     let (mut result, tool_llm_usage, allow_memory_context, usage_source) =
                         if call.name == "index_search" {
-                            if let Some(im) = index_manager {
+                            if let Some(ref im) = index_manager {
                                 let (result, usage, allow_context) =
                                     crate::index::execute_index_search_tool(call, im, session);
                                 (result, usage, allow_context, "index_search")
@@ -1249,7 +1255,7 @@ impl ReactEngine {
 
             // 执行有待处理任务的 Sub Agent
             let sub_result = self
-                .drain_sub_agent_inboxes(session, stream_tx, cmd_rx)
+                .drain_sub_agent_inboxes(session, stream_tx, cmd_rx, memory_handle, &index_manager)
                 .await;
             accumulated_usage.accumulate(&sub_result.usage);
             if sub_result.cancelled {
@@ -1291,7 +1297,22 @@ impl ReactEngine {
             .and_then(|team| team.lock().ok().map(|mut team| team.drain_main_inbox()))
             .unwrap_or_default()
     }
+}
 
+fn format_team_roster(team_arc: &Arc<Mutex<TeamContext>>) -> String {
+    let Ok(team) = team_arc.lock() else {
+        return String::new();
+    };
+    let mut agents = team.registry.alive_agents();
+    agents.sort_by(|a, b| a.role.cmp(&b.role));
+    agents
+        .iter()
+        .map(|a| format!("- {} (@{})", a.label, a.role))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+impl ReactEngine {
     #[allow(clippy::too_many_arguments)]
     fn spawn_ready_sub_agents(
         &self,
@@ -1303,6 +1324,8 @@ impl ReactEngine {
         max_concurrent: usize,
         token_budget: usize,
         sub_max_rounds: usize,
+        memory_handle: Option<&tiangong_memory::MemoryHandle>,
+        index_manager: &Option<std::sync::Arc<crate::index::IndexManager>>,
     ) -> bool {
         let remaining_slots = max_concurrent.saturating_sub(active_sub_agents.len());
         if remaining_slots == 0 {
@@ -1412,6 +1435,34 @@ impl ReactEngine {
             )
             .with_shared_team(team_arc.clone(), agent_id.clone());
 
+            // 通过 SubAgentPromptContext 构建 system prompt
+            let base_config = crate::prompt::SystemPromptConfig::from_configs(
+                self.engine.models_config(),
+                self.engine.agent_config(),
+                &child_session.id,
+            );
+            let team_roster = format_team_roster(team_arc);
+            let ctx = crate::prompt::SubAgentPromptContext::new(
+                &base_config,
+                &system_prompt,
+                &team_roster,
+            );
+            child_session.system_prompt_message = Some(ctx.build(&child_session));
+
+            // 条件性赋予能力：根据 tools 列表决定是否共享 index_manager 和 memory_handle
+            let has_index = tool_names.iter().any(|n| n == "index_search");
+            let has_memory = tool_names.iter().any(|n| n == "recall_memory");
+            let sub_index = if has_index {
+                index_manager.clone()
+            } else {
+                None
+            };
+            let sub_memory = if has_memory {
+                memory_handle.cloned()
+            } else {
+                None
+            };
+
             let (sub_cmd_tx, mut sub_cmd_rx) = tokio_mpsc::unbounded_channel();
             let _ = sub_cmd_tx.send(Command::Message {
                 content: combined_content,
@@ -1432,7 +1483,6 @@ impl ReactEngine {
             let id = agent_id;
             let label = agent_label;
             let role = agent_role;
-            let prompt = system_prompt;
             let start_message_len = child_session.messages.len();
 
             let fut = Box::pin(async move {
@@ -1448,11 +1498,11 @@ impl ReactEngine {
                 let usage = sub_engine
                     .execute_turn(
                         &mut child_session,
-                        &prompt,
+                        "",
                         &child_stream_tx,
                         &mut sub_cmd_rx,
-                        None,
-                        None,
+                        sub_memory.as_ref(),
+                        sub_index,
                     )
                     .await;
                 drop(child_stream_tx);
@@ -1478,6 +1528,8 @@ impl ReactEngine {
         parent_session: &mut Session,
         stream_tx: &StdSender<StreamEvent>,
         cmd_rx: &mut tokio_mpsc::UnboundedReceiver<Command>,
+        memory_handle: Option<&tiangong_memory::MemoryHandle>,
+        index_manager: &Option<std::sync::Arc<crate::index::IndexManager>>,
     ) -> SubAgentDrainResult {
         let mut result = SubAgentDrainResult::default();
 
@@ -1512,6 +1564,8 @@ impl ReactEngine {
             max_concurrent,
             token_budget,
             sub_max_rounds,
+            memory_handle,
+            index_manager,
         ) {
             result.ran = true;
         }
@@ -1542,6 +1596,8 @@ impl ReactEngine {
                             max_concurrent,
                             token_budget,
                             sub_max_rounds,
+                            memory_handle,
+                            index_manager,
                         ) {
                             result.ran = true;
                         }
@@ -1558,6 +1614,8 @@ impl ReactEngine {
                             max_concurrent,
                             token_budget,
                             sub_max_rounds,
+                            memory_handle,
+                            index_manager,
                         )
                     {
                         result.ran = true;
@@ -1734,35 +1792,17 @@ impl ReactEngine {
                 label: agent_label.clone(),
                 status: status.to_string(),
             });
-            let should_dismiss = team
-                .registry
-                .get(&agent_id)
-                .map(|d| d.lifecycle == crate::agent_team::descriptor::AgentLifecycle::Temporary)
-                .unwrap_or(false);
-            if should_dismiss {
-                for path in team.file_locks.release_all(&agent_id) {
-                    let _ = stream_tx.send(StreamEvent::FileLockChanged {
-                        path,
-                        holder_agent_id: Some(agent_id.clone()),
-                        holder_agent_label: Some(agent_label.clone()),
-                        action: "unlocked".to_string(),
-                    });
-                }
-                team.registry.unregister(&agent_id);
-                let _ = stream_tx.send(StreamEvent::AgentStatusChanged {
-                    agent_id,
-                    label: agent_label.clone(),
-                    status: "terminated".to_string(),
-                });
-                append_runtime_tool_message(
+            team.registry.set_session(&agent_id, child_session);
+            team.registry
+                .update_status(&agent_id, crate::agent_team::descriptor::AgentStatus::Idle);
+
+            // 持久化 child_session 到磁盘
+            if let Some(child) = team.registry.get_session(&agent_id) {
+                crate::agent_team::lifecycle::persist_child_session(
                     parent_session,
-                    &format!("sub_agent_{agent_label}"),
-                    format!("[{agent_label}] 临时 Agent 已自动销毁"),
+                    &agent_id,
+                    child,
                 );
-            } else {
-                team.registry.set_session(&agent_id, child_session);
-                team.registry
-                    .update_status(&agent_id, crate::agent_team::descriptor::AgentStatus::Idle);
             }
         }
 

--- a/crates/tiangong-types/src/stream.rs
+++ b/crates/tiangong-types/src/stream.rs
@@ -147,7 +147,6 @@ pub enum StreamEvent {
         agent_id: String,
         role: String,
         label: String,
-        lifecycle: String,
     },
     /// Agent 状态变更
     AgentStatusChanged {

--- a/docs/rfc/0013-sub-agent-architecture-refactor.md
+++ b/docs/rfc/0013-sub-agent-architecture-refactor.md
@@ -1,0 +1,508 @@
+# RFC 0013: Sub Agent 架构重构
+
+- **状态**: Draft
+- **日期**: 2025-07-11
+- **作者**: Hubert Shelley
+- **前置**: RFC 0011 (多智能体协作系统)
+
+## 1. 概述
+
+### 1.1 背景
+
+RFC 0011 定义了多智能体协作系统并已落地实现。经过实际使用和代码 review，发现以下问题：
+
+1. **生命周期复杂度高**：`Temporary` / `Persistent` 双生命周期增加了调度和销毁逻辑的复杂度，LLM 也难以准确判断何时该用 Temporary
+2. **Sub Agent 缺少团队感知**：删除 `sub_agent_team_context_message` 后，Sub Agent 不知道当前团队中有哪些成员，无法有效协作
+3. **能力隔离过度**：Sub Agent 无法使用 `index_search`，导致独立会话中无法搜索代码；`recall_memory` 完全不可用
+4. **System Prompt 构建路径不清晰**：Sub Agent 的 `system_prompt` 参数作为首轮用户消息传入，而非融入 system prompt 主体
+5. **会话恢复丢失历史**：重启后 Sub Agent 的 child_session 被重建为空，丢失全部对话上下文
+6. **消息注入可能丢失**：`dispatch_agent_message` 中 `tx.send` 失败时静默丢弃
+
+### 1.2 目标
+
+在保持 RFC 0011 核心设计（统一 ReactEngine、独立 Session、共享 TeamContext）的基础上：
+
+- 简化生命周期模型
+- 建立 Sub Agent 的团队感知机制
+- 按需赋予 Sub Agent 索引和记忆能力
+- 明确 System Prompt 的分层构建
+- 提升消息投递可靠性
+
+### 1.3 非目标
+
+- 不改变前端 AgentPanel 的交互模式
+- 不改变 StreamEvent 的事件定义
+- 不引入 Sub Agent 嵌套创建（Sub Agent 仍不能创建 Sub Agent）
+
+---
+
+## 2. 生命周期简化
+
+### 2.1 移除 Temporary 生命周期
+
+**现状**：`AgentLifecycle` 有 `Persistent` 和 `Temporary` 两个变体。Temporary Agent 在 `drain_sub_agent_inboxes` 完成后自动销毁（释放锁 + unregister + 发事件）。
+
+**问题**：
+- LLM 难以准确判断一个 Agent 是否"临时"
+- 自动销毁逻辑增加了 `drain_sub_agent_inboxes` 的复杂度
+- Temporary Agent 执行完一轮后如果用户还想追问，Agent 已不存在
+
+**方案**：移除 `AgentLifecycle` 枚举，所有 Sub Agent 统一为 Persistent，只能通过 `dismiss_agent` 主动解散。
+
+### 2.2 改动清单
+
+```
+descriptor.rs
+  - 删除 AgentLifecycle 枚举
+  - AgentDescriptor 移除 lifecycle 字段
+
+tools.rs
+  - create_agent 工具移除 lifecycle 参数
+
+lifecycle.rs
+  - execute_create_agent: 移除 lifecycle 解析和校验
+  - restore_agents_from_session_history: 移除 lifecycle 解析
+  - parse_agent_created_message: 移除 lifecycle 解析
+
+engine.rs (drain_sub_agent_inboxes)
+  - 移除 Temporary Agent 自动销毁分支
+  - 所有 Agent 执行完毕后统一保存 child_session + 恢复 Idle
+```
+
+### 2.3 create_agent 工具新签名
+
+```json
+{
+  "name": "create_agent",
+  "description": "创建一个 Sub Agent 加入团队。Agent 拥有独立的执行上下文和指定角色，持续存在直到被解散。",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "role": {
+        "type": "string",
+        "description": "Agent 角色标识，用于 @提及（如 'pm'、'dev'、'test'）"
+      },
+      "label": {
+        "type": "string",
+        "description": "Agent 显示名称（如 'Project Manager'、'Developer'）"
+      },
+      "system_prompt": {
+        "type": "string",
+        "description": "Agent 的角色系统提示，定义其职责和行为规范"
+      },
+      "tools": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Agent 可用的工具列表。不指定时继承你的全部工具（不含 create_agent/dismiss_agent）。建议根据任务需要精确授权。"
+      }
+    },
+    "required": ["role", "label", "system_prompt"]
+  }
+}
+```
+
+---
+
+## 3. System Prompt 分层构建
+
+### 3.1 设计原则
+
+- `SystemPromptConfig` 保持纯配置快照语义，不混入运行时状态
+- Sub Agent 的 prompt 构建通过独立类型 `SubAgentPromptContext` 完成
+- 公共部分（规则、环境、动态段、摘要）提取为共享函数，消除重复
+
+### 3.2 类型设计
+
+```rust
+/// Sub Agent 的 system prompt 构建上下文
+///
+/// 将基础 SystemPromptConfig（纯配置快照）与运行时上下文
+/// （角色指令、团队成员列表）组合，构建 Sub Agent 专属的 system prompt。
+///
+/// 不修改 SystemPromptConfig，避免配置加载逻辑被运行时状态污染。
+pub struct SubAgentPromptContext<'a> {
+    /// 基础配置快照（引用，不持有）
+    base: &'a SystemPromptConfig,
+    /// Main Agent 生成的角色特化指令
+    role_prompt: &'a str,
+    /// 当前团队成员列表文本
+    team_roster: &'a str,
+}
+```
+
+### 3.3 Prompt 结构对比
+
+```
+Main Agent System Prompt:
+  ┌─────────────────────────────┐
+  │ 身份块 (identity_block)      │
+  │ 规则块 (rules_block)         │
+  │ 用户自定义指令               │
+  │ 环境段 (工作目录、文件根)     │
+  │ 动态段 (多媒体、Skills、团队) │
+  │ 用户偏好与记忆上下文          │
+  │ 对话摘要                     │
+  └─────────────────────────────┘
+
+Sub Agent System Prompt:
+  ┌─────────────────────────────┐
+  │ 角色特化指令 (role_prompt)    │  ← 替代通用身份块
+  │ 规则块 (rules_block)         │  ← 共享
+  │ 环境段 (工作目录、文件根)     │  ← 共享
+  │ 动态段 (多媒体、Skills、团队) │  ← 共享
+  │ 用户偏好与记忆上下文          │  ← 共享
+  │ 当前团队成员列表              │  ← Sub Agent 独有
+  │ 对话摘要                     │  ← 共享
+  └─────────────────────────────┘
+```
+
+### 3.4 公共函数提取
+
+```rust
+/// 收集环境段（工作目录、文件根）
+fn collect_environment_parts(session: &Session) -> Vec<String>;
+
+/// 收集动态段（多媒体、Skills、团队协作、用户上下文）
+fn collect_dynamic_parts(config: &SystemPromptConfig) -> Vec<String>;
+
+/// 收集摘要段
+fn collect_summary_part(session: &Session) -> Option<String>;
+
+/// 组装最终的 System Message
+fn assemble_system_message(parts: Vec<String>) -> Message;
+```
+
+`build_full_system_prompt` 和 `SubAgentPromptContext::build` 均基于这些公共函数构建，消除代码重复。
+
+### 3.5 调用侧改动
+
+**之前**（`spawn_ready_sub_agents`）：
+
+```rust
+// system_prompt 作为 user_input 传入 execute_turn
+let prompt = system_prompt;
+let usage = sub_engine.execute_turn(
+    &mut child_session, &prompt, &child_stream_tx,
+    &mut sub_cmd_rx, None, None,
+).await;
+```
+
+**之后**：
+
+```rust
+// 通过 SubAgentPromptContext 构建 system prompt
+let base_config = SystemPromptConfig::from_configs(
+    self.engine.models_config(),
+    self.engine.agent_config(),
+    &child_session.id,
+);
+let team_roster = format_team_roster_from_registry(&team_arc);
+let ctx = SubAgentPromptContext::new(&base_config, &system_prompt, &team_roster);
+child_session.system_prompt_message = Some(ctx.build(&child_session));
+
+// user_input 为空，首轮消息通过 Command::Message 注入
+let usage = sub_engine.execute_turn(
+    &mut child_session, "", &child_stream_tx,
+    &mut sub_cmd_rx, memory_handle, index_manager,
+).await;
+```
+
+---
+
+## 4. 团队感知机制
+
+### 4.1 设计
+
+Sub Agent 通过两个渠道感知团队成员：
+
+| 渠道 | 时机 | 内容 |
+|------|------|------|
+| System Prompt | 创建/重建时 | 当前所有活跃成员列表 |
+| 消息通知 | 新成员加入时 | 增量通知 |
+
+### 4.2 System Prompt 中的成员列表
+
+`SubAgentPromptContext` 的 `team_roster` 字段在构建时从 registry 生成：
+
+```rust
+fn format_team_roster_from_registry(team_arc: &Arc<Mutex<TeamContext>>) -> String {
+    let Ok(team) = team_arc.lock() else { return String::new(); };
+    let mut agents = team.registry.alive_agents();
+    agents.sort_by(|a, b| a.role.cmp(&b.role));
+    agents.iter().map(|a| {
+        format!("- {} (@{})", a.label, a.role)
+    }).collect::<Vec<_>>().join("\n")
+}
+```
+
+生成的文本示例：
+
+```
+当前团队成员：
+- Developer (@dev)
+- Project Manager (@pm)
+- Tester (@test)
+```
+
+### 4.3 新成员加入通知
+
+`execute_create_agent` 末尾向所有已存在的 Agent 发送通知：
+
+```rust
+// execute_create_agent 末尾追加
+let notification = format!("[团队通知] 新成员 {} (@{}) 已加入团队", label, role);
+for alive in team.registry.alive_agents() {
+    if alive.agent_id != agent_id {
+        team.dispatch_agent_message(
+            &alive.agent_id,
+            AgentMessage {
+                id: scru128::new().to_string(),
+                from: "system".to_string(),
+                to: alive.agent_id.clone(),
+                content: notification.clone(),
+                priority: MessagePriority::Normal,
+                created_at: now_text(),
+            },
+            Vec::new(),
+        );
+    }
+}
+```
+
+### 4.4 System Prompt 重建时机
+
+System Prompt 在以下时机重建（此时 team_roster 自动更新为最新成员列表）：
+
+- Sub Agent 首次执行（`system_prompt_message` 为 None）
+- 上下文压缩后（`maybe_update_context_summary`）
+- 上下文清空后（`reset_context_for_session`）
+
+---
+
+## 5. 能力赋予
+
+### 5.1 设计原则
+
+Sub Agent 的能力完全由 Main Agent 通过 `create_agent` 的 `tools` 参数决定。不指定时继承 Main Agent 的全部工具（排除 `create_agent` 和 `dismiss_agent`）。
+
+### 5.2 Index 能力
+
+**现状**：`spawn_ready_sub_agents` 中 `index_manager` 传 `None`，Sub Agent 调用 `index_search` 返回"未初始化"。
+
+**方案**：共享 Main Agent 的 IndexManager。
+
+```rust
+// spawn_ready_sub_agents 中
+let has_index = tool_names.contains(&"index_search".to_string());
+let sub_index = if has_index {
+    index_manager  // 共享 Main Agent 的 IndexManager
+} else {
+    None
+};
+```
+
+IndexManager 是无状态查询接口，共享无并发问题。Sub Agent 在同一 workspace 下工作，索引数据完全一致。
+
+### 5.3 Memory Recall 能力
+
+**现状**：`spawn_ready_sub_agents` 中 `memory_handle` 传 `None`。
+
+**方案**：由 Main Agent 通过 `tools` 参数决定是否授权。授权时共享 Main Agent 的 MemoryHandle。
+
+```rust
+let has_memory = tool_names.contains(&"recall_memory".to_string());
+let sub_memory = if has_memory {
+    memory_handle  // 共享 Main Agent 的 MemoryHandle
+} else {
+    None
+};
+```
+
+**记忆策略**：共享读取，统一写入。Sub Agent 的 `recall_memory` 查询全局记忆库，但记忆写入由 Main Agent 统一管理——Sub Agent 的 turn result 通过 `deliver_main_message` 回传给 Main Agent，由 Main Agent 提交记忆候选。
+
+### 5.4 工具过滤
+
+`spawn_ready_sub_agents` 中根据 `AgentDescriptor.tools` 过滤可用工具：
+
+```rust
+let sub_tools: Vec<ToolSpec> = self
+    .tools
+    .iter()
+    .filter(|t| tool_names.iter().any(|name| name == &t.name))
+    .filter(|t| !matches!(t.name.as_str(), "create_agent" | "dismiss_agent"))
+    .cloned()
+    .collect();
+```
+
+如果 Main Agent 未在 `tools` 中包含 `index_search` 或 `recall_memory`，对应工具不会出现在 Sub Agent 的工具列表中，LLM 不会尝试调用。
+
+---
+
+## 6. 消息投递可靠性
+
+### 6.1 问题
+
+`TeamContext::dispatch_agent_message` 中，当目标 Agent 正在运行时通过 `tx.send` 注入消息，但发送失败时静默丢弃：
+
+```rust
+pub(crate) fn dispatch_agent_message(&mut self, agent_id: &str, message: AgentMessage, ...) {
+    if let Some(tx) = self.active_agent_senders.get(agent_id) {
+        let _ = tx.send(Command::Message { ... });  // ← 失败时静默丢弃
+    } else {
+        self.registry.deliver_message(agent_id, message);
+    }
+}
+```
+
+### 6.2 方案
+
+发送失败时 fallback 到收件箱：
+
+```rust
+pub(crate) fn dispatch_agent_message(&mut self, agent_id: &str, message: AgentMessage, media: ...) {
+    let dispatched = if let Some(tx) = self.active_agent_senders.get(agent_id) {
+        tx.send(Command::Message {
+            content: format_agent_message_for_prompt(&message),
+            message_id: Some(message.id.clone()),
+            media,
+        }).is_ok()
+    } else {
+        false
+    };
+
+    if !dispatched {
+        self.registry.deliver_message(agent_id, message);
+        if let Some(waker) = &self.dispatch_waker {
+            let _ = waker.send(());
+        }
+    }
+}
+```
+
+---
+
+## 7. 会话恢复改进
+
+### 7.1 现状
+
+`restore_agents_from_session_history` 从主会话 System 消息中解析 Agent 事件并重建注册表，但 child_session 被创建为空，丢失全部对话历史。
+
+### 7.2 方案
+
+将 child_session 持久化到磁盘，恢复时从磁盘加载。
+
+**持久化路径**：
+
+```
+{sessions_dir}/{session_id}/agents/{agent_id}.json
+```
+
+**持久化时机**：
+- Sub Agent 执行完毕后（`drain_sub_agent_inboxes` 结果处理阶段）
+- 会话持久化时同步持久化所有 child_session
+
+**恢复时机**：
+- `restore_agents_from_session_history` 中，优先从磁盘加载 child_session
+- 磁盘文件不存在时 fallback 到创建空 session
+
+### 7.3 改动清单
+
+```rust
+// lifecycle.rs
+fn restore_agents_from_session_history(...) {
+    // ...
+    let child_session = match load_child_session(&sessions_dir, &agent.agent_id) {
+        Some(session) => session,
+        None => create_child_session(parent_session, &agent.label),
+    };
+    team.registry.register_with_session(descriptor, child_session);
+}
+
+// 新增
+fn load_child_session(sessions_dir: &Path, agent_id: &str) -> Option<Session>;
+fn persist_child_session(sessions_dir: &Path, agent_id: &str, session: &Session);
+```
+
+---
+
+## 8. 改动总览
+
+### 8.1 文件改动
+
+| 文件 | 改动类型 | 说明 |
+|------|----------|------|
+| `agent_team/descriptor.rs` | 修改 | 删除 `AgentLifecycle` 枚举，`AgentDescriptor` 移除 `lifecycle` 字段 |
+| `agent_team/tools.rs` | 修改 | `create_agent` 移除 `lifecycle` 参数 |
+| `agent_team/lifecycle.rs` | 修改 | 移除 lifecycle 处理；新增团队通知广播；新增 child_session 持久化 |
+| `agent_team/registry.rs` | 不变 | — |
+| `agent_team/message_bus.rs` | 不变 | — |
+| `agent_team/file_lock.rs` | 不变 | — |
+| `prompt/sections.rs` | 修改 | 新增 `SubAgentPromptContext`；提取公共函数 |
+| `prompt/mod.rs` | 修改 | 导出 `SubAgentPromptContext` |
+| `react/engine.rs` | 修改 | `spawn_ready_sub_agents` 使用 `SubAgentPromptContext`；传入 `index_manager` 和条件性 `memory_handle`；移除 Temporary 销毁逻辑 |
+| `react/context.rs` | 不变 | — |
+| `session.rs` | 不变 | — |
+| `core/mod.rs` | 修改 | 将 `index_manager` 传入 team 调度链路 |
+
+### 8.2 不改动的部分
+
+- `tiangong-types`：StreamEvent 定义不变
+- `tiangong-server`：远端消费逻辑不变
+- `src-tauri/commands.rs`：Tauri 命令层不变
+- `frontend/`：AgentPanel 和消息展示逻辑不变
+- `SystemPromptConfig`：不添加任何新字段
+
+---
+
+## 9. 实现路径
+
+### Phase 1：生命周期简化 + 消息可靠性
+
+- 删除 `AgentLifecycle` 枚举
+- `create_agent` 移除 `lifecycle` 参数
+- `drain_sub_agent_inboxes` 移除 Temporary 自动销毁
+- `dispatch_agent_message` 增加 fallback
+
+**验证**：创建的 Agent 不再自动销毁，只能通过 `dismiss_agent` 解散。消息投递不再丢失。
+
+### Phase 2：System Prompt 分层构建
+
+- 提取公共函数（`collect_environment_parts`、`collect_dynamic_parts`、`collect_summary_part`、`assemble_system_message`）
+- 新增 `SubAgentPromptContext`
+- `spawn_ready_sub_agents` 改用 `SubAgentPromptContext` 构建 system prompt
+
+**验证**：Sub Agent 的 system prompt 包含角色特化指令、环境信息和团队成员列表。
+
+### Phase 3：能力赋予
+
+- `spawn_ready_sub_agents` 传入 `index_manager`
+- `spawn_ready_sub_agents` 根据 `tools` 参数条件性传入 `memory_handle`
+- 未授权的工具从工具列表中过滤
+
+**验证**：授权了 `index_search` 的 Sub Agent 可正常搜索代码；授权了 `recall_memory` 的 Sub Agent 可查询记忆。
+
+### Phase 4：团队感知
+
+- `execute_create_agent` 末尾向现有 Agent 广播新成员通知
+- `format_team_roster_from_registry` 生成成员列表
+
+**验证**：新 Agent 加入后，已有 Agent 收到通知并知道新成员的存在。
+
+### Phase 5：会话持久化
+
+- child_session 持久化到磁盘
+- 恢复时从磁盘加载
+
+**验证**：重启应用后，Sub Agent 保留之前的对话历史。
+
+---
+
+## 10. 约束（不变）
+
+| 约束 | 值 | 说明 |
+|------|-----|------|
+| 最大 Agent 数量 | 8 | 含 Main Agent |
+| Sub Agent 最大轮次 | 10 | 单次执行 |
+| Sub Agent Token 预算 | 200,000 | 所有 Sub Agent 累计 |
+| 并发上限 | 4 | 同时运行的 Sub Agent |
+| 文件锁超时 | 300 秒 | 自动释放 |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -695,8 +695,10 @@ fn start_stream_consumer(
                                     media.clone(),
                                 );
                             } else if !media.is_empty() {
-                                if let Some(message) =
-                                    session.messages.iter_mut().find(|msg| msg.id == *message_id)
+                                if let Some(message) = session
+                                    .messages
+                                    .iter_mut()
+                                    .find(|msg| msg.id == *message_id)
                                 {
                                     if message.media.is_empty() {
                                         message.media = media.clone();
@@ -872,11 +874,10 @@ fn start_stream_consumer(
                             ref agent_id,
                             ref role,
                             ref label,
-                            ref lifecycle,
                         } => {
                             session.append_message(
                                 tiangong_core::session::MessageRole::System,
-                                format!("[Agent] {label} ({role}) 已加入团队 [{lifecycle}] id={agent_id}"),
+                                format!("[Agent] {label} ({role}) 已加入团队 id={agent_id}"),
                             );
                         }
                         StreamEvent::AgentStatusChanged {
@@ -987,7 +988,10 @@ fn start_stream_consumer(
                         } => {
                             session.append_message(
                                 tiangong_core::session::MessageRole::System,
-                                format!("[文件锁] {path} {action} by {}", holder_agent_label.as_deref().unwrap_or("未知")),
+                                format!(
+                                    "[文件锁] {path} {action} by {}",
+                                    holder_agent_label.as_deref().unwrap_or("未知")
+                                ),
                             );
                         }
                         StreamEvent::ContextCompressing { .. } => {}
@@ -996,10 +1000,7 @@ fn start_stream_consumer(
                             summary_up_to,
                             ..
                         } => {
-                            let message = format!(
-                                "[上下文管理] 上下文已{}",
-                                action.display_text()
-                            );
+                            let message = format!("[上下文管理] 上下文已{}", action.display_text());
                             session.append_message(
                                 tiangong_core::session::MessageRole::System,
                                 message,
@@ -1091,8 +1092,7 @@ fn start_stream_consumer(
                         core_state.store.runtime.run.summary = "正在检索记忆...".to_string();
                     }
                     StreamEvent::MemoryRecallProgress { ref phase } => {
-                        core_state.store.runtime.run.summary =
-                            format!("正在检索记忆: {phase}");
+                        core_state.store.runtime.run.summary = format!("正在检索记忆: {phase}");
                     }
                     StreamEvent::MemoryRecallDone { hit_count, .. } => {
                         if *hit_count > 0 {
@@ -1104,34 +1104,50 @@ fn start_stream_consumer(
                         }
                     }
                     StreamEvent::AgentCreated { ref label, .. } => {
-                        core_state.store.runtime.run.summary =
-                            format!("Agent {label} 已加入团队");
+                        core_state.store.runtime.run.summary = format!("Agent {label} 已加入团队");
                     }
-                    StreamEvent::AgentStatusChanged { ref label, ref status, .. } => {
-                        core_state.store.runtime.run.summary =
-                            format!("Agent {label}: {status}");
+                    StreamEvent::AgentStatusChanged {
+                        ref label,
+                        ref status,
+                        ..
+                    } => {
+                        core_state.store.runtime.run.summary = format!("Agent {label}: {status}");
                     }
-                    StreamEvent::AgentNotification { ref agent_label, .. } => {
+                    StreamEvent::AgentNotification {
+                        ref agent_label, ..
+                    } => {
                         core_state.store.runtime.run.summary =
                             format!("Agent {agent_label} 发送了通知");
                     }
-                    StreamEvent::AgentMessage { ref from_agent_label, ref to_agent_label, .. } => {
+                    StreamEvent::AgentMessage {
+                        ref from_agent_label,
+                        ref to_agent_label,
+                        ..
+                    } => {
                         core_state.store.runtime.run.summary =
                             format!("{from_agent_label} → {to_agent_label}");
                     }
-                    StreamEvent::AgentOutput { ref agent_label, .. } => {
+                    StreamEvent::AgentOutput {
+                        ref agent_label, ..
+                    } => {
                         core_state.store.runtime.run.summary =
                             format!("Agent {agent_label} 输出已更新");
                     }
-                    StreamEvent::FileLockChanged { ref path, ref action, ref holder_agent_label, .. } => {
-                        core_state.store.runtime.run.summary =
-                            format!("文件锁 {action}: {path} ({})", holder_agent_label.as_deref().unwrap_or("未知"));
+                    StreamEvent::FileLockChanged {
+                        ref path,
+                        ref action,
+                        ref holder_agent_label,
+                        ..
+                    } => {
+                        core_state.store.runtime.run.summary = format!(
+                            "文件锁 {action}: {path} ({})",
+                            holder_agent_label.as_deref().unwrap_or("未知")
+                        );
                     }
                     StreamEvent::ContextCompressing { .. } => {
                         core_state.store.runtime.run.status =
                             tiangong_core::runtime::RunStatus::Executing;
-                        core_state.store.runtime.run.summary =
-                            "正在压缩早期上下文...".to_string();
+                        core_state.store.runtime.run.summary = "正在压缩早期上下文...".to_string();
                         core_state.store.runtime.run.last_session_id = Some(sid.clone());
                         core_state.store.runtime.run.updated_at =
                             tiangong_core::session::now_text();
@@ -1144,23 +1160,20 @@ fn start_stream_consumer(
                             core_state.report_run_idle(text);
                         }
                     }
-                    StreamEvent::IndexStatus { ref phase, count } => {
-                        match phase.as_str() {
-                            "scanning" => {
-                                core_state.store.runtime.run.summary =
-                                    "正在建立工作区索引...".to_string();
-                            }
-                            "done" => {
-                                core_state.store.runtime.run.summary =
-                                    format!("索引扫描完成: {count} 个文件");
-                            }
-                            "error" => {
-                                core_state.store.runtime.run.summary =
-                                    "索引扫描失败".to_string();
-                            }
-                            _ => {}
+                    StreamEvent::IndexStatus { ref phase, count } => match phase.as_str() {
+                        "scanning" => {
+                            core_state.store.runtime.run.summary =
+                                "正在建立工作区索引...".to_string();
                         }
-                    }
+                        "done" => {
+                            core_state.store.runtime.run.summary =
+                                format!("索引扫描完成: {count} 个文件");
+                        }
+                        "error" => {
+                            core_state.store.runtime.run.summary = "索引扫描失败".to_string();
+                        }
+                        _ => {}
+                    },
                     _ => {}
                 }
                 Ok(())


### PR DESCRIPTION
## Summary

- 移除 `AgentLifecycle` 枚举（Temporary/Persistent），所有 Sub Agent 统一为 Persistent，只能通过 `dismiss_agent` 主动解散
- 新增 `SubAgentPromptContext` 分层构建 Sub Agent 的 System Prompt，包含角色指令、环境信息、团队成员列表
- 根据工具列表条件性共享 Main Agent 的 `IndexManager` 和 `MemoryHandle`
- 创建 Agent 时向已有成员广播新成员通知，注入团队成员列表到 System Prompt
- child_session 持久化到磁盘（`~/.tiangong/sessions/{id}/agents/{agent_id}.json`），恢复时优先从磁盘加载
- 修复 `dispatch_agent_message` 发送失败时静默丢弃的问题，增加 fallback 到收件箱

## Test plan

- [x] 251 个现有测试全部通过
- [x] clippy 无警告
- [x] fmt 格式检查通过
- [x] agent_team 模块所有测试通过（生命周期、消息路由、文件锁、团队广播、会话恢复）
- [x] 手动验证：创建 Sub Agent 后不再自动销毁，只能通过 dismiss 解散
- [x] 手动验证：授权 index_search 的 Sub Agent 可正常搜索代码
- [x] 手动验证：新 Agent 加入后已有 Agent 收到团队通知
- [x] 手动验证：重启后 Sub Agent 保留对话历史