### PR TITLE
style(components): 强化用户消息气泡样式

### DIFF
--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -340,7 +340,7 @@ function UserMessageGroup({ group, runStatus, nonEditableIds, voiceMessages, edi
         </div>
       ) : (
       <div className="flex justify-end" title={formatMessageTime(message.created_at)}>
-        <div className="max-w-[100%] text-muted-foreground">
+        <div className="max-w-[85%] rounded-2xl bg-primary/10 px-4 py-2.5 text-foreground">
           {voiceInfo ? (
             <VoiceBubble
               messageId={message.id}
@@ -1442,7 +1442,7 @@ function AgentTurnView({
         if (frag.type === "user") {
           return (
             <div key={frag.msg.id} className="flex justify-end" title={formatMessageTime(frag.msg.created_at)}>
-              <div className="max-w-[92%] rounded-md border border-border/70 bg-muted/40 px-3 py-1.5 text-sm text-muted-foreground whitespace-pre-wrap break-words">
+              <div className="max-w-[85%] rounded-2xl bg-primary/10 px-4 py-2.5 text-sm text-foreground whitespace-pre-wrap break-words">
                 {textContent(frag.msg)}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- 统一 `UserMessageGroup` 和 `AgentTurnView` 中用户消息的气泡样式
- 改为 `rounded-2xl bg-primary/10` 大圆角+主题色透明背景
- 最大宽度从 100%/92% 缩窄至 85%，文字颜色改为主色调

## Test plan
- [x] 用户消息显示为圆角气泡，有明显背景色
- [x] 深色/浅色主题下视觉正常
- [x] 编辑模式不受影响