### PR TITLE
fix(core): 修复删除 MCP server 后重启又被重新加载的问题

### DIFF
--- a/crates/tiangong-core/src/app_state/facade/storage.rs
+++ b/crates/tiangong-core/src/app_state/facade/storage.rs
@@ -33,6 +33,16 @@ impl TiangongState {
             .sync_mcp_dependency_lock(&self.store.agent.agent_config)
     }
 
+    /// 持久化 agent 配置但跳过 MCP 磁盘合并，用于删除操作。
+    pub(in crate::app_state) fn persist_agent_configs_no_merge_mcp(&self) -> Result<()> {
+        self.services
+            .repository
+            .persist_agent_configs_no_merge_mcp(&self.store.agent.agent_config)?;
+        self.services
+            .repository
+            .sync_mcp_dependency_lock(&self.store.agent.agent_config)
+    }
+
     pub(in crate::app_state) fn persist_to_disk(&mut self) -> Result<()> {
         self.normalize_sessions_for_storage();
         self.services.repository.persist_to_disk(&self.store)

--- a/crates/tiangong-core/src/app_state/repository/persist.rs
+++ b/crates/tiangong-core/src/app_state/repository/persist.rs
@@ -110,6 +110,25 @@ impl AppRepository {
         &self,
         agent_config: &AgentConfig,
     ) -> Result<()> {
+        self.persist_agent_configs_inner(agent_config, true)
+    }
+
+    /// 持久化 agent 配置但跳过 MCP 磁盘合并。
+    ///
+    /// 删除操作必须使用此方法，否则 `merge_mcp_with_disk` 会将磁盘上刚被删除的
+    /// server 视为"其他进程新增"而重新加回，导致删除无法持久化。
+    pub(in crate::app_state) fn persist_agent_configs_no_merge_mcp(
+        &self,
+        agent_config: &AgentConfig,
+    ) -> Result<()> {
+        self.persist_agent_configs_inner(agent_config, false)
+    }
+
+    fn persist_agent_configs_inner(
+        &self,
+        agent_config: &AgentConfig,
+        merge_mcp: bool,
+    ) -> Result<()> {
         ensure_parent_dir(&self.paths.skills_config_path)?;
         ensure_parent_dir(&self.paths.mcp_config_path)?;
 
@@ -127,10 +146,14 @@ impl AppRepository {
             )
         })?;
 
-        // --- mcp.json：合并磁盘上其他进程新增的 server ---
-        let merged_mcp = self.merge_mcp_with_disk(&agent_config.mcp)?;
+        // --- mcp.json ---
+        let final_mcp = if merge_mcp {
+            self.merge_mcp_with_disk(&agent_config.mcp)?
+        } else {
+            agent_config.mcp.clone()
+        };
         let mcp_content =
-            serde_json::to_string_pretty(&merged_mcp).context("序列化 mcp 配置失败")?;
+            serde_json::to_string_pretty(&final_mcp).context("序列化 mcp 配置失败")?;
         fs::write(&self.paths.mcp_config_path, mcp_content).with_context(|| {
             format!(
                 "写入 mcp 配置失败：{}",

--- a/crates/tiangong-core/src/app_state/services/mcp.rs
+++ b/crates/tiangong-core/src/app_state/services/mcp.rs
@@ -150,7 +150,9 @@ impl AppMcpService {
         validate_agent_config(&state.store.agent.agent_config)?;
         state.rebuild_runtime_for_agent_config();
         state.persist_app_only()?;
-        state.persist_agent_configs_only()?;
+        // 跳过 MCP 磁盘合并：否则 merge_mcp_with_disk 会将刚删除的 server
+        // 视为"其他进程新增"而重新加回，导致删除无法持久化。
+        state.persist_agent_configs_no_merge_mcp()?;
         audit::append_audit_log(&audit::AuditEntry::new(
             "mcp.remove",
             name,


### PR DESCRIPTION
## Summary

- 修复删除 MCP server 后重启应用又被重新加载的问题
- 根因：`remove_mcp_server` 持久化时调用 `merge_mcp_with_disk`，该合并逻辑将磁盘上刚被删除的 server 视为"其他进程新增"而重新加回
- 新增 `persist_agent_configs_no_merge_mcp` 方法，删除操作跳过 MCP 磁盘合并，其他操作（注册、启用/禁用）保留多进程合并能力

## Test plan

- [x] 删除一个 MCP server，重启应用，确认该 server 不再出现
- [x] 注册新的 MCP server，重启应用，确认注册正常保留
- [x] 启用/禁用 MCP server，重启应用，确认状态正确