### PR TITLE
fix(app): 修复 macOS 窗口隐藏后点击 Dock 图标无法恢复显示

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -222,6 +222,8 @@ fn run_gui() {
     tauri::Builder::default()
         .manage(tiangong_app::TiangongApp::new())
         .setup(|app| {
+            #[cfg(target_os = "macos")]
+            app.set_activation_policy(tauri::ActivationPolicy::Regular);
             setup_tray(app)?;
             Ok(())
         })
@@ -325,8 +327,16 @@ fn run_gui() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .run(generate_tauri_context())
-        .expect("error while running tauri application");
+        .build(generate_tauri_context())
+        .expect("error while building tauri application")
+        .run(|handle, event| {
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = event {
+                show_main_window(handle);
+            }
+            #[cfg(not(target_os = "macos"))]
+            let _ = (handle, event);
+        });
 
     drop(_guard);
 }


### PR DESCRIPTION
## Summary
- 启动时设置 `ActivationPolicy::Regular` 确保 Dock 图标常驻
- 监听 `RunEvent::Reopen` 事件，点击 Dock 图标时重新显示并聚焦窗口

## Test plan
- [x] 启动应用，确认 Dock 图标正常显示
- [x] 点击关闭按钮，窗口隐藏，应用继续后台运行
- [x] 点击 Dock 图标，窗口重新显示并获得焦点
- [x] 通过托盘菜单"显示天工"也能正常恢复窗口