### PR TITLE
fix(core): 强化附件解析 message_id 提示避免引用错误消息

### DIFF
--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -1244,7 +1244,7 @@ fn attachment_notice_text(msg: &Message) -> String {
         .collect();
     let items = items.join("\n");
     format!(
-        "本条用户消息包含附件，但主模型请求不会直接携带附件内容。需要查看附件内容时，请调用 analyze_attachment 工具，并指定 message_id={} 和附件 index。\n{}",
+        "本条用户消息包含附件，但主模型请求不会直接携带附件内容。需要查看附件内容时，请调用 analyze_attachment 工具，必须使用本提示中的 message_id={}（不要使用其他消息的 ID），并指定附件 index。\n{}",
         msg.id, items
     )
 }

--- a/crates/tiangong-core/src/runtime.rs
+++ b/crates/tiangong-core/src/runtime.rs
@@ -1341,7 +1341,7 @@ pub(crate) fn inject_enhanced_tools(tools: &mut Vec<ToolSpec>, engine: &RuntimeE
     if has_multimodal && !chat_is_multimodal {
         tools.push(ToolSpec {
             name: "analyze_attachment".to_string(),
-            description: "按需调用多模态模型解析用户上传的图片或文件附件。只有当用户问题确实需要查看附件内容时才调用；普通文本对话不要调用。".to_string(),
+            description: "按需调用多模态模型解析用户上传的图片或文件附件。只有当用户问题确实需要查看附件内容时才调用；普通文本对话不要调用。重要：message_id 必须使用用户消息中提示文字所标注的 ID，不要使用其他消息的 ID。".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## Summary
- 修复 `analyze_attachment` 工具在多轮对话中引用错误 `message_id` 的问题
- 在附件提示文字中强调"必须使用本提示中的 message_id，不要使用其他消息的 ID"
- 在 `analyze_attachment` 工具描述中同样强调 message_id 必须使用用户消息中标注的 ID

## 根因
Agent 调用 `analyze_attachment` 时引用了更早消息的 `message_id`，导致多模态模型解析了错误的附件（把用户的 GPU 集群管理面板识别成了之前的 API 用量面板）。

## Test plan
- [ ] 发送带附件的消息后，agent 调用 `analyze_attachment` 时使用正确的 message_id
- [ ] 多轮对话中发送不同附件，agent 能正确区分并解析最新的附件