### PR TITLE
fix(components): 编辑已发送消息体验对齐与附件分析修复

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,187 +1,71 @@
 # 天工项目规划（PLAN）
 
 ## 愿景
-构建一个全功能可扩展的 GUI + CLI + Server 个人智能终端平台，实现"可对话、可规划、可执行、可扩展、可治理、可远程"的 Agent 能力闭环。通过 Connector 机制接入各类 IM 通道，支持图片/视频等多媒体生成，打造个人 AI 中枢。
 
-## 总体目标
-- 产品目标：从桌面对话工具演进为全栈个人智能终端（本地 + 远程 + 多通道）。
-- 架构目标：Workspace 多 crate 分离，核心引擎、前端、Server、Connector、媒体生成各自独立。
-- 安全目标：Server 模式默认安全（本地绑定、Token 认证），Connector 鉴权白名单制。
-- 工程目标：按 Phase 增量交付，每个 Phase 保证功能不回退。
+构建全功能可扩展的 GUI + CLI + Server 个人智能终端平台，实现"可对话、可规划、可执行、可扩展、可治理、可远程"的 Agent 能力闭环。通过 IM Adapter 接入消息通道，通过自动化触发层实现系统级主动调度，打造个人 AI 中枢。
 
-## 当前执行策略（2026-05-12）
-- 架构 RFC：`docs/rfc/0004-full-stack-agent-platform.md`
-- 架构基准：`docs/desktop-agent-technical-architecture.md`
-- Phase 1~17 已完成。
-- Phase 18（Memory 系统）主链路已完成，待验证场景验证。
-- 当前主目标：基于 RFC-0011 实现多智能体协作系统。
-- 当前进展：RFC 已创建，Agent 生命周期、通讯机制、文件编辑锁、前端交互设计已明确。
-- 当前风险：多 Agent 并发执行需处理好消息路由正确性和文件锁死锁问题。
+## 版本规划
 
-## 里程碑
+| 版本 | 里程碑 | 状态 |
+|------|--------|------|
+| 0.1.0 | CLI Agent 基线 + Skill 管理 | ✅ |
+| 0.2.0 | Server + Gateway + 多媒体 + Memory | ✅ |
+| 0.3.0 | 多智能体协作 + 发布分发 + 飞书互联 | ✅ |
+| **0.4.0** | **自动化触发层（cron/webhook/polling）** | **🔲 进行中** |
 
-### Phase 1（CLI Agent 基线，已达成）
-- 单 Agent 对话能力可用。
-- 最小任务执行链路可跑通（输入 -> 规划 -> 执行 -> 反馈）。
-- MCP 本地/远程接入可用。
+## 当前执行策略（2026-05-25）
 
-### Phase 2（Skill 管理 MVP，部分完成）
-- Skill 支持安装、启停、卸载、列表、详情。
-- `/skill` 管理交互对齐 `/mcp`。
-- 动态 Step 执行闭环。
-- 当前重构：根据 RFC-0007 将 Skill 注册事实源改为文件系统目录，保留 MCP 锁机制。
-- 待完成：文件系统注册表、按需实时加载、旧布局迁移、GC 与诊断工具。
+- Phase 1~19 已完成。
+- 当前主目标：实现自动化触发层（Issue #38），完成后发布 0.4.0。
+- 自动化触发层与 IM Adapter 模式正交，互不冲突。
 
-### Phase 3（Workspace 拆分与核心抽离，已完成）
-- 单 crate → Cargo workspace 多 crate。
-- `tiangong-core`：核心引擎独立（无 UI 依赖）。
-- `tiangong-cli`：CLI/TUI 前端独立。
-- `tiangong-gui`：桌面 GUI 前端独立（Tauri + React）。
-- 主二进制统一入口分发。
-- 确保现有功能不回退。
+## 已完成里程碑
 
-### Phase 4（Server 模式）
-- `tiangong-server`：HTTP REST + WebSocket API。
-- 对话、会话管理、Skill/MCP 管理 API。
-- API Token 认证与访问控制。
-- `tiangong server` 命令启动，支持 `-d` / `--daemon` 后台运行。
-- `tiangong server stop` 停止后台运行的 Server。
-- Server 启动时自动加载并启动已启用的 Connector。
+| Phase | 名称 | 关键交付 |
+|-------|------|----------|
+| 1 | CLI Agent 基线 | 单 Agent 对话、MCP 接入 |
+| 2 | Skill 管理 MVP | 安装/启停/卸载、动态 Step 执行 |
+| 3 | Workspace 拆分 | 多 crate 分离（core / cli / gui） |
+| 4 | Server 模式 | HTTP + WebSocket API、Token 认证、守护进程 |
+| 5 | Gateway 与事件总线 | EventBus、统一消息路由 |
+| 6 | IM Adapter 框架 | 外部 Bot 统一入口、飞书 Bot Adapter |
+| 7 | 多媒体能力 | 图片/视频生成、语音识别/合成 |
+| 8 | 生产化与完善 | 日志监控、配置热重载、TLS |
+| 9 | 模型配置重构 | Provider + Model + Routing 三层架构、shadcn/ui |
+| 10 | 友好交互改造 | GUI 简化、流式展示 |
+| 11 | 运行时基础设施 | 统一任务模型、后台任务回流、远程角色模型 |
+| 12 | 事件驱动运行时 | Event-loop 模型替代 Turn-based |
+| 13 | CoreConfig 注入 | 配置外部注入，支持 CLI/GUI/Server |
+| 15 | LLM 协议抽象 | tiangong-llm + tiangong-anthropic、Anthropic 适配 |
+| 16 | 架构收口 | 统一入口、成本可见性、安全审计 |
+| 17 | 多媒体语义收敛 | 结构化图片/视频结果、Connector 视频发送 |
+| 18 | Memory 系统 | tiangong-memory crate、Micro/Meso 记忆链路 |
+| 19 | 多智能体协作 | 动态组队、消息通讯、文件编辑锁、前端交互 |
 
-### Phase 5（Gateway 与事件总线）
-- 事件总线（EventBus）实现层间解耦。
-- Gateway 统一消息路由。
-- 统一消息模型（IncomingMessage / OutgoingMessage）。
+## Phase 20：自动化触发层（进行中）
 
-### Phase 6（Connector 框架与 IM 接入）
-- `tiangong-connector`：Connector trait 定义。
-- 首批适配器：Telegram、Discord、飞书/Lark、Webhook。
-- Connector 配置管理与热插拔。
-- 后续扩展：钉钉、Slack 等。
+> Issue：#38
 
-### Phase 7（多媒体能力）
-- `tiangong-media`：图片/视频生成 + 语音识别/合成框架。
-- 图片生成后端：OpenAI DALL-E / GPT-Image、Flux。
-- 视频生成后端：Sora、Kling。
-- 语音识别后端：OpenAI Whisper、讯飞。
-- 语音合成后端：OpenAI TTS、ElevenLabs。
-- Agent 层集成 MediaAgent。
-- Connector 支持语音消息自动转文字。
+内嵌于 Server 的系统级主动触发能力，与 IM Adapter 模式正交。
 
-### Phase 8（生产化与完善）
-- 日志与监控完善。
-- 配置热重载。
-- TLS、安全加固、Docker 部署支持。
+**设计原则**：
+- 调度器常驻 Server 进程，不做成 tool call
+- Job 持久化（SQLite），启动时恢复
+- 触发 → RuntimeEvent → 现有执行链路
+- 结果可投递到 IM 通道
 
-### Phase 9（模型配置重构与多媒体集成，已完成）
-- `ModelsConfig` 替换 `ModelProviderConfig` 为唯一模型配置源。
-- Provider + Model + Routing 三层架构。
-- GUI 全面升级为 shadcn/ui dashboard 风格，支持暗/亮主题。
-- 意图分类快速路径：简单对话跳过 planning，减少 token 消耗。
-- 多媒体能力通过 Routing 集成到执行引擎。
-
-### Phase 10（友好交互改造，已完成）
-- GUI 样式简化（去头像、去气泡边框）。
-- GUI 解释文本独立流式展示。
-- CLI 实时流式展示。
-
-### Phase 11（架构补全 — 运行时基础设施，已完成）
-> 对照 `docs/desktop-agent-technical-architecture.md` 补全缺失能力
-> 差距分析：`docs/architecture-gap-analysis.md`
-
-**Phase 11-A：基础设施（高优先级）**
-- 统一任务模型：合并 RunStatus / TaskStatus 为 UnifiedTaskStatus，覆盖完整状态机。
-- 查询编排层独立抽象：新建 `orchestrator/` 模块，扩展 QueryMode 为多路由。
-
-**Phase 11-B：执行闭环（高优先级）**
-- 后台任务回流：后台任务完成 → RuntimeEvent → EventBus → 会话注入。
-- 恢复与持久化：任务状态实时持久化，启动时恢复未完成任务现场。
-
-**Phase 11-C：能力增强（中优先级）**
-- 上下文装配层增强：用户偏好/长期记忆注入，预留检索接口。
-- 多代理 Worker 隔离：独立工具集、上下文边界、预算上限。
-- 权限细粒度控制：路径级规则、网络目标限制。
-- 观测与成本治理：请求级/任务级/会话级三层成本聚合。
-
-**Phase 11-D：远程能力（低优先级）**
-- 远程接入角色模型：控制者/观察者角色区分，并通过部署边界与鉴权控制风险。
-
-### Phase 12（事件驱动循环运行时，已完成）
-> RFC：`docs/rfc/0005-event-loop-runtime.md`
-
-将运行时从 Turn-based 改为 Event-loop 模型：
-- Phase A：EventLoopRunner 核心 + 挂起/恢复
-- Phase B：ActiveLoops 管理器 + LoopHost trait
-- Phase C：生命周期管理、优雅关闭与持久化恢复
-- Phase D：清理旧代码（TurnRunner / QueryClassifier / ControlSignal）
-
-### Phase 13（CoreConfig 配置注入，已完成）
-> RFC：`docs/rfc/0006-core-config-provider.md`
-
-将 TiangongCore 的配置从内部磁盘加载改为外部注入：
-- Phase A：定义 CoreConfig + CoreConfigProvider，修改 TiangongCore 构造函数
-- Phase B：CLI/GUI/Server 适配，使用 CoreConfigProvider 注入配置
-- Phase C：tiangong-config 独立 crate（可选），提供磁盘加载、持久化、文件监听
-
-### Phase 15（LLM 协议抽象与 Anthropic 支持，已完成）
-- Provider 配置增加协议类型，区分 OpenAI 兼容与 Anthropic。
-- 新增独立 crate `tiangong-llm`，统一承载 Provider 抽象、领域模型、错误类型与各协议适配。
-- 在 `tiangong-core` 内部维护统一 Provider 抽象和领域模型，Anthropic transport 下沉到独立 crate `tiangong-anthropic`，使用原生 `reqwest + serde` 实现 Messages 与 SSE 解析，`tiangong-llm` 仅负责协议抽象与 provider 封装。
-- `async-openai` 也迁入 `tiangong-llm` 作为 OpenAI 兼容 provider，避免协议实现继续散落在 `tiangong-core`。
-- 对话、流式输出、工具调用、轻量模型调用补齐 Anthropic Messages 适配。
-- GUI / CLI / Server 共享同一套协议能力判断与错误处理。
-
-### Phase 16（架构收口与远程能力补齐，已完成）
-> 对照 `docs/desktop-agent-technical-architecture.md` 的剩余缺口继续推进
-
-- 统一会话入口与运行时事件模型，减少 GUI / Server / Gateway 的入口分叉。
-- 收敛远程角色模型（控制者 / 观察者）与相应权限边界。
-- 收敛 `tiangong-core/src/model.rs` 剩余兼容桥接，继续降低核心层协议细节。
-- 完善安全与审计闭环，补齐路径、网络目标与远程会话绑定的治理能力。
-- 继续补齐观测与成本治理，让请求级 / 任务级 / 会话级统计对齐架构基准。
-- 已完成 Server 信任语义收敛：运行时强制 `full_trust`，远程角色收敛为 `controller / observer`，并移除 Server 端审批 API 与审批事件。
-- 已完成 Server 成本可见性主链路：支持会话级成本查询并继承远程会话可见范围控制。
-- 已完成入口尾项收口：GUI 本地消息入口准备逻辑下沉到 `app_state` ingress 门面，减少本地/远程入口分叉。
-- 已完成文档尾项收口：清理历史文档中的远程审批语义，保证路线与实现一致。
-
-### Phase 17（多媒体结果语义收敛，已完成）
-> 设计说明：`docs/media-capability-architecture-adjustment.md`
-
-- 已为会话消息补齐结构化图片/视频结果语义，避免依赖工具日志文本渲染图片/视频。
-- 已保留 `tiangong-media` 作为多媒体主链路，MCP 仅作为后端适配来源之一。
-- 已在 Core/Tauri/Server 链路中保留结构化媒体资源，避免多媒体结果退化为工具文本。
-- 已补齐 Connector 对结构化视频结果的发送分支。
-
-### Phase 18（Memory 系统，已完成）
-> 设计说明：`docs/memory-system/`
-
-- 将长期记忆从 Core 中拆出为独立 `tiangong-memory` crate，保证可单独集成测试、可复用、可关闭。
-- 已完成 Micro 写入主链路：TurnResult -> EpisodeWriter -> SQLite/Tantivy/向量索引。
-- 已完成 Tool 化按需回忆：主模型通过 `recall_memory` 主动触发 Memory。
-- 已完成结构化产物记忆：媒体 URL、文件路径、工具结果摘要进入 Episode。
-- 已完成 Meso 反刍：从近期 Episode 提炼 Entity/Decision。
-- 已完成多类型记忆提取与智能去重。
-- 已完成运行时粗回忆与重新回忆机制。
-
-### Phase 19（多智能体协作系统，进行中）
-> RFC：`docs/rfc/0011-multi-agent-collaboration.md`
-
-主 Agent 在对话中动态组建团队，Sub Agent 之间通过工具调用互相通讯，共享工作区但通过文件编辑锁防止冲突。用户可直接与任意存活 Agent 交互。
-
-- Phase A：基础框架 — AgentDescriptor / AgentRegistry 数据结构，create_agent / dismiss_agent 工具，Sub Agent ReactEngine 启动与停止
-- Phase B：消息通讯 — send_message / broadcast_message 工具，MessageBus 消息路由，收件箱消息注入 ReactEngine 循环
-- Phase C：文件编辑锁 — FileLockManager 实现，lock_file / unlock_file 工具，write_file / replace_in_file 锁检查集成
-- Phase D：前端交互 — Agent Tab 切换，Sub Agent 直接推送，@提及输入，Agent 状态面板
-- Phase E：完善与优化 — 临时 Agent 自动销毁，锁超时与死锁检测，Agent 错误恢复
+| 子阶段 | 内容 |
+|--------|------|
+| 20-A | 任务模型与存储 — Job/JobRun/JobDelivery 模型、SQLite store、CRUD API |
+| 20-B | Cron 调度器 — 表达式解析、常驻执行器、启动恢复、手动触发 |
+| 20-C | Webhook 触发器 — 端点注册、签名验证、触发接入 |
+| 20-D | Polling 触发器 — HTTP 轮询、条件去重、触发接入 |
+| 20-E | 结果投递与通知 — IM 通道投递、失败重试、Run history API |
+| 20-F | 前端管理界面 — Job 列表/创建/启停、执行历史、手动触发 |
 
 ## 参考文档
-- 项目说明：`README.md`
-- RFC 0001：`docs/rfc/0001-tiangong-desktop-agent-roadmap.md`
-- RFC 0002：`docs/rfc/0002-cli-agent-roadmap.md`
-- RFC 0003：`docs/rfc/0003-skill-market.md`
-- RFC 0004：`docs/rfc/0004-full-stack-agent-platform.md`（全栈平台架构）
-- RFC 0006：`docs/rfc/0006-core-config-provider.md`（CoreConfig 配置注入）
-- RFC 0011：`docs/rfc/0011-multi-agent-collaboration.md`（多智能体协作系统）
+
 - 架构基准：`docs/desktop-agent-technical-architecture.md`
-- 架构差距分析：`docs/architecture-gap-analysis.md`
 - 需求基线：`docs/requirements.md`
+- Server API：`docs/server-api.md`
+- RFC 0011：`docs/rfc/0011-multi-agent-collaboration.md`

--- a/TODO.md
+++ b/TODO.md
@@ -1,99 +1,70 @@
 # TODO - 天工当前开发任务
 
-> 最后更新：2026-05-20
-> 当前主线：发布准备与自动化
-> 参考：`PLAN.md`、`docs/rfc/0011-multi-agent-collaboration.md`
+> 最后更新：2026-05-25
+> 当前主线：Phase 20 — 自动化触发层（0.4.0）
+> 参考：`PLAN.md`、Issue #38
 
 ---
 
-## Phase A：基础框架
+## Phase 20-A：任务模型与存储
 
-- [x] 定义 AgentDescriptor / AgentLifecycle / AgentStatus 类型（`agent_team/descriptor.rs`）
-- [x] 实现 AgentRegistry — 会话级 Agent 注册表（`agent_team/registry.rs`）
-- [x] 定义团队工具 Spec 并注册（`agent_team/tools.rs`）
-- [x] 在 `inject_enhanced_tools` 中注册团队工具
-- [x] 实现 Sub Agent ReactEngine 独立执行循环（`react/engine.rs::drain_sub_agent_inboxes`）
-- [x] 实现 Sub Agent 生命周期管理：创建、解散（`agent_team/lifecycle.rs`）
-- [x] 新增 StreamEvent：AgentCreated / AgentStatusChanged / AgentNotification / AgentMessage / FileLockChanged
-- [x] ReactEngine 拦截团队工具调用（create_agent / dismiss_agent / send_message 等）
-- [x] 前端：Agent Tab 栏基础展示（Agent 列表 + 状态指示器）
+- [ ] 定义 Job 数据模型（id / name / trigger_type / schedule / payload / enabled / created_at / updated_at）
+- [ ] 定义 JobRun 数据模型（id / job_id / status / started_at / finished_at / result）
+- [ ] 定义 JobDelivery 数据模型（id / job_run_id / channel / status / retry_count）
+- [ ] 实现 SQLite job store（建表、CRUD）
+- [ ] 实现 run history 存储（写入、查询、状态更新）
+- [ ] 新增 Job CRUD API（`POST/GET/PUT/DELETE /api/v1/jobs`）
 
-## Phase B：消息通讯
+## Phase 20-B：Cron 调度器
 
-- [x] 定义 AgentMessage 类型（from / to / content / priority）
-- [x] 实现 MessageBus 消息路由（`agent_team/message_bus.rs`）
-- [x] 定义 `send_message` / `broadcast_message` 工具 Spec
-- [x] 实现 Agent 收件箱：消息注入 ReactEngine 上下文
-- [x] 新增 StreamEvent：AgentMessage
-- [x] 前端：Agent 间消息流展示（系统消息形式）
+- [ ] 引入 cron 表达式解析库（如 `cron` 或 `saffron`）
+- [ ] 实现 Scheduler 常驻执行器（tokio spawn，内嵌于 Server 启动流程）
+- [ ] Cron job 触发 → 构造 RuntimeEvent → 进入现有执行链路
+- [ ] Server 启动时从 job store 加载已启用的 cron job 并恢复调度
+- [ ] 支持执行目标指定（main session / isolated session / skill）
+- [ ] 手动触发 API（`POST /api/v1/jobs/:id/trigger`）
 
-## Phase C：文件编辑锁
+## Phase 20-C：Webhook 触发器
 
-- [x] 实现 FileLockManager（`agent_team/file_lock.rs`）
-- [x] 定义 `lock_file` / `unlock_file` 工具 Spec
-- [x] 集成到 `write_file` / `replace_in_file`：执行前检查锁状态
-- [x] 锁超时机制（默认 300 秒自动释放）
-- [x] Agent 销毁时自动释放所有持有锁
-- [x] 主 Agent 拥有锁最高权限（可强制释放）
-- [x] 新增 StreamEvent：FileLockChanged
-- [x] 锁冲突状态报告（active_locks_summary）
+- [ ] Webhook 端点注册（每个 webhook job 分配唯一路径）
+- [ ] 实现 `POST /api/v1/webhooks/:token` 端点
+- [ ] 请求签名验证（HMAC-SHA256）
+- [ ] Webhook 触发 → 构造 RuntimeEvent → 进入现有执行链路
 
-## Phase D：前端交互
+## Phase 20-D：Polling 触发器
 
-- [x] 定义 `notify_user` 工具 Spec，Sub Agent 可直接推送消息到前端
-- [x] 新增 StreamEvent：AgentNotification（携带 agent_id + agent_label）
-- [x] 前端：Agent Tab 切换 — 用户可查看不同 Agent 的执行细节
-- [x] 前端：@提及输入 — 支持 @dev / @test / @all 语法
-- [x] 前端：Agent 面板 — 显示团队成员列表、状态、手动关闭按钮
-- [x] Tauri commands 层处理 Agent 相关事件转发
+- [ ] 实现 HTTP polling 轮询执行器（定时请求指定 URL）
+- [ ] 条件判断与去重（响应内容变化时才触发）
+- [ ] Polling 触发 → 构造 RuntimeEvent → 进入现有执行链路
 
-## Phase E：完善与优化
+## Phase 20-E：结果投递与通知
 
-- [x] 临时 Agent 任务完成后自动销毁
-- [x] Agent 错误恢复：Sub Agent 失败不影响团队其他 Agent
-- [x] 并发限制：最大 8 个 Agent，同时运行 4 个 Sub Agent
-- [x] Token 预算分配：Sub Agent 共享 200K token 预算，超出后暂停后续 Agent
-- [x] system prompt 中补充团队工具使用指引
-- [x] Sub Agent 并行执行（使用 futures::join_all 协作并发）
-- [x] 修复 token 消耗统计口径，展示当前 tokens、压缩进度和总 tokens
+- [ ] 执行结果投递到 IM 通道（复用 `POST /api/v1/messages` 或直接调用 MessageRouter）
+- [ ] 失败重试机制（可配置重试次数与间隔）
+- [ ] Run history 查询 API（`GET /api/v1/jobs/:id/runs`）
+- [ ] 投递状态追踪与查询
 
-## 临时修复任务
+## Phase 20-F：前端管理界面
 
-- [x] 修复 LLM 调用失败日志缺少供应商与模型信息、provider 字段混用协议名导致误判的问题
-- [x] 修复 Markdown 代码块内部误显示行内代码背景色的问题
-- [x] 在前端展示上下文压缩开始和完成状态
-- [x] 修复手动上下文压缩未真实触发 LLM 摘要的问题
-- [x] 调整上下文压缩完成后的前端痕迹展示
-- [x] 修复 Windows 桌面模式运行 shell 时弹出黑框的问题
-- [x] 修复 LLM 流式生成期间前端界面卡死、生成完成后恢复的问题
-- [x] 修复 GitHub Actions Rust/Tauri 构建缺少 protoc 和 GLib 系统依赖的问题
-- [x] 修复 GitHub Actions protoc 安装限流和 nextest 链接器崩溃的问题
-- [x] 修复 GitHub Actions Linux 测试绕开 rust-lld 崩溃的问题
-- [x] 增加 OrbStack Ubuntu 测试脚本并隔离 Linux 构建产物目录
+- [ ] Job 列表页（展示所有 job、状态、下次执行时间）
+- [ ] Job 创建/编辑表单（cron 表达式、webhook URL、polling 配置）
+- [ ] Job 启停开关
+- [ ] 执行历史查看（run 列表、状态、耗时、结果摘要）
+- [ ] 手动触发按钮
 
-## 发布准备任务
+## 发布准备（0.4.0）
 
-- [x] 新增 GitHub Actions 发布流水线，支持手动触发和 `v*` 标签触发
-- [x] 自动构建 macOS、Windows、Linux Tauri 安装包
-- [x] 将安装包上传到 GitHub Release，手动触发默认保持草稿状态
-- [x] 验证发布 workflow 语法、前端构建和 Tauri shell 检查
-- [x] 接入 Tauri updater，通过 GitHub Release 检测和安装新版本
-- [x] 设置界面展示当前版本、检查更新和安装更新按钮
-- [x] 发布流水线注入 updater 签名私钥并生成更新元数据
-- [x] 新增 `tiangong update` 命令，复用 GitHub Release 在线更新链路
-- [x] 发布说明按版本提交内容生成，避免 updater 元数据长期复用固定描述
-
-## Server 与飞书 Bot 互联
-
-- [x] 新增外部 Bot 统一消息入口
-- [x] 外部通道自动映射到独立 Server 会话
-- [x] Desktop 设置页支持运行时启动和停止后台 Server
-- [x] Desktop 菜单栏支持控制后台 Server，关闭主窗口后保持应用驻留
-- [ ] 验证飞书 Bot 可通过 Server API 发送消息并接收回复
+- [ ] 更新 `Cargo.toml` 版本号为 `0.4.0`
+- [ ] 更新 `tauri.conf.json` 版本号
+- [ ] 更新 `CHANGELOG.md`
+- [ ] 验证 cron / webhook / polling 端到端流程
+- [ ] 验证 Server 启动恢复 cron job
+- [ ] 验证前端 Job 管理界面
 
 ---
 
 ## 文档同步要求
 
-- `docs/requirements.md`：补充多智能体协作和发布分发相关需求
-- `docs/rfc/0011-multi-agent-collaboration.md`：实现过程中如有设计变更需同步更新
+- `docs/requirements.md`：补充自动化触发层相关需求
+- `docs/server-api.md`：补充 Job / Webhook API 文档
+- Issue #38：开发完成后关闭

--- a/crates/tiangong-core/src/context/compressor.rs
+++ b/crates/tiangong-core/src/context/compressor.rs
@@ -266,7 +266,7 @@ pub fn compress_loop_messages(
     Ok(result)
 }
 
-pub(crate) fn mark_compact_boundary(messages: &mut [Message], split_point: usize) {
+pub fn mark_compact_boundary(messages: &mut [Message], split_point: usize) {
     for message in messages.iter_mut() {
         message.compact = false;
     }

--- a/crates/tiangong-core/src/context/compressor.rs
+++ b/crates/tiangong-core/src/context/compressor.rs
@@ -266,7 +266,7 @@ pub fn compress_loop_messages(
     Ok(result)
 }
 
-fn mark_compact_boundary(messages: &mut [Message], split_point: usize) {
+pub(crate) fn mark_compact_boundary(messages: &mut [Message], split_point: usize) {
     for message in messages.iter_mut() {
         message.compact = false;
     }

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -645,6 +645,7 @@ pub(crate) fn reset_context_for_session(
 ) {
     let total = session.messages.len();
     session.summary_up_to = total;
+    crate::context::compressor::mark_compact_boundary(&mut session.messages, total);
     session.context_summary = None;
     session.current_tokens = 0;
     session.active_agent_current_tokens = 0;
@@ -824,7 +825,8 @@ pub(crate) fn execute_attachment_analysis_tool(
     };
 
     let media = if let Some(index) = attachment_index {
-        let Some(asset) = source_message.media.get(index) else {
+        let all_media = collect_message_media(source_message);
+        let Some(asset) = all_media.get(index) else {
             return (
                 attachment_tool_result(
                     false,
@@ -839,7 +841,7 @@ pub(crate) fn execute_attachment_analysis_tool(
         };
         vec![asset.clone()]
     } else {
-        source_message.media.clone()
+        collect_message_media(source_message)
     };
 
     if media.is_empty() {
@@ -925,17 +927,47 @@ fn find_attachment_source_message<'a>(
     session: &'a Session,
     message_id: Option<&str>,
 ) -> Option<&'a Message> {
+    let has_media = |msg: &Message| -> bool {
+        !msg.media.is_empty()
+            || msg
+                .content
+                .iter()
+                .any(|b| matches!(b, tiangong_types::message::ContentBlock::Media { .. }))
+    };
     if let Some(message_id) = message_id {
         return session
             .messages
             .iter()
-            .find(|message| message.id == message_id && !message.media.is_empty());
+            .find(|message| message.id == message_id && has_media(message));
     }
     session
         .messages
         .iter()
         .rev()
-        .find(|message| message.role == MessageRole::User && !message.media.is_empty())
+        .find(|message| message.role == MessageRole::User && has_media(message))
+}
+
+fn collect_message_media(message: &Message) -> Vec<tiangong_types::MediaAsset> {
+    let mut assets = Vec::new();
+    for block in &message.content {
+        if let tiangong_types::message::ContentBlock::Media {
+            kind,
+            url,
+            mime_type,
+            title,
+        } = block
+        {
+            assets.push(tiangong_types::MediaAsset {
+                kind: *kind,
+                url: url.clone(),
+                mime_type: mime_type.clone(),
+                title: title.clone(),
+                capability: None,
+            });
+        }
+    }
+    assets.extend(message.media.clone());
+    assets
 }
 
 fn attachment_tool_result(

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -1093,11 +1093,11 @@ fn provider_message_from_session(msg: &Message, include_media: bool) -> Option<C
 }
 
 fn attachment_notice_text(msg: &Message) -> String {
+    let mut media_index = 0usize;
     let items: Vec<String> = msg
         .content
         .iter()
-        .enumerate()
-        .filter_map(|(index, block)| {
+        .filter_map(|block| {
             if let ContentBlock::Media {
                 kind,
                 url: _,
@@ -1107,8 +1107,10 @@ fn attachment_notice_text(msg: &Message) -> String {
             {
                 let title = title.as_deref().unwrap_or("未命名附件");
                 let mime = mime_type.as_deref().unwrap_or("unknown");
+                let idx = media_index;
+                media_index += 1;
                 Some(format!(
-                    "- index={index} kind={kind:?} title={title} mime_type={mime}",
+                    "- index={idx} kind={kind:?} title={title} mime_type={mime}",
                 ))
             } else {
                 None

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -816,6 +816,28 @@ impl Session {
         }
     }
 
+    /// 更新指定消息的文本和媒体内容
+    pub fn update_message_content_with_media(
+        &mut self,
+        message_id: &str,
+        new_text: String,
+        new_media: Vec<tiangong_types::MediaAsset>,
+    ) -> bool {
+        if let Some(msg) = self.messages.iter_mut().find(|m| m.id == message_id) {
+            let mut blocks = vec![ContentBlock::text(new_text)];
+            for asset in &new_media {
+                blocks.push(asset.to_content_block());
+            }
+            msg.content = blocks;
+            msg.media.clear();
+            msg.media_migrated = true;
+            self.updated_at = now_text();
+            true
+        } else {
+            false
+        }
+    }
+
     /// 截断指定消息之后的所有消息（保留该消息本身），返回移除数量
     pub fn truncate_after_message(&mut self, message_id: &str) -> usize {
         let Some(idx) = self.messages.iter().position(|m| m.id == message_id) else {

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -400,8 +400,8 @@ export const api = {
   appendMessage: (sessionId: string, content: string): Promise<boolean> =>
     invoke('append_message', { sessionId, content }),
 
-  editAndResend: (messageId: string, newContent: string): Promise<void> =>
-    invoke('edit_and_resend', { messageId, newContent }),
+  editAndResend: (messageId: string, newContent: string, media?: MediaAsset[]): Promise<void> =>
+    invoke('edit_and_resend', { messageId, newContent, media: media ?? null }),
 
   respondApproval: (requestId: string, approved: boolean): Promise<boolean> =>
     invoke('respond_approval', { requestId, approved }),

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -4,13 +4,22 @@ import { Textarea } from './ui/textarea';
 import { Button } from './ui/button';
 import { Send, Square, FolderOpen, Wrench, Cpu, Mic, Loader2, Keyboard, MessageSquarePlus, ShieldCheck, ShieldOff, Circle, Paperclip, X, Users, Brain } from 'lucide-react';
 import { open } from '@tauri-apps/plugin-dialog';
-import { convertFileSrc } from '@tauri-apps/api/core';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
 import type { DragDropEvent } from '@tauri-apps/api/webview';
 import { api, type MediaAsset, textContent } from '@/api/tauri';
 import { useAudioRecording } from '@/hooks/useAudioRecording';
-
-const MAX_ATTACHMENT_BASE64_BYTES = 50 * 1024 * 1024;
+import {
+  type Attachment,
+  MAX_ATTACHMENT_BASE64_BYTES,
+  imageMimeType,
+  imageExtFromMime,
+  clipboardImagePaths,
+  fileToDataUrl,
+  attachmentFromPath,
+  estimatedBase64Size,
+  resolveAttachmentUrl,
+  attachmentsToBase64Media,
+} from '@/utils/attachments';
 
 interface MentionCandidate {
   value: string;
@@ -33,108 +42,6 @@ const SLASH_COMMANDS: MentionCandidate[] = [
     hint: '清理当前上下文',
   },
 ];
-
-type Attachment = {
-  kind: 'image' | 'file';
-  url: string;
-  title: string;
-  mime_type?: string;
-};
-
-function imageMimeType(path: string): string | undefined {
-  const lower = path.toLowerCase();
-  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
-  if (lower.endsWith('.webp')) return 'image/webp';
-  if (lower.endsWith('.gif')) return 'image/gif';
-  if (lower.endsWith('.png')) return 'image/png';
-  return undefined;
-}
-
-function fileMimeType(path: string): string | undefined {
-  const lower = path.toLowerCase();
-  const imageMime = imageMimeType(lower);
-  if (imageMime) return imageMime;
-  if (lower.endsWith('.pdf')) return 'application/pdf';
-  if (lower.endsWith('.txt')) return 'text/plain';
-  if (lower.endsWith('.md') || lower.endsWith('.markdown')) return 'text/markdown';
-  if (lower.endsWith('.json')) return 'application/json';
-  if (lower.endsWith('.csv')) return 'text/csv';
-  return undefined;
-}
-
-function imageExtFromMime(mimeType: string): string {
-  if (mimeType === 'image/jpeg' || mimeType === 'image/jpg') return 'jpg';
-  if (mimeType === 'image/webp') return 'webp';
-  if (mimeType === 'image/gif') return 'gif';
-  return 'png';
-}
-
-function resolveAttachmentUrl(url: string): string {
-  if (!url) return '';
-  if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('asset://')) {
-    return url;
-  }
-  if (url.startsWith('/')) {
-    return convertFileSrc(url);
-  }
-  return url;
-}
-
-function clipboardImagePaths(text: string): string[] {
-  return text
-    .split(/\r?\n/)
-    .map(part => part.trim())
-    .map(part => part.replace(/^["']|["']$/g, ''))
-    .map(part => {
-      if (!part.startsWith('file://')) return part;
-      try {
-        return decodeURIComponent(part.replace(/^file:\/\//, ''));
-      } catch {
-        return part.replace(/^file:\/\//, '');
-      }
-    })
-    .filter(part => !!part && !!imageMimeType(part));
-}
-
-function fileToDataUrl(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(String(reader.result || ''));
-    reader.onerror = () => reject(reader.error || new Error('读取附件失败'));
-    reader.readAsDataURL(file);
-  });
-}
-
-function attachmentFromPath(path: string): Attachment {
-  const lower = path.toLowerCase();
-  const isImage = /\.(png|jpe?g|webp|gif)$/.test(lower);
-  return {
-    kind: isImage ? 'image' : 'file',
-    url: path,
-    title: path.split('/').pop() || path,
-    mime_type: fileMimeType(path),
-  };
-}
-
-function base64SizeFromDataUrl(dataUrl: string): number {
-  return dataUrl.split(',', 2)[1]?.length ?? 0;
-}
-
-function mimeTypeFromDataUrl(dataUrl: string): string | undefined {
-  const header = dataUrl.split(',', 1)[0] || '';
-  const mime = header.match(/^data:([^;]+);/)?.[1];
-  return mime || undefined;
-}
-
-function assertBase64Size(dataUrl: string, title: string) {
-  if (base64SizeFromDataUrl(dataUrl) > MAX_ATTACHMENT_BASE64_BYTES) {
-    throw new Error(`附件“${title}”超过 50MB，已停止发送。`);
-  }
-}
-
-function estimatedBase64Size(rawBytes: number): number {
-  return Math.ceil(rawBytes / 3) * 4;
-}
 
 export function MessageInput() {
   const inputContent = useStore((state) => state.inputContent);
@@ -418,36 +325,6 @@ export function MessageInput() {
     addAttachments(paths.map(attachmentFromPath));
   }, [addAttachments]);
 
-  const attachmentToBase64Media = async (item: Attachment): Promise<MediaAsset> => {
-    if (item.url.startsWith('data:')) {
-      assertBase64Size(item.url, item.title);
-      return {
-        kind: item.kind,
-        url: item.url,
-        title: item.title,
-        mime_type: item.mime_type || mimeTypeFromDataUrl(item.url),
-        capability: 'multimodal',
-      };
-    }
-
-    const encoded = await api.readAttachmentAsDataUrl(item.url, MAX_ATTACHMENT_BASE64_BYTES);
-    return {
-      kind: item.kind,
-      url: encoded.data_url,
-      title: item.title || encoded.title,
-      mime_type: item.mime_type || encoded.mime_type,
-      capability: 'multimodal',
-    };
-  };
-
-  const attachmentsToBase64Media = async (): Promise<MediaAsset[]> => {
-    const media: MediaAsset[] = [];
-    for (const item of attachments) {
-      media.push(await attachmentToBase64Media(item));
-    }
-    return media;
-  };
-
   useEffect(() => {
     if (!isTextDropTargetActive) {
       setIsDraggingFiles(false);
@@ -657,7 +534,7 @@ export function MessageInput() {
     }
     let media: MediaAsset[];
     try {
-      media = await attachmentsToBase64Media();
+      media = await attachmentsToBase64Media(attachments);
     } catch (err) {
       console.error('附件转换失败:', err);
       alert(err instanceof Error ? err.message : '附件转换失败');
@@ -1004,9 +881,9 @@ export function MessageInput() {
                 <div className="mb-2 flex flex-wrap gap-1.5">
                   {attachments.map(item => (
                     <span
-                      key={item.url}
+                      key={item.title + item.url.slice(0, 40)}
                       className="inline-flex h-9 max-w-[260px] items-center gap-1.5 rounded-md border bg-muted/40 px-2 text-xs"
-                      title={item.url}
+                      title={item.title}
                     >
                       {item.kind === 'image' ? (
                         <img

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -32,7 +32,6 @@ import { api, textContent, type ContentBlock } from "@/api/tauri";
 import { CopyableCodeBlock } from "./CopyableCodeBlock";
 import {
   type Attachment,
-  imageMimeType,
   imageExtFromMime,
   fileToDataUrl,
   attachmentFromPath,

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -19,15 +19,27 @@ import {
   Brain,
   Pencil,
   X,
+  Paperclip,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import { convertFileSrc } from "@tauri-apps/api/core";
+import { open } from '@tauri-apps/plugin-dialog';
 import { ThinkingBlock } from "./ThinkingBlock";
 import { AgentPanel } from "./AgentPanel";
-import { api, textContent, ContentBlock } from "@/api/tauri";
+import { api, textContent, type ContentBlock } from "@/api/tauri";
 import { CopyableCodeBlock } from "./CopyableCodeBlock";
+import {
+  type Attachment,
+  imageMimeType,
+  imageExtFromMime,
+  fileToDataUrl,
+  attachmentFromPath,
+  estimatedBase64Size,
+  resolveAttachmentUrl,
+  attachmentsToBase64Media,
+} from '@/utils/attachments';
 
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
@@ -113,10 +125,11 @@ function MessageActions({ text, showTts }: { text: string; showTts: boolean }) {
   );
 }
 
-function UserMessageActions({ text, messageId, runStatus, onStartEdit }: {
+function UserMessageActions({ text, messageId, runStatus, canEdit, onStartEdit }: {
   text: string;
   messageId: string;
   runStatus: string;
+  canEdit: boolean;
   onStartEdit: (messageId: string, text: string) => void;
 }) {
   const [copied, setCopied] = useState(false);
@@ -142,8 +155,8 @@ function UserMessageActions({ text, messageId, runStatus, onStartEdit }: {
       <button
         onClick={() => onStartEdit(messageId, text)}
         className={btnClass}
-        title={idle ? "编辑并重发" : "执行中无法编辑"}
-        disabled={!idle}
+        title={!canEdit ? "已压缩消息无法编辑" : !idle ? "执行中无法编辑" : "编辑并重发"}
+        disabled={!idle || !canEdit}
       >
         <Pencil className="w-3.5 h-3.5" />
       </button>
@@ -242,11 +255,18 @@ export function MessageList() {
   const [hasTts, setHasTts] = useState(false);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingContent, setEditingContent] = useState("");
+  const [editingAttachments, setEditingAttachments] = useState<Attachment[]>([]);
   const editingTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const [hasMultimodal, setHasMultimodal] = useState(false);
 
   // 检查 TTS 能力
   useEffect(() => {
     api.hasTtsCapability().then(setHasTts).catch(() => setHasTts(false));
+  }, []);
+
+  // 检查多模态能力
+  useEffect(() => {
+    api.hasModelCapability('multimodal').then(setHasMultimodal).catch(() => setHasMultimodal(false));
   }, []);
 
   const isThinking = runStatus !== "idle";
@@ -256,6 +276,21 @@ export function MessageList() {
     if (runStatus !== "idle") return;
     setEditingMessageId(messageId);
     setEditingContent(text);
+    // 从原始消息中提取已有 media 作为初始附件
+    const msg = messages.find(m => m.id === messageId);
+    if (msg && hasMultimodal) {
+      const mediaAttachments: Attachment[] = (Array.isArray(msg.content) ? msg.content : [])
+        .filter((b: ContentBlock) => b.type === 'media' && b.url)
+        .map((b: ContentBlock) => ({
+          kind: b.kind === 'image' ? 'image' : 'file',
+          url: b.url!,
+          title: b.title || '',
+          mime_type: b.mime_type,
+        }));
+      setEditingAttachments(mediaAttachments);
+    } else {
+      setEditingAttachments([]);
+    }
     setTimeout(() => {
       const textarea = editingTextareaRef.current;
       if (textarea) {
@@ -265,16 +300,84 @@ export function MessageList() {
     }, 0);
   };
 
-  const handleConfirmEdit = () => {
+  const handleConfirmEdit = async () => {
     if (!editingMessageId || !editingContent.trim()) return;
-    editAndResend(editingMessageId, editingContent.trim());
+    let media: Awaited<ReturnType<typeof attachmentsToBase64Media>> = [];
+    if (editingAttachments.length > 0 && hasMultimodal) {
+      try {
+        media = await attachmentsToBase64Media(editingAttachments);
+      } catch (err) {
+        console.error('附件转换失败:', err);
+        alert(err instanceof Error ? err.message : '附件转换失败');
+        return;
+      }
+    }
+    editAndResend(editingMessageId, editingContent.trim(), media);
     setEditingMessageId(null);
     setEditingContent("");
+    setEditingAttachments([]);
   };
 
   const handleCancelEdit = () => {
     setEditingMessageId(null);
     setEditingContent("");
+    setEditingAttachments([]);
+  };
+
+  const handleAttachFilesForEdit = async () => {
+    try {
+      const selected = await open({
+        multiple: true,
+        directory: false,
+        title: '选择图片或文件',
+        filters: [
+          { name: '图片和文件', extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif', 'pdf', 'txt', 'md', 'json', 'csv'] },
+        ],
+      });
+      const paths = Array.isArray(selected) ? selected : selected ? [selected] : [];
+      if (paths.length === 0) return;
+      const newAttachments = paths.map(attachmentFromPath);
+      setEditingAttachments(prev => {
+        const next = [...prev];
+        for (const item of newAttachments) {
+          if (!next.some(existing => existing.url === item.url)) {
+            next.push(item);
+          }
+        }
+        return next;
+      });
+    } catch (e) {
+      console.error('选择附件失败:', e);
+    }
+  };
+
+  const handleEditPaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!hasMultimodal) return;
+    const files = Array.from(e.clipboardData.files).filter(file =>
+      file.type.startsWith('image/')
+    );
+    if (files.length > 0) {
+      e.preventDefault();
+      try {
+        const pasted = await Promise.all(files.map(async (file, index) => {
+          const mimeType = file.type || 'image/png';
+          const title = file.name || `pasted-image-${Date.now()}-${index + 1}.${imageExtFromMime(mimeType)}`;
+          if (estimatedBase64Size(file.size) > 50 * 1024 * 1024) {
+            throw new Error(`附件"${title}"超过 50MB，已停止添加。`);
+          }
+          return {
+            kind: 'image' as const,
+            url: await fileToDataUrl(file),
+            title,
+            mime_type: mimeType,
+          };
+        }));
+        setEditingAttachments(prev => [...prev, ...pasted]);
+      } catch (err) {
+        console.error('读取粘贴图片失败:', err);
+        alert(err instanceof Error ? err.message : '读取粘贴图片失败');
+      }
+    }
   };
 
   const messageGroups = useMemo(() => groupMessages(messages), [messages]);
@@ -553,6 +656,36 @@ export function MessageList() {
                 <div key={group.key} className="mt-3 first:mt-0">
                   {isEditing ? (
                     <div className="w-full">
+                      {editingAttachments.length > 0 && (
+                        <div className="mb-2 flex flex-wrap gap-1.5">
+                          {editingAttachments.map(item => (
+                            <span
+                              key={item.title + item.url.slice(0, 40)}
+                              className="inline-flex h-9 max-w-[260px] items-center gap-1.5 rounded-md border bg-muted/40 px-2 text-xs"
+                              title={item.title}
+                            >
+                              {item.kind === 'image' ? (
+                                <img
+                                  src={resolveAttachmentUrl(item.url)}
+                                  alt={item.title}
+                                  className="h-6 w-6 shrink-0 rounded object-cover"
+                                />
+                              ) : (
+                                <Paperclip className="h-3 w-3 shrink-0" />
+                              )}
+                              <span className="truncate">{item.title}</span>
+                              <button
+                                type="button"
+                                onClick={() => setEditingAttachments(prev => prev.filter(a => a.url !== item.url))}
+                                className="ml-1 text-muted-foreground hover:text-foreground"
+                                title="移除附件"
+                              >
+                                <X className="h-3 w-3" />
+                              </button>
+                            </span>
+                          ))}
+                        </div>
+                      )}
                       <Textarea
                         ref={editingTextareaRef}
                         value={editingContent}
@@ -573,12 +706,22 @@ export function MessageList() {
                             handleCancelEdit();
                           }
                         }}
+                        onPaste={handleEditPaste}
                         className="min-h-[60px] max-h-[200px] resize-none text-sm w-full"
                         autoFocus
                       />
                       <div className="flex justify-between items-center mt-1">
                         <span className="text-[10px] text-muted-foreground">Enter 发送 · Shift+Enter 换行 · Esc 取消</span>
                         <div className="flex gap-1.5">
+                          {hasMultimodal && (
+                            <button
+                              onClick={handleAttachFilesForEdit}
+                              className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                              title="添加附件"
+                            >
+                              <Paperclip className="w-3 h-3" />
+                            </button>
+                          )}
                           <button
                             onClick={handleCancelEdit}
                             className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
@@ -625,6 +768,7 @@ export function MessageList() {
                         text={textContent(message)}
                         messageId={message.id}
                         runStatus={runStatus}
+                        canEdit={!message.compact}
                         onStartEdit={handleStartEdit}
                       />
                     </div>

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -154,7 +154,7 @@ function UserMessageActions({ text, messageId, runStatus, canEdit, onStartEdit }
       </button>
       <button
         onClick={() => onStartEdit(messageId, text)}
-        className={btnClass}
+        className={`${btnClass} ${(!idle || !canEdit) ? 'opacity-30 cursor-not-allowed' : ''}`}
         title={!canEdit ? "已压缩消息无法编辑" : !idle ? "执行中无法编辑" : "编辑并重发"}
         disabled={!idle || !canEdit}
       >
@@ -381,6 +381,16 @@ export function MessageList() {
   };
 
   const messageGroups = useMemo(() => groupMessages(messages), [messages]);
+
+  // 计算 compact 边界：compact=true 的消息及其之前的消息都不可编辑
+  const nonEditableIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const msg of messages) {
+      ids.add(msg.id);
+      if (msg.compact) break;
+    }
+    return ids;
+  }, [messages]);
   const streamScrollKey = streamingMessageId
     ? `${streamingMessageId}:${streamingContent.length}:${streamingReasoningContent.length}`
     : "";
@@ -768,7 +778,7 @@ export function MessageList() {
                         text={textContent(message)}
                         messageId={message.id}
                         runStatus={runStatus}
-                        canEdit={!message.compact}
+                        canEdit={!nonEditableIds.has(message.id)}
                         onStartEdit={handleStartEdit}
                       />
                     </div>

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -242,6 +242,7 @@ export function MessageList() {
   const [hasTts, setHasTts] = useState(false);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingContent, setEditingContent] = useState("");
+  const editingTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   // 检查 TTS 能力
   useEffect(() => {
@@ -255,6 +256,13 @@ export function MessageList() {
     if (runStatus !== "idle") return;
     setEditingMessageId(messageId);
     setEditingContent(text);
+    setTimeout(() => {
+      const textarea = editingTextareaRef.current;
+      if (textarea) {
+        textarea.style.height = '60px';
+        textarea.style.height = Math.min(textarea.scrollHeight, 200) + 'px';
+      }
+    }, 0);
   };
 
   const handleConfirmEdit = () => {
@@ -543,42 +551,54 @@ export function MessageList() {
               const isEditing = editingMessageId === message.id;
               return (
                 <div key={group.key} className="mt-3 first:mt-0">
+                  {isEditing ? (
+                    <div className="w-full">
+                      <Textarea
+                        ref={editingTextareaRef}
+                        value={editingContent}
+                        onChange={(e) => {
+                          setEditingContent(e.target.value);
+                          const textarea = editingTextareaRef.current;
+                          if (textarea) {
+                            textarea.style.height = '60px';
+                            textarea.style.height = Math.min(textarea.scrollHeight, 200) + 'px';
+                          }
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229) {
+                            e.preventDefault();
+                            handleConfirmEdit();
+                          }
+                          if (e.key === "Escape") {
+                            handleCancelEdit();
+                          }
+                        }}
+                        className="min-h-[60px] max-h-[200px] resize-none text-sm w-full"
+                        autoFocus
+                      />
+                      <div className="flex justify-between items-center mt-1">
+                        <span className="text-[10px] text-muted-foreground">Enter 发送 · Shift+Enter 换行 · Esc 取消</span>
+                        <div className="flex gap-1.5">
+                          <button
+                            onClick={handleCancelEdit}
+                            className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                          >
+                            <X className="w-3 h-3" />
+                            取消
+                          </button>
+                          <button
+                            onClick={handleConfirmEdit}
+                            className="px-2.5 py-1 text-xs bg-green-600 hover:bg-green-700 text-white rounded transition-colors"
+                          >
+                            发送
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ) : (
                   <div className="flex justify-end" title={formatMessageTime(message.created_at)}>
                     <div className="max-w-[100%] text-muted-foreground">
-                      {isEditing ? (
-                        <div className="w-full">
-                          <Textarea
-                            value={editingContent}
-                            onChange={(e) => setEditingContent(e.target.value)}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                                e.preventDefault();
-                                handleConfirmEdit();
-                              }
-                              if (e.key === "Escape") {
-                                handleCancelEdit();
-                              }
-                            }}
-                            className="min-h-[60px] max-h-[200px] resize-none text-sm"
-                            autoFocus
-                          />
-                          <div className="flex justify-end gap-1.5 mt-1">
-                            <button
-                              onClick={handleCancelEdit}
-                              className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                            >
-                              <X className="w-3 h-3" />
-                              取消
-                            </button>
-                            <button
-                              onClick={handleConfirmEdit}
-                              className="px-2.5 py-1 text-xs bg-green-600 hover:bg-green-700 text-white rounded transition-colors"
-                            >
-                              发送 (⌘+Enter)
-                            </button>
-                          </div>
-                        </div>
-                      ) : voiceInfo ? (
+                      {voiceInfo ? (
                         <VoiceBubble
                           messageId={message.id}
                           audioPath={voiceInfo.audioPath}
@@ -598,6 +618,7 @@ export function MessageList() {
                       )}
                     </div>
                   </div>
+                  )}
                   {textContent(message) && !isEditing && (
                     <div className="flex justify-end">
                       <UserMessageActions

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -193,7 +193,7 @@ interface AppState {
   deleteSession: () => Promise<void>;
 
   sendMessage: (content: string, media?: MediaAsset[]) => Promise<void>;
-  editAndResend: (messageId: string, newContent: string) => Promise<void>;
+  editAndResend: (messageId: string, newContent: string, media?: MediaAsset[]) => Promise<void>;
   cancelTurn: () => Promise<boolean>;
   cancelAgent: (role: string) => Promise<boolean>;
 

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -442,10 +442,10 @@ export const useStore = create<AppState>((set, get) => ({
   },
 
   // 编辑用户消息并从该节点重新发送
-  editAndResend: async (messageId: string, newContent: string) => {
+  editAndResend: async (messageId: string, newContent: string, media: MediaAsset[] = []) => {
     set({ isSending: true });
     try {
-      await api.editAndResend(messageId, newContent);
+      await api.editAndResend(messageId, newContent, media.length > 0 ? media : undefined);
       const runningSessionId = get().activeSessionId;
       set(state => ({
         runStatus: 'executing',

--- a/frontend/src/utils/attachments.ts
+++ b/frontend/src/utils/attachments.ts
@@ -1,0 +1,136 @@
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { api, type MediaAsset } from '@/api/tauri';
+
+export const MAX_ATTACHMENT_BASE64_BYTES = 50 * 1024 * 1024;
+
+export type Attachment = {
+  kind: 'image' | 'file';
+  url: string;
+  title: string;
+  mime_type?: string;
+};
+
+export function imageMimeType(path: string): string | undefined {
+  const lower = path.toLowerCase();
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+  if (lower.endsWith('.webp')) return 'image/webp';
+  if (lower.endsWith('.gif')) return 'image/gif';
+  if (lower.endsWith('.png')) return 'image/png';
+  return undefined;
+}
+
+export function fileMimeType(path: string): string | undefined {
+  const lower = path.toLowerCase();
+  const imageMime = imageMimeType(lower);
+  if (imageMime) return imageMime;
+  if (lower.endsWith('.pdf')) return 'application/pdf';
+  if (lower.endsWith('.txt')) return 'text/plain';
+  if (lower.endsWith('.md') || lower.endsWith('.markdown')) return 'text/markdown';
+  if (lower.endsWith('.json')) return 'application/json';
+  if (lower.endsWith('.csv')) return 'text/csv';
+  return undefined;
+}
+
+export function imageExtFromMime(mimeType: string): string {
+  if (mimeType === 'image/jpeg' || mimeType === 'image/jpg') return 'jpg';
+  if (mimeType === 'image/webp') return 'webp';
+  if (mimeType === 'image/gif') return 'gif';
+  return 'png';
+}
+
+export function resolveAttachmentUrl(url: string): string {
+  if (!url) return '';
+  if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('asset://')) {
+    return url;
+  }
+  if (url.startsWith('/')) {
+    return convertFileSrc(url);
+  }
+  return url;
+}
+
+export function clipboardImagePaths(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map(part => part.trim())
+    .map(part => part.replace(/^["']|["']$/g, ''))
+    .map(part => {
+      if (!part.startsWith('file://')) return part;
+      try {
+        return decodeURIComponent(part.replace(/^file:\/\//, ''));
+      } catch {
+        return part.replace(/^file:\/\//, '');
+      }
+    })
+    .filter(part => !!part && !!imageMimeType(part));
+}
+
+export function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || ''));
+    reader.onerror = () => reject(reader.error || new Error('读取附件失败'));
+    reader.readAsDataURL(file);
+  });
+}
+
+export function attachmentFromPath(path: string): Attachment {
+  const lower = path.toLowerCase();
+  const isImage = /\.(png|jpe?g|webp|gif)$/.test(lower);
+  return {
+    kind: isImage ? 'image' : 'file',
+    url: path,
+    title: path.split('/').pop() || path,
+    mime_type: fileMimeType(path),
+  };
+}
+
+export function base64SizeFromDataUrl(dataUrl: string): number {
+  return dataUrl.split(',', 2)[1]?.length ?? 0;
+}
+
+export function mimeTypeFromDataUrl(dataUrl: string): string | undefined {
+  const header = dataUrl.split(',', 1)[0] || '';
+  const mime = header.match(/^data:([^;]+);/)?.[1];
+  return mime || undefined;
+}
+
+export function assertBase64Size(dataUrl: string, title: string) {
+  if (base64SizeFromDataUrl(dataUrl) > MAX_ATTACHMENT_BASE64_BYTES) {
+    throw new Error(`附件"${title}"超过 50MB，已停止发送。`);
+  }
+}
+
+export function estimatedBase64Size(rawBytes: number): number {
+  return Math.ceil(rawBytes / 3) * 4;
+}
+
+export async function attachmentToBase64Media(item: Attachment): Promise<MediaAsset> {
+  if (item.url.startsWith('data:')) {
+    assertBase64Size(item.url, item.title);
+    return {
+      kind: item.kind,
+      url: item.url,
+      title: item.title,
+      mime_type: item.mime_type || mimeTypeFromDataUrl(item.url),
+      capability: 'multimodal',
+    };
+  }
+
+  const encoded = await api.readAttachmentAsDataUrl(item.url, MAX_ATTACHMENT_BASE64_BYTES);
+  return {
+    kind: item.kind,
+    url: encoded.data_url,
+    title: item.title || encoded.title,
+    mime_type: item.mime_type || encoded.mime_type,
+    capability: 'multimodal',
+  };
+}
+
+export async function attachmentsToBase64Media(items: Attachment[]): Promise<MediaAsset[]> {
+  const media: MediaAsset[] = [];
+  for (const item of items) {
+    media.push(await attachmentToBase64Media(item));
+  }
+  return media;
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1301,10 +1301,17 @@ fn start_stream_consumer(
 pub fn edit_and_resend(
     message_id: String,
     new_content: String,
+    media: Option<Vec<tiangong_types::MediaAsset>>,
     app: AppHandle,
     state: State<TiangongApp>,
 ) -> Result<(), String> {
     use std::sync::mpsc;
+
+    if let Some(ref media_vec) = media {
+        if parse_context_slash_command(&new_content).is_none() && !media_vec.is_empty() {
+            ensure_multimodal_enabled(&state)?;
+        }
+    }
 
     // 1. 查找消息所在会话并验证
     let session_id = state.with_state(|core_state| {
@@ -1314,13 +1321,20 @@ pub fn edit_and_resend(
             .find(|s| s.messages.iter().any(|m| m.id == message_id))
             .ok_or_else(|| anyhow::anyhow!("消息不存在：{message_id}"))?;
 
-        let msg = session
+        let msg_idx = session
             .messages
             .iter()
-            .find(|m| m.id == message_id)
+            .position(|m| m.id == message_id)
             .ok_or_else(|| anyhow::anyhow!("消息不存在"))?;
+        let msg = &session.messages[msg_idx];
         if msg.role != tiangong_core::session::MessageRole::User {
             return Err(anyhow::anyhow!("只能编辑用户消息"));
+        }
+        if msg.compact {
+            return Err(anyhow::anyhow!("该消息已被压缩或清空，无法编辑"));
+        }
+        if msg_idx < session.summary_up_to {
+            return Err(anyhow::anyhow!("该消息已被压缩或清空，无法编辑"));
         }
         Ok(session.id.clone())
     })?;
@@ -1337,13 +1351,43 @@ pub fn edit_and_resend(
             .find(|s| s.id == session_id)
             .ok_or_else(|| anyhow::anyhow!("会话不存在"))?;
 
-        session.update_message_content(&message_id, new_content.clone());
+        if let Some(ref new_media) = media {
+            session.update_message_content_with_media(
+                &message_id,
+                new_content.clone(),
+                new_media.clone(),
+            );
+        } else {
+            session.update_message_content(&message_id, new_content.clone());
+        }
         session.truncate_after_message(&message_id);
-        let message_media = session
+
+        let message_media: Vec<tiangong_types::MediaAsset> = session
             .messages
             .iter()
             .find(|message| message.id == message_id)
-            .map(|message| message.media.clone())
+            .map(|message| {
+                let mut assets = Vec::new();
+                for block in &message.content {
+                    if let tiangong_types::message::ContentBlock::Media {
+                        kind,
+                        url,
+                        mime_type,
+                        title,
+                    } = block
+                    {
+                        assets.push(tiangong_types::MediaAsset {
+                            kind: *kind,
+                            url: url.clone(),
+                            mime_type: mime_type.clone(),
+                            title: title.clone(),
+                            capability: None,
+                        });
+                    }
+                }
+                assets.extend(message.media.clone());
+                assets
+            })
             .unwrap_or_default();
 
         let mut runtime_session = session.clone();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1007,6 +1007,10 @@ fn start_stream_consumer(
                             );
                             // 同步 core worker 中对 session 字段的修改
                             session.summary_up_to = *summary_up_to;
+                            tiangong_core::context::compressor::mark_compact_boundary(
+                                &mut session.messages,
+                                *summary_up_to,
+                            );
                             session.current_tokens = 0;
                             session.active_agent_current_tokens = 0;
                             session.agent_current_tokens.clear();


### PR DESCRIPTION
## Summary
- 编辑已发送消息输入框与底部输入框体验对齐：Enter 发送、Shift+Enter 换行、占满整行宽度、自适应高度
- 编辑模式支持附件上传：文件选择、粘贴图片、附件预览和移除
- 提取附件工具函数到公共模块 `utils/attachments.ts`，MessageInput 和 MessageList 共享
- 后端 `edit_and_resend` 支持 media 参数，新增 `update_message_content_with_media` 方法
- 修复 `analyze_attachment` 从 `content` 的 Media ContentBlock 而非空 `media` 字段查找附件
- 修复 `attachment_notice_text` 中 index 为 content 全局索引而非 media-only 序号导致越界
- 已压缩/清空消息禁用编辑按钮（前端 compact 边界判断 + 后端 compact/summary_up_to 校验）
- 修复 stream consumer 处理 `ContextCompressed` 事件时未同步 compact 标记导致重启后丢失
- 不可编辑消息的编辑按钮置灰显示（opacity-30 + cursor-not-allowed）
- 修复 `resolveAttachmentUrl` 未导入导致粘贴图片后页面渲染崩溃
- 修复附件预览使用 base64 data URL 作为 key/title 导致 DOM 异常

## Test plan
- [x] 发送带图片的消息 → 编辑 → 修改文本/添加移除附件 → 确认重发
- [x] 粘贴图片到输入框 → 正常显示附件预览 → 发送
- [x] 发送带附件消息 → 调用 analyze_attachment → 正确解析附件内容
- [x] 压缩对话后 → 压缩区消息编辑按钮置灰不可点击
- [x] 清理对话后 → 所有消息编辑按钮置灰
- [x] 重启应用 → 压缩/清理标记保留，编辑按钮状态正确
- [x] 新发送消息（压缩之后）→ 编辑按钮正常可用