### PR TITLE
fix: Windows 运行时错误修复

### DIFF
--- a/crates/tiangong-core/src/memory/registry.rs
+++ b/crates/tiangong-core/src/memory/registry.rs
@@ -197,7 +197,7 @@ pub(crate) async fn get_or_init_memory_async(
             Some(handle)
         }
         Err(err) => {
-            tracing::warn!("Memory 启动或连接失败（非致命）: {}", err);
+            tracing::debug!("Memory 启动或连接失败（非致命）: {}", err);
             None
         }
     }

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -711,9 +711,11 @@ impl ReactEngine {
                         }
                     }
                     let err_msg = err.to_string();
-                    // 上下文超限时强制压缩后重试
+                    // 上下文超限或空响应时强制压缩后重试
                     if err_msg.contains("context_window_exceeded")
                         || err_msg.contains("context_length_exceeded")
+                        || (err_msg.contains("content_blocks=0")
+                            && err_msg.contains("stop_reason=end_turn"))
                     {
                         tracing::warn!("检测到上下文超限，尝试强制压缩");
                         let before_summary_up_to = session.summary_up_to;

--- a/crates/tiangong-core/src/tool/search_code.rs
+++ b/crates/tiangong-core/src/tool/search_code.rs
@@ -65,6 +65,12 @@ impl LocalToolExecutor {
         };
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        // 超时时 stdout 可能非常大（日志文件等），截断避免撑爆上下文
+        let stdout = if timed_out {
+            super::common::truncate_output(&stdout)
+        } else {
+            stdout
+        };
         let ok = !timed_out && (output.status.success() || exit_code == 1);
         let summary = if timed_out {
             format!("代码检索超时：pattern={pattern} (timeout_ms={timeout_ms})")

--- a/crates/tiangong-memory/src/election/mod.rs
+++ b/crates/tiangong-memory/src/election/mod.rs
@@ -165,11 +165,17 @@ fn read_leader_info_from_path(path: &PathBuf) -> Result<Option<LeaderInfo>> {
     if !path.exists() {
         return Ok(None);
     }
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("读取 leader 信息失败: {}", path.display()))?;
-    let info = serde_json::from_str(&content)
-        .with_context(|| format!("解析 leader 信息失败: {}", path.display()))?;
-    Ok(Some(info))
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Ok(None),
+    };
+    match serde_json::from_str(&content) {
+        Ok(info) => Ok(Some(info)),
+        Err(_) => {
+            tracing::debug!("leader.json 内容损坏，已忽略：{}", path.display());
+            Ok(None)
+        }
+    }
 }
 
 /// 判断给定 leader 是否仍然健康。


### PR DESCRIPTION
## Summary

- Memory leader.json 损坏时降级为无 leader 并触发重新选举，而非阻断启动
- Memory 启动失败日志从 WARN 降级为 DEBUG，避免日志刷屏
- search_code 超时时截断 stdout 到 6000 字符，防止撑爆上下文
- LLM 返回空响应（content_blocks=0 + end_turn）时自动压缩重试

## Test plan

- [x] Windows 环境下删除 `leader.json` 内容后启动，Memory 应正常重新选举
- [x] `search_code` 在大日志目录上超时时，返回内容不超过 6000 字符
- [x] 对话中触发空响应时，自动压缩上下文并重试而非报错