### PR TITLE
chore: 添加官网子仓库 tiangong-website

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "website"]
+	path = website
+	url = git@github.com:silent-rs/tiangong-website.git


### PR DESCRIPTION
## 变更内容

- 新增 `tiangong-website` 子仓库，放置天工官网静态页面
- 官网包含：Hero、核心能力、技术架构、多智能体协作、自动化触发层、安装引导等板块
- 子仓库地址：https://github.com/silent-rs/tiangong-website