### PR TITLE
fix(gui): 修复 Markdown 回复中本地图片路径无法显示

### DIFF
--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -934,6 +934,13 @@ function resolveAssetUrl(url: string): string {
   return url;
 }
 
+function resolveMarkdownImages(md: string): string {
+  return md.replace(
+    /(!\[[^\]]*\]\()(\/[^\s)]+)(\))/g,
+    (_, prefix, path, suffix) => prefix + resolveAssetUrl(path) + suffix,
+  );
+}
+
 function renderContentMedia(message: MessageItem) {
   const content = Array.isArray(message.content) ? message.content : [];
   const mediaBlocks = content.filter((b) => b.type === 'media');
@@ -1019,7 +1026,7 @@ function StreamingMessage({
       {reasoningContent && (
         <ThinkingBlock content={reasoningContent} defaultExpanded={false} />
       )}
-      <MdPreview modelValue={content} theme={resolvedTheme} previewTheme="github" />
+      <MdPreview modelValue={resolveMarkdownImages(content)} theme={resolvedTheme} previewTheme="github" />
       {content.length > 0 && (
         <span className="inline-block w-1.5 h-4 bg-primary ml-0.5 animate-pulse" />
       )}
@@ -1452,7 +1459,7 @@ function AgentTurnView({
                 </div>
                 <div className="border-l-2 border-green-500/50 pl-3">
                   {agentReply.body ? (
-                    <MdPreview modelValue={agentReply.body} theme={resolvedTheme} previewTheme="github" />
+                    <MdPreview modelValue={resolveMarkdownImages(agentReply.body)} theme={resolvedTheme} previewTheme="github" />
                   ) : null}
                 </div>
                 {agentReply.body && <MessageActions text={agentReply.body} showTts={hasTts} />}
@@ -1469,7 +1476,7 @@ function AgentTurnView({
               ) : textContent(msg) || (msg.media && msg.media.length > 0) || msg.content.some(b => b.type === "media") ? (
                 <div>
                   {renderContentMedia(msg)}
-                  <MdPreview modelValue={textContent(msg)} theme={resolvedTheme} previewTheme="github" />
+                  <MdPreview modelValue={resolveMarkdownImages(textContent(msg))} theme={resolvedTheme} previewTheme="github" />
                 </div>
               ) : null}
               {!isStreaming && msg.content && <MessageActions text={textContent(msg)} showTts={hasTts} />}


### PR DESCRIPTION
## Summary
- 新增 `resolveMarkdownImages()` 函数，在渲染前将 Markdown 中的本地绝对路径图片（`![alt](/local/path)`）通过 `resolveAssetUrl()` 转换为 `asset://` 协议 URL
- 修复 LLM 回复中引用生成图片时因浏览器无法加载本地路径而不显示的问题

## Test plan
- [x] `yarn build` 通过
- [x] 运行应用，调用生成图片工具后确认回复中的 Markdown 图片正常显示