### PR TITLE
feat(gui): 定期自动检查更新并在标题栏提示

### DIFF
--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -84,16 +84,6 @@ export function SettingsDialog() {
               {(saveStatus === 'saved' || saveStatus === 'idle') && '已自动保存'}
               {saveStatus === 'error' && '保存失败'}
             </span>
-            <Button
-              data-no-drag
-              variant="ghost"
-              size="icon"
-              className="ml-1 h-7 w-7 shrink-0"
-              onClick={() => setOpen(false)}
-            >
-              <X className="h-4 w-4" />
-              <span className="sr-only">退出设置</span>
-            </Button>
           </header>
 
           <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 overflow-hidden flex">

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -29,7 +29,19 @@ type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 
 export function SettingsDialog() {
   const [open, setOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState('agent');
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+  const pendingSettingsTab = useStore((s) => s.pendingSettingsTab);
+  const setPendingSettingsTab = useStore((s) => s.setPendingSettingsTab);
+
+  // 响应外部触发打开设置页
+  useEffect(() => {
+    if (pendingSettingsTab) {
+      setActiveTab(pendingSettingsTab);
+      setOpen(true);
+      setPendingSettingsTab(null);
+    }
+  }, [pendingSettingsTab, setPendingSettingsTab]);
 
   useEffect(() => {
     if (!open) {
@@ -84,7 +96,7 @@ export function SettingsDialog() {
             </Button>
           </header>
 
-          <Tabs defaultValue="agent" className="flex-1 overflow-hidden flex">
+          <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 overflow-hidden flex">
             <aside className="w-60 shrink-0 border-r bg-muted/30 flex flex-col">
               <TabsList className="h-auto w-full flex-1 flex-col items-stretch justify-start rounded-none bg-transparent p-2 pt-4">
                 <TabsTrigger value="agent" className="w-full justify-start px-3 py-2">

--- a/frontend/src/components/StatusPanel.tsx
+++ b/frontend/src/components/StatusPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, KeyboardEvent } from 'react';
 import { useStore } from '@/store/useStore';
 import { api } from '@/api/tauri';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { Sun, Moon, Monitor, PanelLeft, SquarePen, Volume2, VolumeX, AudioLines, Globe } from 'lucide-react';
+import { Sun, Moon, Monitor, PanelLeft, SquarePen, Volume2, VolumeX, AudioLines, Globe, ArrowUpCircle } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { useStreamingTts } from '@/hooks/useStreamingTts';
 import { Separator } from './ui/separator';
@@ -23,7 +23,7 @@ interface StatusPanelProps {
 }
 
 export function StatusPanel({ showBrowser, onToggleBrowser }: StatusPanelProps) {
-  const { activeSessionId, isDraft, sessions, loadSessions, createSession } = useStore();
+  const { activeSessionId, isDraft, sessions, loadSessions, createSession, updateAvailable, setPendingSettingsTab } = useStore();
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -185,6 +185,17 @@ export function StatusPanel({ showBrowser, onToggleBrowser }: StatusPanelProps) 
             ) : (
               <VolumeX className="w-3.5 h-3.5" />
             )}
+          </button>
+        )}
+        {updateAvailable && (
+          <button
+            data-no-drag
+            onClick={() => setPendingSettingsTab('about')}
+            className="flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium text-white bg-sky-500 hover:bg-sky-400 transition-colors"
+            title={`发现新版本 ${updateAvailable.version}，点击查看`}
+          >
+            <ArrowUpCircle className="w-3.5 h-3.5" />
+            <span>v{updateAvailable.version}</span>
           </button>
         )}
         <button

--- a/frontend/src/hooks/useUpdateCheck.ts
+++ b/frontend/src/hooks/useUpdateCheck.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import { useStore } from '@/store/useStore';
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+const INITIAL_DELAY_MS = 5000; // 5s
+
+export function useUpdateCheck() {
+  const setUpdateAvailable = useStore((s) => s.setUpdateAvailable);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const doCheck = async () => {
+      if (cancelled) return;
+      try {
+        const { check } = await import('@tauri-apps/plugin-updater');
+        const update = await check({ timeout: 30000 });
+        if (cancelled) return;
+        if (update) {
+          setUpdateAvailable({
+            version: update.version,
+            body: update.body ?? undefined,
+            date: update.date ?? undefined,
+          });
+        }
+        await update?.close().catch(() => {});
+      } catch {
+        // 静默失败，不打扰用户
+      }
+    };
+
+    timerRef.current = setTimeout(() => {
+      doCheck();
+      intervalRef.current = setInterval(doCheck, CHECK_INTERVAL_MS);
+    }, INITIAL_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [setUpdateAvailable]);
+}

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -6,6 +6,7 @@ import { SidebarProvider } from '@/components/ui/sidebar';
 import { LazyMessageList, LazyMessageInput, LazyStatusPanel } from '@/components/LazyComponents';
 import { BrowserPanel } from '@/components/BrowserPanel';
 import { ensureDesktopNotificationPermission } from '@/utils/desktopNotification';
+import { useUpdateCheck } from '@/hooks/useUpdateCheck';
 import type { UnlistenFn } from '@tauri-apps/api/event';
 import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window';
 
@@ -46,6 +47,7 @@ async function expandWindowForBrowser(lock?: () => void, unlock?: () => void) {
 
 export function MainApp() {
   const { loadSessions, updateFromSnapshot } = useStore();
+  useUpdateCheck();
   const [showBrowser, setShowBrowser] = useState(false);
   const [chatPanelWidth, setChatPanelWidth] = useState(MIN_CHAT_WIDTH);
   const [browserUrl, setBrowserUrl] = useState<string | undefined>(undefined);

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -186,6 +186,14 @@ interface AppState {
   isLoadingSessions: boolean;
   isSending: boolean;
 
+  // 更新检查
+  updateAvailable: null | { version: string; body?: string; date?: string };
+  setUpdateAvailable: (info: null | { version: string; body?: string; date?: string }) => void;
+
+  // 从外部触发打开设置页到指定 tab
+  pendingSettingsTab: string | null;
+  setPendingSettingsTab: (tab: string | null) => void;
+
   // 操作
   loadSessions: () => Promise<void>;
   createSession: () => void;
@@ -229,6 +237,10 @@ export const useStore = create<AppState>((set, get) => ({
   mcpServers: null,
   skills: null,
   isDraft: true,
+  updateAvailable: null,
+  setUpdateAvailable: (info) => set({ updateAvailable: info }),
+  pendingSettingsTab: null,
+  setPendingSettingsTab: (tab) => set({ pendingSettingsTab: tab }),
   reasoningEffort: 'medium',
   reasoningEffortPerSession: {},
   setReasoningEffort: (effort: string) => {


### PR DESCRIPTION
## Summary

- 启动 5 秒后自动检查更新，之后每 24 小时定期重查
- 发现新版本时在标题栏浏览器按钮左侧显示天蓝色 `v{version}` 更新标签
- 点击更新标签直接跳转设置页"关于与更新"tab，查看版本号和更新说明
- 跨组件通信通过 Zustand store 的 `pendingSettingsTab` 实现

## Test plan

- [x] Mock 测试通过：模拟更新后标题栏显示天蓝色标签
- [x] 点击标签跳转设置页"关于与更新"tab
- [x] 正式环境发布新版本后验证自动检测