### PR TITLE
fix(core): 修复损坏会话文件导致全部会话无法加载的问题

### DIFF
--- a/crates/tiangong-core/src/app_state/repository/load.rs
+++ b/crates/tiangong-core/src/app_state/repository/load.rs
@@ -15,10 +15,15 @@ impl AppRepository {
                 .unwrap_or_default();
             let mut sessions = Vec::new();
             for session_id in &session_ids {
-                if let Some(session) = self.load_session_from_disk(session_id, legacy_trust_mode)?
-                    && session.parent_session_id.is_none()
-                {
-                    sessions.push(session);
+                match self.load_session_from_disk(session_id, legacy_trust_mode) {
+                    Ok(Some(session)) if session.parent_session_id.is_none() => {
+                        sessions.push(session);
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        self.backup_corrupted_session(session_id);
+                        tracing::warn!("跳过损坏的会话文件 {session_id}: {e:#}");
+                    }
                 }
             }
 
@@ -49,10 +54,15 @@ impl AppRepository {
 
         let mut sessions = Vec::new();
         for session_id in &session_ids {
-            if let Some(session) = self.load_session_from_disk(session_id, legacy_trust_mode)?
-                && session.parent_session_id.is_none()
-            {
-                sessions.push(session);
+            match self.load_session_from_disk(session_id, legacy_trust_mode) {
+                Ok(Some(session)) if session.parent_session_id.is_none() => {
+                    sessions.push(session);
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    self.backup_corrupted_session(session_id);
+                    tracing::warn!("跳过损坏的会话文件 {session_id}: {e:#}");
+                }
             }
         }
         let active_session_id =
@@ -178,6 +188,23 @@ impl AppRepository {
             session.trust_mode = missing_trust_mode;
         }
         Ok(Some(session))
+    }
+
+    fn backup_corrupted_session(&self, session_id: &str) {
+        let path = session_storage_path(&self.paths.sessions_dir_path, session_id);
+        if !path.exists() {
+            return;
+        }
+        let backup_path = path.with_extension("corrupted");
+        let final_path = if backup_path.exists() {
+            let timestamp = chrono::Local::now().format("%Y%m%d%H%M%S");
+            path.with_extension(format!("corrupted.{timestamp}"))
+        } else {
+            backup_path
+        };
+        if let Err(e) = fs::rename(&path, &final_path) {
+            tracing::warn!("备份损坏会话文件失败 {}: {e}", final_path.display());
+        }
     }
 
     pub(in crate::app_state) fn list_session_ids_from_dir(&self) -> Result<Vec<String>> {


### PR DESCRIPTION
## Summary
- 会话文件损坏（JSON 解析失败）时不再通过 `?` 直接向上抛错导致所有会话加载失败，改为逐个 `match` 捕获错误并跳过
- 新增 `backup_corrupted_session()` 方法，将损坏的会话文件重命名为 `.corrupted` 备份，避免反复报错

## Test plan
- [ ] 手动构造一个损坏的 JSON 会话文件放入 `~/.tiangong/sessions/`，验证应用正常启动且其他会话不受影响
- [ ] 确认损坏文件被重命名为 `.corrupted` 后缀