### PR TITLE
fix(gui): 修复 Windows 下设置页标题未左对齐的问题

### DIFF
--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -47,7 +47,7 @@ export function SettingsDialog() {
           {/* 顶部标题栏 — 可拖动窗口 */}
           <header
             className="flex h-12 shrink-0 items-center border-b pr-4 select-none"
-            style={{ paddingLeft: '80px' }}
+            style={{ paddingLeft: navigator.platform.includes('Mac') ? '80px' : '16px' }}
             onMouseDown={(e) => {
               const tag = (e.target as HTMLElement).tagName;
               if (tag === 'INPUT' || tag === 'BUTTON') return;


### PR DESCRIPTION
## 问题

Windows 下设置页顶部标题栏的 `paddingLeft` 硬编码为 `80px`（为 macOS 窗口控制按钮预留），导致标题偏右，与主页不一致。

## 修复

对齐主页 `StatusPanel.tsx` 的做法，根据平台动态设置：
- macOS：`80px`（为红绿灯按钮留空间）
- Windows/Linux：`16px`

## 变更

- `frontend/src/components/SettingsDialog.tsx`：`paddingLeft: '80px'` → `navigator.platform.includes('Mac') ? '80px' : '16px'`

单行改动，无功能影响。