### PR TITLE
refactor(core): 重构模型配置为两层架构，支持 multimodal 对话模型

### DIFF
--- a/crates/tiangong-core/src/app_state/facade/provider_settings.rs
+++ b/crates/tiangong-core/src/app_state/facade/provider_settings.rs
@@ -16,10 +16,10 @@ impl TiangongState {
         }
 
         // 更新 routing 中的 chat 模型
-        self.store.provider.models_config.routing.insert(
-            crate::models_config::ModelCapability::Chat,
-            api_model.to_string(),
-        );
+        self.store
+            .provider
+            .models_config
+            .update_chat_model(api_model.to_string());
         let _ = self.store.provider.models_config.save();
 
         // 重新生成内部 model_config
@@ -57,8 +57,7 @@ impl TiangongState {
             self.store
                 .provider
                 .models_config
-                .routing
-                .insert(crate::models_config::ModelCapability::Chat, first.clone());
+                .update_chat_model(first.clone());
             let _ = self.store.provider.models_config.save();
             self.store.provider.model_config =
                 self.store.provider.models_config.to_chat_provider_config();

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -723,9 +723,9 @@ fn build_engine_from_config(
     use crate::model::OnRetryCallback;
     use crate::models_config::ModelsConfig;
 
-    // 从 LlmConfig 构建兼容的 ModelsConfig（供 system prompt 构建使用）
     let models_config = ModelsConfig::from_llm_config(&config.llm);
     let model_config = models_config.to_chat_provider_config();
+    let chat_is_multimodal = models_config.chat_is_multimodal();
 
     let agent_config = AgentConfig {
         mcp: config.mcp.clone(),
@@ -783,6 +783,14 @@ fn build_engine_from_config(
         engine = engine.with_multimodal_client(
             SingleProviderClient::new(multimodal_config).with_on_retry(on_retry),
         );
+    }
+
+    // 当 chat 模型自带 multimodal 能力但没有独立 multimodal 端点时，
+    // 用 chat client 充当 multimodal_client（用于 ensure_multimodal_enabled 等检查）
+    let needs_fallback_multimodal = !engine.has_multimodal_client() && chat_is_multimodal;
+    if needs_fallback_multimodal {
+        let chat_client = engine.client().clone();
+        engine = engine.with_multimodal_client(chat_client);
     }
 
     engine

--- a/crates/tiangong-core/src/core_config.rs
+++ b/crates/tiangong-core/src/core_config.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use crate::agent_config::{McpConfig, McpServerConfig, SkillsConfig};
 use crate::mcp::McpToolMeta;
 use crate::model::ProviderProtocol;
-use crate::models_config::{ModelCapability, ModelsConfig};
+use crate::models_config::ModelsConfig;
 use crate::permission::TrustMode;
 
 const DEFAULT_CONTEXT_LIMIT: usize = 200_000;
@@ -94,8 +94,10 @@ pub struct LlmConfig {
 impl LlmConfig {
     /// 从 ModelsConfig 解析出 Core 运行所需的扁平端点配置
     pub fn from_models_config(models: &ModelsConfig) -> Self {
-        let resolve = |cap: ModelCapability| -> Option<ModelEndpoint> {
-            let resolved = models.resolve_for_capability(cap)?;
+        use crate::models_config::RoutingSlot;
+
+        let resolve = |slot: RoutingSlot| -> Option<ModelEndpoint> {
+            let resolved = models.resolve_slot(slot)?;
             Some(ModelEndpoint {
                 base_url: resolved.base_url,
                 api_key: resolved.api_key,
@@ -107,15 +109,15 @@ impl LlmConfig {
         };
 
         Self {
-            chat: resolve(ModelCapability::Chat).unwrap_or_default(),
-            lite: resolve(ModelCapability::Lite),
-            image_generation: resolve(ModelCapability::ImageGeneration),
-            tts: resolve(ModelCapability::Tts),
-            stt: resolve(ModelCapability::Stt),
-            video_generation: resolve(ModelCapability::VideoGeneration),
-            multimodal: resolve(ModelCapability::Multimodal),
-            embedding: resolve(ModelCapability::Embedding),
-            rerank: resolve(ModelCapability::Rerank),
+            chat: resolve(RoutingSlot::Chat).unwrap_or_default(),
+            lite: resolve(RoutingSlot::Lite),
+            image_generation: resolve(RoutingSlot::ImageGeneration),
+            tts: resolve(RoutingSlot::Tts),
+            stt: resolve(RoutingSlot::Stt),
+            video_generation: resolve(RoutingSlot::VideoGeneration),
+            multimodal: resolve(RoutingSlot::Multimodal),
+            embedding: resolve(RoutingSlot::Embedding),
+            rerank: resolve(RoutingSlot::Rerank),
         }
     }
 
@@ -359,6 +361,7 @@ pub fn resolve_context_limit(model_name: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models_config::ModelCapability;
 
     #[test]
     fn provider_snapshot_and_generation() {
@@ -424,6 +427,8 @@ mod tests {
 
     #[test]
     fn llm_config_from_models_config_preserves_protocol() {
+        use crate::models_config::RoutingSlot;
+
         let mut models = ModelsConfig::default();
         models.providers.insert(
             "anthropic".to_string(),
@@ -434,8 +439,8 @@ mod tests {
                 protocol: ProviderProtocol::Anthropic,
             },
         );
-        models.models.insert(
-            "chat-model".to_string(),
+        models.routing.insert(
+            RoutingSlot::Chat,
             crate::models_config::ModelEntry {
                 provider: "anthropic".into(),
                 model: "claude-sonnet-4".into(),
@@ -443,9 +448,6 @@ mod tests {
                 options: serde_json::json!({}),
             },
         );
-        models
-            .routing
-            .insert(ModelCapability::Chat, "chat-model".into());
 
         let llm = LlmConfig::from_models_config(&models);
         assert_eq!(llm.chat.protocol, ProviderProtocol::Anthropic);

--- a/crates/tiangong-core/src/models_config.rs
+++ b/crates/tiangong-core/src/models_config.rs
@@ -279,15 +279,49 @@ fn default_options() -> Value {
 /// routing 直接存储 ModelEntry，不再需要中间的 models 映射层。
 /// 支持向后兼容：旧格式 routing 值为字符串（引用 models 中的 key），
 /// 新格式 routing 值为 ModelEntry 对象。
-#[derive(Debug, Clone, Serialize, Default)]
+///
+/// 序列化时优先将 routing 值写为字符串引用（确保旧版本也能读取），
+/// 仅当 models 中找不到匹配条目时才内联写入 ModelEntry。
+#[derive(Debug, Clone, Default)]
 pub struct ModelsConfig {
-    #[serde(default)]
     pub providers: HashMap<String, ProviderConfig>,
     /// 模型注册表 — 存储所有已定义的模型，routing 从中选择
-    #[serde(default)]
     pub models: HashMap<String, ModelEntry>,
-    #[serde(default)]
     pub routing: HashMap<RoutingSlot, ModelEntry>,
+}
+
+/// 自定义序列化：routing 值优先写为字符串引用，确保旧版本可读取
+impl serde::Serialize for ModelsConfig {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut state = serializer.serialize_struct("ModelsConfig", 3)?;
+        state.serialize_field("providers", &self.providers)?;
+        state.serialize_field("models", &self.models)?;
+
+        // routing: 优先写为字符串引用，找不到匹配时内联 ModelEntry
+        let routing_compat: HashMap<RoutingSlot, serde_json::Value> = self
+            .routing
+            .iter()
+            .map(|(slot, entry)| {
+                let key = self
+                    .models
+                    .iter()
+                    .find(|(_, m)| m.provider == entry.provider && m.model == entry.model)
+                    .map(|(k, _)| serde_json::Value::String(k.clone()))
+                    .unwrap_or_else(|| {
+                        serde_json::to_value(entry).unwrap_or(serde_json::Value::Null)
+                    });
+                (*slot, key)
+            })
+            .collect();
+        state.serialize_field("routing", &routing_compat)?;
+
+        state.end()
+    }
 }
 
 /// 向后兼容的反序列化：支持旧格式（routing 值为字符串引用 models）和新格式（routing 值为 ModelEntry）
@@ -431,17 +465,41 @@ impl ModelsConfig {
     }
 
     /// 保存到 ~/.tiangong/models.json
+    ///
+    /// 保存前自动将 routing 中未在 models 注册表里的条目补入 models，
+    /// 确保序列化时 routing 值能写为字符串引用（旧版本兼容）。
     pub fn save(&self) -> Result<()> {
+        let mut cfg = self.clone();
+        cfg.ensure_routing_models_registered();
+
         let path = models_config_path();
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)
                 .with_context(|| format!("创建目录失败：{}", parent.display()))?;
         }
         let content =
-            serde_json::to_string_pretty(self).with_context(|| "序列化 ModelsConfig 失败")?;
+            serde_json::to_string_pretty(&cfg).with_context(|| "序列化 ModelsConfig 失败")?;
         fs::write(&path, content)
             .with_context(|| format!("写入 models.json 失败：{}", path.display()))?;
         Ok(())
+    }
+
+    /// 将 routing 中未在 models 注册表中的条目自动补入 models
+    fn ensure_routing_models_registered(&mut self) {
+        for entry in self.routing.values() {
+            let exists = self
+                .models
+                .iter()
+                .any(|(_, m)| m.provider == entry.provider && m.model == entry.model);
+            if !exists {
+                let key = format!("{}-{}", entry.provider, entry.model);
+                if self.models.contains_key(&key) {
+                    // 名称冲突时追加 slot 后缀
+                    continue;
+                }
+                self.models.insert(key, entry.clone());
+            }
+        }
     }
 
     /// 从旧版 ModelProviderConfig 迁移
@@ -704,5 +762,213 @@ impl ModelsConfig {
             // 回退到 chat 配置
             self.to_chat_provider_config()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_routing_as_string_reference_when_model_exists() {
+        let mut config = ModelsConfig::default();
+        config.providers.insert(
+            "test".to_string(),
+            ProviderConfig {
+                base_url: "https://api.test.com".to_string(),
+                api_key: "key".to_string(),
+                timeout_ms: 60_000,
+                protocol: ProviderProtocol::OpenAiCompatible,
+            },
+        );
+        config.models.insert(
+            "my-chat".to_string(),
+            ModelEntry {
+                provider: "test".to_string(),
+                model: "gpt-4".to_string(),
+                capabilities: vec![ModelCapability::Chat],
+                options: serde_json::json!({}),
+            },
+        );
+        config.routing.insert(
+            RoutingSlot::Chat,
+            ModelEntry {
+                provider: "test".to_string(),
+                model: "gpt-4".to_string(),
+                capabilities: vec![ModelCapability::Chat],
+                options: serde_json::json!({}),
+            },
+        );
+
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(
+            json.contains(r#""chat":"my-chat""#),
+            "routing 值应为字符串引用，实际输出：{json}"
+        );
+    }
+
+    #[test]
+    fn serialize_routing_as_inline_object_when_no_matching_model() {
+        let mut config = ModelsConfig::default();
+        config.providers.insert(
+            "test".to_string(),
+            ProviderConfig {
+                base_url: "https://api.test.com".to_string(),
+                api_key: "key".to_string(),
+                timeout_ms: 60_000,
+                protocol: ProviderProtocol::OpenAiCompatible,
+            },
+        );
+        config.routing.insert(
+            RoutingSlot::Chat,
+            ModelEntry {
+                provider: "test".to_string(),
+                model: "gpt-4".to_string(),
+                capabilities: vec![ModelCapability::Chat],
+                options: serde_json::json!({}),
+            },
+        );
+
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(
+            json.contains(r#""provider":"test""#) && json.contains(r#""model":"gpt-4""#),
+            "无匹配模型时 routing 应内联对象，实际输出：{json}"
+        );
+    }
+
+    #[test]
+    fn deserialize_string_routing_compat() {
+        let json = r#"{
+            "providers": {
+                "test": {
+                    "base_url": "https://api.test.com",
+                    "api_key": "key",
+                    "timeout_ms": 60000,
+                    "protocol": "open_ai_compatible"
+                }
+            },
+            "models": {
+                "my-chat": {
+                    "provider": "test",
+                    "model": "gpt-4",
+                    "capabilities": ["chat"],
+                    "options": {}
+                }
+            },
+            "routing": {
+                "chat": "my-chat"
+            }
+        }"#;
+
+        let config: ModelsConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.routing.get(&RoutingSlot::Chat).unwrap().model,
+            "gpt-4"
+        );
+    }
+
+    #[test]
+    fn deserialize_object_routing_compat() {
+        let json = r#"{
+            "providers": {
+                "test": {
+                    "base_url": "https://api.test.com",
+                    "api_key": "key",
+                    "timeout_ms": 60000,
+                    "protocol": "open_ai_compatible"
+                }
+            },
+            "models": {},
+            "routing": {
+                "chat": {
+                    "provider": "test",
+                    "model": "gpt-4",
+                    "capabilities": ["chat"],
+                    "options": {}
+                }
+            }
+        }"#;
+
+        let config: ModelsConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.routing.get(&RoutingSlot::Chat).unwrap().model,
+            "gpt-4"
+        );
+    }
+
+    #[test]
+    fn roundtrip_serialize_deserialize_preserves_data() {
+        let mut config = ModelsConfig::default();
+        config.providers.insert(
+            "test".to_string(),
+            ProviderConfig {
+                base_url: "https://api.test.com".to_string(),
+                api_key: "key".to_string(),
+                timeout_ms: 60_000,
+                protocol: ProviderProtocol::OpenAiCompatible,
+            },
+        );
+        config.models.insert(
+            "my-chat".to_string(),
+            ModelEntry {
+                provider: "test".to_string(),
+                model: "gpt-4".to_string(),
+                capabilities: vec![ModelCapability::Chat],
+                options: serde_json::json!({"temperature": 0.7}),
+            },
+        );
+        config.routing.insert(
+            RoutingSlot::Chat,
+            ModelEntry {
+                provider: "test".to_string(),
+                model: "gpt-4".to_string(),
+                capabilities: vec![ModelCapability::Chat],
+                options: serde_json::json!({"temperature": 0.7}),
+            },
+        );
+
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        let restored: ModelsConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            restored.routing.get(&RoutingSlot::Chat).unwrap().model,
+            "gpt-4"
+        );
+        assert_eq!(
+            restored
+                .routing
+                .get(&RoutingSlot::Chat)
+                .unwrap()
+                .options
+                .get("temperature")
+                .unwrap(),
+            &serde_json::json!(0.7)
+        );
+    }
+
+    #[test]
+    fn save_auto_registers_routing_entries_to_models() {
+        let mut config = ModelsConfig::default();
+        config.providers.insert(
+            "p".to_string(),
+            ProviderConfig {
+                base_url: "https://api.test.com".to_string(),
+                api_key: "k".to_string(),
+                timeout_ms: 60_000,
+                protocol: ProviderProtocol::OpenAiCompatible,
+            },
+        );
+        config.routing.insert(
+            RoutingSlot::Chat,
+            ModelEntry {
+                provider: "p".to_string(),
+                model: "gpt-4".to_string(),
+                capabilities: vec![ModelCapability::Chat],
+                options: serde_json::json!({}),
+            },
+        );
+
+        let mut cfg = config.clone();
+        cfg.ensure_routing_models_registered();
+        assert!(cfg.models.values().any(|m| m.model == "gpt-4"));
     }
 }

--- a/crates/tiangong-core/src/models_config.rs
+++ b/crates/tiangong-core/src/models_config.rs
@@ -12,13 +12,11 @@ use crate::model::{ModelProviderConfig, ProviderProtocol};
 // 核心类型
 // ---------------------------------------------------------------------------
 
-/// 模型能力枚举
+/// 模型能力枚举 — 描述模型具备什么能力
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ModelCapability {
     Chat,
-    /// 轻量级文本模型（标题生成、意图分类等简单任务）
-    Lite,
     Multimodal,
     ImageGeneration,
     VideoGeneration,
@@ -30,12 +28,114 @@ pub enum ModelCapability {
     Rerank,
 }
 
+/// 路由槽位枚举 — 描述哪个模型负责什么任务
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoutingSlot {
+    Chat,
+    Lite,
+    Multimodal,
+    ImageGeneration,
+    VideoGeneration,
+    Stt,
+    Tts,
+    Embedding,
+    Rerank,
+}
+
+impl RoutingSlot {
+    pub fn key(&self) -> &'static str {
+        match self {
+            RoutingSlot::Chat => "chat",
+            RoutingSlot::Lite => "lite",
+            RoutingSlot::Multimodal => "multimodal",
+            RoutingSlot::ImageGeneration => "image_generation",
+            RoutingSlot::VideoGeneration => "video_generation",
+            RoutingSlot::Stt => "stt",
+            RoutingSlot::Tts => "tts",
+            RoutingSlot::Embedding => "embedding",
+            RoutingSlot::Rerank => "rerank",
+        }
+    }
+
+    pub fn from_key(key: &str) -> Option<Self> {
+        match key {
+            "chat" => Some(RoutingSlot::Chat),
+            "lite" => Some(RoutingSlot::Lite),
+            "multimodal" => Some(RoutingSlot::Multimodal),
+            "image_generation" => Some(RoutingSlot::ImageGeneration),
+            "video_generation" => Some(RoutingSlot::VideoGeneration),
+            "stt" => Some(RoutingSlot::Stt),
+            "tts" => Some(RoutingSlot::Tts),
+            "embedding" => Some(RoutingSlot::Embedding),
+            "rerank" => Some(RoutingSlot::Rerank),
+            _ => None,
+        }
+    }
+
+    pub fn all() -> &'static [RoutingSlot] {
+        &[
+            RoutingSlot::Chat,
+            RoutingSlot::Lite,
+            RoutingSlot::Multimodal,
+            RoutingSlot::ImageGeneration,
+            RoutingSlot::VideoGeneration,
+            RoutingSlot::Stt,
+            RoutingSlot::Tts,
+            RoutingSlot::Embedding,
+            RoutingSlot::Rerank,
+        ]
+    }
+
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            RoutingSlot::Chat => "对话",
+            RoutingSlot::Lite => "轻量文本",
+            RoutingSlot::Multimodal => "多模态",
+            RoutingSlot::ImageGeneration => "图片生成",
+            RoutingSlot::VideoGeneration => "视频生成",
+            RoutingSlot::Stt => "语音识别",
+            RoutingSlot::Tts => "语音合成",
+            RoutingSlot::Embedding => "向量嵌入",
+            RoutingSlot::Rerank => "结果重排",
+        }
+    }
+
+    /// 路由槽位对应的模型能力
+    pub fn capability(&self) -> Option<ModelCapability> {
+        match self {
+            RoutingSlot::Chat => Some(ModelCapability::Chat),
+            RoutingSlot::Lite => None, // Lite 是路由槽位，不对应模型能力
+            RoutingSlot::Multimodal => Some(ModelCapability::Multimodal),
+            RoutingSlot::ImageGeneration => Some(ModelCapability::ImageGeneration),
+            RoutingSlot::VideoGeneration => Some(ModelCapability::VideoGeneration),
+            RoutingSlot::Stt => Some(ModelCapability::Stt),
+            RoutingSlot::Tts => Some(ModelCapability::Tts),
+            RoutingSlot::Embedding => Some(ModelCapability::Embedding),
+            RoutingSlot::Rerank => Some(ModelCapability::Rerank),
+        }
+    }
+
+    /// 从模型能力获取对应的路由槽位
+    pub fn from_capability(cap: ModelCapability) -> Self {
+        match cap {
+            ModelCapability::Chat => RoutingSlot::Chat,
+            ModelCapability::Multimodal => RoutingSlot::Multimodal,
+            ModelCapability::ImageGeneration => RoutingSlot::ImageGeneration,
+            ModelCapability::VideoGeneration => RoutingSlot::VideoGeneration,
+            ModelCapability::Stt => RoutingSlot::Stt,
+            ModelCapability::Tts => RoutingSlot::Tts,
+            ModelCapability::Embedding => RoutingSlot::Embedding,
+            ModelCapability::Rerank => RoutingSlot::Rerank,
+        }
+    }
+}
+
 impl ModelCapability {
     /// 配置键（snake_case）
     pub fn key(&self) -> &'static str {
         match self {
             ModelCapability::Chat => "chat",
-            ModelCapability::Lite => "lite",
             ModelCapability::Multimodal => "multimodal",
             ModelCapability::ImageGeneration => "image_generation",
             ModelCapability::VideoGeneration => "video_generation",
@@ -50,7 +150,6 @@ impl ModelCapability {
     pub fn from_key(key: &str) -> Option<Self> {
         match key {
             "chat" => Some(ModelCapability::Chat),
-            "lite" => Some(ModelCapability::Lite),
             "multimodal" => Some(ModelCapability::Multimodal),
             "image_generation" => Some(ModelCapability::ImageGeneration),
             "video_generation" => Some(ModelCapability::VideoGeneration),
@@ -66,7 +165,6 @@ impl ModelCapability {
     pub fn all() -> &'static [ModelCapability] {
         &[
             ModelCapability::Chat,
-            ModelCapability::Lite,
             ModelCapability::Multimodal,
             ModelCapability::ImageGeneration,
             ModelCapability::VideoGeneration,
@@ -81,7 +179,6 @@ impl ModelCapability {
     pub fn display_name(&self) -> &'static str {
         match self {
             ModelCapability::Chat => "对话",
-            ModelCapability::Lite => "轻量文本",
             ModelCapability::Multimodal => "多模态",
             ModelCapability::ImageGeneration => "图片生成",
             ModelCapability::VideoGeneration => "视频生成",
@@ -96,7 +193,6 @@ impl ModelCapability {
     pub fn intent_label(&self) -> &'static str {
         match self {
             ModelCapability::Chat => "SIMPLE",
-            ModelCapability::Lite => "LITE",
             ModelCapability::Multimodal => "MULTIMODAL",
             ModelCapability::ImageGeneration => "IMAGE",
             ModelCapability::VideoGeneration => "VIDEO",
@@ -113,7 +209,6 @@ impl ModelCapability {
             ModelCapability::Chat => {
                 "简单对话（问候、闲聊、知识问答、翻译、解释概念等不需要执行工具或命令的请求）"
             }
-            ModelCapability::Lite => "轻量文本任务（标题生成、意图分类等内部任务，不参与意图路由）",
             ModelCapability::Multimodal => "多模态请求（需要理解图片、音频等多种输入形式）",
             ModelCapability::ImageGeneration => "图片生成请求（用户要求生成、绘制、创作图片）",
             ModelCapability::VideoGeneration => "视频生成请求（用户要求生成、制作视频）",
@@ -164,19 +259,86 @@ pub struct ModelEntry {
     pub options: Value,
 }
 
+impl Default for ModelEntry {
+    fn default() -> Self {
+        Self {
+            provider: String::new(),
+            model: String::new(),
+            capabilities: vec![],
+            options: default_options(),
+        }
+    }
+}
+
 fn default_options() -> Value {
     Value::Object(serde_json::Map::new())
 }
 
-/// 三层模型配置：Provider + Model + Routing
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+/// 两层模型配置：Provider + Routing
+///
+/// routing 直接存储 ModelEntry，不再需要中间的 models 映射层。
+/// 支持向后兼容：旧格式 routing 值为字符串（引用 models 中的 key），
+/// 新格式 routing 值为 ModelEntry 对象。
+#[derive(Debug, Clone, Serialize, Default)]
 pub struct ModelsConfig {
     #[serde(default)]
     pub providers: HashMap<String, ProviderConfig>,
     #[serde(default)]
-    pub models: HashMap<String, ModelEntry>,
-    #[serde(default)]
-    pub routing: HashMap<ModelCapability, String>,
+    pub routing: HashMap<RoutingSlot, ModelEntry>,
+}
+
+/// 向后兼容的反序列化：支持旧格式（routing 值为字符串引用 models）和新格式（routing 值为 ModelEntry）
+impl<'de> serde::Deserialize<'de> for ModelsConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            #[serde(default)]
+            providers: HashMap<String, ProviderConfig>,
+            #[serde(default)]
+            models: HashMap<String, ModelEntry>,
+            #[serde(default)]
+            routing: HashMap<RoutingSlot, RawRoutingValue>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RawRoutingValue {
+            Key(String),
+            Entry(ModelEntry),
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+
+        let routing: HashMap<RoutingSlot, ModelEntry> = raw
+            .routing
+            .into_iter()
+            .map(|(slot, val)| {
+                let entry = match val {
+                    RawRoutingValue::Key(key) => {
+                        raw.models.get(&key).cloned().unwrap_or_else(|| {
+                            tracing::warn!("路由引用了不存在的模型：{key}");
+                            ModelEntry {
+                                provider: String::new(),
+                                model: key.clone(),
+                                capabilities: vec![],
+                                options: default_options(),
+                            }
+                        })
+                    }
+                    RawRoutingValue::Entry(entry) => entry,
+                };
+                (slot, entry)
+            })
+            .collect();
+
+        Ok(ModelsConfig {
+            providers: raw.providers,
+            routing,
+        })
+    }
 }
 
 /// 解析后的完整模型配置（Provider + Model 合并）
@@ -221,8 +383,26 @@ fn models_config_path() -> PathBuf {
 
 impl ModelsConfig {
     /// 检查指定能力是否已配置可用
+    /// 对于 Multimodal，除了检查独立路由外，也检查 chat 模型是否自带此能力
     pub fn has_capability(&self, capability: ModelCapability) -> bool {
-        self.resolve_for_capability(capability).is_some()
+        let slot = RoutingSlot::from_capability(capability);
+        if self.routing.contains_key(&slot) {
+            return true;
+        }
+        // chat 模型自带 multimodal 能力时，视为多模态可用
+        if capability == ModelCapability::Multimodal && self.chat_is_multimodal() {
+            return true;
+        }
+        false
+    }
+
+    /// 判断 chat 路由指向的模型是否应直接处理图片（跳过 analyze_attachment 工具）
+    /// 以模型定义中声明的 capabilities 为准
+    pub fn chat_is_multimodal(&self) -> bool {
+        let Some(entry) = self.routing.get(&RoutingSlot::Chat) else {
+            return false;
+        };
+        entry.capabilities.contains(&ModelCapability::Multimodal)
     }
 
     /// 返回当前已配置可用的能力列表
@@ -261,14 +441,10 @@ impl ModelsConfig {
     }
 
     /// 从旧版 ModelProviderConfig 迁移
-    ///
-    /// 将旧的单 provider 配置转为一个 "default" provider + 一个 chat model + routing
     pub fn from_legacy(legacy: &ModelProviderConfig) -> Self {
         let mut providers = HashMap::new();
-        let mut models = HashMap::new();
         let mut routing = HashMap::new();
 
-        // 构建 default provider
         let provider = ProviderConfig {
             base_url: legacy.api_base_url.clone(),
             api_key: legacy.api_auth_token.clone(),
@@ -277,68 +453,90 @@ impl ModelsConfig {
         };
         providers.insert("default".to_string(), provider);
 
-        // 构建 chat model
         let model_name = if legacy.api_model.is_empty() {
             "default-chat".to_string()
         } else {
             legacy.api_model.clone()
         };
 
-        let model_entry = ModelEntry {
-            provider: "default".to_string(),
-            model: legacy.api_model.clone(),
-            capabilities: vec![ModelCapability::Chat],
-            options: default_options(),
-        };
-        models.insert(model_name.clone(), model_entry);
-
-        // 如果有 lite model，也添加
-        let lite = legacy.lite_model();
-        if !lite.is_empty() && lite != legacy.api_model {
-            let lite_entry = ModelEntry {
+        routing.insert(
+            RoutingSlot::Chat,
+            ModelEntry {
                 provider: "default".to_string(),
-                model: lite.to_string(),
+                model: model_name,
                 capabilities: vec![ModelCapability::Chat],
                 options: default_options(),
-            };
-            models.insert(lite.to_string(), lite_entry);
+            },
+        );
+
+        let lite = legacy.lite_model();
+        if !lite.is_empty() && lite != legacy.api_model {
+            routing.insert(
+                RoutingSlot::Lite,
+                ModelEntry {
+                    provider: "default".to_string(),
+                    model: lite.to_string(),
+                    capabilities: vec![ModelCapability::Chat],
+                    options: default_options(),
+                },
+            );
         }
 
-        // 设置 routing
-        routing.insert(ModelCapability::Chat, model_name);
-
-        Self {
-            providers,
-            models,
-            routing,
-        }
+        Self { providers, routing }
     }
 
     /// 从 LlmConfig 构建兼容的 ModelsConfig
     ///
-    /// 将扁平的 LlmConfig 端点映射为 Provider + Model + Routing 三层结构，
-    /// 使 system prompt 构建等代码无需修改。
+    /// 将扁平的 LlmConfig 端点映射为 Provider + Routing 两层结构。
+    /// 当多个能力使用相同端点时，合并 capabilities 到已有的路由条目。
     pub fn from_llm_config(llm: &crate::core_config::LlmConfig) -> Self {
-        let mut providers = HashMap::new();
-        let mut models = HashMap::new();
-        let mut routing = HashMap::new();
+        let mut providers: HashMap<String, ProviderConfig> = HashMap::new();
+        let mut routing: HashMap<RoutingSlot, ModelEntry> = HashMap::new();
 
-        // 辅助：注册一个端点为 provider + model + routing
-        let mut register =
-            |name: &str, endpoint: &crate::core_config::ModelEndpoint, cap: ModelCapability| {
-                let provider_key = format!("{name}-provider");
-                providers.insert(
-                    provider_key.clone(),
-                    ProviderConfig {
-                        base_url: endpoint.base_url.clone(),
-                        api_key: endpoint.api_key.clone(),
-                        timeout_ms: endpoint.timeout_ms,
-                        protocol: endpoint.protocol,
+        // 跟踪已注册的端点签名，用于合并相同端点的能力
+        let mut seen: HashMap<(String, String), RoutingSlot> = HashMap::new();
+
+        let mut register = |name: &str,
+                            endpoint: &crate::core_config::ModelEndpoint,
+                            slot: RoutingSlot,
+                            cap: ModelCapability| {
+            let provider_key = format!("{name}-provider");
+            providers.insert(
+                provider_key.clone(),
+                ProviderConfig {
+                    base_url: endpoint.base_url.clone(),
+                    api_key: endpoint.api_key.clone(),
+                    timeout_ms: endpoint.timeout_ms,
+                    protocol: endpoint.protocol,
+                },
+            );
+
+            let sig = (endpoint.base_url.clone(), endpoint.model.clone());
+
+            if let Some(&first_slot) = seen.get(&sig) {
+                // 相同端点已注册 — 合并能力到已有条目
+                if let Some(entry) = routing.get_mut(&first_slot)
+                    && !entry.capabilities.contains(&cap)
+                {
+                    entry.capabilities.push(cap);
+                }
+                // 为当前槽位创建带完整能力的条目
+                let merged_caps = routing
+                    .get(&first_slot)
+                    .map(|e| e.capabilities.clone())
+                    .unwrap_or_default();
+                routing.insert(
+                    slot,
+                    ModelEntry {
+                        provider: provider_key,
+                        model: endpoint.model.clone(),
+                        capabilities: merged_caps,
+                        options: endpoint.options.clone(),
                     },
                 );
-                let model_key = format!("{name}-model");
-                models.insert(
-                    model_key.clone(),
+            } else {
+                routing.insert(
+                    slot,
                     ModelEntry {
                         provider: provider_key,
                         model: endpoint.model.clone(),
@@ -346,40 +544,57 @@ impl ModelsConfig {
                         options: endpoint.options.clone(),
                     },
                 );
-                routing.insert(cap, model_key);
-            };
+                seen.insert(sig, slot);
+            }
+        };
 
         // Chat（必须）
-        register("chat", &llm.chat, ModelCapability::Chat);
+        register("chat", &llm.chat, RoutingSlot::Chat, ModelCapability::Chat);
 
         // 可选能力
         if let Some(ref ep) = llm.image_generation {
-            register("image", ep, ModelCapability::ImageGeneration);
+            register(
+                "image",
+                ep,
+                RoutingSlot::ImageGeneration,
+                ModelCapability::ImageGeneration,
+            );
         }
         if let Some(ref ep) = llm.tts {
-            register("tts", ep, ModelCapability::Tts);
+            register("tts", ep, RoutingSlot::Tts, ModelCapability::Tts);
         }
         if let Some(ref ep) = llm.stt {
-            register("stt", ep, ModelCapability::Stt);
+            register("stt", ep, RoutingSlot::Stt, ModelCapability::Stt);
         }
         if let Some(ref ep) = llm.video_generation {
-            register("video", ep, ModelCapability::VideoGeneration);
+            register(
+                "video",
+                ep,
+                RoutingSlot::VideoGeneration,
+                ModelCapability::VideoGeneration,
+            );
         }
         if let Some(ref ep) = llm.multimodal {
-            register("multimodal", ep, ModelCapability::Multimodal);
+            register(
+                "multimodal",
+                ep,
+                RoutingSlot::Multimodal,
+                ModelCapability::Multimodal,
+            );
         }
         if let Some(ref ep) = llm.embedding {
-            register("embedding", ep, ModelCapability::Embedding);
+            register(
+                "embedding",
+                ep,
+                RoutingSlot::Embedding,
+                ModelCapability::Embedding,
+            );
         }
         if let Some(ref ep) = llm.rerank {
-            register("rerank", ep, ModelCapability::Rerank);
+            register("rerank", ep, RoutingSlot::Rerank, ModelCapability::Rerank);
         }
 
-        Self {
-            providers,
-            models,
-            routing,
-        }
+        Self { providers, routing }
     }
 
     /// 解析 api_key 中的 ${ENV_VAR} 引用
@@ -391,25 +606,31 @@ impl ModelsConfig {
         }
     }
 
-    /// 获取指定能力的路由模型名称
+    /// 获取指定路由槽位的模型名称
     pub fn routed_model(&self, capability: ModelCapability) -> Option<&str> {
-        self.routing.get(&capability).map(|s| s.as_str())
+        let slot = RoutingSlot::from_capability(capability);
+        self.routing.get(&slot).map(|e| e.model.as_str())
     }
 
-    /// 获取指定能力的完整配置（Provider + Model 合并）
+    /// 获取指定路由槽位的完整配置（Provider + Model 合并）
     pub fn resolve_for_capability(&self, capability: ModelCapability) -> Option<ResolvedModel> {
-        let model_name = self.routing.get(&capability)?;
-        let model_entry = self.models.get(model_name)?;
-        let provider = self.providers.get(&model_entry.provider)?;
+        let slot = RoutingSlot::from_capability(capability);
+        self.resolve_slot(slot)
+    }
+
+    /// 按路由槽位获取完整配置
+    pub fn resolve_slot(&self, slot: RoutingSlot) -> Option<ResolvedModel> {
+        let entry = self.routing.get(&slot)?;
+        let provider = self.providers.get(&entry.provider)?;
 
         Some(ResolvedModel {
-            provider: model_entry.provider.clone(),
+            provider: entry.provider.clone(),
             base_url: provider.base_url.clone(),
             api_key: Self::resolve_api_key(&provider.api_key),
             timeout_ms: provider.timeout_ms,
             protocol: provider.protocol,
-            model: model_entry.model.clone(),
-            options: model_entry.options.clone(),
+            model: entry.model.clone(),
+            options: entry.options.clone(),
         })
     }
 
@@ -418,9 +639,26 @@ impl ModelsConfig {
         self.has_capability(ModelCapability::Chat)
     }
 
-    /// 检查配置是否为空（无 provider 也无 model）
+    /// 检查配置是否为空（无 provider 也无 routing）
     pub fn is_empty(&self) -> bool {
-        self.providers.is_empty() && self.models.is_empty()
+        self.providers.is_empty() && self.routing.is_empty()
+    }
+
+    /// 更新 chat 路由的模型名称，保留其他字段不变
+    pub fn update_chat_model(&mut self, model: String) {
+        if let Some(entry) = self.routing.get_mut(&RoutingSlot::Chat) {
+            entry.model = model;
+        } else {
+            self.routing.insert(
+                RoutingSlot::Chat,
+                ModelEntry {
+                    provider: "default".to_string(),
+                    model,
+                    capabilities: vec![ModelCapability::Chat],
+                    options: default_options(),
+                },
+            );
+        }
     }
 
     /// 从 chat routing 生成 ModelProviderConfig（内部用于构建 SingleProviderClient）
@@ -441,7 +679,7 @@ impl ModelsConfig {
 
     /// 从 lite routing 生成 ModelProviderConfig（未配置时回退到 chat）
     pub fn to_lite_provider_config(&self) -> ModelProviderConfig {
-        if let Some(resolved) = self.resolve_for_capability(ModelCapability::Lite) {
+        if let Some(resolved) = self.resolve_slot(RoutingSlot::Lite) {
             ModelProviderConfig {
                 api_auth_token: resolved.api_key,
                 api_base_url: resolved.base_url,

--- a/crates/tiangong-core/src/models_config.rs
+++ b/crates/tiangong-core/src/models_config.rs
@@ -283,6 +283,9 @@ fn default_options() -> Value {
 pub struct ModelsConfig {
     #[serde(default)]
     pub providers: HashMap<String, ProviderConfig>,
+    /// 模型注册表 — 存储所有已定义的模型，routing 从中选择
+    #[serde(default)]
+    pub models: HashMap<String, ModelEntry>,
     #[serde(default)]
     pub routing: HashMap<RoutingSlot, ModelEntry>,
 }
@@ -336,6 +339,7 @@ impl<'de> serde::Deserialize<'de> for ModelsConfig {
 
         Ok(ModelsConfig {
             providers: raw.providers,
+            models: raw.models,
             routing,
         })
     }
@@ -482,12 +486,16 @@ impl ModelsConfig {
             );
         }
 
-        Self { providers, routing }
+        Self {
+            providers,
+            models: HashMap::new(),
+            routing,
+        }
     }
 
     /// 从 LlmConfig 构建兼容的 ModelsConfig
     ///
-    /// 将扁平的 LlmConfig 端点映射为 Provider + Routing 两层结构。
+    /// 将扁平的 LlmConfig 端点映射为 Provider + Routing 结构。
     /// 当多个能力使用相同端点时，合并 capabilities 到已有的路由条目。
     pub fn from_llm_config(llm: &crate::core_config::LlmConfig) -> Self {
         let mut providers: HashMap<String, ProviderConfig> = HashMap::new();
@@ -594,7 +602,11 @@ impl ModelsConfig {
             register("rerank", ep, RoutingSlot::Rerank, ModelCapability::Rerank);
         }
 
-        Self { providers, routing }
+        Self {
+            providers,
+            models: HashMap::new(),
+            routing,
+        }
     }
 
     /// 解析 api_key 中的 ${ENV_VAR} 引用

--- a/crates/tiangong-core/src/prompt/sections.rs
+++ b/crates/tiangong-core/src/prompt/sections.rs
@@ -30,11 +30,12 @@ fn rules_block() -> String {
 
 /// 多媒体能力 section
 fn build_media_section(models_config: &ModelsConfig) -> String {
-    use crate::models_config::ModelCapability;
+    use crate::models_config::{ModelCapability, RoutingSlot};
 
     let mut hints = Vec::new();
     for cap in ModelCapability::media_capabilities() {
-        if let Some(resolved) = models_config.resolve_for_capability(*cap) {
+        let slot = RoutingSlot::from_capability(*cap);
+        if let Some(resolved) = models_config.resolve_slot(slot) {
             hints.push(format!(
                 "- {}：已配置（模型：{}）",
                 cap.display_name(),

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -546,7 +546,7 @@ impl ReactEngine {
                 thinking,
                 reasoning_effort,
                 thinking_disabled,
-                include_media: false,
+                include_media: self.engine.chat_is_multimodal(),
             };
 
             let pending_msg_id = scru128::new().to_string();

--- a/crates/tiangong-core/src/runtime.rs
+++ b/crates/tiangong-core/src/runtime.rs
@@ -166,6 +166,10 @@ impl RuntimeEngine {
     pub fn has_multimodal_client(&self) -> bool {
         self.multimodal_client.is_some()
     }
+    /// 对话模型本身是否具备 multimodal 能力（multimodal 路由与 chat 路由指向同一模型）
+    pub fn chat_is_multimodal(&self) -> bool {
+        self.models_config.chat_is_multimodal()
+    }
     /// 获取 AgentConfig 引用
     pub fn agent_config(&self) -> &AgentConfig {
         &self.agent_config
@@ -1230,7 +1234,7 @@ pub(crate) fn inject_enhanced_tools(tools: &mut Vec<ToolSpec>, engine: &RuntimeE
         .unwrap_or_else(|| {
             engine
                 .models_config()
-                .resolve_for_capability(crate::models_config::ModelCapability::ImageGeneration)
+                .resolve_slot(crate::models_config::RoutingSlot::ImageGeneration)
                 .is_some()
         });
     let has_video_gen = engine
@@ -1239,7 +1243,7 @@ pub(crate) fn inject_enhanced_tools(tools: &mut Vec<ToolSpec>, engine: &RuntimeE
         .unwrap_or_else(|| {
             engine
                 .models_config()
-                .resolve_for_capability(crate::models_config::ModelCapability::VideoGeneration)
+                .resolve_slot(crate::models_config::RoutingSlot::VideoGeneration)
                 .is_some()
         });
     let has_tts = engine
@@ -1248,7 +1252,7 @@ pub(crate) fn inject_enhanced_tools(tools: &mut Vec<ToolSpec>, engine: &RuntimeE
         .unwrap_or_else(|| {
             engine
                 .models_config()
-                .resolve_for_capability(crate::models_config::ModelCapability::Tts)
+                .resolve_slot(crate::models_config::RoutingSlot::Tts)
                 .is_some()
         });
     let has_stt = engine
@@ -1257,12 +1261,14 @@ pub(crate) fn inject_enhanced_tools(tools: &mut Vec<ToolSpec>, engine: &RuntimeE
         .unwrap_or_else(|| {
             engine
                 .models_config()
-                .resolve_for_capability(crate::models_config::ModelCapability::Stt)
+                .resolve_slot(crate::models_config::RoutingSlot::Stt)
                 .is_some()
         });
     let has_multimodal = engine.has_multimodal_client();
+    // 当对话模型本身就是 multimodal 时，图片直接随消息发送，不需要工具
+    let chat_is_multimodal = engine.chat_is_multimodal();
 
-    if has_multimodal {
+    if has_multimodal && !chat_is_multimodal {
         tools.push(ToolSpec {
             name: "analyze_attachment".to_string(),
             description: "按需调用多模态模型解析用户上传的图片或文件附件。只有当用户问题确实需要查看附件内容时才调用；普通文本对话不要调用。".to_string(),

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -238,8 +238,7 @@ export interface ModelEntryView {
 
 export interface ModelsConfigView {
   providers: Record<string, ProviderConfigView>;
-  models: Record<string, ModelEntryView>;
-  routing: Record<string, string>;
+  routing: Record<string, ModelEntryView>;
 }
 
 export interface ModelCapabilityInfo {

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -238,6 +238,7 @@ export interface ModelEntryView {
 
 export interface ModelsConfigView {
   providers: Record<string, ProviderConfigView>;
+  models: Record<string, ModelEntryView>;
   routing: Record<string, ModelEntryView>;
 }
 

--- a/frontend/src/components/SettingsButton.tsx
+++ b/frontend/src/components/SettingsButton.tsx
@@ -13,6 +13,7 @@ export function SettingsButton() {
   const [showApiKey, setShowApiKey] = useState(false);
   const [config, setConfig] = useState<ModelsConfigView>({
     providers: {},
+    models: {},
     routing: {},
   });
   const [originalConfig, setOriginalConfig] = useState<ModelsConfigView>({ ...config });

--- a/frontend/src/components/SettingsButton.tsx
+++ b/frontend/src/components/SettingsButton.tsx
@@ -13,7 +13,6 @@ export function SettingsButton() {
   const [showApiKey, setShowApiKey] = useState(false);
   const [config, setConfig] = useState<ModelsConfigView>({
     providers: {},
-    models: {},
     routing: {},
   });
   const [originalConfig, setOriginalConfig] = useState<ModelsConfigView>({ ...config });

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -433,7 +433,7 @@ function LLMSettings({ onSaveStatusChange }: { onSaveStatusChange: (status: Save
           <ProviderModelsView config={modelsConfig} onChange={handleChange} capabilities={capabilities} />
         )}
         {subTab === 'routing' && (
-          <RoutingSection config={modelsConfig} onChange={handleChange} capabilities={capabilities} />
+          <RoutingSection config={modelsConfig} onChange={handleChange} />
         )}
         {subTab === 'memory' && (
           <MemorySettings
@@ -1356,16 +1356,11 @@ function ProviderForm({
 function RoutingSection({
   config,
   onChange,
-  capabilities,
 }: {
   config: ModelsConfigView;
   onChange: (c: ModelsConfigView) => void;
-  capabilities: ModelCapabilityInfo[];
 }) {
   const modelKeys = Object.keys(config.models).sort();
-  const routingCapabilities = capabilities.filter(
-    (cap) => cap.key !== 'embedding' && cap.key !== 'rerank',
-  );
   const [routeSearch, setRouteSearch] = useState<Record<string, string>>({});
   const modelLabel = (modelKey: string) => {
     const model = config.models[modelKey];
@@ -1373,20 +1368,41 @@ function RoutingSection({
     return `${model.provider} / ${model.model}`;
   };
 
-  const setRoute = (capKey: string, modelKey: string) => {
+  // 路由槽位定义（不依赖 capabilities 列表，直接枚举）
+  const routingSlots = [
+    { key: 'chat', display_name: '对话' },
+    { key: 'lite', display_name: '轻量文本' },
+    { key: 'multimodal', display_name: '多模态' },
+    { key: 'image_generation', display_name: '图片生成' },
+    { key: 'video_generation', display_name: '视频生成' },
+    { key: 'stt', display_name: '语音识别' },
+    { key: 'tts', display_name: '语音合成' },
+  ];
+
+  // 根据 routing entry 找到对应的 models key
+  const findModelKeyForRoute = (slotKey: string): string | null => {
+    const entry = config.routing[slotKey];
+    if (!entry) return null;
+    return modelKeys.find((mk) => {
+      const m = config.models[mk];
+      return m && m.provider === entry.provider && m.model === entry.model;
+    }) || null;
+  };
+
+  const setRoute = (slotKey: string, modelKey: string) => {
     const next = { ...config };
     const newRouting = { ...next.routing };
     if (modelKey === '__none__') {
-      delete newRouting[capKey];
+      delete newRouting[slotKey];
     } else {
       const entry = next.models[modelKey];
       if (entry) {
-        newRouting[capKey] = { ...entry };
+        newRouting[slotKey] = { ...entry };
       }
     }
     next.routing = newRouting;
     onChange(next);
-    setRouteSearch((prev) => ({ ...prev, [capKey]: '' }));
+    setRouteSearch((prev) => ({ ...prev, [slotKey]: '' }));
   };
 
   return (
@@ -1399,15 +1415,16 @@ function RoutingSection({
       </div>
 
       <div className="space-y-2 flex-1 min-h-0 overflow-y-auto">
-        {routingCapabilities.map((cap) => {
-          const currentEntry = config.routing[cap.key];
-          const search = routeSearch[cap.key] || '';
+        {routingSlots.map((slot) => {
+          const currentModelKey = findModelKeyForRoute(slot.key);
+          const search = routeSearch[slot.key] || '';
           const filtered = modelKeys
             .filter((mk) => {
               const m = config.models[mk];
               if (m.capabilities.length === 0) return true;
-              if (m.capabilities.includes(cap.key)) return true;
-              if (cap.key === 'chat' && m.capabilities.includes('multimodal')) return true;
+              if (m.capabilities.includes(slot.key)) return true;
+              if (slot.key === 'lite' && m.capabilities.includes('chat')) return true;
+              if (slot.key === 'chat' && m.capabilities.includes('multimodal')) return true;
               return false;
             })
             .filter((mk) => {
@@ -1416,55 +1433,38 @@ function RoutingSection({
               return mk.toLowerCase().includes(q) || modelLabel(mk).toLowerCase().includes(q);
             });
           return (
-            <Card key={cap.key}>
+            <Card key={slot.key}>
               <CardContent className="p-3">
                 <div className="flex items-center gap-4">
                   <div className="w-28 shrink-0">
-                    <div className="text-sm font-medium leading-tight">{cap.display_name}</div>
-                    <div className="text-xs text-muted-foreground">({cap.key})</div>
+                    <div className="text-sm font-medium leading-tight">{slot.display_name}</div>
+                    <div className="text-xs text-muted-foreground">({slot.key})</div>
                   </div>
-                  {currentEntry ? (
-                    <div className="flex-1 flex items-center gap-2">
-                      <span className="text-sm flex-1">{currentEntry.provider} / {currentEntry.model}</span>
-                      <span className="text-xs text-muted-foreground">
-                        [{currentEntry.capabilities.join(', ') || '无能力'}]
-                      </span>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 text-destructive hover:text-destructive"
-                        onClick={() => setRoute(cap.key, '__none__')}
-                      >
-                        移除
-                      </Button>
-                    </div>
-                  ) : (
-                    <Select
-                      value="__none__"
-                      onValueChange={(v) => setRoute(cap.key, v)}
-                    >
-                      <SelectTrigger className="h-8 text-sm flex-1">
-                        <SelectValue placeholder="-- 未配置 --" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <div className="p-1.5 border-b" onPointerDown={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
-                          <Input
-                            value={search}
-                            onChange={(e) => setRouteSearch((prev) => ({ ...prev, [cap.key]: e.target.value }))}
-                            className="h-7 text-xs"
-                            placeholder="搜索模型..."
-                          />
-                        </div>
-                        <SelectItem value="__none__">-- 未配置 --</SelectItem>
-                        {filtered.map((mk) => (
-                          <SelectItem key={mk} value={mk}>{modelLabel(mk)}</SelectItem>
-                        ))}
-                        {filtered.length === 0 && (
-                          <div className="px-2 py-3 text-xs text-muted-foreground text-center">无匹配模型</div>
-                        )}
-                      </SelectContent>
-                    </Select>
-                  )}
+                  <Select
+                    value={currentModelKey || '__none__'}
+                    onValueChange={(v) => setRoute(slot.key, v)}
+                  >
+                    <SelectTrigger className="h-8 text-sm flex-1">
+                      <SelectValue placeholder="-- 未配置 --" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <div className="p-1.5 border-b" onPointerDown={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+                        <Input
+                          value={search}
+                          onChange={(e) => setRouteSearch((prev) => ({ ...prev, [slot.key]: e.target.value }))}
+                          className="h-7 text-xs"
+                          placeholder="搜索模型..."
+                        />
+                      </div>
+                      <SelectItem value="__none__">-- 未配置 --</SelectItem>
+                      {filtered.map((mk) => (
+                        <SelectItem key={mk} value={mk}>{modelLabel(mk)}</SelectItem>
+                      ))}
+                      {filtered.length === 0 && (
+                        <div className="px-2 py-3 text-xs text-muted-foreground text-center">无匹配模型</div>
+                      )}
+                    </SelectContent>
+                  </Select>
                 </div>
               </CardContent>
             </Card>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -329,6 +329,7 @@ function LLMSettings({ onSaveStatusChange }: { onSaveStatusChange: (status: Save
   const [subTab, setSubTab] = useState<LLMSubTab>('providers');
   const [modelsConfig, setModelsConfig] = useState<ModelsConfigView>({
     providers: {},
+    models: {},
     routing: {},
   });
   const [capabilities, setCapabilities] = useState<ModelCapabilityInfo[]>([]);
@@ -508,7 +509,7 @@ function MemorySettings({
   }, []);
 
   const modelKeysFor = (acceptedCapabilities: string[]) =>
-    Object.entries(modelsConfig.routing)
+    Object.entries(modelsConfig.models)
       .filter(([, model]) => {
         if (model.capabilities.length === 0) return true;
         return acceptedCapabilities.some((capability) => model.capabilities.includes(capability));
@@ -516,7 +517,7 @@ function MemorySettings({
       .map(([key]) => key);
 
   const modelLabel = (modelKey: string) => {
-    const model = modelsConfig.routing[modelKey];
+    const model = modelsConfig.models[modelKey];
     if (!model) return modelKey;
     return `${model.provider} / ${model.model}`;
   };
@@ -529,7 +530,7 @@ function MemorySettings({
   };
 
   const embeddingDimension = config.embedding_key
-    ? Number(modelsConfig.routing[config.embedding_key]?.options?.dimension || 0)
+    ? Number(modelsConfig.models[config.embedding_key]?.options?.dimension || 0)
     : 0;
 
   if (isLoading) {
@@ -798,7 +799,7 @@ function ProviderModelsView({
     : (sortedProviderKeys[0] || '');
   const selectedConfig = config.providers[activeProvider] || null;
   const providerModels = activeProvider
-    ? Object.entries(config.routing).filter(([, m]) => m.provider === activeProvider).sort(([a], [b]) => a.localeCompare(b))
+    ? Object.entries(config.models).filter(([, m]) => m.provider === activeProvider).sort(([a], [b]) => a.localeCompare(b))
     : [];
 
   // ---- Provider handlers ----
@@ -816,6 +817,13 @@ function ProviderModelsView({
     const next = { ...config };
     const { [key]: _, ...rest } = next.providers;
     next.providers = rest;
+    // 清理引用该 provider 的模型
+    const newModels = { ...next.models };
+    for (const [mk, mv] of Object.entries(newModels)) {
+      if (mv.provider === key) delete newModels[mk];
+    }
+    next.models = newModels;
+    // 清理引用该 provider 的路由
     const newRouting = { ...next.routing };
     for (const [slot, entry] of Object.entries(newRouting)) {
       if (entry.provider === key) delete newRouting[slot];
@@ -851,14 +859,14 @@ function ProviderModelsView({
   const openEditModel = (key: string) => {
     setModelModalMode('edit');
     setEditingModelKey(key);
-    setModelDraft({ ...config.routing[key] });
+    setModelDraft({ ...config.models[key] });
     setAvailableModels([]);
   };
 
   const saveModelEdit = () => {
     if (!editingModelKey) return;
     const next = { ...config };
-    next.routing = { ...next.routing, [editingModelKey]: { ...modelDraft } };
+    next.models = { ...next.models, [editingModelKey]: { ...modelDraft } };
     onChange(next);
     setModelModalMode(null);
   };
@@ -866,17 +874,25 @@ function ProviderModelsView({
   const addModel = () => {
     if (!modelDraft.model.trim()) return;
     let key = modelDraft.model.trim();
-    if (config.routing[key]) key = `${modelDraft.provider}-${key}`;
+    if (config.models[key]) key = `${modelDraft.provider}-${key}`;
     const next = { ...config };
-    next.routing = { ...next.routing, [key]: { ...modelDraft } };
+    next.models = { ...next.models, [key]: { ...modelDraft } };
     onChange(next);
     setModelModalMode(null);
   };
 
   const removeModel = (key: string) => {
     const next = { ...config };
-    const { [key]: _, ...rest } = next.routing;
-    next.routing = rest;
+    const { [key]: _, ...rest } = next.models;
+    next.models = rest;
+    // 同时清理路由中引用该模型的条目
+    const newRouting = { ...next.routing };
+    for (const [slot, entry] of Object.entries(newRouting)) {
+      if (entry.provider === config.models[key]?.provider && entry.model === config.models[key]?.model) {
+        delete newRouting[slot];
+      }
+    }
+    next.routing = newRouting;
     onChange(next);
   };
 
@@ -1346,28 +1362,31 @@ function RoutingSection({
   onChange: (c: ModelsConfigView) => void;
   capabilities: ModelCapabilityInfo[];
 }) {
-  const routingEntries = Object.entries(config.routing).sort(([a], [b]) => a.localeCompare(b));
+  const modelKeys = Object.keys(config.models).sort();
   const routingCapabilities = capabilities.filter(
     (cap) => cap.key !== 'embedding' && cap.key !== 'rerank',
   );
-
-  const modelLabel = (slotKey: string) => {
-    const entry = config.routing[slotKey];
-    if (!entry) return slotKey;
-    return `${entry.provider} / ${entry.model}`;
+  const [routeSearch, setRouteSearch] = useState<Record<string, string>>({});
+  const modelLabel = (modelKey: string) => {
+    const model = config.models[modelKey];
+    if (!model) return modelKey;
+    return `${model.provider} / ${model.model}`;
   };
 
-  const setRoute = (capKey: string, sourceSlot: string) => {
+  const setRoute = (capKey: string, modelKey: string) => {
     const next = { ...config };
     const newRouting = { ...next.routing };
-    if (sourceSlot === '__none__') {
+    if (modelKey === '__none__') {
       delete newRouting[capKey];
-    } else if (newRouting[sourceSlot]) {
-      // 复制源路由条目到目标槽位
-      newRouting[capKey] = { ...newRouting[sourceSlot] };
+    } else {
+      const entry = next.models[modelKey];
+      if (entry) {
+        newRouting[capKey] = { ...entry };
+      }
     }
     next.routing = newRouting;
     onChange(next);
+    setRouteSearch((prev) => ({ ...prev, [capKey]: '' }));
   };
 
   return (
@@ -1382,7 +1401,20 @@ function RoutingSection({
       <div className="space-y-2 flex-1 min-h-0 overflow-y-auto">
         {routingCapabilities.map((cap) => {
           const currentEntry = config.routing[cap.key];
-          const hasRoute = !!currentEntry;
+          const search = routeSearch[cap.key] || '';
+          const filtered = modelKeys
+            .filter((mk) => {
+              const m = config.models[mk];
+              if (m.capabilities.length === 0) return true;
+              if (m.capabilities.includes(cap.key)) return true;
+              if (cap.key === 'chat' && m.capabilities.includes('multimodal')) return true;
+              return false;
+            })
+            .filter((mk) => {
+              if (!search) return true;
+              const q = search.toLowerCase();
+              return mk.toLowerCase().includes(q) || modelLabel(mk).toLowerCase().includes(q);
+            });
           return (
             <Card key={cap.key}>
               <CardContent className="p-3">
@@ -1391,7 +1423,7 @@ function RoutingSection({
                     <div className="text-sm font-medium leading-tight">{cap.display_name}</div>
                     <div className="text-xs text-muted-foreground">({cap.key})</div>
                   </div>
-                  {hasRoute ? (
+                  {currentEntry ? (
                     <div className="flex-1 flex items-center gap-2">
                       <span className="text-sm flex-1">{currentEntry.provider} / {currentEntry.model}</span>
                       <span className="text-xs text-muted-foreground">
@@ -1415,14 +1447,21 @@ function RoutingSection({
                         <SelectValue placeholder="-- 未配置 --" />
                       </SelectTrigger>
                       <SelectContent>
+                        <div className="p-1.5 border-b" onPointerDown={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+                          <Input
+                            value={search}
+                            onChange={(e) => setRouteSearch((prev) => ({ ...prev, [cap.key]: e.target.value }))}
+                            className="h-7 text-xs"
+                            placeholder="搜索模型..."
+                          />
+                        </div>
                         <SelectItem value="__none__">-- 未配置 --</SelectItem>
-                        {routingEntries
-                          .filter(([slotKey]) => slotKey !== cap.key)
-                          .map(([slotKey]) => (
-                            <SelectItem key={slotKey} value={slotKey}>
-                              {modelLabel(slotKey)}
-                            </SelectItem>
-                          ))}
+                        {filtered.map((mk) => (
+                          <SelectItem key={mk} value={mk}>{modelLabel(mk)}</SelectItem>
+                        ))}
+                        {filtered.length === 0 && (
+                          <div className="px-2 py-3 text-xs text-muted-foreground text-center">无匹配模型</div>
+                        )}
                       </SelectContent>
                     </Select>
                   )}
@@ -1433,7 +1472,7 @@ function RoutingSection({
         })}
       </div>
 
-      {routingEntries.length === 0 && (
+      {modelKeys.length === 0 && (
         <p className="text-xs text-muted-foreground mt-3">
           请先在模型页中添加模型定义，然后回来配置路由
         </p>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -329,7 +329,6 @@ function LLMSettings({ onSaveStatusChange }: { onSaveStatusChange: (status: Save
   const [subTab, setSubTab] = useState<LLMSubTab>('providers');
   const [modelsConfig, setModelsConfig] = useState<ModelsConfigView>({
     providers: {},
-    models: {},
     routing: {},
   });
   const [capabilities, setCapabilities] = useState<ModelCapabilityInfo[]>([]);
@@ -509,7 +508,7 @@ function MemorySettings({
   }, []);
 
   const modelKeysFor = (acceptedCapabilities: string[]) =>
-    Object.entries(modelsConfig.models)
+    Object.entries(modelsConfig.routing)
       .filter(([, model]) => {
         if (model.capabilities.length === 0) return true;
         return acceptedCapabilities.some((capability) => model.capabilities.includes(capability));
@@ -517,7 +516,7 @@ function MemorySettings({
       .map(([key]) => key);
 
   const modelLabel = (modelKey: string) => {
-    const model = modelsConfig.models[modelKey];
+    const model = modelsConfig.routing[modelKey];
     if (!model) return modelKey;
     return `${model.provider} / ${model.model}`;
   };
@@ -530,7 +529,7 @@ function MemorySettings({
   };
 
   const embeddingDimension = config.embedding_key
-    ? Number(modelsConfig.models[config.embedding_key]?.options?.dimension || 0)
+    ? Number(modelsConfig.routing[config.embedding_key]?.options?.dimension || 0)
     : 0;
 
   if (isLoading) {
@@ -799,7 +798,7 @@ function ProviderModelsView({
     : (sortedProviderKeys[0] || '');
   const selectedConfig = config.providers[activeProvider] || null;
   const providerModels = activeProvider
-    ? Object.entries(config.models).filter(([, m]) => m.provider === activeProvider).sort(([a], [b]) => a.localeCompare(b))
+    ? Object.entries(config.routing).filter(([, m]) => m.provider === activeProvider).sort(([a], [b]) => a.localeCompare(b))
     : [];
 
   // ---- Provider handlers ----
@@ -817,15 +816,9 @@ function ProviderModelsView({
     const next = { ...config };
     const { [key]: _, ...rest } = next.providers;
     next.providers = rest;
-    const newModels = { ...next.models };
-    for (const [mk, mv] of Object.entries(newModels)) {
-      if (mv.provider === key) delete newModels[mk];
-    }
-    next.models = newModels;
     const newRouting = { ...next.routing };
-    const remainingModelKeys = new Set(Object.keys(newModels));
-    for (const [cap, modelKey] of Object.entries(newRouting)) {
-      if (!remainingModelKeys.has(modelKey)) delete newRouting[cap];
+    for (const [slot, entry] of Object.entries(newRouting)) {
+      if (entry.provider === key) delete newRouting[slot];
     }
     next.routing = newRouting;
     onChange(next);
@@ -858,14 +851,14 @@ function ProviderModelsView({
   const openEditModel = (key: string) => {
     setModelModalMode('edit');
     setEditingModelKey(key);
-    setModelDraft({ ...config.models[key] });
+    setModelDraft({ ...config.routing[key] });
     setAvailableModels([]);
   };
 
   const saveModelEdit = () => {
     if (!editingModelKey) return;
     const next = { ...config };
-    next.models = { ...next.models, [editingModelKey]: { ...modelDraft } };
+    next.routing = { ...next.routing, [editingModelKey]: { ...modelDraft } };
     onChange(next);
     setModelModalMode(null);
   };
@@ -873,22 +866,17 @@ function ProviderModelsView({
   const addModel = () => {
     if (!modelDraft.model.trim()) return;
     let key = modelDraft.model.trim();
-    if (config.models[key]) key = `${modelDraft.provider}-${key}`;
+    if (config.routing[key]) key = `${modelDraft.provider}-${key}`;
     const next = { ...config };
-    next.models = { ...next.models, [key]: { ...modelDraft } };
+    next.routing = { ...next.routing, [key]: { ...modelDraft } };
     onChange(next);
     setModelModalMode(null);
   };
 
   const removeModel = (key: string) => {
     const next = { ...config };
-    const { [key]: _, ...rest } = next.models;
-    next.models = rest;
-    const newRouting = { ...next.routing };
-    for (const [cap, modelName] of Object.entries(newRouting)) {
-      if (modelName === key) delete newRouting[cap];
-    }
-    next.routing = newRouting;
+    const { [key]: _, ...rest } = next.routing;
+    next.routing = rest;
     onChange(next);
   };
 
@@ -1358,28 +1346,28 @@ function RoutingSection({
   onChange: (c: ModelsConfigView) => void;
   capabilities: ModelCapabilityInfo[];
 }) {
-  const modelKeys = Object.keys(config.models).sort();
+  const routingEntries = Object.entries(config.routing).sort(([a], [b]) => a.localeCompare(b));
   const routingCapabilities = capabilities.filter(
     (cap) => cap.key !== 'embedding' && cap.key !== 'rerank',
   );
-  const [routeSearch, setRouteSearch] = useState<Record<string, string>>({});
-  const modelLabel = (modelKey: string) => {
-    const model = config.models[modelKey];
-    if (!model) return modelKey;
-    return `${model.provider} / ${model.model}`;
+
+  const modelLabel = (slotKey: string) => {
+    const entry = config.routing[slotKey];
+    if (!entry) return slotKey;
+    return `${entry.provider} / ${entry.model}`;
   };
 
-  const setRoute = (capKey: string, modelName: string) => {
+  const setRoute = (capKey: string, sourceSlot: string) => {
     const next = { ...config };
     const newRouting = { ...next.routing };
-    if (modelName === '__none__') {
+    if (sourceSlot === '__none__') {
       delete newRouting[capKey];
-    } else {
-      newRouting[capKey] = modelName;
+    } else if (newRouting[sourceSlot]) {
+      // 复制源路由条目到目标槽位
+      newRouting[capKey] = { ...newRouting[sourceSlot] };
     }
     next.routing = newRouting;
     onChange(next);
-    setRouteSearch((prev) => ({ ...prev, [capKey]: '' }));
   };
 
   return (
@@ -1393,20 +1381,8 @@ function RoutingSection({
 
       <div className="space-y-2 flex-1 min-h-0 overflow-y-auto">
         {routingCapabilities.map((cap) => {
-          const search = routeSearch[cap.key] || '';
-          const filtered = modelKeys
-            .filter((mk) => {
-              const m = config.models[mk];
-              if (m.capabilities.length === 0) return true;
-              if (m.capabilities.includes(cap.key)) return true;
-              if (cap.key === 'lite' && m.capabilities.includes('chat')) return true;
-              return false;
-            })
-            .filter((mk) => {
-              if (!search) return true;
-              const q = search.toLowerCase();
-              return mk.toLowerCase().includes(q) || modelLabel(mk).toLowerCase().includes(q);
-            });
+          const currentEntry = config.routing[cap.key];
+          const hasRoute = !!currentEntry;
           return (
             <Card key={cap.key}>
               <CardContent className="p-3">
@@ -1415,31 +1391,41 @@ function RoutingSection({
                     <div className="text-sm font-medium leading-tight">{cap.display_name}</div>
                     <div className="text-xs text-muted-foreground">({cap.key})</div>
                   </div>
-                  <Select
-                    value={config.routing[cap.key] || '__none__'}
-                    onValueChange={(v) => setRoute(cap.key, v)}
-                  >
-                    <SelectTrigger className="h-8 text-sm flex-1">
-                      <SelectValue placeholder="-- 未配置 --" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <div className="p-1.5 border-b" onPointerDown={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
-                        <Input
-                          value={search}
-                          onChange={(e) => setRouteSearch((prev) => ({ ...prev, [cap.key]: e.target.value }))}
-                          className="h-7 text-xs"
-                          placeholder="搜索模型..."
-                        />
-                      </div>
-                      <SelectItem value="__none__">-- 未配置 --</SelectItem>
-                      {filtered.map((mk) => (
-                        <SelectItem key={mk} value={mk}>{modelLabel(mk)}</SelectItem>
-                      ))}
-                      {filtered.length === 0 && (
-                        <div className="px-2 py-3 text-xs text-muted-foreground text-center">无匹配模型</div>
-                      )}
-                    </SelectContent>
-                  </Select>
+                  {hasRoute ? (
+                    <div className="flex-1 flex items-center gap-2">
+                      <span className="text-sm flex-1">{currentEntry.provider} / {currentEntry.model}</span>
+                      <span className="text-xs text-muted-foreground">
+                        [{currentEntry.capabilities.join(', ') || '无能力'}]
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 text-destructive hover:text-destructive"
+                        onClick={() => setRoute(cap.key, '__none__')}
+                      >
+                        移除
+                      </Button>
+                    </div>
+                  ) : (
+                    <Select
+                      value="__none__"
+                      onValueChange={(v) => setRoute(cap.key, v)}
+                    >
+                      <SelectTrigger className="h-8 text-sm flex-1">
+                        <SelectValue placeholder="-- 未配置 --" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__none__">-- 未配置 --</SelectItem>
+                        {routingEntries
+                          .filter(([slotKey]) => slotKey !== cap.key)
+                          .map(([slotKey]) => (
+                            <SelectItem key={slotKey} value={slotKey}>
+                              {modelLabel(slotKey)}
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -1447,7 +1433,7 @@ function RoutingSection({
         })}
       </div>
 
-      {modelKeys.length === 0 && (
+      {routingEntries.length === 0 && (
         <p className="text-xs text-muted-foreground mt-3">
           请先在模型页中添加模型定义，然后回来配置路由
         </p>

--- a/src-tauri/src/view.rs
+++ b/src-tauri/src/view.rs
@@ -324,16 +324,17 @@ pub struct ModelEntryView {
     pub options: serde_json::Value,
 }
 
-/// 完整的三层模型配置（前端使用）
+/// 两层模型配置（前端使用）
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelsConfigView {
     pub providers: HashMap<String, ProviderConfigView>,
-    pub models: HashMap<String, ModelEntryView>,
-    pub routing: HashMap<String, String>,
+    pub routing: HashMap<String, ModelEntryView>,
 }
 
 impl ModelsConfigView {
     pub fn from_core(config: &tiangong_core::models_config::ModelsConfig) -> Self {
+        use tiangong_core::models_config::RoutingSlot;
+
         let providers = config
             .providers
             .iter()
@@ -350,12 +351,14 @@ impl ModelsConfigView {
             })
             .collect();
 
-        let models = config
-            .models
+        let routing = config
+            .routing
             .iter()
+            .filter(|(k, _)| !matches!(k, RoutingSlot::Embedding | RoutingSlot::Rerank))
             .map(|(k, v)| {
+                let key = serde_json::to_value(k).unwrap_or_default();
                 (
-                    k.clone(),
+                    key.as_str().unwrap_or_default().to_string(),
                     ModelEntryView {
                         provider: v.provider.clone(),
                         model: v.model.clone(),
@@ -371,32 +374,12 @@ impl ModelsConfigView {
             })
             .collect();
 
-        let routing = config
-            .routing
-            .iter()
-            .filter(|(k, _)| {
-                !matches!(
-                    k,
-                    tiangong_core::models_config::ModelCapability::Embedding
-                        | tiangong_core::models_config::ModelCapability::Rerank
-                )
-            })
-            .map(|(k, v)| {
-                let key = serde_json::to_value(k).unwrap_or_default();
-                (key.as_str().unwrap_or_default().to_string(), v.clone())
-            })
-            .collect();
-
-        Self {
-            providers,
-            models,
-            routing,
-        }
+        Self { providers, routing }
     }
 
     pub fn to_core(&self) -> tiangong_core::models_config::ModelsConfig {
         use tiangong_core::models_config::{
-            ModelCapability, ModelEntry, ModelsConfig, ProviderConfig,
+            ModelCapability, ModelEntry, ModelsConfig, ProviderConfig, RoutingSlot,
         };
 
         let providers = self
@@ -415,10 +398,15 @@ impl ModelsConfigView {
             })
             .collect();
 
-        let models = self
-            .models
+        let routing = self
+            .routing
             .iter()
-            .map(|(k, v)| {
+            .filter_map(|(k, v)| {
+                let json_str = format!("\"{}\"", k);
+                let slot: RoutingSlot = serde_json::from_str(&json_str).ok()?;
+                if matches!(slot, RoutingSlot::Embedding | RoutingSlot::Rerank) {
+                    return None;
+                }
                 let capabilities: Vec<ModelCapability> = v
                     .capabilities
                     .iter()
@@ -427,36 +415,19 @@ impl ModelsConfigView {
                         serde_json::from_str(&json_str).ok()
                     })
                     .collect();
-                (
-                    k.clone(),
+                Some((
+                    slot,
                     ModelEntry {
                         provider: v.provider.clone(),
                         model: v.model.clone(),
                         capabilities,
                         options: v.options.clone(),
                     },
-                )
+                ))
             })
             .collect();
 
-        let routing = self
-            .routing
-            .iter()
-            .filter_map(|(k, v)| {
-                let json_str = format!("\"{}\"", k);
-                let cap: ModelCapability = serde_json::from_str(&json_str).ok()?;
-                if matches!(cap, ModelCapability::Embedding | ModelCapability::Rerank) {
-                    return None;
-                }
-                Some((cap, v.clone()))
-            })
-            .collect();
-
-        ModelsConfig {
-            providers,
-            models,
-            routing,
-        }
+        ModelsConfig { providers, routing }
     }
 }
 
@@ -526,26 +497,35 @@ fn resolved_model_by_key(
     models: &tiangong_core::models_config::ModelsConfig,
     model_key: &str,
 ) -> Result<tiangong_core::models_config::ResolvedModel, String> {
-    let model_entry = models
-        .models
-        .get(model_key)
-        .ok_or_else(|| format!("模型不存在：{model_key}"))?;
-    let provider = models.providers.get(&model_entry.provider).ok_or_else(|| {
-        format!(
-            "模型 {model_key} 引用的 Provider 不存在：{}",
-            model_entry.provider
-        )
-    })?;
-
-    Ok(tiangong_core::models_config::ResolvedModel {
-        provider: model_entry.provider.clone(),
-        base_url: provider.base_url.clone(),
-        api_key: tiangong_core::models_config::ModelsConfig::resolve_api_key(&provider.api_key),
-        timeout_ms: provider.timeout_ms,
-        protocol: provider.protocol,
-        model: model_entry.model.clone(),
-        options: model_entry.options.clone(),
-    })
+    // 优先按路由槽位 key 查找
+    if let Some(slot) = tiangong_core::models_config::RoutingSlot::from_key(model_key) {
+        if let Some(resolved) = models.resolve_slot(slot) {
+            return Ok(resolved);
+        }
+    }
+    // 回退：按模型名称在路由条目中搜索
+    models
+        .routing
+        .iter()
+        .find_map(|(_, entry)| {
+            if entry.model == model_key {
+                let provider = models.providers.get(&entry.provider)?;
+                Some(tiangong_core::models_config::ResolvedModel {
+                    provider: entry.provider.clone(),
+                    base_url: provider.base_url.clone(),
+                    api_key: tiangong_core::models_config::ModelsConfig::resolve_api_key(
+                        &provider.api_key,
+                    ),
+                    timeout_ms: provider.timeout_ms,
+                    protocol: provider.protocol,
+                    model: entry.model.clone(),
+                    options: entry.options.clone(),
+                })
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| format!("模型不存在：{model_key}"))
 }
 
 fn resolve_memory_llm(
@@ -643,13 +623,13 @@ fn find_model_key(
     model_name: &str,
     protocol: tiangong_core::model::ProviderProtocol,
 ) -> Option<String> {
-    models.models.iter().find_map(|(model_key, model)| {
-        let provider = models.providers.get(&model.provider)?;
+    models.routing.iter().find_map(|(slot, entry)| {
+        let provider = models.providers.get(&entry.provider)?;
         if provider.base_url == base_url
             && provider.protocol == protocol
-            && model.model == model_name
+            && entry.model == model_name
         {
-            Some(model_key.clone())
+            Some(slot.key().to_string())
         } else {
             None
         }

--- a/src-tauri/src/view.rs
+++ b/src-tauri/src/view.rs
@@ -324,10 +324,11 @@ pub struct ModelEntryView {
     pub options: serde_json::Value,
 }
 
-/// 两层模型配置（前端使用）
+/// 模型配置（前端使用）
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelsConfigView {
     pub providers: HashMap<String, ProviderConfigView>,
+    pub models: HashMap<String, ModelEntryView>,
     pub routing: HashMap<String, ModelEntryView>,
 }
 
@@ -346,6 +347,27 @@ impl ModelsConfigView {
                         api_key: v.api_key.clone(),
                         timeout_ms: v.timeout_ms,
                         protocol: v.protocol.as_str().to_string(),
+                    },
+                )
+            })
+            .collect();
+
+        let models = config
+            .models
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    ModelEntryView {
+                        provider: v.provider.clone(),
+                        model: v.model.clone(),
+                        capabilities: v
+                            .capabilities
+                            .iter()
+                            .map(|c| serde_json::to_value(c).unwrap_or_default())
+                            .map(|v| v.as_str().unwrap_or_default().to_string())
+                            .collect(),
+                        options: v.options.clone(),
                     },
                 )
             })
@@ -374,7 +396,11 @@ impl ModelsConfigView {
             })
             .collect();
 
-        Self { providers, routing }
+        Self {
+            providers,
+            models,
+            routing,
+        }
     }
 
     pub fn to_core(&self) -> tiangong_core::models_config::ModelsConfig {
@@ -393,6 +419,30 @@ impl ModelsConfigView {
                         api_key: v.api_key.clone(),
                         timeout_ms: v.timeout_ms,
                         protocol: v.protocol.parse().unwrap_or_default(),
+                    },
+                )
+            })
+            .collect();
+
+        let models = self
+            .models
+            .iter()
+            .map(|(k, v)| {
+                let capabilities: Vec<ModelCapability> = v
+                    .capabilities
+                    .iter()
+                    .filter_map(|c| {
+                        let json_str = format!("\"{}\"", c);
+                        serde_json::from_str(&json_str).ok()
+                    })
+                    .collect();
+                (
+                    k.clone(),
+                    ModelEntry {
+                        provider: v.provider.clone(),
+                        model: v.model.clone(),
+                        capabilities,
+                        options: v.options.clone(),
                     },
                 )
             })
@@ -427,7 +477,11 @@ impl ModelsConfigView {
             })
             .collect();
 
-        ModelsConfig { providers, routing }
+        ModelsConfig {
+            providers,
+            models,
+            routing,
+        }
     }
 }
 
@@ -503,24 +557,30 @@ fn resolved_model_by_key(
             return Ok(resolved);
         }
     }
+    // 从模型注册表查找
+    let resolve_entry = |entry: &tiangong_core::models_config::ModelEntry| {
+        let provider = models.providers.get(&entry.provider)?;
+        Some(tiangong_core::models_config::ResolvedModel {
+            provider: entry.provider.clone(),
+            base_url: provider.base_url.clone(),
+            api_key: tiangong_core::models_config::ModelsConfig::resolve_api_key(&provider.api_key),
+            timeout_ms: provider.timeout_ms,
+            protocol: provider.protocol,
+            model: entry.model.clone(),
+            options: entry.options.clone(),
+        })
+    };
+    if let Some(entry) = models.models.get(model_key) {
+        return resolve_entry(entry)
+            .ok_or_else(|| format!("模型 {model_key} 引用的 Provider 不存在"));
+    }
     // 回退：按模型名称在路由条目中搜索
     models
         .routing
         .iter()
         .find_map(|(_, entry)| {
             if entry.model == model_key {
-                let provider = models.providers.get(&entry.provider)?;
-                Some(tiangong_core::models_config::ResolvedModel {
-                    provider: entry.provider.clone(),
-                    base_url: provider.base_url.clone(),
-                    api_key: tiangong_core::models_config::ModelsConfig::resolve_api_key(
-                        &provider.api_key,
-                    ),
-                    timeout_ms: provider.timeout_ms,
-                    protocol: provider.protocol,
-                    model: entry.model.clone(),
-                    options: entry.options.clone(),
-                })
+                resolve_entry(entry)
             } else {
                 None
             }
@@ -623,6 +683,22 @@ fn find_model_key(
     model_name: &str,
     protocol: tiangong_core::model::ProviderProtocol,
 ) -> Option<String> {
+    // 优先从模型注册表查找
+    let from_models = models.models.iter().find_map(|(key, entry)| {
+        let provider = models.providers.get(&entry.provider)?;
+        if provider.base_url == base_url
+            && provider.protocol == protocol
+            && entry.model == model_name
+        {
+            Some(key.clone())
+        } else {
+            None
+        }
+    });
+    if from_models.is_some() {
+        return from_models;
+    }
+    // 回退：从路由条目查找
     models.routing.iter().find_map(|(slot, entry)| {
         let provider = models.providers.get(&entry.provider)?;
         if provider.base_url == base_url


### PR DESCRIPTION
## Summary
- 重构 `ModelsConfig` 为两层架构（Provider + Routing），routing 直接存储 `ModelEntry`，去掉中间的 models 映射层
- 新增 `RoutingSlot` 枚举，将路由槽位与模型能力解耦，支持 `lite` 等纯路由槽位
- 支持对话模型本身具备 multimodal 能力时直接处理图片，无需额外 `analyze_attachment` 工具调用
- 前端路由设置改为直接展示 ModelEntry 对象，修复路由下拉框和 lite 槽位缺失问题

## 变更点
- `models_config.rs`: 新增 `RoutingSlot` 枚举，routing 从 `HashMap<ModelCapability, String>` 改为 `HashMap<RoutingSlot, ModelEntry>`，向后兼容旧格式反序列化
- `core/mod.rs`: 当 chat 模型自带 multimodal 能力但没有独立 multimodal 端点时，用 chat client 充当 multimodal_client
- `runtime.rs`: 新增 `chat_is_multimodal()` 方法，`inject_enhanced_tools` 中 multimodal 模型跳过图片分析工具
- `react/engine.rs`: `include_media` 根据 chat 模型能力动态决定
- `view.rs` + `SettingsDialog.tsx`: 路由设置 UI 适配新格式，修复下拉框和 lite 槽位问题
- `core_config.rs`: `LlmConfig::from_models_config` 使用 `RoutingSlot` 替代 `ModelCapability`
- `provider_settings.rs`: `select_model` / `refresh_model_list` 使用 `update_chat_model` 方法

## Test plan
- [x] cargo check --workspace 通过
- [x] 验证 GLM（Anthropic 协议）对话和 thinking 输出正常
- [x] 验证 DeepSeek（OpenAI 兼容）对话和 thinking 输出正常
- [x] 验证设置页路由下拉框正确展示模型列表
- [x] 验证 multimodal 模型（如 gpt-5.5）直接处理图片，不触发 analyze_attachment 工具
- [x] 验证从旧版 models.json 格式迁移正常（向后兼容）