### PR TITLE
fix(core): 浏览器反馈只注入消息不触发 react 循环

### DIFF
--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -616,11 +616,13 @@ async fn worker_loop_async(
                     .as_deref()
                     .map(|s| !s.trim().is_empty())
                     .unwrap_or(false);
+                let agent_triggered = session_has_recent_browser_tool_call(&session);
                 tracing::info!(
                     session_id = %session.id,
                     url = %url,
                     text_len = text.len(),
                     has_feedback,
+                    agent_triggered,
                     "inject browser content command received"
                 );
                 crate::react::message::inject_browser_content_to_session(
@@ -636,6 +638,15 @@ async fn worker_loop_async(
                     },
                     has_feedback,
                 );
+                if !agent_triggered {
+                    tracing::info!(
+                        session_id = %session.id,
+                        url = %url,
+                        "browser content injected without triggering agent execution"
+                    );
+                    let _ = stream_tx.send(StreamEvent::Done { usage: None });
+                    continue;
+                }
                 let browser_input = format!("[浏览器页面更新] {url}");
                 execute_turn_async(
                     &mut session,
@@ -700,6 +711,28 @@ async fn worker_loop_async(
     }
 
     session
+}
+
+/// Agent 通过 tool_override 调用的浏览器相关工具名称
+const BROWSER_TOOL_NAMES: &[&str] = &[
+    "web_fetch",
+    "web_form_extract",
+    "web_form_fill",
+    "web_click",
+    "web_query_dom",
+    "web_locate_element",
+];
+
+/// 检查 session 最近消息中是否存在 agent 发起的浏览器工具调用。
+/// 用于判断浏览器反馈是否需要触发 agent 执行。
+fn session_has_recent_browser_tool_call(session: &Session) -> bool {
+    session.messages.iter().rev().take(16).any(|msg| {
+        msg.role == MessageRole::Assistant
+            && msg
+                .tool_calls
+                .iter()
+                .any(|tc| BROWSER_TOOL_NAMES.contains(&tc.name.as_str()))
+    })
 }
 
 fn index_turn_messages(

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -611,18 +611,15 @@ async fn worker_loop_async(
                 active_tab_id,
                 feedback,
             } => {
-                let turn_start_idx = session.messages.len();
                 let has_feedback = feedback
                     .as_deref()
                     .map(|s| !s.trim().is_empty())
                     .unwrap_or(false);
-                let agent_triggered = session_has_recent_browser_tool_call(&session);
                 tracing::info!(
                     session_id = %session.id,
                     url = %url,
                     text_len = text.len(),
                     has_feedback,
-                    agent_triggered,
                     "inject browser content command received"
                 );
                 crate::react::message::inject_browser_content_to_session(
@@ -638,47 +635,7 @@ async fn worker_loop_async(
                     },
                     has_feedback,
                 );
-                if !agent_triggered {
-                    tracing::info!(
-                        session_id = %session.id,
-                        url = %url,
-                        "browser content injected without triggering agent execution"
-                    );
-                    let _ = stream_tx.send(StreamEvent::Done { usage: None });
-                    continue;
-                }
-                let browser_input = format!("[浏览器页面更新] {url}");
-                execute_turn_async(
-                    &mut session,
-                    &browser_input,
-                    engine.as_ref().unwrap(),
-                    &tools,
-                    &mcp_targets,
-                    &stream_tx,
-                    &mut cmd_rx,
-                    memory.handle.as_ref(),
-                    index_manager.clone(),
-                    team_context.clone(),
-                )
-                .await;
-                if let Some(ref im) = index_manager {
-                    index_turn_messages(im, &session, turn_start_idx);
-                }
-                if let Some(handle) = memory.handle.as_ref() {
-                    let enhanced_result = build_enhanced_memory_turn_result(
-                        &session,
-                        turn_start_idx,
-                        &browser_input,
-                        vec![],
-                    );
-                    tokio::task::block_in_place(|| {
-                        handle.run_enhanced_micro_rumination_blocking(enhanced_result);
-                    });
-                    turn_count += 1;
-                    if turn_count.is_multiple_of(10) {
-                        handle.run_meta_rumination();
-                    }
-                }
+                let _ = stream_tx.send(StreamEvent::Done { usage: None });
             }
             Command::CompressContext => {
                 compress_context_for_session(&mut session, engine.as_ref().unwrap(), &stream_tx);
@@ -711,28 +668,6 @@ async fn worker_loop_async(
     }
 
     session
-}
-
-/// Agent 通过 tool_override 调用的浏览器相关工具名称
-const BROWSER_TOOL_NAMES: &[&str] = &[
-    "web_fetch",
-    "web_form_extract",
-    "web_form_fill",
-    "web_click",
-    "web_query_dom",
-    "web_locate_element",
-];
-
-/// 检查 session 最近消息中是否存在 agent 发起的浏览器工具调用。
-/// 用于判断浏览器反馈是否需要触发 agent 执行。
-fn session_has_recent_browser_tool_call(session: &Session) -> bool {
-    session.messages.iter().rev().take(16).any(|msg| {
-        msg.role == MessageRole::Assistant
-            && msg
-                .tool_calls
-                .iter()
-                .any(|tc| BROWSER_TOOL_NAMES.contains(&tc.name.as_str()))
-    })
 }
 
 fn index_turn_messages(


### PR DESCRIPTION
## Summary
- 移除 `InjectBrowserContent` 处理中的 `execute_turn_async` 调用
- 浏览器反馈现在只将页面内容作为消息注入到 session，不再主动触发 agent 执行
- agent 执行中时，react 循环内部已通过 `handle_plugin_commands` 自然处理浏览器命令
- agent 空闲时，消息被添加到 session 等待下次用户交互时使用

## Test plan
- [x] agent 执行浏览器操作后，确认 react 循环能自然处理浏览器反馈
- [x] 用户手动浏览页面时，确认 agent 不会被触发执行
- [x] 用户手动浏览后发送消息，确认 agent 能看到之前的浏览器上下文