### PR TITLE
fix(core): 修复 LLM 生成中无法打断的问题

### DIFF
--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -4,6 +4,7 @@
 //! CLI / GUI / Server / Connector 统一通过 TiangongCore 运行。
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Sender, Sender as StdSender};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{self, JoinHandle};
@@ -50,6 +51,8 @@ pub struct TiangongCore {
     session_id: String,
     /// 独立的信任模式（共享引用，实时生效）
     shared_trust_mode: Arc<RwLock<crate::permission::TrustMode>>,
+    /// 取消标志（stream consumer 检查此标志跳过 Delta/Reasoning 事件）
+    cancel_flag: Arc<AtomicBool>,
 }
 
 impl TiangongCore {
@@ -148,6 +151,7 @@ impl TiangongCore {
             worker: Some(worker),
             session_id,
             shared_trust_mode,
+            cancel_flag: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -188,7 +192,12 @@ impl TiangongCore {
     }
 
     pub fn cancel(&self) -> bool {
+        self.cancel_flag.store(true, Ordering::Release);
         self.send_cmd(Command::Cancel)
+    }
+
+    pub fn cancel_flag(&self) -> Arc<AtomicBool> {
+        self.cancel_flag.clone()
     }
 
     pub fn cancel_agent(&self, role: String) -> bool {

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -75,6 +75,7 @@ pub type ModelFunctionResponse = ModelResponse;
 pub struct ModelStreamChunk {
     pub content: String,
     pub reasoning_content: String,
+    pub usage: Option<tiangong_llm::usage::TokenUsageData>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -151,12 +152,14 @@ pub trait ModelClient {
             on_delta(&ModelStreamChunk {
                 content: String::new(),
                 reasoning_content: resp.reasoning_content.clone(),
+                usage: None,
             });
         }
         if !resp.text.is_empty() {
             on_delta(&ModelStreamChunk {
                 content: resp.text.clone(),
                 reasoning_content: String::new(),
+                usage: None,
             });
         }
         Ok(resp)
@@ -180,12 +183,14 @@ pub trait ModelClient {
             on_delta(&ModelStreamChunk {
                 content: String::new(),
                 reasoning_content: resp.reasoning_content.clone(),
+                usage: None,
             });
         }
         if !resp.text.is_empty() {
             on_delta(&ModelStreamChunk {
                 content: resp.text.clone(),
                 reasoning_content: String::new(),
+                usage: None,
             });
         }
         Ok(resp)
@@ -570,12 +575,14 @@ impl SingleProviderClient {
                     let _ = fallback_tx.send(ModelStreamChunk {
                         content: String::new(),
                         reasoning_content: response.reasoning_content.clone(),
+                        usage: None,
                     });
                 }
                 if !response.text.is_empty() {
                     let _ = fallback_tx.send(ModelStreamChunk {
                         content: response.text.clone(),
                         reasoning_content: String::new(),
+                        usage: None,
                     });
                 }
                 Ok(response)
@@ -624,6 +631,7 @@ impl SingleProviderClient {
                         let _ = chunk_tx.send(ModelStreamChunk {
                             content: String::new(),
                             reasoning_content: delta,
+                            usage: None,
                         });
                     }
                 }
@@ -638,6 +646,7 @@ impl SingleProviderClient {
                         let _ = chunk_tx.send(ModelStreamChunk {
                             content: delta,
                             reasoning_content: String::new(),
+                            usage: None,
                         });
                     }
                 }
@@ -671,7 +680,12 @@ impl SingleProviderClient {
                     }
                 }
                 ProviderStreamEvent::Usage(stream_usage) => {
-                    merge_stream_usage(&mut usage, stream_usage)
+                    merge_stream_usage(&mut usage, stream_usage);
+                    let _ = chunk_tx.send(ModelStreamChunk {
+                        content: String::new(),
+                        reasoning_content: String::new(),
+                        usage: Some(usage.clone()),
+                    });
                 }
                 ProviderStreamEvent::Error(message) => return Err(anyhow!(message)),
                 ProviderStreamEvent::MessageStart
@@ -765,12 +779,14 @@ impl SingleProviderClient {
                         on_delta(&ModelStreamChunk {
                             content: String::new(),
                             reasoning_content: resp.reasoning_content.clone(),
+                            usage: None,
                         });
                     }
                     if !resp.text.is_empty() {
                         on_delta(&ModelStreamChunk {
                             content: resp.text.clone(),
                             reasoning_content: String::new(),
+                            usage: None,
                         });
                     }
                     Ok(resp)
@@ -783,12 +799,14 @@ impl SingleProviderClient {
                 on_delta(&ModelStreamChunk {
                     content: String::new(),
                     reasoning_content: resp.reasoning_content.clone(),
+                    usage: None,
                 });
             }
             if !resp.text.is_empty() {
                 on_delta(&ModelStreamChunk {
                     content: resp.text.clone(),
                     reasoning_content: String::new(),
+                    usage: None,
                 });
             }
             Ok(resp)
@@ -1513,6 +1531,7 @@ async fn consume_provider_stream_events_async(
                     on_delta(&ModelStreamChunk {
                         content: String::new(),
                         reasoning_content: delta.clone(),
+                        usage: None,
                     });
                 }
             }
@@ -1527,6 +1546,7 @@ async fn consume_provider_stream_events_async(
                     on_delta(&ModelStreamChunk {
                         content: delta,
                         reasoning_content: String::new(),
+                        usage: None,
                     });
                 }
             }

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -292,7 +292,7 @@ impl SingleProviderClient {
         Ok(models)
     }
 
-    fn protocol(&self) -> ProviderProtocol {
+    pub fn protocol(&self) -> ProviderProtocol {
         self.cfg.api_protocol
     }
 

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -32,6 +32,25 @@ use tiangong_types::{StreamEvent, StreamToolCall};
 
 use crate::agent_team::lifecycle::TeamContext;
 
+/// 取消时 LLM 请求的处理策略，按 Provider 协议区分。
+enum CancelStrategy {
+    /// Anthropic: usage 在 message_start 就返回 prompt_tokens，可直接 abort
+    AbortWithStreamingUsage,
+    /// OpenAI 兼容: usage 仅在流式最后一个 chunk 返回，需等请求完成
+    WaitForUsage,
+}
+
+impl CancelStrategy {
+    fn from_protocol(protocol: tiangong_llm::model::ProviderProtocol) -> Self {
+        match protocol {
+            tiangong_llm::model::ProviderProtocol::Anthropic => {
+                CancelStrategy::AbortWithStreamingUsage
+            }
+            tiangong_llm::model::ProviderProtocol::OpenAiCompatible => CancelStrategy::WaitForUsage,
+        }
+    }
+}
+
 #[derive(Default)]
 struct SubAgentDrainResult {
     usage: TokenUsage,
@@ -492,37 +511,28 @@ impl ReactEngine {
             let client = select_client_for_request(&self.engine, &req).clone();
             let req_clone = req.clone();
             let tools_clone = request_tools.clone();
-            let llm_fut = tokio::task::spawn(async move {
+            let mut llm_fut = Some(tokio::task::spawn(async move {
                 client
                     .stream_function_calls_with_tool_choice(req_clone, tools_clone, None, chunk_tx)
                     .await
-            });
-
+            }));
             let mut user_message_injected_during_stream = false;
             let mut streaming_usage = tiangong_types::TokenUsage::default();
+            let cancel_strategy = CancelStrategy::from_protocol(self.engine.client().protocol());
             let response_result: anyhow::Result<crate::model::ModelFunctionResponse> = loop {
                 tokio::select! {
                     biased;
                     cmd_opt = cmd_rx.recv() => {
                         match cmd_opt {
                             Some(Command::Cancel) | Some(Command::Shutdown) | None => {
-                                llm_fut.abort();
-                                sink.finish();
-                                if streaming_usage.total_tokens > 0 {
-                                    accumulated_usage.accumulate(&streaming_usage);
-                                    crate::react::context::emit_token_usage(
-                                        stream_tx,
-                                        &streaming_usage,
-                                        None,
-                                        self.engine.context_limit,
-                                        "cancelled",
-                                        None,
-                                    );
+                                match cancel_strategy {
+                                    CancelStrategy::AbortWithStreamingUsage => {
+                                        break Err(anyhow::anyhow!("__cancelled_abort__"));
+                                    }
+                                    CancelStrategy::WaitForUsage => {
+                                        break Err(anyhow::anyhow!("__cancelled_wait_usage__"));
+                                    }
                                 }
-                                let _ = stream_tx.send(StreamEvent::Error {
-                                    message: "已取消".into(),
-                                });
-                                return accumulated_usage;
                             }
                             Some(Command::Message { content, message_id, media }) => {
                                 let mid = append_or_reuse_user_message(
@@ -576,7 +586,7 @@ impl ReactEngine {
                                 sink.push_chunk(&chunk)
                             }
                             None => {
-                                let response_result = match llm_fut.await {
+                                let response_result = match llm_fut.take().unwrap().await {
                                     Ok(r) => r,
                                     Err(e) if e.is_cancelled() => {
                                         sink.finish();
@@ -599,6 +609,67 @@ impl ReactEngine {
                 Ok(r) => r,
                 Err(err) => {
                     let err_msg = err.to_string();
+                    // Anthropic 取消：abort + 上报已收集的 streaming_usage
+                    if err_msg == "__cancelled_abort__" {
+                        if let Some(handle) = llm_fut.take() {
+                            handle.abort();
+                        }
+                        if streaming_usage.total_tokens > 0 {
+                            accumulated_usage.accumulate(&streaming_usage);
+                            emit_token_usage(
+                                stream_tx,
+                                &streaming_usage,
+                                None,
+                                self.engine.context_limit,
+                                "cancelled",
+                                None,
+                            );
+                        }
+                        let _ = stream_tx.send(StreamEvent::Error {
+                            message: "已取消".into(),
+                        });
+                        return accumulated_usage;
+                    }
+                    // OpenAI 取消：等 LLM 自然完成以获取准确 usage
+                    if err_msg == "__cancelled_wait_usage__" {
+                        if let Some(handle) = llm_fut.take() {
+                            if let Ok(Ok(resp)) = handle.await {
+                                accumulated_usage.accumulate(&resp.usage);
+                                emit_token_usage(
+                                    stream_tx,
+                                    &resp.usage,
+                                    None,
+                                    self.engine.context_limit,
+                                    "cancelled",
+                                    None,
+                                );
+                            } else if streaming_usage.total_tokens > 0 {
+                                accumulated_usage.accumulate(&streaming_usage);
+                                emit_token_usage(
+                                    stream_tx,
+                                    &streaming_usage,
+                                    None,
+                                    self.engine.context_limit,
+                                    "cancelled",
+                                    None,
+                                );
+                            }
+                        } else if streaming_usage.total_tokens > 0 {
+                            accumulated_usage.accumulate(&streaming_usage);
+                            emit_token_usage(
+                                stream_tx,
+                                &streaming_usage,
+                                None,
+                                self.engine.context_limit,
+                                "cancelled",
+                                None,
+                            );
+                        }
+                        let _ = stream_tx.send(StreamEvent::Error {
+                            message: "已取消".into(),
+                        });
+                        return accumulated_usage;
+                    }
                     // 上下文超限时强制压缩后重试
                     if err_msg.contains("context_window_exceeded")
                         || err_msg.contains("context_length_exceeded")

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -499,7 +499,7 @@ impl ReactEngine {
             });
 
             let mut user_message_injected_during_stream = false;
-            let mut generated_chars: usize = 0;
+            let mut streaming_usage = tiangong_types::TokenUsage::default();
             let response_result: anyhow::Result<crate::model::ModelFunctionResponse> = loop {
                 tokio::select! {
                     biased;
@@ -508,16 +508,11 @@ impl ReactEngine {
                             Some(Command::Cancel) | Some(Command::Shutdown) | None => {
                                 llm_fut.abort();
                                 sink.finish();
-                                let estimated_tokens = generated_chars.div_ceil(3);
-                                if estimated_tokens > 0 {
-                                    let partial_usage = tiangong_types::TokenUsage {
-                                        completion_tokens: estimated_tokens,
-                                        ..Default::default()
-                                    };
-                                    accumulated_usage.accumulate(&partial_usage);
+                                if streaming_usage.total_tokens > 0 {
+                                    accumulated_usage.accumulate(&streaming_usage);
                                     crate::react::context::emit_token_usage(
                                         stream_tx,
-                                        &partial_usage,
+                                        &streaming_usage,
                                         None,
                                         self.engine.context_limit,
                                         "cancelled",
@@ -573,8 +568,11 @@ impl ReactEngine {
                     chunk_opt = chunk_rx.recv() => {
                         match chunk_opt {
                             Some(chunk) => {
-                                generated_chars +=
-                                    chunk.content.len() + chunk.reasoning_content.len();
+                                if let Some(ref chunk_usage) = chunk.usage {
+                                    let tu: tiangong_types::TokenUsage =
+                                        chunk_usage.clone().into();
+                                    streaming_usage.accumulate(&tu);
+                                }
                                 sink.push_chunk(&chunk)
                             }
                             None => {

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -664,17 +664,29 @@ impl ReactEngine {
                                 accumulated_usage.accumulate(&streaming_usage);
                                 emit_cancel_usage(
                                     stream_tx,
-                                    &streaming_usage,
+                                    &accumulated_usage,
                                     self.engine.context_limit,
                                 );
                                 return accumulated_usage;
                             }
                             CancelSignal::WaitForUsage => {
+                                accumulated_usage.accumulate(&streaming_usage);
+                                // 先上报已知的 streaming_usage 作为保底
+                                if streaming_usage.total_tokens > 0 {
+                                    emit_token_usage(
+                                        stream_tx,
+                                        &streaming_usage,
+                                        None,
+                                        self.engine.context_limit,
+                                        "cancelled",
+                                        None,
+                                    );
+                                }
                                 // 立即通知前端取消已完成
                                 let _ = stream_tx.send(StreamEvent::Error {
                                     message: "已取消".into(),
                                 });
-                                // 后台等待 LLM 自然完成以获取 usage（带超时保护）
+                                // 后台等待 LLM 自然完成以补充完整 usage
                                 if let Some(handle) = llm_fut.take() {
                                     let ctx_limit = self.engine.context_limit;
                                     let tx = stream_tx.clone();
@@ -687,7 +699,7 @@ impl ReactEngine {
                                                 &resp.usage,
                                                 None,
                                                 ctx_limit,
-                                                "cancelled",
+                                                "cancelled_background",
                                                 None,
                                             );
                                         }

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -51,6 +51,53 @@ impl CancelStrategy {
     }
 }
 
+/// select! 循环 break 时携带的取消信号，替代魔术字符串。
+#[derive(Clone, Copy)]
+enum CancelSignal {
+    /// 直接 abort LLM future，上报已累积的 streaming_usage
+    Abort,
+    /// 在后台等待 LLM 自然完成以获取 usage，前端立即响应取消
+    WaitForUsage,
+}
+
+impl CancelSignal {
+    /// 从 anyhow::Error 中提取 CancelSignal，如果不是取消信号返回 None。
+    fn from_error(err: &anyhow::Error) -> Option<Self> {
+        err.downcast_ref::<Self>().copied()
+    }
+}
+
+impl std::fmt::Display for CancelSignal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CancelSignal::Abort => write!(f, "cancelled (abort)"),
+            CancelSignal::WaitForUsage => write!(f, "cancelled (wait for usage)"),
+        }
+    }
+}
+
+impl std::fmt::Debug for CancelSignal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+impl std::error::Error for CancelSignal {}
+
+/// 取消时统一上报 token usage 并发送 Error 事件。
+fn emit_cancel_usage(
+    stream_tx: &StdSender<StreamEvent>,
+    usage: &tiangong_types::TokenUsage,
+    context_limit: usize,
+) {
+    if usage.total_tokens > 0 {
+        emit_token_usage(stream_tx, usage, None, context_limit, "cancelled", None);
+    }
+    let _ = stream_tx.send(StreamEvent::Error {
+        message: "已取消".into(),
+    });
+}
+
 #[derive(Default)]
 struct SubAgentDrainResult {
     usage: TokenUsage,
@@ -527,10 +574,10 @@ impl ReactEngine {
                             Some(Command::Cancel) | Some(Command::Shutdown) | None => {
                                 match cancel_strategy {
                                     CancelStrategy::AbortWithStreamingUsage => {
-                                        break Err(anyhow::anyhow!("__cancelled_abort__"));
+                                        break Err(anyhow::Error::new(CancelSignal::Abort));
                                     }
                                     CancelStrategy::WaitForUsage => {
-                                        break Err(anyhow::anyhow!("__cancelled_wait_usage__"));
+                                        break Err(anyhow::Error::new(CancelSignal::WaitForUsage));
                                     }
                                 }
                             }
@@ -608,68 +655,49 @@ impl ReactEngine {
             let response = match response_result {
                 Ok(r) => r,
                 Err(err) => {
-                    let err_msg = err.to_string();
-                    // Anthropic 取消：abort + 上报已收集的 streaming_usage
-                    if err_msg == "__cancelled_abort__" {
-                        if let Some(handle) = llm_fut.take() {
-                            handle.abort();
-                        }
-                        if streaming_usage.total_tokens > 0 {
-                            accumulated_usage.accumulate(&streaming_usage);
-                            emit_token_usage(
-                                stream_tx,
-                                &streaming_usage,
-                                None,
-                                self.engine.context_limit,
-                                "cancelled",
-                                None,
-                            );
-                        }
-                        let _ = stream_tx.send(StreamEvent::Error {
-                            message: "已取消".into(),
-                        });
-                        return accumulated_usage;
-                    }
-                    // OpenAI 取消：等 LLM 自然完成以获取准确 usage
-                    if err_msg == "__cancelled_wait_usage__" {
-                        if let Some(handle) = llm_fut.take() {
-                            if let Ok(Ok(resp)) = handle.await {
-                                accumulated_usage.accumulate(&resp.usage);
-                                emit_token_usage(
-                                    stream_tx,
-                                    &resp.usage,
-                                    None,
-                                    self.engine.context_limit,
-                                    "cancelled",
-                                    None,
-                                );
-                            } else if streaming_usage.total_tokens > 0 {
+                    if let Some(signal) = CancelSignal::from_error(&err) {
+                        match signal {
+                            CancelSignal::Abort => {
+                                if let Some(handle) = llm_fut.take() {
+                                    handle.abort();
+                                }
                                 accumulated_usage.accumulate(&streaming_usage);
-                                emit_token_usage(
+                                emit_cancel_usage(
                                     stream_tx,
                                     &streaming_usage,
-                                    None,
                                     self.engine.context_limit,
-                                    "cancelled",
-                                    None,
                                 );
+                                return accumulated_usage;
                             }
-                        } else if streaming_usage.total_tokens > 0 {
-                            accumulated_usage.accumulate(&streaming_usage);
-                            emit_token_usage(
-                                stream_tx,
-                                &streaming_usage,
-                                None,
-                                self.engine.context_limit,
-                                "cancelled",
-                                None,
-                            );
+                            CancelSignal::WaitForUsage => {
+                                // 立即通知前端取消已完成
+                                let _ = stream_tx.send(StreamEvent::Error {
+                                    message: "已取消".into(),
+                                });
+                                // 后台等待 LLM 自然完成以获取 usage（带超时保护）
+                                if let Some(handle) = llm_fut.take() {
+                                    let ctx_limit = self.engine.context_limit;
+                                    let tx = stream_tx.clone();
+                                    tokio::task::spawn(async move {
+                                        if let Ok(Ok(resp)) = handle.await
+                                            && resp.usage.total_tokens > 0
+                                        {
+                                            emit_token_usage(
+                                                &tx,
+                                                &resp.usage,
+                                                None,
+                                                ctx_limit,
+                                                "cancelled",
+                                                None,
+                                            );
+                                        }
+                                    });
+                                }
+                                return accumulated_usage;
+                            }
                         }
-                        let _ = stream_tx.send(StreamEvent::Error {
-                            message: "已取消".into(),
-                        });
-                        return accumulated_usage;
                     }
+                    let err_msg = err.to_string();
                     // 上下文超限时强制压缩后重试
                     if err_msg.contains("context_window_exceeded")
                         || err_msg.contains("context_length_exceeded")

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -499,6 +499,7 @@ impl ReactEngine {
             });
 
             let mut user_message_injected_during_stream = false;
+            let mut generated_chars: usize = 0;
             let response_result: anyhow::Result<crate::model::ModelFunctionResponse> = loop {
                 tokio::select! {
                     biased;
@@ -507,6 +508,22 @@ impl ReactEngine {
                             Some(Command::Cancel) | Some(Command::Shutdown) | None => {
                                 llm_fut.abort();
                                 sink.finish();
+                                let estimated_tokens = generated_chars.div_ceil(3);
+                                if estimated_tokens > 0 {
+                                    let partial_usage = tiangong_types::TokenUsage {
+                                        completion_tokens: estimated_tokens,
+                                        ..Default::default()
+                                    };
+                                    accumulated_usage.accumulate(&partial_usage);
+                                    crate::react::context::emit_token_usage(
+                                        stream_tx,
+                                        &partial_usage,
+                                        None,
+                                        self.engine.context_limit,
+                                        "cancelled",
+                                        None,
+                                    );
+                                }
                                 let _ = stream_tx.send(StreamEvent::Error {
                                     message: "已取消".into(),
                                 });
@@ -555,7 +572,11 @@ impl ReactEngine {
                     }
                     chunk_opt = chunk_rx.recv() => {
                         match chunk_opt {
-                            Some(chunk) => sink.push_chunk(&chunk),
+                            Some(chunk) => {
+                                generated_chars +=
+                                    chunk.content.len() + chunk.reasoning_content.len();
+                                sink.push_chunk(&chunk)
+                            }
                             None => {
                                 let response_result = match llm_fut.await {
                                     Ok(r) => r,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -679,16 +679,21 @@ async fn send_message_inner(
         return Ok(());
     }
 
-    let cancel_flag = {
-        let cores = state.cores.lock().map_err(|e| e.to_string())?;
-        cores
-            .get(&sid)
-            .map(|c| c.cancel_flag())
-            .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicBool::new(false)))
-    };
+    let cancel_flag = get_cancel_flag(&state, &sid)?;
     start_stream_consumer(app, stream_rx, cancel_flag);
 
     Ok(())
+}
+
+fn get_cancel_flag(
+    state: &TiangongApp,
+    sid: &str,
+) -> Result<Arc<std::sync::atomic::AtomicBool>, String> {
+    let cores = state.cores.lock().map_err(|e| e.to_string())?;
+    Ok(cores
+        .get(sid)
+        .map(|c| c.cancel_flag())
+        .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicBool::new(false))))
 }
 
 /// 消费 SessionStreamEvent：emit 给前端 + 更新 RunStatus + Done 时同步 session
@@ -1481,13 +1486,7 @@ pub async fn edit_and_resend(
     }
 
     if is_new_core {
-        let cancel_flag = {
-            let cores = state.cores.lock().map_err(|e| e.to_string())?;
-            cores
-                .get(&sid)
-                .map(|c| c.cancel_flag())
-                .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicBool::new(false)))
-        };
+        let cancel_flag = get_cancel_flag(&state, &sid)?;
         start_stream_consumer(app, stream_rx, cancel_flag);
     }
 
@@ -1526,13 +1525,7 @@ async fn ensure_active_context_core(
     let (stream_tx, stream_rx) = mpsc::channel::<tiangong_types::SessionStreamEvent>();
     let (sid, is_new_core) = state.ensure_core(&session_id, session_snapshot, stream_tx);
     if is_new_core {
-        let cancel_flag = {
-            let cores = state.cores.lock().map_err(|e| e.to_string())?;
-            cores
-                .get(&sid)
-                .map(|c| c.cancel_flag())
-                .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicBool::new(false)))
-        };
+        let cancel_flag = get_cancel_flag(state, &sid)?;
         start_stream_consumer(app, stream_rx, cancel_flag);
     }
     Ok(sid)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4,6 +4,8 @@ use base64::{engine::general_purpose, Engine as _};
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State, Window};
@@ -677,7 +679,14 @@ async fn send_message_inner(
         return Ok(());
     }
 
-    start_stream_consumer(app, stream_rx);
+    let cancel_flag = {
+        let cores = state.cores.lock().map_err(|e| e.to_string())?;
+        cores
+            .get(&sid)
+            .map(|c| c.cancel_flag())
+            .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicBool::new(false)))
+    };
+    start_stream_consumer(app, stream_rx, cancel_flag);
 
     Ok(())
 }
@@ -686,6 +695,7 @@ async fn send_message_inner(
 fn start_stream_consumer(
     app: AppHandle,
     stream_rx: std::sync::mpsc::Receiver<tiangong_types::SessionStreamEvent>,
+    cancel_flag: Arc<std::sync::atomic::AtomicBool>,
 ) {
     use tiangong_types::StreamEvent;
 
@@ -694,6 +704,18 @@ fn start_stream_consumer(
         let mut assistant_msg_id: Option<String> = None;
         let mut last_tool_args_summary = String::new();
         for session_event in stream_rx.iter() {
+            let event = &session_event.event;
+
+            // 取消时跳过文本增量事件，只处理终止事件
+            if cancel_flag.load(Ordering::Acquire)
+                && matches!(
+                    event,
+                    StreamEvent::Delta { .. } | StreamEvent::Reasoning { .. }
+                )
+            {
+                continue;
+            }
+
             // 先 emit 完整事件给前端，再解构
             let _ = app.emit("stream_event", &session_event);
 
@@ -1252,6 +1274,8 @@ fn start_stream_consumer(
             }
 
             if is_done || is_error {
+                cancel_flag.store(false, Ordering::Release);
+
                 // Done：先持久化，再异步生成标题（不阻塞消费线程）
                 let final_sid = sid.clone();
 
@@ -1457,13 +1481,18 @@ pub async fn edit_and_resend(
     }
 
     if is_new_core {
-        start_stream_consumer(app, stream_rx);
+        let cancel_flag = {
+            let cores = state.cores.lock().map_err(|e| e.to_string())?;
+            cores
+                .get(&sid)
+                .map(|c| c.cancel_flag())
+                .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicBool::new(false)))
+        };
+        start_stream_consumer(app, stream_rx, cancel_flag);
     }
 
     Ok(())
 }
-
-/// 取消当前执行
 #[tauri::command]
 pub async fn cancel_turn(state: State<'_, TiangongApp>) -> Result<bool, String> {
     let session_id = state
@@ -1497,7 +1526,14 @@ async fn ensure_active_context_core(
     let (stream_tx, stream_rx) = mpsc::channel::<tiangong_types::SessionStreamEvent>();
     let (sid, is_new_core) = state.ensure_core(&session_id, session_snapshot, stream_tx);
     if is_new_core {
-        start_stream_consumer(app, stream_rx);
+        let cancel_flag = {
+            let cores = state.cores.lock().map_err(|e| e.to_string())?;
+            cores
+                .get(&sid)
+                .map(|c| c.cancel_flag())
+                .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicBool::new(false)))
+        };
+        start_stream_consumer(app, stream_rx, cancel_flag);
     }
     Ok(sid)
 }


### PR DESCRIPTION
## Summary
- 新增 `Arc<AtomicBool>` cancel_flag 实现无锁取消信号，解决 `tokio::sync::Mutex` 锁竞争导致取消命令无法及时发出的问题
- 按 Provider 协议区分取消策略：Anthropic 协议直接 abort，OpenAI 兼容协议后台等待 usage 完成后上报
- 使用 `CancelSignal` 枚举替代魔术字符串，提取 `emit_cancel_usage` 辅助函数消除重复逻辑
- `ModelStreamChunk` 增加 `usage` 字段传递真实 streaming token 数据
- stream consumer 中 cancel_flag 为 true 时跳过 Delta/Reasoning 事件，确保取消后数据层不存储新数据
- 提取 `get_cancel_flag` 辅助函数消除 commands.rs 中的重复逻辑

## Test plan
- [x] 发送一条消息，在流式输出过程中点击「停止」
- [x] 验证文本立即停止输出
- [x] 验证 token 统计正确记录了中断前的消耗
- [x] 验证 UI 状态正确回到 idle
- [x] 发送新消息，验证正常工作（cancel flag 已重置）
- [x] 验证 Anthropic 协议取消时 token usage 正常上报
- [x] 验证 OpenAI 兼容协议取消时 token usage 正常上报