### PR TITLE
chore(deps): 调整 tiangong-deepseek 为独立可发布到 crates.io 的配置

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9522,7 +9522,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-deepseek"
-version = "0.4.0"
+version = "0.1.0"
 dependencies = [
  "eventsource-stream",
  "futures-util",

--- a/crates/tiangong-deepseek/Cargo.toml
+++ b/crates/tiangong-deepseek/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
 name = "tiangong-deepseek"
-version.workspace = true
+version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
+description = "An asynchronous Rust client for the DeepSeek API, supporting chat completions (with SSE streaming), model listing, and balance queries."
+repository = "https://github.com/silent-rs/silent-Tiangong"
+keywords = ["deepseek", "llm", "ai", "openai", "chat"]
+categories = ["api-bindings", "asynchronous", "web-programming::http-client"]
 
 [dependencies]
-thiserror = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-reqwest = { workspace = true, default-features = false, features = ["json", "rustls", "stream"] }
-eventsource-stream = { workspace = true }
-futures-util = { workspace = true }
+thiserror = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
+eventsource-stream = "0.2"
+futures-util = "0.3"

--- a/crates/tiangong-deepseek/README.md
+++ b/crates/tiangong-deepseek/README.md
@@ -1,0 +1,79 @@
+# tiangong-deepseek
+
+An asynchronous Rust client for the [DeepSeek API](https://api-docs.deepseek.com/).
+
+## Features
+
+- **Chat Completions** — synchronous and SSE streaming, with tool calling and reasoning support
+- **Model Listing** — list available models
+- **Balance Queries** — check account balance (CNY / USD)
+- **Context Caching** — `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` exposed in usage
+- **Retryable Errors** — `DeepSeekError::is_retryable()` for transport and rate-limit failures
+
+## Quick Start
+
+```toml
+[dependencies]
+tiangong-deepseek = "0.1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+```
+
+```rust
+use tiangong_deepseek::{DeepSeekConfig, DeepSeekClient, types::*};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = DeepSeekConfig::new("your-api-key");
+    let client = DeepSeekClient::from_config(config)?;
+
+    // Chat completion
+    let response = client.chat().create(ChatCompletionRequest {
+        model: "deepseek-chat".into(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::json!("Hello!")),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }).await?;
+    println!("{}", response.choices[0].message.content.unwrap_or_default());
+
+    // Streaming
+    let stream = client.chat().create_stream(ChatCompletionRequest {
+        model: "deepseek-chat".into(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: Some(serde_json::json!("Explain Rust in one sentence.")),
+            ..Default::default()
+        }],
+        stream: Some(true),
+        ..Default::default()
+    }).await?;
+
+    use futures_util::StreamExt;
+    tokio::pin!(stream);
+    while let Some(event) = stream.next().await {
+        match event? {
+            StreamEvent::TextDelta(text) => print!("{text}"),
+            StreamEvent::Done => println!(),
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+```
+
+> `ChatMessage` fields like `name`, `tool_calls`, `tool_call_id`, and `prefix` default to `None`/`false` via `#[serde(default)]`. You can use `..Default::default()` to omit them.
+
+## API Coverage
+
+| Endpoint | Method | Status |
+|----------|--------|--------|
+| `/chat/completions` | POST | Supported (sync + SSE stream) |
+| `/models` | GET | Supported |
+| `/user/balance` | GET | Supported |
+
+## License
+
+Apache License 2.0

--- a/crates/tiangong-deepseek/src/chat.rs
+++ b/crates/tiangong-deepseek/src/chat.rs
@@ -90,5 +90,7 @@ pub(crate) fn parse_stream_chunk(data: &str) -> Result<StreamEvent, DeepSeekErro
         }
     }
 
-    Err(DeepSeekError::Stream(format!("无法解析流式块：{data}")))
+    Err(DeepSeekError::Stream(format!(
+        "failed to parse stream chunk: {data}"
+    )))
 }

--- a/crates/tiangong-deepseek/src/error.rs
+++ b/crates/tiangong-deepseek/src/error.rs
@@ -2,28 +2,28 @@ use thiserror::Error;
 
 #[derive(Debug, Error, Clone)]
 pub enum DeepSeekError {
-    #[error("配置错误：{0}")]
+    #[error("configuration error: {0}")]
     Config(String),
 
-    #[error("传输错误：{0}")]
+    #[error("transport error: {0}")]
     Transport(String),
 
-    #[error("认证失败：{0}")]
+    #[error("authentication failed: {0}")]
     Authentication(String),
 
-    #[error("请求无效：{0}")]
+    #[error("invalid request: {0}")]
     InvalidRequest(String),
 
-    #[error("请求被限流：{0}")]
+    #[error("rate limited: {0}")]
     RateLimited(String),
 
-    #[error("序列化失败：{0}")]
+    #[error("serialization error: {0}")]
     Serialization(String),
 
-    #[error("流式处理失败：{0}")]
+    #[error("stream error: {0}")]
     Stream(String),
 
-    #[error("DeepSeek API 错误：{0}")]
+    #[error("API error: {0}")]
     Api(String),
 }
 

--- a/crates/tiangong-deepseek/src/types/chat.rs
+++ b/crates/tiangong-deepseek/src/types/chat.rs
@@ -6,16 +6,17 @@ use crate::error::DeepSeekError;
 
 // ── 请求类型 ──────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum MessageRole {
     System,
+    #[default]
     User,
     Assistant,
     Tool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct ChatMessage {
     pub role: MessageRole,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,7 +82,7 @@ pub struct ThinkingConfig {
     pub budget_tokens: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct ChatCompletionRequest {
     pub model: String,
     pub messages: Vec<ChatMessage>,


### PR DESCRIPTION
## Summary
- Cargo.toml 脱离 workspace 依赖，直接指定版本号（`0.1.0`），添加 description/repository/keywords/categories 元数据
- 错误信息从中文改为英文，便于国际用户使用
- `MessageRole`、`ChatMessage`、`ChatCompletionRequest` 添加 `Default` derive
- 新增 README.md（功能介绍、Quick Start 示例、API 覆盖表格）

## 发布状态
已成功发布到 crates.io: https://crates.io/crates/tiangong-deepseek

## Test plan
- [x] `cargo check -p tiangong-deepseek` 通过
- [x] `cargo clippy -p tiangong-deepseek` 无警告
- [x] `cargo nextest run -p tiangong-deepseek` 24 个测试全部通过
- [x] `cargo publish -p tiangong-deepseek --dry-run` 成功
- [x] `cargo publish -p tiangong-deepseek` 已发布