### PR TITLE
fix(browser): 修复内嵌浏览器多项异常

### DIFF
--- a/crates/tiangong-core/src/agents/execution_prompt_agent.rs
+++ b/crates/tiangong-core/src/agents/execution_prompt_agent.rs
@@ -88,6 +88,7 @@ pub(crate) fn build_step_execution_prompt(
 14. 当前步骤支持多轮执行：若本轮尚未完成，请继续调用工具；最终必须调用 `mark_step_completed` 结束该步骤。
 15. 当工具返回成功输出时，应先判断是否已满足用户请求；若仅是中间结果，调用 `mark_step_completed(continue_execution=true)` 并提供下一步。
 16. 当用户要求创建或安装 Skill 时，使用 `write_file` 将文件写入 Skill 目录（{skills_dir}/<skill-id>/）。每个 Skill 必须包含 skill.toml（清单）和 SKILL.md（入口文档），可选包含脚本等附加文件。skill.toml 格式：id（小写字母数字短横线）、name（显示名）、version、entry="SKILL.md"、available=true、[source] type="agent"、[requires] mcp=[]、[permissions]（fs_read/fs_write/cmd_exec/net 按需声明）。创建完成后告知用户刷新 Skill 列表即可使用。
+17. 当用户要求用浏览器打开页面或本地 HTML 文件时，必须使用 `web_fetch`（传入 file:// 路径或 URL），不要使用 `run_shell` 调用系统浏览器（如 open、xdg-open）。
 
 用户输入：
 {user_input}

--- a/crates/tiangong-core/src/agents/execution_tool_agent.rs
+++ b/crates/tiangong-core/src/agents/execution_tool_agent.rs
@@ -94,7 +94,7 @@ pub(crate) fn basic_file_function_tools() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "web_fetch".to_string(),
-            description: "受控获取 HTTP/HTTPS URL。text 模式读取网页/文本正文；download 模式下载在线文件到允许写入目录，可替代 curl/wget。".to_string(),
+            description: "使用内嵌浏览器获取 URL 内容。支持 HTTP/HTTPS 网页和本地 file:// 或绝对路径的 HTML 文件。当用户要求在浏览器中打开页面或预览 HTML 时必须使用此工具，不要使用 run_shell 调用系统浏览器。".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -184,17 +184,6 @@ pub(crate) fn basic_file_function_tools() -> Vec<ToolSpec> {
                     "selector": { "type": "string", "description": "要点击的元素的 CSS 选择器" }
                 },
                 "required": ["selector"]
-            }),
-        },
-        ToolSpec {
-            name: "web_load_html".to_string(),
-            description: "在天工内嵌浏览器中加载 HTML 内容。适用于预览本地 HTML 文件、展示生成的网页内容等场景。加载后可继续使用 web_browse 等工具交互。".to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "html": { "type": "string", "description": "要加载的 HTML 内容（完整的 HTML 字符串）" }
-                },
-                "required": ["html"]
             }),
         },
         ToolSpec {

--- a/crates/tiangong-plugin-browser/src/handler.rs
+++ b/crates/tiangong-plugin-browser/src/handler.rs
@@ -225,6 +225,13 @@ pub async fn browser_command_handler(
                 let manager = BrowserManager {
                     state: browser_state.clone(),
                 };
+                // 浏览器未打开时先打开，再加载 HTML
+                if !manager.is_open() {
+                    if let Some((x, y, w, h)) = default_browser_rect(&app) {
+                        let _ = manager.open(&app, "about:blank", x, y, w, h);
+                    }
+                    let _ = app.emit("browser:open", "about:blank");
+                }
                 let result = tokio::task::spawn_blocking(move || manager.load_html(&html))
                     .await
                     .unwrap_or(Err("加载 HTML 任务失败".to_string()));

--- a/crates/tiangong-plugin-browser/src/manager.rs
+++ b/crates/tiangong-plugin-browser/src/manager.rs
@@ -248,10 +248,16 @@ impl BrowserManager {
                             Err(e) => e.into_inner(),
                         };
                         match s.webview {
-                            Some(ref wv) => match wv.url() {
-                                Ok(u) => u.to_string(),
-                                Err(_) => continue,
-                            },
+                            Some(ref wv) => {
+                                // wry 的 url() 在 WebView 无 URL 时会 panic（webview.URL().unwrap() on None），
+                                // 使用 catch_unwind 防止整个应用崩溃。
+                                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                    wv.url()
+                                })) {
+                                    Ok(Ok(u)) => u.to_string(),
+                                    _ => continue,
+                                }
+                            }
                             None => break,
                         }
                     };
@@ -340,8 +346,12 @@ impl BrowserManager {
         }
         if let Some(webview) = &state.webview {
             let parsed_url: Url = url.parse().map_err(|e| format!("URL 解析失败：{e}"))?;
-            webview
-                .navigate(parsed_url)
+            // wry 的 navigate 内部 NSURL::URLWithString 可能 panic，用 catch_unwind 保护
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                webview.navigate(parsed_url)
+            }));
+            result
+                .map_err(|_| "WebView 导航内部错误".to_string())?
                 .map_err(|e| format!("导航失败：{e}"))?;
         }
         Ok(())
@@ -359,8 +369,11 @@ impl BrowserManager {
             let parsed_url: Url = data_url
                 .parse()
                 .map_err(|e| format!("data URL 构造失败：{e}"))?;
-            webview
-                .navigate(parsed_url)
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                webview.navigate(parsed_url)
+            }));
+            result
+                .map_err(|_| "WebView 导航内部错误".to_string())?
                 .map_err(|e| format!("加载 HTML 失败：{e}"))?;
         }
         Ok(())
@@ -550,9 +563,9 @@ impl BrowserManager {
         // 导航到新标签 URL
         if let Some(webview) = &state.webview {
             let parsed_url: Url = url.parse().map_err(|e| format!("URL 解析失败：{e}"))?;
-            webview
-                .navigate(parsed_url)
-                .map_err(|e| format!("导航失败：{e}"))?;
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _ = webview.navigate(parsed_url);
+            }));
         }
         Ok(tab_id)
     }
@@ -573,9 +586,9 @@ impl BrowserManager {
         state.active_tab_id = Some(tab_id.to_string());
         if let Some(webview) = &state.webview {
             let parsed_url: Url = tab_url.parse().map_err(|e| format!("URL 解析失败：{e}"))?;
-            webview
-                .navigate(parsed_url)
-                .map_err(|e| format!("导航失败：{e}"))?;
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _ = webview.navigate(parsed_url);
+            }));
         }
         Ok(())
     }
@@ -602,7 +615,11 @@ impl BrowserManager {
                 });
                 state.active_tab_id = Some(new_id);
                 if let Some(webview) = &state.webview {
-                    let _ = webview.navigate(Url::parse("about:blank").unwrap());
+                    if let Ok(parsed_url) = Url::parse("about:blank") {
+                        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            let _ = webview.navigate(parsed_url);
+                        }));
+                    }
                 }
             } else {
                 let new_pos = pos.min(state.tabs.len() - 1);
@@ -613,7 +630,9 @@ impl BrowserManager {
                 state.active_tab_id = Some(new_id);
                 if let Some(webview) = &state.webview {
                     if let Ok(parsed_url) = new_url.parse::<Url>() {
-                        let _ = webview.navigate(parsed_url);
+                        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            let _ = webview.navigate(parsed_url);
+                        }));
                     }
                 }
             }

--- a/crates/tiangong-plugin-browser/src/page_fetcher.rs
+++ b/crates/tiangong-plugin-browser/src/page_fetcher.rs
@@ -236,13 +236,21 @@ impl BrowserToolOverride {
             .get("mode")
             .and_then(|v| v.as_str())
             .unwrap_or("text");
-        if mode != "text" {
-            return Box::pin(async { None });
-        }
         let url = match call.arguments.get("url").and_then(|v| v.as_str()) {
             Some(u) => u.to_string(),
             None => return Box::pin(async { None }),
         };
+
+        // 本地路径统一转为 file:// URL，与 HTTP 走同一条浏览器打开路径
+        let url = if url.starts_with('/') {
+            format!("file://{url}")
+        } else {
+            url
+        };
+
+        if mode != "text" {
+            return Box::pin(async { None });
+        }
         let max_chars = call
             .arguments
             .get("max_chars")
@@ -251,7 +259,19 @@ impl BrowserToolOverride {
 
         let fetcher = fetcher.clone();
         Box::pin(async move {
-            let result = fetcher.fetch_page(&url, max_chars).await?;
+            let result = match fetcher.fetch_page(&url, max_chars).await {
+                Some(r) => r,
+                None => {
+                    return Some(tiangong_core::tool::ToolResult {
+                        ok: false,
+                        summary: "浏览器获取页面失败".to_string(),
+                        stdout: String::new(),
+                        stderr: "浏览器无法获取页面内容".to_string(),
+                        exit_code: 1,
+                        execution: None,
+                    });
+                }
+            };
             let summary = if result.ok {
                 format!("浏览器获取成功：{}", result.title)
             } else {
@@ -286,7 +306,20 @@ impl BrowserToolOverride {
     > {
         let fetcher = fetcher.clone();
         Box::pin(async move {
-            let snapshot = fetcher.observe_page().await?;
+            let snapshot = match fetcher.observe_page().await {
+                Some(s) => s,
+                None => {
+                    return Some(tiangong_core::tool::ToolResult {
+                        ok: false,
+                        summary: "浏览器未打开或页面未加载".to_string(),
+                        stdout: String::new(),
+                        stderr: "请先使用 web_fetch 打开一个页面，或使用 browser_open 打开浏览器"
+                            .to_string(),
+                        exit_code: 1,
+                        execution: None,
+                    });
+                }
+            };
             let content = if snapshot.text.is_empty() {
                 format!(
                     "浏览器页面：{}\nURL：{}\n状态：页面内容为空",
@@ -316,7 +349,19 @@ impl BrowserToolOverride {
     > {
         let fetcher = fetcher.clone();
         Box::pin(async move {
-            let result = fetcher.form_extract().await?;
+            let result = match fetcher.form_extract().await {
+                Some(r) => r,
+                None => {
+                    return Some(tiangong_core::tool::ToolResult {
+                        ok: false,
+                        summary: "浏览器未打开，无法提取表单".to_string(),
+                        stdout: String::new(),
+                        stderr: "请先使用 web_fetch 打开页面".to_string(),
+                        exit_code: 1,
+                        execution: None,
+                    });
+                }
+            };
             let total_fields: usize = result.forms.iter().map(|f| f.fields.len()).sum();
             let output = serde_json::to_string_pretty(&result)
                 .unwrap_or_else(|_| "序列化表单数据失败".to_string());
@@ -361,7 +406,19 @@ impl BrowserToolOverride {
             .to_string();
         let fetcher = fetcher.clone();
         Box::pin(async move {
-            let result = fetcher.form_fill(&selector, &value, &strategy).await?;
+            let result = match fetcher.form_fill(&selector, &value, &strategy).await {
+                Some(r) => r,
+                None => {
+                    return Some(tiangong_core::tool::ToolResult {
+                        ok: false,
+                        summary: "浏览器未打开，无法填写字段".to_string(),
+                        stdout: String::new(),
+                        stderr: "请先使用 web_fetch 打开页面".to_string(),
+                        exit_code: 1,
+                        execution: None,
+                    });
+                }
+            };
             let strategy_used = result.strategy.clone().unwrap_or_default();
             if result.ok {
                 Some(tiangong_core::tool::ToolResult {
@@ -399,7 +456,19 @@ impl BrowserToolOverride {
             .to_string();
         let fetcher = fetcher.clone();
         Box::pin(async move {
-            let result = fetcher.click_element(&selector).await?;
+            let result = match fetcher.click_element(&selector).await {
+                Some(r) => r,
+                None => {
+                    return Some(tiangong_core::tool::ToolResult {
+                        ok: false,
+                        summary: "浏览器未打开，无法点击元素".to_string(),
+                        stdout: String::new(),
+                        stderr: "请先使用 web_fetch 打开页面".to_string(),
+                        exit_code: 1,
+                        execution: None,
+                    });
+                }
+            };
             if result.ok {
                 Some(tiangong_core::tool::ToolResult {
                     ok: true,
@@ -421,42 +490,6 @@ impl BrowserToolOverride {
             }
         })
     }
-
-    fn handle_web_load_html(
-        fetcher: &Arc<dyn PageFetcher>,
-        call: &tiangong_core::model::ToolCall,
-    ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Option<tiangong_core::tool::ToolResult>> + Send>,
-    > {
-        let html = call
-            .arguments
-            .get("html")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let fetcher = fetcher.clone();
-        Box::pin(async move {
-            let result = fetcher.load_html(&html).await?;
-            match result {
-                Ok(()) => Some(tiangong_core::tool::ToolResult {
-                    ok: true,
-                    summary: "HTML 内容已加载到浏览器".to_string(),
-                    stdout: String::new(),
-                    stderr: String::new(),
-                    exit_code: 0,
-                    execution: None,
-                }),
-                Err(err) => Some(tiangong_core::tool::ToolResult {
-                    ok: false,
-                    summary: "加载 HTML 失败".to_string(),
-                    stdout: String::new(),
-                    stderr: err,
-                    exit_code: 1,
-                    execution: None,
-                }),
-            }
-        })
-    }
 }
 
 impl tiangong_core::tool_override::ToolOverrideHandler for BrowserToolOverride {
@@ -472,7 +505,6 @@ impl tiangong_core::tool_override::ToolOverrideHandler for BrowserToolOverride {
             "web_form_extract" => Self::handle_web_form_extract(&self.fetcher),
             "web_form_fill" => Self::handle_web_form_fill(&self.fetcher, call),
             "web_click" => Self::handle_web_click(&self.fetcher, call),
-            "web_load_html" => Self::handle_web_load_html(&self.fetcher, call),
             _ => Box::pin(async { None }),
         }
     }

--- a/frontend/src/components/BrowserPanel.tsx
+++ b/frontend/src/components/BrowserPanel.tsx
@@ -20,7 +20,9 @@ interface TabInfo {
 function normalizeBrowserUrl(rawUrl: string): string {
   const trimmed = rawUrl.trim();
   if (!trimmed) return '';
-  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//i.test(trimmed)) return trimmed;
+  if (/^about:/i.test(trimmed)) return trimmed;
+  if (/^\//.test(trimmed)) return `file://${trimmed}`;
   return `https://${trimmed}`;
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -243,8 +243,7 @@ fn run_gui() {
                 state.register_tool_override("web_browse", handler.clone());
                 state.register_tool_override("web_form_extract", handler.clone());
                 state.register_tool_override("web_form_fill", handler.clone());
-                state.register_tool_override("web_click", handler.clone());
-                state.register_tool_override("web_load_html", handler);
+                state.register_tool_override("web_click", handler);
             }
 
             // 监听浏览器页面加载事件，自动注入内容到当前活跃会话


### PR DESCRIPTION
## Summary
- 修复 wry 内部 `url()`/`navigate()` 的 `unwrap()` 导致应用 panic 崩溃
- 修复浏览器工具覆盖在浏览器未打开时返回 `None` 导致"未知函数调用"错误
- 修复 `LoadHtml` 命令浏览器未打开时静默成功但不显示内容
- `web_fetch` 支持 `file://` 和本地路径，统一走浏览器打开路径
- 移除 `web_load_html` 工具，简化工具链
- 地址栏 URL 标准化支持 `file://`、`about:` 等协议前缀
- 执行提示和工具描述引导 agent 优先使用内嵌浏览器

## Test plan
- [x] Agent 使用 `web_fetch file:///path/to/file.html` 可在内嵌浏览器中打开本地 HTML
- [x] Agent 使用 `web_fetch https://...` 正常获取远程页面
- [x] 设置页下拉框模型选择正常工作（z-index 修复已合入 release/0.7.0）
- [x] 浏览器未打开时工具返回明确错误信息而非"未知函数调用"
- [x] cargo check / clippy / nextest / yarn build 全部通过