### PR TITLE
fix(ui): 修复低分辨率下设置按钮不可见并适配初始窗口尺寸

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -28,7 +28,7 @@ export function AppSidebar() {
   };
 
   const content = (
-    <div className="flex flex-col h-full min-w-[var(--sidebar-width,16rem)]">
+    <div className="flex flex-col h-full min-h-0 min-w-[var(--sidebar-width,16rem)]">
       {/* 新建会话 */}
       <div className="p-2 shrink-0">
         <Button
@@ -43,7 +43,7 @@ export function AppSidebar() {
       </div>
 
       {/* 会话列表 */}
-      <ScrollArea className="flex-1 px-2">
+      <ScrollArea className="flex-1 min-h-0 px-2">
         <div className="space-y-1 py-1">
           {isLoadingSessions ? (
             <div className="px-3 py-2 text-sm text-muted-foreground">加载中...</div>
@@ -119,7 +119,7 @@ export function AppSidebar() {
 
   return (
     <aside
-      className="shrink-0 border-r bg-sidebar text-sidebar-foreground flex flex-col overflow-hidden transition-[width] duration-200 ease-linear"
+      className="shrink-0 min-h-0 border-r bg-sidebar text-sidebar-foreground flex flex-col overflow-hidden transition-[width] duration-200 ease-linear"
       style={{ width: open ? 'var(--sidebar-width, 16rem)' : '0px' }}
     >
       {content}

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -8,7 +8,7 @@ import { BrowserPanel } from '@/components/BrowserPanel';
 import { ensureDesktopNotificationPermission } from '@/utils/desktopNotification';
 import { useUpdateCheck } from '@/hooks/useUpdateCheck';
 import type { UnlistenFn } from '@tauri-apps/api/event';
-import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window';
+import { getCurrentWindow, LogicalSize, currentMonitor } from '@tauri-apps/api/window';
 
 /** 根据窗口逻辑高度计算 4:3 浏览器宽度 */
 function calcBrowserWidth(logicalHeight: number): number {
@@ -30,6 +30,48 @@ const SIDEBAR_WIDTH = 256;
 
 /** 主内容在打开侧边栏后保留的最小可用宽度 */
 const MIN_CONTENT_WIDTH_WITH_SIDEBAR = 400;
+
+/** 屏幕工作区四周保留的边距，避免初始窗口贴边 */
+const SCREEN_EDGE_MARGIN = 32;
+
+/** 启动时裁剪窗口的最小高度兜底 */
+const MIN_INITIAL_HEIGHT = 480;
+
+/** 启动时按当前屏幕工作区裁剪窗口：仅当默认/上次的窗口尺寸超出屏幕可视区时才缩小 */
+async function fitWindowToScreen(
+  lock: () => void,
+  unlock: () => void,
+  onNarrow?: (logicalW: number) => void,
+): Promise<void> {
+  try {
+    const appWindow = getCurrentWindow();
+    const [monitor, scaleFactor, innerSize] = await Promise.all([
+      currentMonitor(),
+      appWindow.scaleFactor(),
+      appWindow.innerSize(),
+    ]);
+    if (!monitor) return;
+
+    const monitorW = monitor.size.width / scaleFactor;
+    const monitorH = monitor.size.height / scaleFactor;
+    const maxW = Math.max(MIN_CHAT_WIDTH, monitorW - SCREEN_EDGE_MARGIN * 2);
+    const maxH = Math.max(MIN_INITIAL_HEIGHT, monitorH - SCREEN_EDGE_MARGIN * 2);
+
+    let logicalW = innerSize.width / scaleFactor;
+    let logicalH = innerSize.height / scaleFactor;
+    let changed = false;
+    if (logicalW > maxW) { logicalW = maxW; changed = true; }
+    if (logicalH > maxH) { logicalH = maxH; changed = true; }
+    if (!changed) return;
+
+    lock();
+    await appWindow.setSize(new LogicalSize(logicalW, logicalH));
+    unlock();
+    onNarrow?.(logicalW);
+  } catch (error) {
+    console.warn('适配窗口到屏幕失败:', error);
+  }
+}
 
 /** 扩展窗口以容纳浏览器面板：对话区缩至最小宽度 + 浏览器面板宽度 */
 async function expandWindowForBrowser(lock?: () => void, unlock?: () => void) {
@@ -184,6 +226,13 @@ export function MainApp() {
   useEffect(() => {
     ensureDesktopNotificationPermission().catch(console.warn);
 
+    // 启动时按当前屏幕工作区裁剪初始窗口，避免低分辨率屏幕上窗口超出可视区
+    fitWindowToScreen(lockResize, unlockResize, (logicalW) => {
+      if (logicalW <= SIDEBAR_RESTORE_THRESHOLD) {
+        setSidebarOpenByLayout(false);
+      }
+    }).catch(console.warn);
+
     loadSessions();
 
     const flushSnapshot = () => {
@@ -302,7 +351,7 @@ export function MainApp() {
       window.removeEventListener('tiangong:open-browser', onOpenBrowser);
       unlistenRef.current?.();
     };
-  }, [setSidebarOpenByLayout, openBrowserPanel]);
+  }, [setSidebarOpenByLayout, openBrowserPanel, lockResize, unlockResize]);
 
   return (
     <SidebarProvider open={sidebarOpen} onOpenChange={handleSidebarChange}>


### PR DESCRIPTION
## Summary
- 修复侧边栏布局缺少 `min-h-0` 导致会话列表撑高后底部设置按钮被 `overflow-hidden` 裁掉的问题
- 启动时按当前屏幕工作区裁剪初始窗口尺寸，仅在超出可视区时收缩，避免低分辨率屏幕首次开窗即超出
- 裁剪后宽度低于侧边栏恢复阈值时同步收起侧边栏，保持与运行时响应式一致

## Test plan
- [x] 在常规分辨率（≥1400×900）下打开应用，验证默认窗口尺寸与设置按钮可见性无回归
- [x] 将窗口高度调小（如 600px），打开多个会话，确认设置按钮始终可见、会话列表内部滚动
- [x] 在低分辨率屏幕（或调小系统分辨率）下首次启动，验证窗口被裁剪到可视区内且布局正常
- [x] 外接屏切换后再启动，验证窗口不会超出新屏幕的工作区

Closes #136