### PR TITLE
feat(deepseek): 添加独立 DeepSeek API 支持

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9521,6 +9521,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiangong-deepseek"
+version = "0.4.0"
+dependencies = [
+ "eventsource-stream",
+ "futures-util",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tiangong-entry"
 version = "0.4.0"
 dependencies = [
@@ -9549,6 +9561,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tiangong-anthropic",
+ "tiangong-deepseek",
  "tiangong-types",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/tiangong-types",
     "crates/tiangong-anthropic",
+    "crates/tiangong-deepseek",
     "crates/tiangong-llm",
     "crates/tiangong-memory",
     "crates/tiangong-core",
@@ -21,6 +22,7 @@ version = "0.4.0"
 [workspace.dependencies]
 tiangong-anthropic = { path = "crates/tiangong-anthropic" }
 tiangong-cli = { path = "crates/tiangong-cli" }
+tiangong-deepseek = { path = "crates/tiangong-deepseek" }
 tiangong-config = { path = "crates/tiangong-config" }
 tiangong-core = { path = "crates/tiangong-core" }
 tiangong-entry = { path = "crates/tiangong-entry" }

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -14,6 +14,7 @@ use tiangong_llm::message::{
 };
 use tiangong_llm::provider::LlmProvider;
 use tiangong_llm::providers::anthropic::{AnthropicConfig, AnthropicProvider};
+use tiangong_llm::providers::deepseek::{DeepSeekConfig, DeepSeekProvider};
 use tiangong_llm::providers::openai::{OpenAiCompatibleConfig, OpenAiCompatibleProvider};
 use tiangong_llm::request::ProviderRequest;
 use tiangong_llm::response::{ProviderResponse, StopReason};
@@ -244,6 +245,13 @@ impl SingleProviderClient {
                 .await
                 .map(|items| items.into_iter().map(|item| item.id).collect::<Vec<_>>())
                 .map_err(map_llm_error)?
+        } else if cfg.api_protocol == ProviderProtocol::DeepSeek {
+            let provider = build_deepseek_provider_from_config(cfg, timeout_ms, None)?;
+            provider
+                .list_models()
+                .await
+                .map(|items| items.into_iter().map(|item| item.id).collect::<Vec<_>>())
+                .map_err(map_llm_error)?
         } else {
             let provider = build_openai_provider_from_config(cfg, timeout_ms, None)?;
             provider
@@ -266,6 +274,20 @@ impl SingleProviderClient {
         let timeout_ms = parse_timeout_ms(&cfg.api_timeout_ms)?;
         if cfg.api_protocol == ProviderProtocol::Anthropic {
             let provider = build_anthropic_provider_from_config(cfg, timeout_ms, None)?;
+            let runtime = TokioRuntimeBuilder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("初始化异步运行时失败")?;
+            let mut models = runtime
+                .block_on(provider.list_models())
+                .map(|items| items.into_iter().map(|item| item.id).collect::<Vec<_>>())
+                .map_err(map_llm_error)?;
+            models.sort();
+            models.dedup();
+            return Ok(models);
+        }
+        if cfg.api_protocol == ProviderProtocol::DeepSeek {
+            let provider = build_deepseek_provider_from_config(cfg, timeout_ms, None)?;
             let runtime = TokioRuntimeBuilder::new_current_thread()
                 .enable_all()
                 .build()
@@ -308,6 +330,20 @@ impl SingleProviderClient {
             ProviderProtocol::OpenAiCompatible => Ok(ProviderDispatch::OpenAi(Box::new(
                 build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?,
             ))),
+            ProviderProtocol::DeepSeek => {
+                let mut config = DeepSeekConfig::new(self.cfg.api_auth_token.trim().to_string());
+                config.base_url = if self.cfg.api_base_url.trim().is_empty() {
+                    None
+                } else {
+                    Some(self.cfg.api_base_url.clone())
+                };
+                config.timeout = Duration::from_millis(timeout_ms);
+                config.max_retries = MAX_RETRIES;
+                config.retry_notifier = self.on_retry.clone();
+                Ok(ProviderDispatch::DeepSeek(Box::new(
+                    DeepSeekProvider::from_config(config)?,
+                )))
+            }
         }
     }
 
@@ -929,6 +965,27 @@ fn build_openai_provider_from_config(
     config.max_retries = MAX_RETRIES;
     config.retry_notifier = on_retry;
     Ok(OpenAiCompatibleProvider::new(config))
+}
+
+fn build_deepseek_provider_from_config(
+    cfg: &ModelProviderConfig,
+    timeout_ms: u64,
+    on_retry: Option<OnRetryCallback>,
+) -> Result<DeepSeekProvider> {
+    let token = cfg.api_auth_token.trim();
+    if token.is_empty() {
+        return Err(anyhow!("API_AUTH_TOKEN 不能为空，无法发起 DeepSeek 请求"));
+    }
+    let mut config = DeepSeekConfig::new(token.to_string());
+    config.base_url = if cfg.api_base_url.trim().is_empty() {
+        None
+    } else {
+        Some(cfg.api_base_url.clone())
+    };
+    config.timeout = Duration::from_millis(timeout_ms);
+    config.max_retries = MAX_RETRIES;
+    config.retry_notifier = on_retry;
+    DeepSeekProvider::from_config(config).map_err(|err| anyhow!("{err}"))
 }
 
 fn build_provider_request(
@@ -1618,6 +1675,7 @@ async fn consume_provider_stream_events_async(
 enum ProviderDispatch {
     Anthropic(Box<AnthropicProvider>),
     OpenAi(Box<OpenAiCompatibleProvider>),
+    DeepSeek(Box<DeepSeekProvider>),
 }
 
 impl ProviderDispatch {
@@ -1628,6 +1686,7 @@ impl ProviderDispatch {
         match self {
             ProviderDispatch::Anthropic(provider) => provider.stream(request).await,
             ProviderDispatch::OpenAi(provider) => provider.stream(request).await,
+            ProviderDispatch::DeepSeek(provider) => provider.stream(request).await,
         }
     }
 }

--- a/crates/tiangong-core/src/observe/collector.rs
+++ b/crates/tiangong-core/src/observe/collector.rs
@@ -95,6 +95,7 @@ mod tests {
                 prompt_tokens: 100,
                 completion_tokens: 50,
                 total_tokens: 150,
+                ..Default::default()
             },
         );
         collector.record_llm_call(
@@ -103,6 +104,7 @@ mod tests {
                 prompt_tokens: 200,
                 completion_tokens: 100,
                 total_tokens: 300,
+                ..Default::default()
             },
         );
         collector.end_task();
@@ -123,6 +125,7 @@ mod tests {
                 prompt_tokens: 100,
                 completion_tokens: 50,
                 total_tokens: 150,
+                ..Default::default()
             },
         );
         collector.end_task();
@@ -134,6 +137,7 @@ mod tests {
                 prompt_tokens: 200,
                 completion_tokens: 100,
                 total_tokens: 300,
+                ..Default::default()
             },
         );
         collector.end_task();
@@ -153,6 +157,7 @@ mod tests {
                 prompt_tokens: 100,
                 completion_tokens: 50,
                 total_tokens: 150,
+                ..Default::default()
             },
         );
 

--- a/crates/tiangong-core/src/observe/cost.rs
+++ b/crates/tiangong-core/src/observe/cost.rs
@@ -191,11 +191,13 @@ mod tests {
             prompt_tokens: 100,
             completion_tokens: 50,
             total_tokens: 150,
+            ..Default::default()
         });
         summary.add_llm_usage(&TokenUsage {
             prompt_tokens: 200,
             completion_tokens: 100,
             total_tokens: 300,
+            ..Default::default()
         });
         summary.add_tool_call();
 

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -46,7 +46,8 @@ impl CancelStrategy {
             tiangong_llm::model::ProviderProtocol::Anthropic => {
                 CancelStrategy::AbortWithStreamingUsage
             }
-            tiangong_llm::model::ProviderProtocol::OpenAiCompatible => CancelStrategy::WaitForUsage,
+            tiangong_llm::model::ProviderProtocol::OpenAiCompatible
+            | tiangong_llm::model::ProviderProtocol::DeepSeek => CancelStrategy::WaitForUsage,
         }
     }
 }

--- a/crates/tiangong-deepseek/Cargo.toml
+++ b/crates/tiangong-deepseek/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tiangong-deepseek"
+version.workspace = true
+edition = "2024"
+license = "Apache-2.0"
+
+[dependencies]
+thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["json", "rustls", "stream"] }
+eventsource-stream = { workspace = true }
+futures-util = { workspace = true }

--- a/crates/tiangong-deepseek/src/balance.rs
+++ b/crates/tiangong-deepseek/src/balance.rs
@@ -1,0 +1,17 @@
+use crate::client::DeepSeekClient;
+use crate::error::DeepSeekError;
+use crate::types::BalanceResponse;
+
+pub struct Balance<'c> {
+    client: &'c DeepSeekClient,
+}
+
+impl<'c> Balance<'c> {
+    pub fn new(client: &'c DeepSeekClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn get(&self) -> Result<BalanceResponse, DeepSeekError> {
+        self.client.get("/user/balance").await
+    }
+}

--- a/crates/tiangong-deepseek/src/chat.rs
+++ b/crates/tiangong-deepseek/src/chat.rs
@@ -1,0 +1,94 @@
+use eventsource_stream::Eventsource;
+use futures_util::{StreamExt, stream};
+
+use crate::client::DeepSeekClient;
+use crate::error::DeepSeekError;
+use crate::types::{
+    ChatCompletionRequest, ChatCompletionResponse, EventStream, StreamChunk, StreamEvent,
+};
+
+pub struct Chat<'c> {
+    client: &'c DeepSeekClient,
+}
+
+impl<'c> Chat<'c> {
+    pub fn new(client: &'c DeepSeekClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn create(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, DeepSeekError> {
+        self.client.post("/chat/completions", &request).await
+    }
+
+    pub async fn create_stream(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<EventStream, DeepSeekError> {
+        let response = self
+            .client
+            .post_stream_raw("/chat/completions", &request)
+            .await?;
+
+        let sse_stream = response.bytes_stream().eventsource();
+        let stream = stream::unfold(sse_stream, |mut sse_stream| async move {
+            match sse_stream.next().await {
+                Some(Ok(message)) => {
+                    if message.data == "[DONE]" {
+                        return Some((Ok(StreamEvent::Done), sse_stream));
+                    }
+                    let event = parse_stream_chunk(&message.data);
+                    Some((event, sse_stream))
+                }
+                Some(Err(err)) => Some((Err(DeepSeekError::Stream(err.to_string())), sse_stream)),
+                None => None,
+            }
+        });
+        Ok(Box::pin(stream))
+    }
+}
+
+fn parse_stream_chunk(data: &str) -> Result<StreamEvent, DeepSeekError> {
+    let chunk: StreamChunk = serde_json::from_str(data)
+        .map_err(|err| DeepSeekError::Serialization(format!("{err}: {data}")))?;
+
+    if let Some(usage) = chunk.usage {
+        return Ok(StreamEvent::Usage(usage));
+    }
+
+    for choice in chunk.choices {
+        let delta = choice.delta;
+
+        if let Some(reasoning) = delta.reasoning_content.filter(|s| !s.is_empty()) {
+            return Ok(StreamEvent::ReasoningDelta(reasoning));
+        }
+        if let Some(content) = delta.content.filter(|s| !s.is_empty()) {
+            return Ok(StreamEvent::TextDelta(content));
+        }
+        if let Some(tool_calls) = delta.tool_calls {
+            for tc in tool_calls {
+                if let Some(func) = tc.function.as_ref()
+                    && let Some(name) = func.name.as_ref().filter(|n| !n.is_empty())
+                {
+                    let id = tc.id.clone().unwrap_or_default();
+                    return Ok(StreamEvent::ToolCallStart {
+                        id,
+                        name: name.clone(),
+                    });
+                }
+                if let Some(func) = tc.function
+                    && let Some(args) = func.arguments.filter(|a| !a.is_empty())
+                {
+                    return Ok(StreamEvent::ToolCallDelta {
+                        index: tc.index,
+                        arguments: args,
+                    });
+                }
+            }
+        }
+    }
+
+    Err(DeepSeekError::Stream(format!("无法解析流式块：{data}")))
+}

--- a/crates/tiangong-deepseek/src/chat.rs
+++ b/crates/tiangong-deepseek/src/chat.rs
@@ -50,7 +50,7 @@ impl<'c> Chat<'c> {
     }
 }
 
-fn parse_stream_chunk(data: &str) -> Result<StreamEvent, DeepSeekError> {
+pub(crate) fn parse_stream_chunk(data: &str) -> Result<StreamEvent, DeepSeekError> {
     let chunk: StreamChunk = serde_json::from_str(data)
         .map_err(|err| DeepSeekError::Serialization(format!("{err}: {data}")))?;
 

--- a/crates/tiangong-deepseek/src/client.rs
+++ b/crates/tiangong-deepseek/src/client.rs
@@ -1,0 +1,168 @@
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::balance::Balance;
+use crate::chat::Chat;
+use crate::config::DeepSeekConfig;
+use crate::error::DeepSeekError;
+use crate::models::Models;
+
+#[derive(Clone)]
+pub struct DeepSeekClient {
+    http_client: reqwest::Client,
+    stream_http_client: reqwest::Client,
+    config: DeepSeekConfig,
+}
+
+impl DeepSeekClient {
+    pub fn from_config(config: DeepSeekConfig) -> Result<Self, DeepSeekError> {
+        let http_client = reqwest::Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|err| DeepSeekError::Transport(err.to_string()))?;
+        let stream_http_client = reqwest::Client::builder()
+            .build()
+            .map_err(|err| DeepSeekError::Transport(err.to_string()))?;
+        Ok(Self {
+            http_client,
+            stream_http_client,
+            config,
+        })
+    }
+
+    // ── 能力访问器 ──────────────────────────────────────────
+
+    pub fn chat(&self) -> Chat<'_> {
+        Chat::new(self)
+    }
+
+    pub fn models(&self) -> Models<'_> {
+        Models::new(self)
+    }
+
+    pub fn balance(&self) -> Balance<'_> {
+        Balance::new(self)
+    }
+
+    // ── 通用 HTTP 方法 ──────────────────────────────────────
+
+    pub(crate) async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, DeepSeekError> {
+        let url = self.build_url(path);
+        let response = self
+            .http_client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        parse_json_response(response).await
+    }
+
+    pub(crate) async fn post<T: Serialize, R: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &T,
+    ) -> Result<R, DeepSeekError> {
+        let url = self.build_url(path);
+        let response = self
+            .http_client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .header("Content-Type", "application/json")
+            .json(body)
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        parse_json_response(response).await
+    }
+
+    pub(crate) async fn post_stream_raw(
+        &self,
+        path: &str,
+        body: &(impl Serialize + ?Sized),
+    ) -> Result<reqwest::Response, DeepSeekError> {
+        let url = self.build_url(path);
+        let response = self
+            .stream_http_client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .header("Content-Type", "application/json")
+            .header(reqwest::header::ACCEPT, "text/event-stream")
+            .json(body)
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+
+        if !response.status().is_success() {
+            return Err(parse_error_response(response).await);
+        }
+
+        Ok(response)
+    }
+
+    fn build_url(&self, path: &str) -> String {
+        format!(
+            "{}/{}",
+            self.config.base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}
+
+fn map_reqwest_error(err: reqwest::Error) -> DeepSeekError {
+    if err.is_timeout() {
+        DeepSeekError::Transport(format!("timeout: {err}"))
+    } else {
+        DeepSeekError::Transport(err.to_string())
+    }
+}
+
+async fn parse_error_response(response: reqwest::Response) -> DeepSeekError {
+    let status = response.status();
+    let body = response.bytes().await.unwrap_or_default();
+    let body_text = String::from_utf8_lossy(&body).to_string();
+    classify_http_error(status, body_text)
+}
+
+async fn parse_json_response<T: DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T, DeepSeekError> {
+    let status = response.status();
+    let body = response
+        .bytes()
+        .await
+        .map_err(|err| DeepSeekError::Transport(err.to_string()))?;
+
+    if !status.is_success() {
+        let body_text = String::from_utf8_lossy(&body).to_string();
+        return Err(classify_http_error(status, body_text));
+    }
+
+    serde_json::from_slice(&body).map_err(|err| {
+        DeepSeekError::Serialization(format!(
+            "{err}: {}",
+            String::from_utf8_lossy(&body[..body.len().min(512)])
+        ))
+    })
+}
+
+fn classify_http_error(status: reqwest::StatusCode, body_text: String) -> DeepSeekError {
+    if is_rate_limited_status_or_body(status, &body_text) {
+        return DeepSeekError::RateLimited(body_text);
+    }
+
+    match status.as_u16() {
+        400 => DeepSeekError::InvalidRequest(body_text),
+        401 | 403 => DeepSeekError::Authentication(body_text),
+        _ if status.is_server_error() => DeepSeekError::Transport(body_text),
+        _ => DeepSeekError::Api(body_text),
+    }
+}
+
+fn is_rate_limited_status_or_body(status: reqwest::StatusCode, body_text: &str) -> bool {
+    let lower = body_text.to_ascii_lowercase();
+    matches!(status.as_u16(), 429 | 529)
+        || lower.contains("rate limit")
+        || lower.contains("too many requests")
+        || lower.contains("overloaded_error")
+}

--- a/crates/tiangong-deepseek/src/config.rs
+++ b/crates/tiangong-deepseek/src/config.rs
@@ -1,0 +1,18 @@
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct DeepSeekConfig {
+    pub api_key: String,
+    pub base_url: String,
+    pub timeout: Duration,
+}
+
+impl DeepSeekConfig {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            base_url: "https://api.deepseek.com".to_string(),
+            timeout: Duration::from_secs(60),
+        }
+    }
+}

--- a/crates/tiangong-deepseek/src/error.rs
+++ b/crates/tiangong-deepseek/src/error.rs
@@ -1,0 +1,34 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone)]
+pub enum DeepSeekError {
+    #[error("配置错误：{0}")]
+    Config(String),
+
+    #[error("传输错误：{0}")]
+    Transport(String),
+
+    #[error("认证失败：{0}")]
+    Authentication(String),
+
+    #[error("请求无效：{0}")]
+    InvalidRequest(String),
+
+    #[error("请求被限流：{0}")]
+    RateLimited(String),
+
+    #[error("序列化失败：{0}")]
+    Serialization(String),
+
+    #[error("流式处理失败：{0}")]
+    Stream(String),
+
+    #[error("DeepSeek API 错误：{0}")]
+    Api(String),
+}
+
+impl DeepSeekError {
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, Self::Transport(_) | Self::RateLimited(_))
+    }
+}

--- a/crates/tiangong-deepseek/src/lib.rs
+++ b/crates/tiangong-deepseek/src/lib.rs
@@ -9,3 +9,6 @@ pub mod types;
 pub use client::DeepSeekClient;
 pub use config::DeepSeekConfig;
 pub use error::DeepSeekError;
+
+#[cfg(test)]
+mod tests;

--- a/crates/tiangong-deepseek/src/lib.rs
+++ b/crates/tiangong-deepseek/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod balance;
+pub mod chat;
+pub mod client;
+pub mod config;
+pub mod error;
+pub mod models;
+pub mod types;
+
+pub use client::DeepSeekClient;
+pub use config::DeepSeekConfig;
+pub use error::DeepSeekError;

--- a/crates/tiangong-deepseek/src/models.rs
+++ b/crates/tiangong-deepseek/src/models.rs
@@ -1,0 +1,17 @@
+use crate::client::DeepSeekClient;
+use crate::error::DeepSeekError;
+use crate::types::ListModelsResponse;
+
+pub struct Models<'c> {
+    client: &'c DeepSeekClient,
+}
+
+impl<'c> Models<'c> {
+    pub fn new(client: &'c DeepSeekClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn list(&self) -> Result<ListModelsResponse, DeepSeekError> {
+        self.client.get("/models").await
+    }
+}

--- a/crates/tiangong-deepseek/src/tests.rs
+++ b/crates/tiangong-deepseek/src/tests.rs
@@ -1,0 +1,447 @@
+use serde_json::json;
+
+use crate::chat::parse_stream_chunk;
+use crate::config::DeepSeekConfig;
+use crate::error::DeepSeekError;
+use crate::types::{
+    BalanceResponse, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, Currency,
+    ListModelsResponse, MessageRole, ReasoningEffort, StreamEvent, ThinkingConfig, ToolCall,
+    ToolSpec, Usage,
+};
+
+// ── 配置 ──────────────────────────────────────────────
+
+#[test]
+fn config_default_values() {
+    let config = DeepSeekConfig::new("test-key");
+    assert_eq!(config.api_key, "test-key");
+    assert_eq!(config.base_url, "https://api.deepseek.com");
+}
+
+// ── 错误类型 ──────────────────────────────────────────
+
+#[test]
+fn error_retryable() {
+    assert!(DeepSeekError::Transport("timeout".into()).is_retryable());
+    assert!(DeepSeekError::RateLimited("429".into()).is_retryable());
+    assert!(!DeepSeekError::Authentication("401".into()).is_retryable());
+    assert!(!DeepSeekError::InvalidRequest("400".into()).is_retryable());
+    assert!(!DeepSeekError::Serialization("parse error".into()).is_retryable());
+    assert!(!DeepSeekError::Api("unknown".into()).is_retryable());
+}
+
+// ── Chat 类型序列化 ──────────────────────────────────
+
+#[test]
+fn chat_message_role_serde() {
+    let cases = vec![
+        (MessageRole::System, "\"system\""),
+        (MessageRole::User, "\"user\""),
+        (MessageRole::Assistant, "\"assistant\""),
+        (MessageRole::Tool, "\"tool\""),
+    ];
+    for (role, expected) in cases {
+        assert_eq!(serde_json::to_string(&role).unwrap(), expected);
+        assert_eq!(serde_json::from_str::<MessageRole>(expected).unwrap(), role);
+    }
+}
+
+#[test]
+fn chat_message_skip_none_fields() {
+    let msg = ChatMessage {
+        role: MessageRole::User,
+        content: Some(json!("hello")),
+        name: None,
+        tool_calls: None,
+        tool_call_id: None,
+        prefix: false,
+    };
+    let serialized = serde_json::to_string(&msg).unwrap();
+    assert!(!serialized.contains("name"));
+    assert!(!serialized.contains("tool_calls"));
+    assert!(!serialized.contains("tool_call_id"));
+    assert!(!serialized.contains("prefix"));
+}
+
+#[test]
+fn chat_message_with_tool_calls() {
+    let msg = ChatMessage {
+        role: MessageRole::Assistant,
+        content: None,
+        name: None,
+        tool_calls: Some(vec![ToolCall {
+            id: "call_123".into(),
+            kind: "function".into(),
+            function: crate::types::FunctionCall {
+                name: "get_weather".into(),
+                arguments: r#"{"city":"Beijing"}"#.into(),
+            },
+        }]),
+        tool_call_id: None,
+        prefix: false,
+    };
+    let value = serde_json::to_value(&msg).unwrap();
+    assert_eq!(value["tool_calls"][0]["type"], "function");
+    assert_eq!(value["tool_calls"][0]["function"]["name"], "get_weather");
+}
+
+#[test]
+fn chat_request_serialization() {
+    let request = ChatCompletionRequest {
+        model: "deepseek-v4-flash".into(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(json!("hello")),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            prefix: false,
+        }],
+        max_tokens: Some(1024),
+        temperature: Some(0.7),
+        top_p: None,
+        stream: None,
+        stream_options: None,
+        stop: None,
+        tools: None,
+        tool_choice: None,
+        thinking: None,
+        reasoning_effort: None,
+        response_format: None,
+        user_id: None,
+    };
+    let value = serde_json::to_value(&request).unwrap();
+    assert_eq!(value["model"], "deepseek-v4-flash");
+    assert_eq!(value["max_tokens"], 1024);
+    assert!((value["temperature"].as_f64().unwrap() - 0.7).abs() < 0.01);
+    assert!(!value.as_object().unwrap().contains_key("top_p"));
+}
+
+#[test]
+fn thinking_config_serialization() {
+    let enabled = ThinkingConfig {
+        thinking_type: "enabled".into(),
+        budget_tokens: Some(8192),
+    };
+    let value = serde_json::to_value(&enabled).unwrap();
+    assert_eq!(value["type"], "enabled");
+    assert_eq!(value["budget_tokens"], 8192);
+
+    let disabled = ThinkingConfig {
+        thinking_type: "disabled".into(),
+        budget_tokens: None,
+    };
+    let value = serde_json::to_value(&disabled).unwrap();
+    assert_eq!(value["type"], "disabled");
+    assert!(!value.as_object().unwrap().contains_key("budget_tokens"));
+}
+
+#[test]
+fn reasoning_effort_serde() {
+    assert_eq!(
+        serde_json::to_string(&ReasoningEffort::High).unwrap(),
+        "\"high\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ReasoningEffort::Max).unwrap(),
+        "\"max\""
+    );
+}
+
+// ── Chat 响应反序列化 ──────────────────────────────────
+
+#[test]
+fn chat_response_deserialization() {
+    let raw = json!({
+        "id": "chatcmpl-abc123",
+        "object": "chat.completion",
+        "created": 1700000000u64,
+        "model": "deepseek-v4-flash",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "Hello! How can I help?"
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 8,
+            "total_tokens": 18,
+            "prompt_cache_hit_tokens": 5,
+            "prompt_cache_miss_tokens": 5
+        },
+        "system_fingerprint": "fp_123"
+    });
+    let response: ChatCompletionResponse = serde_json::from_value(raw).unwrap();
+    assert_eq!(response.id, "chatcmpl-abc123");
+    assert_eq!(response.choices.len(), 1);
+    assert_eq!(
+        response.choices[0].message.content.as_deref(),
+        Some("Hello! How can I help?")
+    );
+    assert_eq!(response.usage.prompt_cache_hit_tokens, Some(5));
+    assert_eq!(response.usage.prompt_cache_miss_tokens, Some(5));
+}
+
+#[test]
+fn chat_response_with_reasoning() {
+    let raw = json!({
+        "id": "chatcmpl-reasoning",
+        "object": "chat.completion",
+        "created": 1700000000u64,
+        "model": "deepseek-v4-pro",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "The answer is 42.",
+                "reasoning_content": "Let me think about this..."
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        },
+        "system_fingerprint": ""
+    });
+    let response: ChatCompletionResponse = serde_json::from_value(raw).unwrap();
+    assert_eq!(
+        response.choices[0].message.reasoning_content.as_deref(),
+        Some("Let me think about this...")
+    );
+}
+
+#[test]
+fn chat_response_with_tool_calls() {
+    let raw = json!({
+        "id": "chatcmpl-tools",
+        "object": "chat.completion",
+        "created": 1700000000u64,
+        "model": "deepseek-v4-flash",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": "{\"city\":\"Beijing\"}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {
+            "prompt_tokens": 20,
+            "completion_tokens": 15,
+            "total_tokens": 35
+        },
+        "system_fingerprint": ""
+    });
+    let response: ChatCompletionResponse = serde_json::from_value(raw).unwrap();
+    let tool_calls = response.choices[0].message.tool_calls.as_ref().unwrap();
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].function.name, "get_weather");
+    assert_eq!(response.choices[0].finish_reason, "tool_calls");
+}
+
+// ── 流式 chunk 解析 ──────────────────────────────────
+
+#[test]
+fn stream_text_delta() {
+    let data = r#"{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}"#;
+    let event = parse_stream_chunk(data).unwrap();
+    assert!(matches!(event, StreamEvent::TextDelta(ref s) if s == "Hello"));
+}
+
+#[test]
+fn stream_reasoning_delta() {
+    let data = r#"{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"reasoning_content":"thinking..."},"finish_reason":null}]}"#;
+    let event = parse_stream_chunk(data).unwrap();
+    assert!(matches!(
+        event,
+        StreamEvent::ReasoningDelta(ref s) if s == "thinking..."
+    ));
+}
+
+#[test]
+fn stream_tool_call_start() {
+    let data = r#"{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_001","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}"#;
+    let event = parse_stream_chunk(data).unwrap();
+    match event {
+        StreamEvent::ToolCallStart { id, name } => {
+            assert_eq!(id, "call_001");
+            assert_eq!(name, "get_weather");
+        }
+        _ => panic!("expected ToolCallStart, got {event:?}"),
+    }
+}
+
+#[test]
+fn stream_tool_call_delta() {
+    let data = r#"{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":"}}]},"finish_reason":null}]}"#;
+    let event = parse_stream_chunk(data).unwrap();
+    match event {
+        StreamEvent::ToolCallDelta { index, arguments } => {
+            assert_eq!(index, 0);
+            assert_eq!(arguments, "{\"city\":");
+        }
+        _ => panic!("expected ToolCallDelta, got {event:?}"),
+    }
+}
+
+#[test]
+fn stream_usage_event() {
+    let data = r#"{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-flash","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150,"prompt_cache_hit_tokens":80}}"#;
+    let event = parse_stream_chunk(data).unwrap();
+    match event {
+        StreamEvent::Usage(usage) => {
+            assert_eq!(usage.prompt_tokens, 100);
+            assert_eq!(usage.prompt_cache_hit_tokens, Some(80));
+        }
+        _ => panic!("expected Usage, got {event:?}"),
+    }
+}
+
+#[test]
+fn stream_empty_delta_is_error() {
+    let data = r#"{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{}}]}"#;
+    assert!(parse_stream_chunk(data).is_err());
+}
+
+#[test]
+fn stream_invalid_json_is_error() {
+    let result = parse_stream_chunk("not json");
+    assert!(result.is_err());
+}
+
+// ── 模型列表反序列化 ──────────────────────────────────
+
+#[test]
+fn list_models_response() {
+    let raw = json!({
+        "object": "list",
+        "data": [
+            {"id": "deepseek-v4-flash", "object": "model", "owned_by": "deepseek"},
+            {"id": "deepseek-v4-pro", "object": "model", "owned_by": "deepseek"}
+        ]
+    });
+    let response: ListModelsResponse = serde_json::from_value(raw).unwrap();
+    assert_eq!(response.data.len(), 2);
+    assert_eq!(response.data[0].id, "deepseek-v4-flash");
+    assert_eq!(response.data[1].owned_by, "deepseek");
+}
+
+// ── 余额响应反序列化 ──────────────────────────────────
+
+#[test]
+fn balance_response_deserialization() {
+    let raw = json!({
+        "is_available": true,
+        "balance_infos": [
+            {
+                "currency": "CNY",
+                "total_balance": "10.50",
+                "granted_balance": "5.00",
+                "topped_up_balance": "5.50"
+            },
+            {
+                "currency": "USD",
+                "total_balance": "2.00",
+                "granted_balance": "0.00",
+                "topped_up_balance": "2.00"
+            }
+        ]
+    });
+    let response: BalanceResponse = serde_json::from_value(raw).unwrap();
+    assert!(response.is_available);
+    assert_eq!(response.balance_infos.len(), 2);
+    assert_eq!(response.balance_infos[0].currency, Currency::Cny);
+    assert_eq!(response.balance_infos[0].total_balance, "10.50");
+    assert_eq!(response.balance_infos[1].currency, Currency::Usd);
+}
+
+#[test]
+fn balance_response_unavailable() {
+    let raw = json!({
+        "is_available": false,
+        "balance_infos": []
+    });
+    let response: BalanceResponse = serde_json::from_value(raw).unwrap();
+    assert!(!response.is_available);
+    assert!(response.balance_infos.is_empty());
+}
+
+// ── Usage 类型 ──────────────────────────────────────
+
+#[test]
+fn usage_with_cache_tokens() {
+    let raw = json!({
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+        "prompt_cache_hit_tokens": 80,
+        "prompt_cache_miss_tokens": 20,
+        "completion_tokens_details": {
+            "reasoning_tokens": 30
+        }
+    });
+    let usage: Usage = serde_json::from_value(raw).unwrap();
+    assert_eq!(usage.prompt_tokens, 100);
+    assert_eq!(usage.prompt_cache_hit_tokens, Some(80));
+    assert_eq!(usage.prompt_cache_miss_tokens, Some(20));
+    assert_eq!(
+        usage.completion_tokens_details.unwrap().reasoning_tokens,
+        Some(30)
+    );
+}
+
+#[test]
+fn usage_without_cache_tokens() {
+    let raw = json!({
+        "prompt_tokens": 50,
+        "completion_tokens": 25,
+        "total_tokens": 75
+    });
+    let usage: Usage = serde_json::from_value(raw).unwrap();
+    assert_eq!(usage.prompt_cache_hit_tokens, None);
+    assert_eq!(usage.prompt_cache_miss_tokens, None);
+    assert!(usage.completion_tokens_details.is_none());
+}
+
+// ── 工具定义序列化 ──────────────────────────────────
+
+#[test]
+fn tool_spec_serialization() {
+    let spec = ToolSpec {
+        kind: "function".into(),
+        function: crate::types::FunctionSpec {
+            name: "get_weather".into(),
+            description: Some("Get weather for a city".into()),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"}
+                },
+                "required": ["city"]
+            })),
+            strict: false,
+        },
+    };
+    let value = serde_json::to_value(&spec).unwrap();
+    assert_eq!(value["type"], "function");
+    assert_eq!(value["function"]["name"], "get_weather");
+    assert!(
+        !value["function"]
+            .as_object()
+            .unwrap()
+            .contains_key("strict")
+    );
+}

--- a/crates/tiangong-deepseek/src/types/balance.rs
+++ b/crates/tiangong-deepseek/src/types/balance.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BalanceResponse {
+    pub is_available: bool,
+    pub balance_infos: Vec<BalanceInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BalanceInfo {
+    pub currency: Currency,
+    pub total_balance: String,
+    pub granted_balance: String,
+    pub topped_up_balance: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Currency {
+    #[serde(rename = "CNY")]
+    Cny,
+    #[serde(rename = "USD")]
+    Usd,
+}

--- a/crates/tiangong-deepseek/src/types/chat.rs
+++ b/crates/tiangong-deepseek/src/types/chat.rs
@@ -1,0 +1,238 @@
+use futures_util::stream::BoxStream;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::DeepSeekError;
+
+// ── 请求类型 ──────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChatMessage {
+    pub role: MessageRole,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub prefix: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !value
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub function: FunctionCall,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FunctionCall {
+    pub name: String,
+    pub arguments: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolSpec {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub function: FunctionSpec,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FunctionSpec {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Value>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub strict: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEffort {
+    High,
+    Max,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ThinkingConfig {
+    #[serde(rename = "type")]
+    pub thinking_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget_tokens: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChatCompletionRequest {
+    pub model: String,
+    pub messages: Vec<ChatMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<StreamOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ToolSpec>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ThinkingConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StreamOptions {
+    pub include_usage: bool,
+}
+
+// ── 响应类型 ──────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChatCompletionResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub choices: Vec<Choice>,
+    pub usage: Usage,
+    #[serde(default)]
+    pub system_fingerprint: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Choice {
+    pub index: u32,
+    pub message: ChoiceMessage,
+    pub finish_reason: String,
+    #[serde(default)]
+    pub logprobs: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChoiceMessage {
+    pub role: MessageRole,
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub reasoning_content: Option<String>,
+    #[serde(default)]
+    pub tool_calls: Option<Vec<ToolCall>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Usage {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_tokens: u64,
+    #[serde(default)]
+    pub prompt_cache_hit_tokens: Option<u64>,
+    #[serde(default)]
+    pub prompt_cache_miss_tokens: Option<u64>,
+    #[serde(default)]
+    pub completion_tokens_details: Option<CompletionTokensDetails>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompletionTokensDetails {
+    #[serde(default)]
+    pub reasoning_tokens: Option<u64>,
+}
+
+// ── 流式类型 ──────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StreamChunk {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    #[serde(default)]
+    pub choices: Vec<StreamChoice>,
+    #[serde(default)]
+    pub usage: Option<Usage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StreamChoice {
+    pub index: u32,
+    pub delta: StreamDelta,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct StreamDelta {
+    #[serde(default)]
+    pub role: Option<MessageRole>,
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub reasoning_content: Option<String>,
+    #[serde(default)]
+    pub tool_calls: Option<Vec<StreamToolCall>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StreamToolCall {
+    pub index: u32,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(rename = "type", default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub function: Option<StreamFunctionCall>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StreamFunctionCall {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub arguments: Option<String>,
+}
+
+// ── 流式事件（解析后的高层事件） ──────────────────────────
+
+#[derive(Debug, Clone)]
+pub enum StreamEvent {
+    ReasoningDelta(String),
+    TextDelta(String),
+    ToolCallStart { id: String, name: String },
+    ToolCallDelta { index: u32, arguments: String },
+    Usage(Usage),
+    Done,
+    Error(String),
+}
+
+pub type EventStream = BoxStream<'static, Result<StreamEvent, DeepSeekError>>;

--- a/crates/tiangong-deepseek/src/types/mod.rs
+++ b/crates/tiangong-deepseek/src/types/mod.rs
@@ -1,0 +1,12 @@
+pub mod balance;
+pub mod chat;
+pub mod model;
+
+pub use balance::{BalanceInfo, BalanceResponse, Currency};
+pub use chat::{
+    ChatCompletionRequest, ChatCompletionResponse, ChatMessage, Choice, ChoiceMessage,
+    CompletionTokensDetails, EventStream, FunctionCall, FunctionSpec, MessageRole, ReasoningEffort,
+    StreamChoice, StreamChunk, StreamDelta, StreamEvent, StreamFunctionCall, StreamOptions,
+    StreamToolCall, ThinkingConfig, ToolCall, ToolSpec, Usage,
+};
+pub use model::{ListModelsResponse, Model};

--- a/crates/tiangong-deepseek/src/types/model.rs
+++ b/crates/tiangong-deepseek/src/types/model.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Model {
+    pub id: String,
+    pub object: String,
+    pub owned_by: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListModelsResponse {
+    pub object: String,
+    pub data: Vec<Model>,
+}

--- a/crates/tiangong-llm/Cargo.toml
+++ b/crates/tiangong-llm/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 tiangong-anthropic = { workspace = true }
+tiangong-deepseek = { workspace = true }
 tiangong-types = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/tiangong-llm/src/model.rs
+++ b/crates/tiangong-llm/src/model.rs
@@ -10,6 +10,7 @@ pub enum ProviderProtocol {
     #[default]
     OpenAiCompatible,
     Anthropic,
+    DeepSeek,
 }
 
 impl ProviderProtocol {
@@ -17,6 +18,7 @@ impl ProviderProtocol {
         match self {
             ProviderProtocol::OpenAiCompatible => "openai_compatible",
             ProviderProtocol::Anthropic => "anthropic",
+            ProviderProtocol::DeepSeek => "deepseek",
         }
     }
 }
@@ -28,6 +30,7 @@ impl FromStr for ProviderProtocol {
         match s.trim() {
             "" | "openai_compatible" => Ok(ProviderProtocol::OpenAiCompatible),
             "anthropic" => Ok(ProviderProtocol::Anthropic),
+            "deepseek" => Ok(ProviderProtocol::DeepSeek),
             other => Err(anyhow!("不支持的 provider 协议：{other}")),
         }
     }

--- a/crates/tiangong-llm/src/providers/deepseek/client.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/client.rs
@@ -1,0 +1,204 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures_util::Stream;
+use tiangong_deepseek::types::{ChatCompletionRequest, ChatCompletionResponse, EventStream};
+
+use crate::error::LlmError;
+use crate::model::ProviderModelInfo;
+use crate::stream::ProviderStreamEvent;
+
+use super::config::DeepSeekConfig;
+use super::error::map_deepseek_error;
+
+pub type DeepSeekStream =
+    std::pin::Pin<Box<dyn Stream<Item = Result<ProviderStreamEvent, LlmError>> + Send>>;
+
+#[async_trait]
+pub(crate) trait DeepSeekTransport: Send + Sync {
+    async fn create(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, LlmError>;
+
+    async fn create_stream(&self, request: ChatCompletionRequest) -> Result<EventStream, LlmError>;
+
+    async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError>;
+}
+
+#[derive(Clone)]
+pub struct NativeDeepSeekTransport {
+    client: tiangong_deepseek::DeepSeekClient,
+}
+
+impl NativeDeepSeekTransport {
+    pub fn new(config: &DeepSeekConfig) -> Result<Self, LlmError> {
+        let mut native = tiangong_deepseek::DeepSeekConfig::new(config.api_key.clone());
+        native.base_url = config.resolved_base_url();
+        native.timeout = config.timeout;
+
+        let client =
+            tiangong_deepseek::DeepSeekClient::from_config(native).map_err(map_deepseek_error)?;
+        Ok(Self { client })
+    }
+}
+
+#[async_trait]
+impl DeepSeekTransport for NativeDeepSeekTransport {
+    async fn create(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, LlmError> {
+        self.client
+            .chat()
+            .create(request)
+            .await
+            .map_err(map_deepseek_error)
+    }
+
+    async fn create_stream(&self, request: ChatCompletionRequest) -> Result<EventStream, LlmError> {
+        self.client
+            .chat()
+            .create_stream(request)
+            .await
+            .map_err(map_deepseek_error)
+    }
+
+    async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
+        let response = self
+            .client
+            .models()
+            .list()
+            .await
+            .map_err(map_deepseek_error)?;
+        Ok(response
+            .data
+            .into_iter()
+            .map(|item| ProviderModelInfo {
+                id: item.id.clone(),
+                display_name: Some(item.id),
+            })
+            .collect())
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DeepSeekClient<T = NativeDeepSeekTransport> {
+    transport: T,
+    config: DeepSeekConfig,
+}
+
+impl DeepSeekClient<NativeDeepSeekTransport> {
+    pub fn from_config(config: DeepSeekConfig) -> Result<Self, LlmError> {
+        let transport = NativeDeepSeekTransport::new(&config)?;
+        Ok(Self { transport, config })
+    }
+}
+
+impl<T> DeepSeekClient<T>
+where
+    T: DeepSeekTransport,
+{
+    pub async fn create(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, LlmError> {
+        let model = request.model.clone();
+        self.run_with_retry("deepseek_complete", &model, false, || {
+            let request = request.clone();
+            async { self.transport.create(request).await }
+        })
+        .await
+    }
+
+    pub async fn create_stream(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<EventStream, LlmError> {
+        let model = request.model.clone();
+        self.run_with_retry("deepseek_stream", &model, true, || {
+            let request = request.clone();
+            async { self.transport.create_stream(request).await }
+        })
+        .await
+    }
+
+    pub async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
+        self.run_with_retry("deepseek_list_models", "<list_models>", false, || async {
+            self.transport.list_models().await
+        })
+        .await
+    }
+
+    async fn run_with_retry<F, Fut, R>(
+        &self,
+        operation: &'static str,
+        model: &str,
+        stream: bool,
+        mut f: F,
+    ) -> Result<R, LlmError>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<R, LlmError>>,
+    {
+        let mut attempt = 0u32;
+        let mut delay_ms = 1000u64;
+
+        loop {
+            let start = std::time::Instant::now();
+            tracing::info!(
+                operation,
+                provider = "deepseek",
+                model,
+                stream,
+                attempt,
+                "开始 DeepSeek 请求"
+            );
+            match f().await {
+                Ok(result) => {
+                    tracing::info!(
+                        operation,
+                        provider = "deepseek",
+                        model,
+                        stream,
+                        attempt,
+                        latency_ms = start.elapsed().as_millis() as u64,
+                        "DeepSeek 请求完成"
+                    );
+                    return Ok(result);
+                }
+                Err(err) if err.is_retryable() && attempt < self.config.max_retries => {
+                    attempt += 1;
+                    tracing::warn!(
+                        operation,
+                        provider = "deepseek",
+                        model,
+                        stream,
+                        attempt,
+                        delay_ms,
+                        error = %err,
+                        "DeepSeek 请求失败，准备重试"
+                    );
+                    if let Some(notifier) = &self.config.retry_notifier {
+                        notifier(attempt, self.config.max_retries, delay_ms, &err.to_string());
+                    }
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                    delay_ms *= 2;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        operation,
+                        provider = "deepseek",
+                        model,
+                        stream,
+                        attempt,
+                        latency_ms = start.elapsed().as_millis() as u64,
+                        error = %err,
+                        "DeepSeek 请求失败"
+                    );
+                    return Err(err);
+                }
+            }
+        }
+    }
+}

--- a/crates/tiangong-llm/src/providers/deepseek/config.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/config.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+pub type RetryNotifier = Arc<dyn Fn(u32, u32, u64, &str) + Send + Sync>;
+
+/// DeepSeek provider 配置。
+#[derive(Clone)]
+pub struct DeepSeekConfig {
+    pub api_key: String,
+    pub base_url: Option<String>,
+    pub timeout: Duration,
+    pub max_retries: u32,
+    pub retry_notifier: Option<RetryNotifier>,
+}
+
+impl std::fmt::Debug for DeepSeekConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeepSeekConfig")
+            .field("api_key", &(!self.api_key.is_empty()))
+            .field("base_url", &self.base_url)
+            .field("timeout", &self.timeout)
+            .field("max_retries", &self.max_retries)
+            .field("retry_notifier", &self.retry_notifier.is_some())
+            .finish()
+    }
+}
+
+impl DeepSeekConfig {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            base_url: None,
+            timeout: Duration::from_secs(60),
+            max_retries: 3,
+            retry_notifier: None,
+        }
+    }
+
+    pub fn resolved_base_url(&self) -> String {
+        self.base_url
+            .as_deref()
+            .filter(|url| !url.trim().is_empty())
+            .unwrap_or("https://api.deepseek.com")
+            .trim_end_matches('/')
+            .to_string()
+    }
+}

--- a/crates/tiangong-llm/src/providers/deepseek/error.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/error.rs
@@ -1,0 +1,17 @@
+use crate::error::LlmError;
+
+pub fn map_deepseek_error(error: tiangong_deepseek::DeepSeekError) -> LlmError {
+    match error {
+        tiangong_deepseek::DeepSeekError::Config(msg) => LlmError::Configuration(msg),
+        tiangong_deepseek::DeepSeekError::Transport(msg) => LlmError::Transport(msg),
+        tiangong_deepseek::DeepSeekError::Authentication(msg) => LlmError::Authentication(msg),
+        tiangong_deepseek::DeepSeekError::InvalidRequest(msg) => LlmError::InvalidRequest(msg),
+        tiangong_deepseek::DeepSeekError::RateLimited(msg) => LlmError::RateLimited(msg),
+        tiangong_deepseek::DeepSeekError::Serialization(msg) => LlmError::Serialization(msg),
+        tiangong_deepseek::DeepSeekError::Stream(msg) => LlmError::Stream(msg),
+        tiangong_deepseek::DeepSeekError::Api(msg) => LlmError::Provider {
+            provider: "deepseek",
+            message: msg,
+        },
+    }
+}

--- a/crates/tiangong-llm/src/providers/deepseek/mapping.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/mapping.rs
@@ -1,0 +1,322 @@
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+
+use crate::message::{ChatMessage, MessageContent, MessageRole};
+use crate::request::{ProviderRequest, ReasoningEffort};
+use crate::response::{ProviderResponse, StopReason};
+use crate::tool::{ToolChoice, ToolSpec};
+use crate::usage::TokenUsageData;
+
+pub fn to_deepseek_request(
+    req: &ProviderRequest,
+) -> Result<tiangong_deepseek::types::ChatCompletionRequest> {
+    let messages = build_messages(req)?;
+    let thinking = build_thinking(req);
+    let reasoning_effort = build_reasoning_effort(req);
+
+    let mut tool_choice_value = None;
+    let mut tools_value = None;
+    if !req.tools.is_empty() {
+        tools_value = Some(build_tools(&req.tools));
+        tool_choice_value = build_tool_choice(req.tool_choice.as_ref());
+    }
+
+    Ok(tiangong_deepseek::types::ChatCompletionRequest {
+        model: req.model.clone(),
+        messages,
+        max_tokens: Some(req.max_tokens),
+        temperature: req.temperature,
+        top_p: req.top_p,
+        stream: None,
+        stream_options: None,
+        stop: if req.stop_sequences.is_empty() {
+            None
+        } else {
+            Some(json!(req.stop_sequences))
+        },
+        tools: tools_value,
+        tool_choice: tool_choice_value,
+        thinking,
+        reasoning_effort,
+        response_format: None,
+        user_id: None,
+    })
+}
+
+fn build_messages(req: &ProviderRequest) -> Result<Vec<tiangong_deepseek::types::ChatMessage>> {
+    let mut messages = Vec::new();
+
+    if let Some(system) = req.system.as_ref().filter(|s| !s.trim().is_empty()) {
+        messages.push(tiangong_deepseek::types::ChatMessage {
+            role: tiangong_deepseek::types::MessageRole::System,
+            content: Some(Value::String(system.clone())),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            prefix: false,
+        });
+    }
+
+    for message in &req.messages {
+        match message.role {
+            MessageRole::System => {}
+            MessageRole::User => {
+                if let Some(msg) = build_user_message(message) {
+                    messages.push(msg);
+                }
+            }
+            MessageRole::Assistant => {
+                let text = extract_text(message);
+                let tool_calls = build_assistant_tool_calls(message);
+                if !text.is_empty() || !tool_calls.is_empty() {
+                    messages.push(tiangong_deepseek::types::ChatMessage {
+                        role: tiangong_deepseek::types::MessageRole::Assistant,
+                        content: if text.is_empty() {
+                            None
+                        } else {
+                            Some(Value::String(text))
+                        },
+                        name: None,
+                        tool_calls: if tool_calls.is_empty() {
+                            None
+                        } else {
+                            Some(tool_calls)
+                        },
+                        tool_call_id: None,
+                        prefix: false,
+                    });
+                }
+            }
+            MessageRole::Tool => {
+                for result in message.content.iter().filter_map(|c| match c {
+                    MessageContent::ToolResult(r) => Some(r),
+                    _ => None,
+                }) {
+                    let content = match &result.content {
+                        crate::tool::ToolResultContent::Text(text) => text.clone(),
+                        crate::tool::ToolResultContent::Json(value) => value.to_string(),
+                    };
+                    messages.push(tiangong_deepseek::types::ChatMessage {
+                        role: tiangong_deepseek::types::MessageRole::Tool,
+                        content: Some(Value::String(content)),
+                        name: None,
+                        tool_calls: None,
+                        tool_call_id: Some(result.tool_call_id.clone()),
+                        prefix: false,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(messages)
+}
+
+fn build_user_message(message: &ChatMessage) -> Option<tiangong_deepseek::types::ChatMessage> {
+    let text = extract_text(message);
+    let images: Vec<_> = message
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            MessageContent::Image(img) => Some(img),
+            _ => None,
+        })
+        .collect();
+
+    if images.is_empty() {
+        if text.trim().is_empty() {
+            return None;
+        }
+        return Some(tiangong_deepseek::types::ChatMessage {
+            role: tiangong_deepseek::types::MessageRole::User,
+            content: Some(Value::String(text)),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            prefix: false,
+        });
+    }
+
+    let mut content = Vec::new();
+    if !text.is_empty() {
+        content.push(json!({"type": "text", "text": text}));
+    }
+    for image in images {
+        content.push(json!({
+            "type": "image_url",
+            "image_url": { "url": image.data }
+        }));
+    }
+    Some(tiangong_deepseek::types::ChatMessage {
+        role: tiangong_deepseek::types::MessageRole::User,
+        content: Some(Value::Array(content)),
+        name: None,
+        tool_calls: None,
+        tool_call_id: None,
+        prefix: false,
+    })
+}
+
+fn build_assistant_tool_calls(message: &ChatMessage) -> Vec<tiangong_deepseek::types::ToolCall> {
+    message
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            MessageContent::ToolCall(tc) => Some(tiangong_deepseek::types::ToolCall {
+                id: tc.id.clone(),
+                kind: "function".to_string(),
+                function: tiangong_deepseek::types::FunctionCall {
+                    name: tc.name.clone(),
+                    arguments: tc.arguments.to_string(),
+                },
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+fn build_tools(specs: &[ToolSpec]) -> Vec<tiangong_deepseek::types::ToolSpec> {
+    specs
+        .iter()
+        .map(|spec| tiangong_deepseek::types::ToolSpec {
+            kind: "function".to_string(),
+            function: tiangong_deepseek::types::FunctionSpec {
+                name: spec.name.clone(),
+                description: Some(spec.description.clone()),
+                parameters: Some(spec.input_schema.clone()),
+                strict: false,
+            },
+        })
+        .collect()
+}
+
+fn build_tool_choice(choice: Option<&ToolChoice>) -> Option<Value> {
+    match choice {
+        Some(ToolChoice::Any) => Some(json!("required")),
+        Some(ToolChoice::Auto) => Some(json!("auto")),
+        Some(ToolChoice::Tool(name)) => Some(json!({
+            "type": "function",
+            "function": { "name": name }
+        })),
+        None => None,
+    }
+}
+
+fn build_thinking(req: &ProviderRequest) -> Option<tiangong_deepseek::types::ThinkingConfig> {
+    if req.thinking_disabled {
+        Some(tiangong_deepseek::types::ThinkingConfig {
+            thinking_type: "disabled".to_string(),
+            budget_tokens: None,
+        })
+    } else {
+        req.thinking
+            .as_ref()
+            .map(|thinking| tiangong_deepseek::types::ThinkingConfig {
+                thinking_type: "enabled".to_string(),
+                budget_tokens: Some(thinking.budget_tokens),
+            })
+    }
+}
+
+fn build_reasoning_effort(
+    req: &ProviderRequest,
+) -> Option<tiangong_deepseek::types::ReasoningEffort> {
+    req.reasoning_effort.map(|effort| match effort {
+        ReasoningEffort::Low | ReasoningEffort::Medium | ReasoningEffort::High => {
+            tiangong_deepseek::types::ReasoningEffort::High
+        }
+        ReasoningEffort::Max => tiangong_deepseek::types::ReasoningEffort::Max,
+    })
+}
+
+fn extract_text(message: &ChatMessage) -> String {
+    message
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            MessageContent::Text(text) => Some(text.clone()),
+            MessageContent::ToolResult(result) => Some(match &result.content {
+                crate::tool::ToolResultContent::Text(text) => text.clone(),
+                crate::tool::ToolResultContent::Json(value) => value.to_string(),
+            }),
+            MessageContent::File(file) => Some(format!(
+                "<attachment title=\"{}\" mime_type=\"{}\">\n{}\n</attachment>",
+                file.title.as_deref().unwrap_or("attachment"),
+                file.mime_type,
+                file.data
+            )),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn from_deepseek_response(
+    response: tiangong_deepseek::types::ChatCompletionResponse,
+) -> Result<ProviderResponse> {
+    let choice = response
+        .choices
+        .first()
+        .ok_or_else(|| anyhow!("DeepSeek 响应缺少 choices"))?;
+
+    let text = choice.message.content.as_deref().unwrap_or("").to_string();
+    let reasoning_content = choice.message.reasoning_content.clone();
+
+    let mut content = Vec::new();
+    if !text.trim().is_empty() {
+        content.push(MessageContent::Text(text.trim().to_string()));
+    }
+    if let Some(tool_calls) = &choice.message.tool_calls {
+        for tc in tool_calls {
+            let arguments =
+                serde_json::from_str(&tc.function.arguments).unwrap_or_else(|_| json!({}));
+            content.push(MessageContent::ToolCall(crate::tool::ToolCall {
+                id: tc.id.clone(),
+                name: tc.function.name.clone(),
+                arguments,
+            }));
+        }
+    }
+
+    let usage = parse_usage(&response.usage);
+    let raw = serde_json::to_value(&response).unwrap_or_default();
+    let id = response.id;
+    let model = response.model;
+
+    Ok(ProviderResponse {
+        id: Some(id),
+        model: Some(model),
+        assistant_message: ChatMessage {
+            role: MessageRole::Assistant,
+            content,
+        },
+        reasoning_content,
+        stop_reason: Some(map_stop_reason(&choice.finish_reason)),
+        usage: Some(usage),
+        raw: Some(raw),
+    })
+}
+
+fn parse_usage(usage: &tiangong_deepseek::types::Usage) -> TokenUsageData {
+    TokenUsageData {
+        prompt_tokens: usage.prompt_tokens as usize,
+        completion_tokens: usage.completion_tokens as usize,
+        total_tokens: usage.total_tokens as usize,
+        prompt_cache_hit_tokens: usage.prompt_cache_hit_tokens.map(|v| v as usize),
+        prompt_cache_miss_tokens: usage.prompt_cache_miss_tokens.map(|v| v as usize),
+    }
+}
+
+pub fn parse_stream_usage(usage: &tiangong_deepseek::types::Usage) -> TokenUsageData {
+    parse_usage(usage)
+}
+
+fn map_stop_reason(reason: &str) -> StopReason {
+    match reason {
+        "stop" => StopReason::EndTurn,
+        "tool_calls" => StopReason::ToolUse,
+        "length" => StopReason::MaxTokens,
+        "content_filter" | "insufficient_system_resource" => StopReason::Other(reason.to_string()),
+        _ => StopReason::Other(reason.to_string()),
+    }
+}

--- a/crates/tiangong-llm/src/providers/deepseek/mod.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/mod.rs
@@ -1,0 +1,9 @@
+mod client;
+mod config;
+mod error;
+mod mapping;
+mod provider;
+mod stream;
+
+pub use config::DeepSeekConfig;
+pub use provider::DeepSeekProvider;

--- a/crates/tiangong-llm/src/providers/deepseek/provider.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/provider.rs
@@ -1,0 +1,66 @@
+use async_trait::async_trait;
+
+use crate::error::LlmError;
+use crate::model::ProviderModelInfo;
+use crate::provider::{LlmProvider, ProviderCapabilities};
+use crate::request::ProviderRequest;
+use crate::response::ProviderResponse;
+use crate::stream::ProviderStream;
+
+use super::client::{DeepSeekClient, NativeDeepSeekTransport};
+use super::config::DeepSeekConfig;
+use super::mapping::{from_deepseek_response, to_deepseek_request};
+use super::stream::map_deepseek_stream;
+
+#[derive(Clone)]
+pub struct DeepSeekProvider<T = NativeDeepSeekTransport> {
+    client: DeepSeekClient<T>,
+}
+
+impl DeepSeekProvider<NativeDeepSeekTransport> {
+    pub fn from_config(config: DeepSeekConfig) -> Result<Self, LlmError> {
+        Ok(Self {
+            client: DeepSeekClient::from_config(config)?,
+        })
+    }
+
+    pub fn new(config: DeepSeekConfig) -> Result<Self, LlmError> {
+        Self::from_config(config)
+    }
+}
+
+#[async_trait]
+impl<T> LlmProvider for DeepSeekProvider<T>
+where
+    T: super::client::DeepSeekTransport,
+{
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            streaming: true,
+            tool_calling: true,
+            system_prompt: true,
+            list_models: true,
+        }
+    }
+
+    async fn complete(&self, req: ProviderRequest) -> Result<ProviderResponse, LlmError> {
+        let request =
+            to_deepseek_request(&req).map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
+        let response = self.client.create(request).await?;
+        from_deepseek_response(response).map_err(|err| LlmError::Provider {
+            provider: "deepseek",
+            message: err.to_string(),
+        })
+    }
+
+    async fn stream(&self, req: ProviderRequest) -> Result<ProviderStream, LlmError> {
+        let request =
+            to_deepseek_request(&req).map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
+        let event_stream = self.client.create_stream(request).await?;
+        Ok(map_deepseek_stream(event_stream))
+    }
+
+    async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
+        self.client.list_models().await
+    }
+}

--- a/crates/tiangong-llm/src/providers/deepseek/stream.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/stream.rs
@@ -1,0 +1,56 @@
+use futures_util::{StreamExt, stream};
+
+use crate::error::LlmError;
+use crate::stream::ProviderStreamEvent;
+use crate::tool::ToolCall;
+
+use super::error::map_deepseek_error;
+use super::mapping::parse_stream_usage;
+
+pub fn map_deepseek_stream(
+    event_stream: tiangong_deepseek::types::EventStream,
+) -> super::client::DeepSeekStream {
+    let mapped = event_stream.map(|result| match result {
+        Ok(event) => map_event(event),
+        Err(err) => vec![Err(map_deepseek_error(err))],
+    });
+    Box::pin(mapped.flat_map(stream::iter))
+}
+
+fn map_event(
+    event: tiangong_deepseek::types::StreamEvent,
+) -> Vec<Result<ProviderStreamEvent, LlmError>> {
+    match event {
+        tiangong_deepseek::types::StreamEvent::ReasoningDelta(delta) => {
+            vec![Ok(ProviderStreamEvent::ReasoningDelta(delta))]
+        }
+        tiangong_deepseek::types::StreamEvent::TextDelta(delta) => {
+            vec![Ok(ProviderStreamEvent::TextDelta(delta))]
+        }
+        tiangong_deepseek::types::StreamEvent::ToolCallStart { id, name } => {
+            vec![Ok(ProviderStreamEvent::ToolCallStart(ToolCall {
+                id,
+                name,
+                arguments: serde_json::json!({}),
+            }))]
+        }
+        tiangong_deepseek::types::StreamEvent::ToolCallDelta { index, arguments } => {
+            vec![Ok(ProviderStreamEvent::ToolCallDelta {
+                call_id: index.to_string(),
+                partial_json: arguments,
+            })]
+        }
+        tiangong_deepseek::types::StreamEvent::Usage(usage) => {
+            vec![Ok(ProviderStreamEvent::Usage(parse_stream_usage(&usage)))]
+        }
+        tiangong_deepseek::types::StreamEvent::Done => {
+            vec![Ok(ProviderStreamEvent::MessageEnd)]
+        }
+        tiangong_deepseek::types::StreamEvent::Error(message) => {
+            vec![Err(LlmError::Provider {
+                provider: "deepseek",
+                message,
+            })]
+        }
+    }
+}

--- a/crates/tiangong-llm/src/providers/mod.rs
+++ b/crates/tiangong-llm/src/providers/mod.rs
@@ -1,2 +1,3 @@
 pub mod anthropic;
+pub mod deepseek;
 pub mod openai;

--- a/crates/tiangong-llm/src/providers/openai/mapping.rs
+++ b/crates/tiangong-llm/src/providers/openai/mapping.rs
@@ -303,6 +303,8 @@ pub fn parse_usage(usage: &Value) -> TokenUsageData {
         prompt_tokens: prompt,
         completion_tokens: completion,
         total_tokens: total,
+        prompt_cache_hit_tokens: None,
+        prompt_cache_miss_tokens: None,
     }
 }
 

--- a/crates/tiangong-llm/src/text.rs
+++ b/crates/tiangong-llm/src/text.rs
@@ -10,6 +10,7 @@ use crate::message::{ChatMessage, MessageContent, MessageRole};
 use crate::model::ProviderProtocol;
 use crate::provider::LlmProvider;
 use crate::providers::anthropic::{AnthropicConfig, AnthropicProvider};
+use crate::providers::deepseek::{DeepSeekConfig, DeepSeekProvider};
 use crate::providers::openai::{OpenAiCompatibleConfig, OpenAiCompatibleProvider};
 use crate::request::ProviderRequest;
 
@@ -104,6 +105,15 @@ fn build_provider(config: &LlmEndpointConfig) -> Result<Box<dyn LlmProvider>, Ll
             provider_config.timeout = config.timeout;
             provider_config.max_retries = config.max_retries;
             Ok(Box::new(AnthropicProvider::from_config(provider_config)?))
+        }
+        ProviderProtocol::DeepSeek => {
+            let mut provider_config = DeepSeekConfig::new(config.api_key.clone());
+            if !config.base_url.trim().is_empty() {
+                provider_config.base_url = Some(config.base_url.clone());
+            }
+            provider_config.timeout = config.timeout;
+            provider_config.max_retries = config.max_retries;
+            Ok(Box::new(DeepSeekProvider::from_config(provider_config)?))
         }
     }
 }

--- a/crates/tiangong-llm/src/usage.rs
+++ b/crates/tiangong-llm/src/usage.rs
@@ -6,6 +6,10 @@ pub struct TokenUsageData {
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
     pub total_tokens: usize,
+    #[serde(default)]
+    pub prompt_cache_hit_tokens: Option<usize>,
+    #[serde(default)]
+    pub prompt_cache_miss_tokens: Option<usize>,
 }
 
 impl TokenUsageData {
@@ -14,6 +18,8 @@ impl TokenUsageData {
             prompt_tokens,
             completion_tokens,
             total_tokens: prompt_tokens + completion_tokens,
+            prompt_cache_hit_tokens: None,
+            prompt_cache_miss_tokens: None,
         }
     }
 }
@@ -24,6 +30,8 @@ impl From<TokenUsageData> for tiangong_types::TokenUsage {
             prompt_tokens: value.prompt_tokens,
             completion_tokens: value.completion_tokens,
             total_tokens: value.total_tokens,
+            prompt_cache_hit_tokens: value.prompt_cache_hit_tokens,
+            prompt_cache_miss_tokens: value.prompt_cache_miss_tokens,
         }
     }
 }

--- a/crates/tiangong-types/src/tests.rs
+++ b/crates/tiangong-types/src/tests.rs
@@ -37,11 +37,15 @@ fn token_usage_accumulate() {
         prompt_tokens: 100,
         completion_tokens: 50,
         total_tokens: 150,
+        prompt_cache_hit_tokens: None,
+        prompt_cache_miss_tokens: None,
     };
     let b = TokenUsage {
         prompt_tokens: 200,
         completion_tokens: 100,
         total_tokens: 300,
+        prompt_cache_hit_tokens: None,
+        prompt_cache_miss_tokens: None,
     };
     a.accumulate(&b);
     assert_eq!(a.total_tokens, 450);

--- a/crates/tiangong-types/src/token.rs
+++ b/crates/tiangong-types/src/token.rs
@@ -8,6 +8,10 @@ pub struct TokenUsage {
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
     pub total_tokens: usize,
+    #[serde(default)]
+    pub prompt_cache_hit_tokens: Option<usize>,
+    #[serde(default)]
+    pub prompt_cache_miss_tokens: Option<usize>,
 }
 
 impl TokenUsage {
@@ -16,5 +20,17 @@ impl TokenUsage {
         self.prompt_tokens += other.prompt_tokens;
         self.completion_tokens += other.completion_tokens;
         self.total_tokens += other.total_tokens;
+        if let (Some(a), Some(b)) = (
+            self.prompt_cache_hit_tokens.as_mut(),
+            other.prompt_cache_hit_tokens,
+        ) {
+            *a += b;
+        }
+        if let (Some(a), Some(b)) = (
+            self.prompt_cache_miss_tokens.as_mut(),
+            other.prompt_cache_miss_tokens,
+        ) {
+            *a += b;
+        }
     }
 }

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -39,7 +39,7 @@
 #### 模型配置
 - 模型配置必须独立为 `models.json`，采用 Provider 与 Model 分离设计。
 - Provider 层只定义连接信息（`base_url`、`api_key`、`timeout_ms`），可被多个模型共享。
-- Provider 层必须支持声明请求协议类型，至少包含 `openai_compatible` 与 `anthropic` 两种协议；未显式配置时默认按 `openai_compatible` 处理。
+- Provider 层必须支持声明请求协议类型，至少包含 `openai_compatible`、`anthropic` 与 `deepseek` 三种协议；未显式配置时默认按 `openai_compatible` 处理。
 - Model 层引用 Provider，声明实际模型 ID 和能力列表（`capabilities`），携带专属参数（`options`）。
 - 能力类型包括：`chat`（常规对话/推理）、`lite`（轻量文本）、`multimodal`（多模态理解）、`embedding`（通用向量嵌入）、`rerank`（通用结果重排）、`image_generation`（图片生成）、`video_generation`（视频生成）、`stt`（语音识别）、`tts`（语音合成）。
 - 一个模型可声明多种能力（如 gpt-4o 同时支持 chat 和 multimodal）。
@@ -51,7 +51,8 @@
 - `api_key` 必须支持环境变量引用（`${ENV_VAR}` 语法），避免明文存储。
 - 核心对话链路必须按 Provider 协议动态构建请求，不允许将所有聊天模型强制视为 OpenAI 兼容接口。
 - 当 `chat` 或 `lite` routing 指向 `anthropic` Provider 时，必须支持 Anthropic Messages 请求格式的同步、流式、工具调用与轻量模型调用，并保持 CLI/GUI/Server 行为一致。
-- Rust 侧 LLM 协议层必须沉淀为独立库（当前为 `tiangong-llm`），由该库统一维护 Provider 抽象、领域模型与错误边界；Anthropic 适配层必须拆分为独立 crate `tiangong-anthropic`，由该 crate 内部使用 `reqwest + serde` 原生实现 Anthropic Messages 与 SSE 解析，并通过 `tiangong-llm` 接入上层；OpenAI 兼容适配层内部可接入 `async-openai`，但第三方 SDK 类型不允许泄漏到上层业务。
+- 当 `chat` 或 `lite` routing 指向 `deepseek` Provider 时，必须支持 DeepSeek Chat Completions 请求格式的同步、流式、工具调用与轻量模型调用，包括思考模式（thinking）控制、reasoning_effort 映射（Low/Medium/High → high，Max → max）以及上下文缓存 token 报告，并保持 CLI/GUI/Server 行为一致。
+- Rust 侧 LLM 协议层必须沉淀为独立库（当前为 `tiangong-llm`），由该库统一维护 Provider 抽象、领域模型与错误边界；Anthropic 适配层必须拆分为独立 crate `tiangong-anthropic`，DeepSeek 适配层必须拆分为独立 crate `tiangong-deepseek`，由该 crate 内部使用 `reqwest + serde` 原生实现 DeepSeek Chat Completions 与 SSE 解析，并通过 `tiangong-llm` 接入上层；OpenAI 兼容适配层内部可接入 `async-openai`，但第三方 SDK 类型不允许泄漏到上层业务。
 - 必须维护 `tiangong-llm` 的架构约束文档，明确其职责仅限统一抽象、Provider 封装、请求/响应映射、错误边界与流事件边界；新增协议或修复兼容问题时不得继续将 transport、业务规则和上层策略堆叠进该 crate，后续若需拆分 transport 或共享执行器，必须以该文档为准。
 
 #### Server 模式

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -666,7 +666,7 @@ function MemoryModelSelectSection({
 // ---------------------------------------------------------------------------
 
 const DEFAULT_PROVIDERS: Record<string, ProviderConfigView> = {
-  'DeepSeek': { base_url: 'https://api.deepseek.com', api_key: '', timeout_ms: 300000, protocol: 'openai_compatible' },
+  'DeepSeek': { base_url: 'https://api.deepseek.com', api_key: '', timeout_ms: 300000, protocol: 'deepseek' },
   '智谱': { base_url: 'https://open.bigmodel.cn/api/paas/v4', api_key: '', timeout_ms: 300000, protocol: 'openai_compatible' },
 };
 
@@ -677,10 +677,6 @@ interface UrlPreset {
 }
 
 const DEFAULT_PROVIDER_URL_PRESETS: Record<string, UrlPreset[]> = {
-  'DeepSeek': [
-    { label: 'OpenAI 兼容', url: 'https://api.deepseek.com', protocol: 'openai_compatible' },
-    { label: 'Anthropic 兼容', url: 'https://api.deepseek.com/anthropic', protocol: 'anthropic' },
-  ],
   '智谱': [
     { label: 'OpenAI 兼容（通用）', url: 'https://open.bigmodel.cn/api/paas/v4', protocol: 'openai_compatible' },
     { label: 'OpenAI 兼容（Coding 套餐）', url: 'https://open.bigmodel.cn/api/coding/paas/v4', protocol: 'openai_compatible' },
@@ -924,6 +920,37 @@ function ProviderModelsView({
     try { setTtsVoices(await api.listTtsVoices()); } catch { setTtsVoices([]); } finally { setIsFetchingVoices(false); }
   };
 
+  // DeepSeek 自动获取模型：选中 DeepSeek 且有 api-key 时自动拉取并填充
+  useEffect(() => {
+    if (activeProvider !== 'DeepSeek' || !selectedConfig?.api_key?.trim()) return;
+    if (isFetchingModels) return;
+
+    let cancelled = false;
+    const autoFetch = async () => {
+      const provider = config.providers[activeProvider];
+      if (!provider?.base_url || !provider?.api_key) return;
+      setIsFetchingModels(true);
+      try {
+        const models = await api.fetchProviderModels(provider.base_url, provider.api_key, provider.timeout_ms, provider.protocol);
+        if (cancelled || models.length === 0) return;
+        const next = { ...config };
+        for (const modelId of models) {
+          if (!next.models[modelId]) {
+            next.models = { ...next.models, [modelId]: { provider: activeProvider, model: modelId, capabilities: ['chat'], options: {} } };
+          }
+        }
+        onChange(next);
+      } catch {
+        // 静默失败，不影响 UI
+      } finally {
+        if (!cancelled) setIsFetchingModels(false);
+      }
+    };
+    autoFetch();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeProvider, selectedConfig?.api_key]);
+
   const probeEmbeddingDimension = async () => {
     const provider = config.providers[modelDraft.provider];
     if (!provider?.base_url || !modelDraft.model.trim()) {
@@ -1016,6 +1043,7 @@ function ProviderModelsView({
                   </div>
                   <p className="text-xs text-muted-foreground mt-1">支持 {'${ENV_VAR}'} 引用环境变量</p>
                 </div>
+                {activeProvider !== 'DeepSeek' && (
                 <div>
                   <Label className="text-xs">Base URL</Label>
                   {(() => {
@@ -1070,7 +1098,9 @@ function ProviderModelsView({
                     );
                   })()}
                 </div>
+                )}
                 <div className="flex gap-3">
+                  {activeProvider !== 'DeepSeek' && (
                   <div className="flex-1">
                     <Label className="text-xs">协议</Label>
                     <Select
@@ -1088,6 +1118,7 @@ function ProviderModelsView({
                       </SelectContent>
                     </Select>
                   </div>
+                  )}
                   <div className="w-32">
                     <Label className="text-xs">超时 (ms)</Label>
                     <Input

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -714,7 +714,7 @@ function ProviderBalanceSection({ providerName }: { providerName: string }) {
 
   return (
     <div className="mt-3 pt-3 border-t">
-      <div className="flex items-center gap-2 mb-2">
+      <div className="flex items-center gap-3 flex-wrap">
         <Label className="text-xs">账户余额</Label>
         <Button
           size="sm"
@@ -725,24 +725,22 @@ function ProviderBalanceSection({ providerName }: { providerName: string }) {
         >
           {loading ? '查询中...' : '查询余额'}
         </Button>
-      </div>
-      {error && <p className="text-xs text-destructive">{error}</p>}
-      {balance && (
-        <div className="space-y-1">
-          <div className="flex items-center gap-2 text-xs">
-            <span className={balance.is_available ? 'text-green-500' : 'text-destructive'}>
+        {error && <span className="text-xs text-destructive">{error}</span>}
+        {balance && (
+          <div className="flex items-center gap-3 flex-wrap">
+            <span className={`text-xs font-medium ${balance.is_available ? 'text-green-500' : 'text-destructive'}`}>
               {balance.is_available ? '可用' : '不可用'}
             </span>
+            {balance.balance_infos.map((info, i) => (
+              <span key={i} className="text-xs text-muted-foreground">
+                {info.currency === 'CNY' ? '¥' : '$'}{info.total_balance}
+                <span className="ml-1.5 opacity-70">充值 {info.topped_up_balance}</span>
+                <span className="ml-1.5 opacity-70">赠金 {info.granted_balance}</span>
+              </span>
+            ))}
           </div>
-          {balance.balance_infos.map((info, i) => (
-            <div key={i} className="text-xs text-muted-foreground flex gap-3">
-              <span>{info.currency === 'CNY' ? '¥' : '$'}{info.total_balance}</span>
-              <span>充值 {info.topped_up_balance}</span>
-              <span>赠金 {info.granted_balance}</span>
-            </div>
-          ))}
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- 创建独立的 `tiangong-deepseek` crate，参照 async-openai 模式封装 DeepSeek API，支持对话补全（含流式）、模型列表、余额查询三个能力模块，全异步设计
- 在 `tiangong-llm` 中添加 `providers/deepseek/` 适配层，实现 `LlmProvider` trait，接入 Provider 调度系统
- 设置页 DeepSeek 供应商固定 `deepseek` 协议，隐藏 Base URL 和协议选择，填写 API Key 后自动获取模型列表
- 加载配置时自动迁移已保存的 DeepSeek 旧协议为 `deepseek`
- 扩展 `TokenUsage` / `TokenUsageData` 支持 `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`
- 24 个单元测试覆盖类型序列化、流式解析、余额响应等

## Test plan

- [x] `cargo check --workspace` 编译通过
- [x] `cargo clippy --workspace --all-targets --tests --benches -- -D warnings` 无警告
- [x] `cargo fmt -- --check` 格式正确
- [x] `cargo nextest run --workspace` 测试通过
- [x] `yarn build` 前端构建通过
- [x] 手动验证：设置页填写 DeepSeek API Key 后自动拉取模型列表
- [x] 手动验证：余额查询功能正常
- [x] 手动验证：对话使用 deepseek 协议正常工作