### PR TITLE
fix(core): 修复 workspace 目录变更未同步到会话和运行中 core 的问题

### DIFF
--- a/crates/tiangong-core/src/app_state/facade/sessions/queries.rs
+++ b/crates/tiangong-core/src/app_state/facade/sessions/queries.rs
@@ -115,6 +115,13 @@ impl TiangongState {
 
     pub fn update_workspace_dir(&mut self, workspace_dir: String) -> Result<()> {
         self.store.session.workspace_dir = workspace_dir;
+        for session in &mut self.store.session.sessions {
+            if session.cwd_mode == crate::session::SessionCwdMode::Inherit
+                && !session.has_user_messages()
+            {
+                session.cwd = self.store.session.workspace_dir.clone();
+            }
+        }
         self.persist_app_only()
     }
 
@@ -139,9 +146,12 @@ impl TiangongState {
             if session.cwd_mode == crate::session::SessionCwdMode::Isolated {
                 return Err(anyhow::anyhow!("隔离模式会话不允许修改工作目录"));
             }
+            // 已有对话的会话不允许切换工作目录
+            if session.has_user_messages() {
+                return Err(anyhow::anyhow!("已有对话的会话不允许切换工作目录"));
+            }
             session.cwd = cwd;
             session.cwd_mode = crate::session::SessionCwdMode::Custom;
-            session.updated_at = now_text();
         }
         self.persist_session_and_app(&active_id)
     }

--- a/crates/tiangong-core/src/app_state/tests/mod.rs
+++ b/crates/tiangong-core/src/app_state/tests/mod.rs
@@ -3,3 +3,4 @@ mod repository;
 mod runtime;
 mod skill;
 mod state;
+mod workspace_cwd;

--- a/crates/tiangong-core/src/app_state/tests/workspace_cwd.rs
+++ b/crates/tiangong-core/src/app_state/tests/workspace_cwd.rs
@@ -1,0 +1,253 @@
+use anyhow::Result;
+
+use super::super::*;
+use super::common::with_isolated_state;
+use crate::session::{MessageRole, SessionCwdMode};
+
+#[test]
+fn has_user_messages_returns_false_for_empty_session() -> Result<()> {
+    with_isolated_state("tiangong-cwd-has-user-msg-empty", |_paths, state| {
+        state.create_session();
+        let session = state.active_session().unwrap();
+        assert!(!session.has_user_messages());
+        Ok(())
+    })
+}
+
+#[test]
+fn has_user_messages_returns_true_after_user_message() -> Result<()> {
+    with_isolated_state("tiangong-cwd-has-user-msg-true", |_paths, state| {
+        state.create_session();
+        state.prepare_active_user_message_ingress("hello")?;
+        let session = state.active_session().unwrap();
+        assert!(session.has_user_messages());
+        Ok(())
+    })
+}
+
+#[test]
+fn has_user_messages_returns_false_with_only_assistant_messages() -> Result<()> {
+    with_isolated_state("tiangong-cwd-has-user-msg-assistant", |_paths, state| {
+        state.create_session();
+        let session_id = state.active_session_id().to_string();
+        state
+            .sessions_mut()
+            .iter_mut()
+            .find(|s| s.id == session_id)
+            .unwrap()
+            .append_message(MessageRole::Assistant, "hi there");
+        let session = state.active_session().unwrap();
+        assert!(!session.has_user_messages());
+        Ok(())
+    })
+}
+
+#[test]
+fn update_workspace_dir_syncs_inherit_sessions_without_messages() -> Result<()> {
+    with_isolated_state("tiangong-cwd-workspace-sync-inherit", |paths, state| {
+        state.create_session();
+        let session_id = state.active_session_id().to_string();
+        let original_cwd = state.active_session().unwrap().cwd.clone();
+
+        let new_dir = paths.workspace.join("new-project");
+        std::fs::create_dir_all(&new_dir)?;
+        state.update_workspace_dir(new_dir.to_string_lossy().to_string())?;
+
+        let session = state
+            .sessions()
+            .iter()
+            .find(|s| s.id == session_id)
+            .unwrap();
+        assert_eq!(session.cwd, new_dir.to_string_lossy().to_string());
+        assert_ne!(session.cwd, original_cwd);
+        assert_eq!(session.cwd_mode, SessionCwdMode::Inherit);
+        Ok(())
+    })
+}
+
+#[test]
+fn update_workspace_dir_skips_inherit_sessions_with_messages() -> Result<()> {
+    with_isolated_state(
+        "tiangong-cwd-workspace-skip-has-messages",
+        |paths, state| {
+            state.create_session();
+            let session_id = state.active_session_id().to_string();
+            state.prepare_active_user_message_ingress("hello")?;
+
+            let original_cwd = state
+                .sessions()
+                .iter()
+                .find(|s| s.id == session_id)
+                .unwrap()
+                .cwd
+                .clone();
+
+            let new_dir = paths.workspace.join("new-project");
+            std::fs::create_dir_all(&new_dir)?;
+            state.update_workspace_dir(new_dir.to_string_lossy().to_string())?;
+
+            let session = state
+                .sessions()
+                .iter()
+                .find(|s| s.id == session_id)
+                .unwrap();
+            assert_eq!(session.cwd, original_cwd, "已有对话的会话 cwd 不应被更新");
+            assert_eq!(session.cwd_mode, SessionCwdMode::Inherit);
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn update_workspace_dir_skips_custom_mode_sessions() -> Result<()> {
+    with_isolated_state("tiangong-cwd-workspace-skip-custom", |paths, state| {
+        state.create_session();
+        let session_id = state.active_session_id().to_string();
+
+        let custom_dir = paths.workspace.join("custom-dir");
+        std::fs::create_dir_all(&custom_dir)?;
+        let s = state
+            .sessions_mut()
+            .iter_mut()
+            .find(|s| s.id == session_id)
+            .unwrap();
+        s.cwd = custom_dir.to_string_lossy().to_string();
+        s.cwd_mode = SessionCwdMode::Custom;
+
+        let new_dir = paths.workspace.join("new-project");
+        std::fs::create_dir_all(&new_dir)?;
+        state.update_workspace_dir(new_dir.to_string_lossy().to_string())?;
+
+        let session = state
+            .sessions()
+            .iter()
+            .find(|s| s.id == session_id)
+            .unwrap();
+        assert_eq!(
+            session.cwd,
+            custom_dir.to_string_lossy().to_string(),
+            "Custom 模式会话 cwd 不应被更新"
+        );
+        assert_eq!(session.cwd_mode, SessionCwdMode::Custom);
+        Ok(())
+    })
+}
+
+#[test]
+fn update_active_session_cwd_rejects_sessions_with_messages() -> Result<()> {
+    with_isolated_state(
+        "tiangong-cwd-session-reject-has-messages",
+        |paths, state| {
+            state.create_session();
+            state.prepare_active_user_message_ingress("hello")?;
+
+            let new_dir = paths.workspace.join("new-project");
+            std::fs::create_dir_all(&new_dir)?;
+            let result = state.update_active_session_cwd(new_dir.to_string_lossy().to_string());
+
+            assert!(result.is_err(), "已有对话的会话应拒绝切换 cwd");
+            assert!(result.unwrap_err().to_string().contains("已有对话"));
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn update_active_session_cwd_allows_empty_sessions() -> Result<()> {
+    with_isolated_state("tiangong-cwd-session-allow-empty", |paths, state| {
+        state.create_session();
+        let session_id = state.active_session_id().to_string();
+
+        let new_dir = paths.workspace.join("new-project");
+        std::fs::create_dir_all(&new_dir)?;
+        state.update_active_session_cwd(new_dir.to_string_lossy().to_string())?;
+
+        let session = state
+            .sessions()
+            .iter()
+            .find(|s| s.id == session_id)
+            .unwrap();
+        assert_eq!(session.cwd, new_dir.to_string_lossy().to_string());
+        assert_eq!(session.cwd_mode, SessionCwdMode::Custom);
+        Ok(())
+    })
+}
+
+#[test]
+fn update_active_session_cwd_rejects_isolated_sessions() -> Result<()> {
+    with_isolated_state("tiangong-cwd-session-reject-isolated", |paths, state| {
+        state.create_session();
+        let session_id = state.active_session_id().to_string();
+        let s = state
+            .sessions_mut()
+            .iter_mut()
+            .find(|s| s.id == session_id)
+            .unwrap();
+        s.cwd_mode = SessionCwdMode::Isolated;
+
+        let new_dir = paths.workspace.join("new-project");
+        std::fs::create_dir_all(&new_dir)?;
+        let result = state.update_active_session_cwd(new_dir.to_string_lossy().to_string());
+
+        assert!(result.is_err(), "Isolated 模式会话应拒绝修改 cwd");
+        assert!(result.unwrap_err().to_string().contains("隔离模式"));
+        Ok(())
+    })
+}
+
+#[test]
+fn update_workspace_dir_mixed_sessions() -> Result<()> {
+    with_isolated_state("tiangong-cwd-workspace-mixed", |paths, state| {
+        // 会话 A：Inherit 模式，无对话 → 应被更新
+        state.create_session();
+        let id_a = state.active_session_id().to_string();
+
+        // 会话 B：Inherit 模式，有对话 → 不应被更新
+        state.create_session();
+        let id_b = state.active_session_id().to_string();
+        state.prepare_active_user_message_ingress("hello")?;
+
+        // 会话 C：Custom 模式，无对话 → 不应被更新
+        state.create_session();
+        let id_c = state.active_session_id().to_string();
+        let custom_dir = paths.workspace.join("custom");
+        std::fs::create_dir_all(&custom_dir)?;
+        let s = state
+            .sessions_mut()
+            .iter_mut()
+            .find(|s| s.id == id_c)
+            .unwrap();
+        s.cwd = custom_dir.to_string_lossy().to_string();
+        s.cwd_mode = SessionCwdMode::Custom;
+
+        let new_dir = paths.workspace.join("new-workspace");
+        std::fs::create_dir_all(&new_dir)?;
+        state.update_workspace_dir(new_dir.to_string_lossy().to_string())?;
+
+        let get_cwd = |id: &str, st: &TiangongState| -> String {
+            st.sessions()
+                .iter()
+                .find(|s| s.id == id)
+                .unwrap()
+                .cwd
+                .clone()
+        };
+
+        assert_eq!(
+            get_cwd(&id_a, state),
+            new_dir.to_string_lossy().to_string(),
+            "Inherit 无对话会话应被更新"
+        );
+        assert_ne!(
+            get_cwd(&id_b, state),
+            new_dir.to_string_lossy().to_string(),
+            "Inherit 有对话会话不应被更新"
+        );
+        assert_eq!(
+            get_cwd(&id_c, state),
+            custom_dir.to_string_lossy().to_string(),
+            "Custom 会话不应被更新"
+        );
+        Ok(())
+    })
+}

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -219,6 +219,10 @@ pub struct SessionTaskPlan {
 }
 
 impl Session {
+    pub fn has_user_messages(&self) -> bool {
+        self.messages.iter().any(|m| m.role == MessageRole::User)
+    }
+
     /// 迁移旧格式数据：将 message.media 合并到 message.content 中。
     pub fn migrate_legacy_content(&mut self) {
         for message in &mut self.messages {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2044,23 +2044,120 @@ pub fn get_workspace_dir(state: State<TiangongApp>) -> Result<String, String> {
 
 /// 设置 Desktop 工作空间目录
 #[tauri::command]
-pub fn set_workspace_dir(workspace_dir: String, state: State<TiangongApp>) -> Result<(), String> {
+pub fn set_workspace_dir(
+    workspace_dir: String,
+    app: AppHandle,
+    state: State<TiangongApp>,
+) -> Result<(), String> {
     let path = std::path::Path::new(&workspace_dir);
     if !path.is_dir() {
         return Err(format!("路径不存在或不是目录：{workspace_dir}"));
     }
-    state.with_state(|core_state| core_state.update_workspace_dir(workspace_dir))
+
+    let old_workspace_dir =
+        state.with_state_read(|core_state| Ok(core_state.workspace_dir().to_string()))?;
+    let cwd_changed = old_workspace_dir != workspace_dir;
+
+    state.with_state(|core_state| core_state.update_workspace_dir(workspace_dir.clone()))?;
+
+    // 同步活跃 core 的 cwd（仅限无对话的 Inherit 会话）
+    let active_session_id = state.with_state_read(|core_state| {
+        Ok(core_state
+            .sessions()
+            .iter()
+            .find(|s| s.id == core_state.active_session_id())
+            .filter(|s| s.cwd_mode == tiangong_core::session::SessionCwdMode::Inherit)
+            .filter(|s| !s.has_user_messages())
+            .map(|s| s.id.clone()))
+    })?;
+    if let Some(sid) = &active_session_id {
+        let cores = state.cores.lock().map_err(|e| e.to_string())?;
+        if let Some(core) = cores.get(sid) {
+            let _ = core.update_cwd(workspace_dir.clone());
+        }
+    }
+
+    // 索引：仅在目录实际变化且索引不存在时创建
+    if cwd_changed
+        && !workspace_dir.is_empty()
+        && !tiangong_core::index::workspace_index_exists(std::path::Path::new(&workspace_dir))
+    {
+        let app_clone = app.clone();
+        let cwd = workspace_dir.clone();
+        thread::spawn(move || {
+            match tiangong_core::index::rebuild_workspace_index_for_gui(std::path::Path::new(&cwd))
+            {
+                Ok(count) => eprintln!("Workspace 索引扫描完成: {count} 个文件"),
+                Err(e) => eprintln!("Workspace 索引扫描失败: {e}"),
+            }
+            if let Ok(snapshot) = app_clone
+                .state::<TiangongApp>()
+                .with_state_read(|s| Ok(build_full_snapshot_with_status(s, false)))
+            {
+                let _ = app_clone.emit("run_snapshot", &snapshot);
+            }
+        });
+    }
+
+    Ok(())
 }
 
 /// 设置活动会话的工作目录
 #[tauri::command]
-pub fn set_session_cwd(cwd: String, state: State<TiangongApp>) -> Result<(), String> {
-    // 验证路径存在且是目录
+pub fn set_session_cwd(
+    cwd: String,
+    app: AppHandle,
+    state: State<TiangongApp>,
+) -> Result<(), String> {
     let path = std::path::Path::new(&cwd);
     if !path.is_dir() {
         return Err(format!("路径不存在或不是目录：{cwd}"));
     }
-    state.with_state(|core_state| core_state.update_active_session_cwd(cwd))
+
+    let old_cwd = state.with_state_read(|core_state| {
+        Ok(core_state
+            .active_session()
+            .map(|s| s.cwd.clone())
+            .unwrap_or_default())
+    })?;
+    let cwd_changed = old_cwd != cwd;
+
+    state.with_state(|core_state| core_state.update_active_session_cwd(cwd.clone()))?;
+
+    // 同步活跃 core 的 cwd
+    let active_session_id =
+        state.with_state_read(|core_state| Ok(core_state.active_session_id().to_string()))?;
+    {
+        let cores = state.cores.lock().map_err(|e| e.to_string())?;
+        if let Some(core) = cores.get(&active_session_id) {
+            let _ = core.update_cwd(cwd.clone());
+        }
+    }
+
+    // 索引：仅在目录实际变化且索引不存在时创建
+    if cwd_changed
+        && !cwd.is_empty()
+        && !tiangong_core::index::workspace_index_exists(std::path::Path::new(&cwd))
+    {
+        let app_clone = app.clone();
+        let cwd_path = cwd.clone();
+        thread::spawn(move || {
+            match tiangong_core::index::rebuild_workspace_index_for_gui(std::path::Path::new(
+                &cwd_path,
+            )) {
+                Ok(count) => eprintln!("Session cwd 索引扫描完成: {count} 个文件"),
+                Err(e) => eprintln!("Session cwd 索引扫描失败: {e}"),
+            }
+            if let Ok(snapshot) = app_clone
+                .state::<TiangongApp>()
+                .with_state_read(|s| Ok(build_full_snapshot_with_status(s, false)))
+            {
+                let _ = app_clone.emit("run_snapshot", &snapshot);
+            }
+        });
+    }
+
+    Ok(())
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- `update_workspace_dir` 同步更新无对话的 Inherit 模式会话 cwd，跳过有对话和 Custom 模式的会话
- `set_workspace_dir` / `set_session_cwd` 即时通知运行中 TiangongCore 更新 cwd
- 目录变更时后台创建索引（已存在则跳过）
- 已有对话的会话禁止切换工作目录，防止执行上下文异常

## 修改文件
- `session.rs` — 新增 `has_user_messages()` 方法
- `queries.rs` — `update_workspace_dir` 同步无对话 Inherit 会话；`update_active_session_cwd` 拒绝已有对话的会话
- `commands.rs` — `set_workspace_dir` / `set_session_cwd` 增加即时 core 同步和索引创建
- `tests/workspace_cwd.rs` — 10 个测试覆盖全部场景

## Test plan
- [x] `has_user_messages` — 空会话、有用户消息、仅有助手消息
- [x] `update_workspace_dir` — 同步无对话 Inherit 会话、跳过有对话会话、跳过 Custom 会话、混合会话
- [x] `update_active_session_cwd` — 允许空会话、拒绝有对话会话、拒绝 Isolated 会话