### PR TITLE
fix(core): 防止加载失败时 persist_app_only 覆盖 app.json

### DIFF
--- a/crates/tiangong-core/src/app_state/facade/lifecycle.rs
+++ b/crates/tiangong-core/src/app_state/facade/lifecycle.rs
@@ -73,8 +73,10 @@ impl TiangongState {
             },
         };
 
+        let mut loaded_from_disk = false;
         if let Ok(Some(loaded)) = state.load_from_disk() {
             state.apply_loaded_state(loaded);
+            loaded_from_disk = true;
         } else if let Ok(Some(legacy_loaded)) = state.load_from_legacy_disk() {
             state.apply_loaded_state(legacy_loaded);
             let _ = state.persist_to_disk();
@@ -83,13 +85,14 @@ impl TiangongState {
 
         state.migrate_legacy_skill_layout_if_needed();
 
-        if !state
-            .services
-            .repository
-            .paths()
-            .skills_config_path
-            .exists()
-            || !state.services.repository.paths().mcp_config_path.exists()
+        if loaded_from_disk
+            && (!state
+                .services
+                .repository
+                .paths()
+                .skills_config_path
+                .exists()
+                || !state.services.repository.paths().mcp_config_path.exists())
         {
             let _ = state.persist_app_only();
         }


### PR DESCRIPTION
## Summary
- 修复 `load_from_disk()` 返回 Err 时，`persist_app_only()` 将默认值写入 app.json 覆盖原有配置的问题
- 增加 `loaded_from_disk` 守卫，仅在成功从磁盘加载配置后才允许 `persist_app_only` 写入

## 修复场景
当会话文件损坏或磁盘读取异常导致 `load_from_disk()` 失败时，应用状态保留默认值（`workspace_dir` 为当前目录、`model_list` 为空等）。此时若 `persist_app_only()` 被触发，会用默认值覆盖 app.json，导致用户的 workspace_dir、model_list 等配置丢失。

## Test plan
- [x] cargo check --workspace
- [x] cargo clippy --workspace
- [x] cargo nextest run --workspace