### PR TITLE
feat(core): 支持通过对话创建 Skill

### DIFF
--- a/crates/tiangong-core/src/agents/execution_prompt_agent.rs
+++ b/crates/tiangong-core/src/agents/execution_prompt_agent.rs
@@ -64,6 +64,7 @@ pub(crate) fn build_step_execution_prompt(
             .join("\n")
     };
     let mcp_function_names_text = format_mcp_function_name_hint(mcp_function_targets);
+    let skills_dir = default_skills_dir_display();
     format!(
         r#"你是执行智能体，负责执行当前 plan 步骤并确保结果可落地。
 
@@ -86,6 +87,7 @@ pub(crate) fn build_step_execution_prompt(
 13. 若配置缺失，直接执行目标业务命令并根据错误回传定位问题，不要先做环境枚举。
 14. 当前步骤支持多轮执行：若本轮尚未完成，请继续调用工具；最终必须调用 `mark_step_completed` 结束该步骤。
 15. 当工具返回成功输出时，应先判断是否已满足用户请求；若仅是中间结果，调用 `mark_step_completed(continue_execution=true)` 并提供下一步。
+16. 当用户要求创建或安装 Skill 时，使用 `write_file` 将文件写入 Skill 目录（{skills_dir}/<skill-id>/）。每个 Skill 必须包含 skill.toml（清单）和 SKILL.md（入口文档），可选包含脚本等附加文件。skill.toml 格式：id（小写字母数字短横线）、name（显示名）、version、entry="SKILL.md"、available=true、[source] type="agent"、[requires] mcp=[]、[permissions]（fs_read/fs_write/cmd_exec/net 按需声明）。创建完成后告知用户刷新 Skill 列表即可使用。
 
 用户输入：
 {user_input}
@@ -112,6 +114,7 @@ pub(crate) fn build_step_execution_prompt(
         previous_plan_result_text = previous_plan_result_text,
         skill_context = skill_context,
         mcp_function_names_text = mcp_function_names_text,
+        skills_dir = skills_dir,
         step_name = step.name,
         step_desc = step.description
     )
@@ -229,4 +232,17 @@ fn indent_multiline(text: &str, spaces: usize) -> String {
         .map(|line| format!("{pad}{line}"))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn default_skills_dir_display() -> String {
+    let home = std::env::var_os("HOME")
+        .filter(|v| !v.is_empty())
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("USERPROFILE")
+                .filter(|v| !v.is_empty())
+                .map(std::path::PathBuf::from)
+        })
+        .unwrap_or_else(|| std::path::PathBuf::from("~"));
+    home.join(".tiangong/skills").display().to_string()
 }


### PR DESCRIPTION
## Summary
- 在执行智能体 prompt 中添加 Skill 创建指引，告知 agent skill 目录路径和 skill.toml 格式
- Agent 可使用已有的 `write_file` 工具将 skill.toml + SKILL.md 写入 `~/.tiangong/skills/<id>/` 目录
- 用户在对话中提供 skill 信息（描述、URL、外部 skill 目录），agent 自动转换并写入，用户刷新 Skill 列表即可使用

## Test plan
- [x] 对话中输入"帮我创建一个 xxx skill"，agent 能正确使用 write_file 写入 skill.toml 和 SKILL.md
- [x] 创建的 skill 文件格式正确，刷新 skill 列表后可见且可用
- [x] 现有 skill 安装功能不受影响