### PR TITLE
refactor(core): 调整 ProviderProtocol 序列化为简短名称

### DIFF
--- a/crates/tiangong-llm/src/model.rs
+++ b/crates/tiangong-llm/src/model.rs
@@ -4,8 +4,7 @@ use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 
 /// Provider 协议类型。
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ProviderProtocol {
     #[default]
     OpenAiCompatible,
@@ -13,10 +12,23 @@ pub enum ProviderProtocol {
     DeepSeek,
 }
 
+impl Serialize for ProviderProtocol {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ProviderProtocol {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 impl ProviderProtocol {
     pub fn as_str(&self) -> &'static str {
         match self {
-            ProviderProtocol::OpenAiCompatible => "openai_compatible",
+            ProviderProtocol::OpenAiCompatible => "openai",
             ProviderProtocol::Anthropic => "anthropic",
             ProviderProtocol::DeepSeek => "deepseek",
         }
@@ -28,9 +40,11 @@ impl FromStr for ProviderProtocol {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim() {
-            "" | "openai_compatible" => Ok(ProviderProtocol::OpenAiCompatible),
+            "" | "openai" | "openai_compatible" | "open_ai_compatible" => {
+                Ok(ProviderProtocol::OpenAiCompatible)
+            }
             "anthropic" => Ok(ProviderProtocol::Anthropic),
-            "deepseek" => Ok(ProviderProtocol::DeepSeek),
+            "deepseek" | "deep_seek" => Ok(ProviderProtocol::DeepSeek),
             other => Err(anyhow!("不支持的 provider 协议：{other}")),
         }
     }

--- a/crates/tiangong-llm/src/providers/openai/client.rs
+++ b/crates/tiangong-llm/src/providers/openai/client.rs
@@ -78,7 +78,7 @@ impl OpenAiClient {
         let start = std::time::Instant::now();
         tracing::info!(
             operation = "openai_rerank",
-            provider = "openai_compatible",
+            provider = "openai",
             model,
             stream = false,
             attempt = 0,
@@ -94,7 +94,7 @@ impl OpenAiClient {
             let body = response.text().await.unwrap_or_default();
             tracing::warn!(
                 operation = "openai_rerank",
-                provider = "openai_compatible",
+                provider = "openai",
                 model,
                 stream = false,
                 attempt = 0,
@@ -103,7 +103,7 @@ impl OpenAiClient {
                 "OpenAI 兼容请求失败"
             );
             return Err(LlmError::Provider {
-                provider: "openai_compatible",
+                provider: "openai",
                 message: format!("Rerank API 返回错误 {status}: {body}"),
             });
         }
@@ -114,7 +114,7 @@ impl OpenAiClient {
             .map_err(|err| LlmError::Serialization(err.to_string()))?;
         tracing::info!(
             operation = "openai_rerank",
-            provider = "openai_compatible",
+            provider = "openai",
             model,
             stream = false,
             attempt = 0,
@@ -128,7 +128,7 @@ impl OpenAiClient {
         let start = std::time::Instant::now();
         tracing::info!(
             operation = "openai_list_models",
-            provider = "openai_compatible",
+            provider = "openai",
             model = "<list_models>",
             stream = false,
             attempt = 0,
@@ -153,7 +153,7 @@ impl OpenAiClient {
             let body = response.text().await.unwrap_or_default();
             tracing::warn!(
                 operation = "openai_list_models",
-                provider = "openai_compatible",
+                provider = "openai",
                 model = "<list_models>",
                 stream = false,
                 attempt = 0,
@@ -171,7 +171,7 @@ impl OpenAiClient {
                 return Err(LlmError::RateLimited(message));
             }
             return Err(LlmError::Provider {
-                provider: "openai_compatible",
+                provider: "openai",
                 message,
             });
         }
@@ -189,12 +189,12 @@ impl OpenAiClient {
             .map_err(|err| LlmError::Transport(err.to_string()))?;
         let parsed: ModelsResponse =
             serde_json::from_str(&body).map_err(|err| LlmError::Provider {
-                provider: "openai_compatible",
+                provider: "openai",
                 message: format!("failed to deserialize api response: {err}: {body}"),
             })?;
         tracing::info!(
             operation = "openai_list_models",
-            provider = "openai_compatible",
+            provider = "openai",
             model = "<list_models>",
             stream = false,
             attempt = 0,
@@ -239,7 +239,7 @@ impl OpenAiClient {
             let start = std::time::Instant::now();
             tracing::info!(
                 operation,
-                provider = "openai_compatible",
+                provider = "openai",
                 model,
                 stream,
                 attempt,
@@ -249,7 +249,7 @@ impl OpenAiClient {
                 Ok(value) => {
                     tracing::info!(
                         operation,
-                        provider = "openai_compatible",
+                        provider = "openai",
                         model,
                         stream,
                         attempt,
@@ -265,7 +265,7 @@ impl OpenAiClient {
                     }
                     tracing::warn!(
                         operation,
-                        provider = "openai_compatible",
+                        provider = "openai",
                         model,
                         stream,
                         attempt,
@@ -279,7 +279,7 @@ impl OpenAiClient {
                 Err(err) => {
                     tracing::warn!(
                         operation,
-                        provider = "openai_compatible",
+                        provider = "openai",
                         model,
                         stream,
                         attempt,

--- a/crates/tiangong-llm/src/providers/openai/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai/provider.rs
@@ -73,7 +73,7 @@ impl LlmProvider for OpenAiCompatibleProvider {
             .map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
         let response = self.client.complete(&model, payload).await?;
         parse_complete_response(&response).map_err(|err| LlmError::Provider {
-            provider: "openai_compatible",
+            provider: "openai",
             message: err.to_string(),
         })
     }

--- a/frontend/src/components/SettingsButton.tsx
+++ b/frontend/src/components/SettingsButton.tsx
@@ -62,7 +62,7 @@ export function SettingsButton() {
     base_url: '',
     api_key: '',
     timeout_ms: 60000,
-    protocol: 'openai_compatible',
+    protocol: 'openai',
   };
 
   const updateProvider = (updates: Partial<ProviderConfigView>) => {
@@ -128,14 +128,14 @@ export function SettingsButton() {
             <div className="space-y-2">
               <Label>协议类型</Label>
               <Select
-                value={firstProvider.protocol || 'openai_compatible'}
+                value={firstProvider.protocol || 'openai'}
                 onValueChange={(value) => updateProvider({ protocol: value })}
               >
                 <SelectTrigger className="bg-[#1E1E1E] border-[#3C3C3C] text-white">
                   <SelectValue placeholder="选择协议" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="openai_compatible">OpenAI 兼容</SelectItem>
+                  <SelectItem value="openai">OpenAI 兼容</SelectItem>
                   <SelectItem value="anthropic">Anthropic</SelectItem>
                 </SelectContent>
               </Select>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -667,7 +667,7 @@ function MemoryModelSelectSection({
 
 const DEFAULT_PROVIDERS: Record<string, ProviderConfigView> = {
   'DeepSeek': { base_url: 'https://api.deepseek.com', api_key: '', timeout_ms: 300000, protocol: 'deepseek' },
-  '智谱': { base_url: 'https://open.bigmodel.cn/api/paas/v4', api_key: '', timeout_ms: 300000, protocol: 'openai_compatible' },
+  '智谱': { base_url: 'https://open.bigmodel.cn/api/paas/v4', api_key: '', timeout_ms: 300000, protocol: 'openai' },
 };
 
 interface UrlPreset {
@@ -678,15 +678,15 @@ interface UrlPreset {
 
 const DEFAULT_PROVIDER_URL_PRESETS: Record<string, UrlPreset[]> = {
   '智谱': [
-    { label: 'OpenAI 兼容（通用）', url: 'https://open.bigmodel.cn/api/paas/v4', protocol: 'openai_compatible' },
-    { label: 'OpenAI 兼容（Coding 套餐）', url: 'https://open.bigmodel.cn/api/coding/paas/v4', protocol: 'openai_compatible' },
+    { label: 'OpenAI 兼容（通用）', url: 'https://open.bigmodel.cn/api/paas/v4', protocol: 'openai' },
+    { label: 'OpenAI 兼容（Coding 套餐）', url: 'https://open.bigmodel.cn/api/coding/paas/v4', protocol: 'openai' },
     { label: 'Anthropic 兼容（Coding 套餐）', url: 'https://open.bigmodel.cn/api/anthropic', protocol: 'anthropic' },
   ],
 };
 
 // 协议对应的默认 URL
 const PROTOCOL_DEFAULTS: Record<string, string> = {
-  openai_compatible: 'https://api.openai.com/v1',
+  openai: 'https://api.openai.com/v1',
   anthropic: 'https://api.anthropic.com',
 };
 
@@ -770,7 +770,7 @@ function ProviderModelsView({
   const [showAddProvider, setShowAddProvider] = useState(false);
   const [newProviderKey, setNewProviderKey] = useState('');
   const [newProviderDraft, setNewProviderDraft] = useState<ProviderConfigView>({
-    base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai_compatible',
+    base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai',
   });
   const [showNewApiKey, setShowNewApiKey] = useState(false);
 
@@ -839,7 +839,7 @@ function ProviderModelsView({
     setSelectedProvider(key);
     setShowAddProvider(false);
     setNewProviderKey('');
-    setNewProviderDraft({ base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai_compatible' });
+    setNewProviderDraft({ base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai' });
   };
 
   // ---- Model handlers ----
@@ -1008,7 +1008,7 @@ function ProviderModelsView({
           ))}
         </div>
         <div className="border-t p-2">
-          <Button size="sm" className="w-full" onClick={() => { setShowAddProvider(true); setNewProviderKey(''); setNewProviderDraft({ base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai_compatible' }); setShowNewApiKey(false); }}>
+          <Button size="sm" className="w-full" onClick={() => { setShowAddProvider(true); setNewProviderKey(''); setNewProviderDraft({ base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai' }); setShowNewApiKey(false); }}>
             <Plus className="w-3 h-3 mr-1" />自定义供应商
           </Button>
         </div>
@@ -1106,7 +1106,7 @@ function ProviderModelsView({
                   <div className="flex-1">
                     <Label className="text-xs">协议</Label>
                     <Select
-                      value={selectedConfig.protocol || 'openai_compatible'}
+                      value={selectedConfig.protocol || 'openai'}
                       onValueChange={(v) => {
                         const next = { ...config };
                         next.providers = { ...next.providers, [activeProvider]: { ...selectedConfig, protocol: v } };
@@ -1115,7 +1115,7 @@ function ProviderModelsView({
                     >
                       <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="openai_compatible">OpenAI 兼容</SelectItem>
+                        <SelectItem value="openai">OpenAI 兼容</SelectItem>
                         <SelectItem value="anthropic">Anthropic</SelectItem>
                       </SelectContent>
                     </Select>
@@ -1353,14 +1353,14 @@ function ProviderForm({
       <div>
         <Label className="text-xs">请求格式（协议类型）</Label>
         <Select
-          value={draft.protocol || 'openai_compatible'}
+          value={draft.protocol || 'openai'}
           onValueChange={handleProtocolChange}
         >
           <SelectTrigger className="text-sm h-8">
             <SelectValue placeholder="选择协议" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="openai_compatible">OpenAI 兼容</SelectItem>
+            <SelectItem value="openai">OpenAI 兼容</SelectItem>
             <SelectItem value="anthropic">Anthropic</SelectItem>
           </SelectContent>
         </Select>

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3087,8 +3087,8 @@ pub async fn probe_embedding_dimension(
 ) -> Result<usize, String> {
     use tiangong_core::models_config::ModelsConfig;
 
-    let protocol = protocol.unwrap_or_else(|| "openai_compatible".to_string());
-    if protocol != "openai_compatible" {
+    let protocol = protocol.unwrap_or_else(|| "openai".to_string());
+    if protocol != "openai" {
         return Err("Embedding 维度探测仅支持 OpenAI 兼容协议".to_string());
     }
 


### PR DESCRIPTION
## Summary
- `OpenAiCompatible` 序列化为 `openai`（原 `openai_compatible` / `open_ai_compatible`）
- `DeepSeek` 序列化为 `deepseek`（原 `deep_seek`）
- `Anthropic` 序列化为 `anthropic`（不变）
- 通过自定义 `Serialize`/`Deserialize` 实现和 `FromStr` 兼容所有旧配置值

## 向后兼容
反序列化同时接受新旧值：`openai`、`openai_compatible`、`open_ai_compatible`、`deepseek`、`deep_seek`

## Test plan
- [x] `cargo nextest run --workspace` 全部通过（含兼容性测试）
- [x] `cargo clippy` 无警告
- [x] `yarn build` 通过