### PR TITLE
refactor(core): 重构 Memory 初始化链路为全异步 + 修复 UTF-8 截断 panic

### DIFF
--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -29,12 +29,10 @@ pub use crate::memory::gui_api::*;
 pub(crate) use crate::memory::recall::{
     duplicate_memory_recall_tool_result, execute_memory_recall_tool, inject_memory_recall_tool,
 };
-pub(crate) use crate::memory::registry::{
-    WorkerMemoryContext, get_or_init_memory, get_or_init_memory_async,
-};
+pub(crate) use crate::memory::registry::{WorkerMemoryContext, get_or_init_memory_async};
 pub use crate::memory::registry::{
-    get_or_init_memory_handle, get_or_init_memory_handle_async, load_memory_config,
-    save_memory_config, shutdown_memory_registry_blocking,
+    get_or_init_memory_handle_async, load_memory_config, save_memory_config,
+    shutdown_memory_registry_blocking,
 };
 
 pub(crate) mod command;
@@ -119,19 +117,19 @@ impl TiangongCore {
         process_type: tiangong_memory::ProcessType,
     ) -> Self {
         let config_snapshot = config.snapshot();
-        let memory_handle =
-            get_or_init_memory(&config_snapshot, config.generation(), process_type.clone());
+        let config_generation = config.generation();
         let initial_trust_mode = session.trust_mode;
         let shared_trust_mode = Arc::new(RwLock::new(initial_trust_mode));
         let session_id = session.id.clone();
         let (cmd_tx, cmd_rx) = tokio_mpsc::unbounded_channel::<Command>();
 
         let worker_trust_mode = shared_trust_mode.clone();
-        let worker_process_type = process_type.clone();
         let worker = thread::spawn(move || {
             let memory = WorkerMemoryContext {
-                handle: memory_handle,
-                process_type: worker_process_type,
+                handle: None,
+                process_type,
+                initial_config_snapshot: Some(config_snapshot),
+                initial_config_generation: config_generation,
             };
             worker_loop(
                 config,
@@ -293,6 +291,16 @@ async fn worker_loop_async(
 ) -> Session {
     let session_id = session.id.clone();
     let mut last_cfg_gen = 0u64;
+
+    // 在 Worker 的 tokio runtime 中异步初始化 Memory Handle
+    if let Some(ref cfg) = memory.initial_config_snapshot {
+        memory.handle = get_or_init_memory_async(
+            cfg,
+            memory.initial_config_generation,
+            memory.process_type.clone(),
+        )
+        .await;
+    }
     let mut engine: Option<RuntimeEngine> = None;
     let mut tools: Vec<ToolSpec> = Vec::new();
     let mut mcp_targets: HashMap<String, McpFunctionTarget> = HashMap::new();

--- a/crates/tiangong-core/src/memory/registry.rs
+++ b/crates/tiangong-core/src/memory/registry.rs
@@ -51,86 +51,8 @@ struct MemoryRerankSummary {
 pub(crate) struct WorkerMemoryContext {
     pub handle: Option<tiangong_memory::MemoryHandle>,
     pub process_type: tiangong_memory::ProcessType,
-}
-
-/// 获取或初始化全局 Memory Handle（同步）。
-pub(crate) fn get_or_init_memory(
-    config: &CoreConfig,
-    config_generation: u64,
-    process_type: tiangong_memory::ProcessType,
-) -> Option<tiangong_memory::MemoryHandle> {
-    let options = config.to_memory_options();
-    let config_summary = memory_config_summary_from_options(&options);
-    let slot = MEMORY_HANDLE.get_or_init(|| Mutex::new(None));
-    let mut guard = match slot.lock() {
-        Ok(guard) => guard,
-        Err(err) => {
-            tracing::warn!("Memory Handle registry 已污染，尝试恢复: {}", err);
-            err.into_inner()
-        }
-    };
-    if let Some(entry) = guard.as_mut() {
-        entry.last_used_at = now_text();
-        let summary_changed = memory_config_changed(&entry.config_summary, &config_summary);
-        let generation_changed = entry.config_generation != config_generation;
-        if generation_changed {
-            entry.config_generation = config_generation;
-        }
-        if summary_changed {
-            if memory_config_can_update_in_place(&entry.config_summary, &config_summary) {
-                match entry.handle.reconfigure_blocking(options) {
-                    Ok(()) => {
-                        tracing::info!(
-                            created_at = %entry.created_at,
-                            last_used_at = %entry.last_used_at,
-                            "Memory 配置已原地热更新"
-                        );
-                        entry.config_summary = config_summary;
-                        entry.restart_required = false;
-                    }
-                    Err(err) => {
-                        entry.restart_required = true;
-                        tracing::warn!(
-                            created_at = %entry.created_at,
-                            last_used_at = %entry.last_used_at,
-                            "Memory 配置热更新失败，继续复用旧 handle 并标记待重启: {}", err
-                        );
-                    }
-                }
-            } else {
-                entry.restart_required = true;
-                tracing::warn!(
-                    created_at = %entry.created_at,
-                    last_used_at = %entry.last_used_at,
-                    "Memory 配置变化需要重启 actor，当前继续复用旧 handle 并标记待重启"
-                );
-            }
-        }
-        return Some(entry.handle.clone());
-    }
-
-    match start_or_connect_memory(options, process_type) {
-        Ok(managed) => {
-            let handle = managed.handle();
-            let is_leader = managed.is_leader();
-            tracing::info!(is_leader, "Memory 已启动或连接");
-            let now = now_text();
-            *guard = Some(MemoryEntry {
-                managed,
-                handle: handle.clone(),
-                config_summary,
-                config_generation,
-                created_at: now.clone(),
-                last_used_at: now,
-                restart_required: false,
-            });
-            Some(handle)
-        }
-        Err(err) => {
-            tracing::warn!("Memory 启动或连接失败（非致命）: {}", err);
-            None
-        }
-    }
+    pub initial_config_snapshot: Option<std::sync::Arc<crate::core_config::CoreConfig>>,
+    pub initial_config_generation: u64,
 }
 
 /// 获取或初始化全局 Memory Handle（异步）。
@@ -279,45 +201,6 @@ pub(crate) async fn get_or_init_memory_async(
             None
         }
     }
-}
-
-fn start_or_connect_memory(
-    options: tiangong_memory::MemoryOptions,
-    process_type: tiangong_memory::ProcessType,
-) -> anyhow::Result<tiangong_memory::ManagedMemory> {
-    if tokio::runtime::Handle::try_current().is_ok() {
-        return std::thread::Builder::new()
-            .name("memory-start-or-connect".to_string())
-            .spawn(move || start_or_connect_memory_blocking(options, process_type))?
-            .join()
-            .map_err(|_| anyhow::anyhow!("Memory 启动线程 panic"))?;
-    }
-    start_or_connect_memory_blocking(options, process_type)
-}
-
-fn start_or_connect_memory_blocking(
-    options: tiangong_memory::MemoryOptions,
-    process_type: tiangong_memory::ProcessType,
-) -> anyhow::Result<tiangong_memory::ManagedMemory> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()?;
-    runtime.block_on(tiangong_memory::start_or_connect_with_options(
-        options,
-        process_type,
-    ))
-}
-
-/// 获取或初始化全局 Memory Handle，供 GUI/Server 侧管理入口复用。
-pub fn get_or_init_memory_handle(
-    config_provider: &CoreConfigProvider,
-) -> Option<tiangong_memory::MemoryHandle> {
-    let config = config_provider.snapshot();
-    get_or_init_memory(
-        &config,
-        config_provider.generation(),
-        tiangong_memory::ProcessType::Gui,
-    )
 }
 
 /// 异步获取或初始化全局 Memory Handle，供 Tauri async command 复用。
@@ -488,19 +371,24 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn memory_registry_reuses_global_handle_regardless_of_workspace() {
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(clippy::await_holding_lock)]
+    async fn memory_registry_reuses_global_handle_regardless_of_workspace() {
         let _lock = memory_registry_test_lock();
         let _env = MemoryRegistryEnvGuard::enter();
         shutdown_memory_registry_blocking();
 
         let config = CoreConfig::default();
 
-        let handle_a = get_or_init_memory(&config, 1, tiangong_memory::ProcessType::Cli)
+        let handle_a = get_or_init_memory_async(&config, 1, tiangong_memory::ProcessType::Cli)
+            .await
             .expect("memory handle 应启动成功");
-        let handle_a_again = get_or_init_memory(&config, 1, tiangong_memory::ProcessType::Cli)
-            .expect("memory handle 应可复用");
-        let handle_b = get_or_init_memory(&config, 1, tiangong_memory::ProcessType::Cli)
+        let handle_a_again =
+            get_or_init_memory_async(&config, 1, tiangong_memory::ProcessType::Cli)
+                .await
+                .expect("memory handle 应可复用");
+        let handle_b = get_or_init_memory_async(&config, 1, tiangong_memory::ProcessType::Cli)
+            .await
             .expect("memory handle 应启动成功");
 
         assert!(
@@ -538,21 +426,26 @@ mod tests {
         shutdown_memory_registry_blocking();
     }
 
-    #[test]
-    fn memory_registry_hot_updates_memory_config_in_place() {
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(clippy::await_holding_lock)]
+    async fn memory_registry_hot_updates_memory_config_in_place() {
         let _lock = memory_registry_test_lock();
         let _env = MemoryRegistryEnvGuard::enter();
         shutdown_memory_registry_blocking();
 
         let initial = CoreConfig::default();
-        let initial_handle = get_or_init_memory(&initial, 1, tiangong_memory::ProcessType::Cli)
-            .expect("初始 MemoryHandle 应启动成功");
+        let initial_handle =
+            get_or_init_memory_async(&initial, 1, tiangong_memory::ProcessType::Cli)
+                .await
+                .expect("初始 MemoryHandle 应启动成功");
 
         write_memory_test_config(1024, tiangong_memory::MemoryVectorMode::EmbeddedLanceDb);
         let updated = CoreConfig::default();
         let expected_summary = memory_config_summary(&updated);
-        let updated_handle = get_or_init_memory(&updated, 2, tiangong_memory::ProcessType::Cli)
-            .expect("MemoryHandle 应支持热更新后继续可用");
+        let updated_handle =
+            get_or_init_memory_async(&updated, 2, tiangong_memory::ProcessType::Cli)
+                .await
+                .expect("MemoryHandle 应支持热更新后继续可用");
 
         assert!(
             initial_handle.is_same_handle(&updated_handle),
@@ -570,19 +463,21 @@ mod tests {
         shutdown_memory_registry_blocking();
     }
 
-    #[test]
-    fn memory_registry_reacts_to_core_config_provider_hot_reload() {
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(clippy::await_holding_lock)]
+    async fn memory_registry_reacts_to_core_config_provider_hot_reload() {
         let _lock = memory_registry_test_lock();
         let _env = MemoryRegistryEnvGuard::enter();
         shutdown_memory_registry_blocking();
 
         let provider = CoreConfigProvider::new(CoreConfig::default());
         let initial_snapshot = provider.snapshot();
-        let initial_handle = get_or_init_memory(
+        let initial_handle = get_or_init_memory_async(
             &initial_snapshot,
             provider.generation(),
             tiangong_memory::ProcessType::Cli,
         )
+        .await
         .expect("初始 MemoryHandle 应启动成功");
 
         write_memory_test_config(2048, tiangong_memory::MemoryVectorMode::EmbeddedLanceDb);
@@ -591,11 +486,12 @@ mod tests {
         });
         let updated_snapshot = provider.snapshot();
         let expected_summary = memory_config_summary(&updated_snapshot);
-        let updated_handle = get_or_init_memory(
+        let updated_handle = get_or_init_memory_async(
             &updated_snapshot,
             provider.generation(),
             tiangong_memory::ProcessType::Cli,
         )
+        .await
         .expect("配置热重载后 MemoryHandle 应继续可用");
 
         assert!(

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -685,11 +685,18 @@ impl SingleProviderClient {
             if name.trim().is_empty() {
                 continue;
             }
+            let raw_args_preview = raw_args
+                .char_indices()
+                .take_while(|(i, _)| *i < 256)
+                .last()
+                .map(|(i, c)| i + c.len_utf8())
+                .map(|end| &raw_args[..end])
+                .unwrap_or("");
             tracing::info!(
                 tool_call_id = %id,
                 tool_name = %name,
                 raw_args_len = raw_args.len(),
-                raw_args_preview = &raw_args[..raw_args.len().min(256)],
+                %raw_args_preview,
                 "解析 tool call arguments"
             );
             let arguments = parse_tool_arguments_or_error(&name, &id, &raw_args);

--- a/crates/tiangong-memory/src/handle.rs
+++ b/crates/tiangong-memory/src/handle.rs
@@ -55,49 +55,6 @@ impl MemoryHandle {
         Arc::ptr_eq(&self.inner, &other.inner)
     }
 
-    /// 同步热更新 Memory Actor 配置。
-    ///
-    /// 该方法用于 Core 工作线程响应配置 generation 变化；远程 handle 暂不支持
-    /// 跨进程重配置，调用方应在本进程 registry 内使用。
-    ///
-    /// 当在 tokio 异步运行时内调用时，自动将阻塞操作转移到独立线程以避免 panic。
-    pub fn reconfigure_blocking(&self, options: MemoryOptions) -> Result<()> {
-        match self.inner.as_ref() {
-            HandleInner::Local { tx } => {
-                let (reply_tx, reply_rx) = std::sync::mpsc::channel();
-                if tokio::runtime::Handle::try_current().is_ok() {
-                    let tx = tx.clone();
-                    let send_ok = std::thread::Builder::new()
-                        .name("memory-reconfigure".to_string())
-                        .spawn(move || {
-                            tx.blocking_send(MemoryCommand::Reconfigure {
-                                options: Box::new(options),
-                                reply: reply_tx,
-                            })
-                            .is_ok()
-                        })
-                        .with_context(|| "创建 Memory 热更新线程失败")?
-                        .join()
-                        .map_err(|_| anyhow::anyhow!("Memory 热更新线程 panic"))?;
-                    if !send_ok {
-                        return Err(anyhow!("发送 Memory 热更新命令失败"));
-                    }
-                } else {
-                    tx.blocking_send(MemoryCommand::Reconfigure {
-                        options: Box::new(options),
-                        reply: reply_tx,
-                    })
-                    .with_context(|| "发送 Memory 热更新命令失败")?;
-                }
-                reply_rx
-                    .recv_timeout(Duration::from_secs(30))
-                    .with_context(|| "等待 Memory 热更新结果超时或失败")?
-                    .map_err(|err| anyhow!(err))
-            }
-            HandleInner::Remote { .. } => Err(anyhow!("远程 MemoryHandle 暂不支持配置热更新")),
-        }
-    }
-
     /// 异步热更新 Memory Actor 配置。
     pub async fn reconfigure(&self, options: MemoryOptions) -> Result<()> {
         match self.inner.as_ref() {


### PR DESCRIPTION
## Summary

- 将 Memory 初始化从 `TiangongCore` 构造函数延迟到 Worker 线程内部的异步循环中完成，消除同步方法在 tokio runtime 内的阻塞风险
- 删除 `get_or_init_memory`（同步）、`start_or_connect_memory`、`reconfigure_blocking` 等 runtime 检测 workaround 代码，净减 140+ 行
- 修复 tool call 参数预览截断时因中文字符跨越字节边界导致的 panic（`&raw_args[..256]` → `char_indices` 安全截断）

## 改动细节

### Memory 异步重构
- `WorkerMemoryContext` 新增 `initial_config_snapshot` / `initial_config_generation` 字段
- `with_session_for_process` 不再同步调用 `get_or_init_memory`，改为将配置传入 Worker
- `worker_loop_async` 在主循环前用 `get_or_init_memory_async` 初始化 Memory Handle
- 所有外部调用者（Tauri/CLI/Server/Scheduler）无需修改

### UTF-8 截断修复
- `model.rs` 中工具调用参数预览改用 `char_indices` 找到安全的 UTF-8 边界进行截断

## Test plan

- [x] `cargo check --workspace` 编译通过
- [x] `cargo clippy --workspace --all-targets --tests --benches -- -D warnings` 无警告
- [x] `cargo nextest run --workspace` 271 测试全部通过
- [x] GUI 模式启动，发送消息，Memory 正常初始化和召回
- [x] CLI 模式发送消息，Memory 正常工作

Closes #83