### PR TITLE
fix(gui): 修复设置页更新tab未复用全局更新状态

### DIFF
--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -2412,6 +2412,7 @@ function formatBytes(value: number) {
 }
 
 function AppUpdateSettings() {
+  const storeUpdate = useStore((s) => s.updateAvailable);
   const [currentVersion, setCurrentVersion] = useState('');
   const [availableUpdate, setAvailableUpdate] = useState<{
     version: string;
@@ -2443,6 +2444,38 @@ function AppUpdateSettings() {
       updateRef.current = null;
     };
   }, []);
+
+  // 从全局 store 预填充更新信息并静默获取可用的 Update 对象
+  useEffect(() => {
+    if (!storeUpdate || updateRef.current) return;
+    let mounted = true;
+    setAvailableUpdate({
+      version: storeUpdate.version,
+      currentVersion: '',
+      date: storeUpdate.date,
+      body: storeUpdate.body,
+    });
+    (async () => {
+      try {
+        const { check } = await import('@tauri-apps/plugin-updater');
+        const update = await check({ timeout: 30000 });
+        if (!mounted) return;
+        await updateRef.current?.close().catch(() => {});
+        updateRef.current = update;
+        if (update) {
+          setAvailableUpdate({
+            version: update.version,
+            currentVersion: update.currentVersion,
+            date: update.date,
+            body: update.body,
+          });
+        }
+      } catch {
+        // 静默失败，用户可手动重试
+      }
+    })();
+    return () => { mounted = false; };
+  }, [storeUpdate]);
 
   const handleCheckUpdate = async () => {
     setIsChecking(true);
@@ -2568,7 +2601,7 @@ function AppUpdateSettings() {
                 </>
               )}
             </Button>
-            <Button onClick={handleInstallUpdate} disabled={!availableUpdate || isChecking || isInstalling}>
+            <Button onClick={handleInstallUpdate} disabled={!updateRef.current || isChecking || isInstalling}>
               {isInstalling ? (
                 <>
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />


### PR DESCRIPTION
## Summary
- 修复从状态栏点击更新通知进入设置页后，更新tab显示空状态，需要再次手动点击"检查更新"的问题
- `AppUpdateSettings` 组件现在会从全局 Zustand store 读取已有的更新信息并预填充显示
- 后台静默调用 `check()` 获取可用的 `Update` 对象，完成后用户可直接点击"下载并安装"

## Test plan
- [x] 启动应用，等待后台自动检查发现更新
- [x] 确认状态栏出现更新通知按钮
- [x] 点击通知进入设置页"关于"tab，验证更新信息已自动显示
- [x] 验证"下载并安装"按钮在短暂等待后自动可用，无需手动点击"检查更新"
- [x] 验证手动点击"检查更新"仍正常工作