### PR TITLE
feat(build): 添加阿里云 OSS 更新渠道

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,3 +227,92 @@ jobs:
           updaterJsonPreferNsis: true
           assetNamePattern: "Tiangong_[version]_[platform]_[arch][setup][ext]"
           args: ${{ matrix.args }}
+
+  upload-to-oss:
+    name: Upload to Aliyun OSS
+    needs: publish-tauri
+    runs-on: ubuntu-22.04
+    if: ${{ needs.publish-tauri.result == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve release tag
+        id: release
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            tag="$GITHUB_REF_NAME"
+          else
+            tag="${{ inputs.tag }}"
+            if [[ -z "$tag" ]]; then
+              tag="app-v__VERSION__"
+            fi
+          fi
+          # Strip leading 'v' or 'app-v' to get bare version
+          version="${tag#app-v}"
+          version="${version#v}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          mkdir -p oss-upload
+          cd oss-upload
+
+          # Download latest.json
+          gh release download "$RELEASE_TAG" --repo "${{ github.repository }}" \
+            --pattern "latest.json" --clobber
+
+          # Download all platform installers and signatures
+          gh release download "$RELEASE_TAG" --repo "${{ github.repository }}" \
+            --pattern "*.dmg" --pattern "*.dmg.sig" \
+            --pattern "*.AppImage" --pattern "*.AppImage.sig" \
+            --pattern "*-setup.exe" --pattern "*-setup.exe.sig" \
+            --clobber || true
+
+      - name: Prepare OSS latest.json
+        working-directory: oss-upload
+        run: |
+          # Replace GitHub download URLs with OSS URLs in latest.json
+          sed -i \
+            's|https://github.com/${{ github.repository }}/releases/download/|https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/|g' \
+            latest.json
+
+          echo "--- OSS latest.json ---"
+          cat latest.json
+
+      - name: Install ossutil
+        run: |
+          curl -fsSL https://gosspublic.alicdn.com/ossutil/1.7.18/ossutil-v1.7.18-linux-amd64.zip -o /tmp/ossutil.zip
+          unzip -o /tmp/ossutil.zip -d /tmp/ossutil
+          sudo cp /tmp/ossutil/ossutil-v1.7.18-linux-amd64/ossutil /usr/local/bin/ossutil
+
+      - name: Configure ossutil
+        run: |
+          ossutil config \
+            -e oss-cn-hangzhou.aliyuncs.com \
+            -i "${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}" \
+            -k "${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}"
+
+      - name: Upload version assets to OSS
+        working-directory: oss-upload
+        run: |
+          VERSION="${{ steps.release.outputs.version }}"
+          echo "Uploading version assets to OSS: v${VERSION}/"
+
+          # Upload installers and signatures to versioned path
+          for f in *.dmg *.dmg.sig *.AppImage *.AppImage.sig *-setup.exe *-setup.exe.sig; do
+            if [[ -f "$f" ]]; then
+              echo "  Uploading $f -> v${VERSION}/${f}"
+              ossutil cp "$f" "oss://silent-tiangong/v${VERSION}/${f}" -f
+            fi
+          done
+
+      - name: Upload latest.json to OSS
+        working-directory: oss-upload
+        run: |
+          echo "Uploading latest.json to OSS root"
+          ossutil cp latest.json "oss://silent-tiangong/latest.json" -f

--- a/crates/tiangong-entry/src/update.rs
+++ b/crates/tiangong-entry/src/update.rs
@@ -59,10 +59,10 @@ pub(crate) fn run_update_command(args: UpdateArgs) -> anyhow::Result<()> {
         }
     }
 
-    if let Some(err) = last_error {
-        if manifest.is_none() {
-            return Err(err);
-        }
+    if let Some(err) = last_error
+        && manifest.is_none()
+    {
+        return Err(err);
     }
 
     let Some(manifest) = manifest else {

--- a/crates/tiangong-entry/src/update.rs
+++ b/crates/tiangong-entry/src/update.rs
@@ -7,8 +7,10 @@ use serde::Deserialize;
 
 use crate::args::UpdateArgs;
 
-const DEFAULT_UPDATE_ENDPOINT: &str =
-    "https://github.com/silent-rs/silent-Tiangong/releases/latest/download/latest.json";
+const UPDATE_ENDPOINTS: &[&str] = &[
+    "https://github.com/silent-rs/silent-Tiangong/releases/latest/download/latest.json",
+    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/latest.json",
+];
 
 #[derive(Debug, Deserialize)]
 struct ReleaseManifest {
@@ -28,14 +30,40 @@ struct ReleasePlatform {
 }
 
 pub(crate) fn run_update_command(args: UpdateArgs) -> anyhow::Result<()> {
-    let endpoint = args
+    let endpoints: Vec<&str> = if let Some(custom) = args
         .endpoint
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(DEFAULT_UPDATE_ENDPOINT);
+    {
+        vec![custom]
+    } else {
+        UPDATE_ENDPOINTS.to_vec()
+    };
 
-    let Some(manifest) = fetch_release_manifest(endpoint)? else {
+    let mut manifest = None;
+    let mut last_error = None;
+    for endpoint in &endpoints {
+        match fetch_release_manifest(endpoint) {
+            Ok(Some(m)) => {
+                manifest = Some(m);
+                break;
+            }
+            Ok(None) => {
+                // 404 — 没有发布，继续尝试下一个
+                last_error = None;
+            }
+            Err(e) => {
+                last_error = Some(e);
+            }
+        }
+    }
+
+    if last_error.is_some() && manifest.is_none() {
+        return Err(last_error.unwrap());
+    }
+
+    let Some(manifest) = manifest else {
         println!("当前没有可用的在线更新发布。");
         return Ok(());
     };

--- a/crates/tiangong-entry/src/update.rs
+++ b/crates/tiangong-entry/src/update.rs
@@ -59,8 +59,10 @@ pub(crate) fn run_update_command(args: UpdateArgs) -> anyhow::Result<()> {
         }
     }
 
-    if last_error.is_some() && manifest.is_none() {
-        return Err(last_error.unwrap());
+    if let Some(err) = last_error {
+        if manifest.is_none() {
+            return Err(err);
+        }
     }
 
     let Some(manifest) = manifest else {

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -2507,7 +2507,7 @@ function AppUpdateSettings() {
               <div className="text-sm text-muted-foreground">当前版本</div>
               <div className="mt-1 text-2xl font-semibold">{currentVersion || '读取中...'}</div>
             </div>
-            <Badge variant="outline">GitHub Release</Badge>
+            <Badge variant="outline">GitHub / OSS</Badge>
           </div>
 
           {availableUpdate ? (
@@ -2525,7 +2525,7 @@ function AppUpdateSettings() {
             </div>
           ) : (
             <div className="rounded-md border p-3 text-sm text-muted-foreground">
-              更新检查会从 GitHub Release 获取最新版本信息。
+              更新检查会依次从 GitHub Release 和阿里云 OSS 获取最新版本信息。
             </div>
           )}
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,7 +53,8 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERBQUE2RDc2MjQwN0I5QzMKUldURHVRY2tkbTJxMmtTTnJnZk9GSVd3amFmb3VoYjVmdFdGbHZCRHZ1VVZCeS9JcS8rUHBVVDgK",
       "endpoints": [
-        "https://github.com/silent-rs/silent-Tiangong/releases/latest/download/latest.json"
+        "https://github.com/silent-rs/silent-Tiangong/releases/latest/download/latest.json",
+        "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/latest.json"
       ],
       "windows": {
         "installMode": "passive"


### PR DESCRIPTION
## Summary

- 添加阿里云 OSS（bucket: `silent-tiangong`）作为 GitHub 的备用更新源
- GUI 更新：tauri.conf.json endpoints 支持 fallback（GitHub → OSS）
- CLI 更新：依次尝试多个 endpoint，第一个成功即返回
- 前端 UI 提示体现 GitHub / OSS 双渠道
- 发布流程：release.yml 新增 `upload-to-oss` job，构建完成后自动将安装包和 latest.json 同步到 OSS

## 所需 GitHub Secrets

发布前需在仓库 Settings → Secrets 中添加：
- `ALIYUN_OSS_ACCESS_KEY_ID` — 阿里云 AccessKey ID
- `ALIYUN_OSS_ACCESS_KEY_SECRET` — 阿里云 AccessKey Secret

## OSS 路径结构

```
silent-tiangong.oss-cn-hangzhou.aliyuncs.com/
  latest.json
  v0.4.1/
    Tiangong_0.4.1_macOS_aarch64.dmg
    Tiangong_0.4.1_macOS_aarch64.dmg.sig
    ...
```

## Test plan

- [x] 推送 tag 触发发布后，检查 GitHub Release 构建成功
- [x] 检查 OSS bucket 中 latest.json 和安装包是否上传成功
- [x] 手动将 endpoints 只保留 OSS 地址测试更新检查是否正常
- [x] CLI 运行 `tiangong update --check` 验证多 endpoint fallback