### PR TITLE
fix(core): 仅在发送新消息时更新 session.updated_at

### DIFF
--- a/crates/tiangong-core/src/app_state/facade/sessions/ingress.rs
+++ b/crates/tiangong-core/src/app_state/facade/sessions/ingress.rs
@@ -33,6 +33,7 @@ impl TiangongState {
             String::new(),
             media,
         );
+        self.store.session.sessions[idx].updated_at = now_text();
         self.persist_session_and_app(&session_id)?;
         let session = self.store.session.sessions[idx].clone();
         self.store.session.input_draft.clear();
@@ -69,6 +70,7 @@ impl TiangongState {
         };
 
         session.append_message(role, content);
+        session.updated_at = now_text();
         self.persist_session_and_app(session_id)
     }
 }

--- a/crates/tiangong-core/src/app_state/facade/sessions/management.rs
+++ b/crates/tiangong-core/src/app_state/facade/sessions/management.rs
@@ -85,7 +85,6 @@ impl TiangongState {
         };
 
         session.title = new_title.to_string();
-        session.updated_at = now_text();
         self.store.session.session_title_draft = session.title.clone();
         self.persist_session_and_app(&active_id)
     }

--- a/crates/tiangong-core/src/app_state/mod.rs
+++ b/crates/tiangong-core/src/app_state/mod.rs
@@ -131,7 +131,6 @@ impl TiangongState {
             return Err(anyhow::anyhow!("当前会话不存在，无法设置信任模式"));
         };
         session.trust_mode = mode;
-        session.updated_at = now_text();
         // 兼容旧的状态读取；真实来源是当前会话。
         self.store.agent.agent_config.trust_mode = mode;
         self.services.runtime.permission_gate().set_trust_mode(mode);
@@ -161,7 +160,6 @@ impl TiangongState {
             .find(|session| session.id == active_id)
         {
             session.reasoning_effort = Some(effort);
-            session.updated_at = now_text();
             self.persist_session_and_app(&active_id)
         } else {
             self.persist_app_only()

--- a/crates/tiangong-core/src/react/message.rs
+++ b/crates/tiangong-core/src/react/message.rs
@@ -2,7 +2,7 @@
 
 use std::sync::mpsc::Sender as StdSender;
 
-use crate::session::{Message, MessageRole, MessageToolCall, Session, now_text};
+use crate::session::{Message, MessageRole, MessageToolCall, Session};
 use tiangong_types::{MediaAsset, StreamEvent};
 
 const MEMORY_LOOP_FEEDBACK_MAX_CHARS: usize = 12_000;
@@ -81,7 +81,6 @@ pub(crate) fn append_assistant_tool_call_message(
     message.reasoning_signature = reasoning_signature;
     message.tool_calls = tool_calls;
     session.messages.push(message);
-    session.updated_at = now_text();
 }
 
 pub(crate) fn append_tool_result_message(
@@ -96,7 +95,6 @@ pub(crate) fn append_tool_result_message(
     message.tool_name = Some(tool_name.to_string());
     message.tool_result_is_error = is_error;
     session.messages.push(message);
-    session.updated_at = now_text();
 }
 
 pub(crate) fn append_runtime_tool_message(

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -347,7 +347,6 @@ impl Session {
             compact: false,
             created_at: now_text(),
         });
-        self.updated_at = now_text();
     }
 
     pub fn append_message_with_reasoning(
@@ -372,7 +371,6 @@ impl Session {
             compact: false,
             created_at: now_text(),
         });
-        self.updated_at = now_text();
     }
 
     /// 使用预生成的 ID 追加消息（流式场景：Delta/Reasoning 事件先于消息创建）
@@ -415,7 +413,6 @@ impl Session {
             compact: false,
             created_at: now_text(),
         });
-        self.updated_at = now_text();
     }
 
     pub fn append_worker_message(
@@ -450,7 +447,6 @@ impl Session {
             compact: false,
             created_at: now_text(),
         });
-        self.updated_at = now_text();
     }
 
     pub fn start_task(
@@ -479,7 +475,6 @@ impl Session {
             llm_calls: Vec::new(),
             worker_results: Vec::new(),
         });
-        self.updated_at = now_text();
     }
 
     pub fn mark_task_executing(&mut self, task_id: &str, plan_snapshot: Option<String>) {
@@ -496,7 +491,6 @@ impl Session {
             record.plan_snapshot = Some(plan_snapshot);
         }
         record.updated_at = now_text();
-        self.updated_at = now_text();
     }
 
     pub fn bind_task_assistant_message_id(&mut self, task_id: &str, assistant_message_id: String) {
@@ -509,7 +503,6 @@ impl Session {
         };
         record.assistant_message_id = assistant_message_id;
         record.updated_at = now_text();
-        self.updated_at = now_text();
     }
 
     pub fn sync_task_plans(&mut self, task_id: &str, plans: &[PlanItem]) {
@@ -579,7 +572,6 @@ impl Session {
                 self.task_plans.push(target);
             }
         }
-        self.updated_at = now_text();
     }
 
     pub fn delete_pending_task_plan(&mut self, pending_index: usize) -> bool {
@@ -591,7 +583,6 @@ impl Session {
             return false;
         };
         self.task_plans.remove(pos);
-        self.updated_at = now_text();
         true
     }
 
@@ -615,7 +606,6 @@ impl Session {
         for (slot, item) in pending_positions.iter().zip(pending) {
             self.task_plans[*slot] = item;
         }
-        self.updated_at = now_text();
         true
     }
 
@@ -665,7 +655,6 @@ impl Session {
         let now = now_text();
         record.updated_at = now.clone();
         record.finished_at = Some(now);
-        self.updated_at = now_text();
     }
 
     pub fn fail_task(
@@ -730,7 +719,6 @@ impl Session {
         let now = now_text();
         record.updated_at = now.clone();
         record.finished_at = Some(now);
-        self.updated_at = now_text();
     }
 
     pub fn recover_interrupted_tasks(&mut self) -> usize {
@@ -748,9 +736,6 @@ impl Session {
                 record.updated_at = now.clone();
                 record.finished_at = Some(now);
             }
-        }
-        if recovered > 0 {
-            self.updated_at = now_text();
         }
         recovered
     }
@@ -782,7 +767,6 @@ impl Session {
     pub fn rebuild_system_prompt(&mut self, config: &crate::prompt::SystemPromptConfig) {
         let msg = crate::prompt::sections::build_full_system_prompt(self, config);
         self.system_prompt_message = Some(msg);
-        self.updated_at = now_text();
     }
 
     /// 构建 LLM 请求上下文
@@ -809,7 +793,6 @@ impl Session {
     pub fn update_message_content(&mut self, message_id: &str, new_content: String) -> bool {
         if let Some(msg) = self.messages.iter_mut().find(|m| m.id == message_id) {
             msg.content = vec![ContentBlock::text(new_content)];
-            self.updated_at = now_text();
             true
         } else {
             false
@@ -823,7 +806,6 @@ impl Session {
         };
         let remove_count = self.messages.len() - idx - 1;
         self.messages.truncate(idx + 1);
-        self.updated_at = now_text();
         remove_count
     }
 }


### PR DESCRIPTION
## Summary
- 将 session `updated_at` 的更新从 20 处内部操作收敛到 2 个消息发送入口（用户发送消息 + 外部事件注入）
- 移除任务状态变更、标题修改、信任模式切换、系统提示重建、流式消息处理等操作中对 `updated_at` 的误更新

## 修改文件
- `session.rs` — 移除 16 个方法中的 `self.updated_at = now_text()`
- `react/message.rs` — 移除流式消息处理中的 2 处更新
- `app_state/mod.rs` — 移除 set_trust_mode / set_reasoning_effort 中的 2 处更新
- `management.rs` — 移除 save_active_session_title 中的 1 处更新
- `ingress.rs` — 在用户发送消息和外部事件注入入口添加更新

## Test plan
- [x] 验证用户发送新消息时 session 的 updated_at 正确更新
- [x] 验证切换会话、修改标题、设置信任模式等操作不再触发 updated_at 更新
- [x] 验证任务执行、plan 变更等内部流程不影响 updated_at