### PR TITLE
feat(terminal): Agent 交互式终端操作能力（vi/nano/REPL + swap 处理）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,6 +2405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "descape"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "700357d9fb22b5232a85e34a413c1a76ae649f532c31107e402dc84e9c03bfb2"
+
+[[package]]
 name = "diffy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9638,6 +9644,7 @@ name = "tiangong-plugin-terminal"
 version = "0.8.3"
 dependencies = [
  "anyhow",
+ "descape",
  "portable-pty",
  "scru128",
  "serde",

--- a/crates/tiangong-core/src/agents/execution_tool_agent.rs
+++ b/crates/tiangong-core/src/agents/execution_tool_agent.rs
@@ -242,16 +242,29 @@ pub(crate) fn basic_file_function_tools() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "run_shell".to_string(),
-            description: "执行 shell 脚本，自动派生 bash/sh/powershell 参数".to_string(),
+            description: "执行 shell 脚本，自动派生 bash/sh/powershell 参数。需启动交互式程序（vi/nano/REPL）时传 interactive=true，命令在终端面板进入交互态供用户操作".to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "script": { "type": "string", "description": "shell 脚本文本" },
                     "shell": { "type": "string", "description": "shell 类型：auto/bash/sh/powershell/pwsh，默认 auto" },
                     "cwd": { "type": "string", "description": "工作目录（可选）" },
-                    "timeout": { "type": "integer", "description": "超时时间（秒），0 或不填表示不限时", "minimum": 0 }
+                    "timeout": { "type": "integer", "description": "超时时间（秒），0 或不填表示不限时", "minimum": 0 },
+                    "interactive": { "type": "boolean", "description": "是否以交互模式启动（用于 vi/vim/nano/ssh/python REPL 等交互程序）。true 时命令在终端面板进入交互态，用户可手动操作；禁止配合 heredoc/管道使用。默认 false" }
                 },
                 "required": ["script"]
+            }),
+        },
+        ToolSpec {
+            name: "terminal_send".to_string(),
+            description: "向已进入交互态的终端发送按键/文本，并返回屏幕新快照。用于持续操作交互程序（vi/nano/REPL）：每次发送后自动等待屏幕变化，返回当前显示内容。先用 run_shell{interactive:true} 启动交互程序，再用本工具操作。例如 vi 遇到 swap 提示时发 \"d\" 删除 swap、编辑后发 \"\\x1b:wq\\r\" 保存退出。input 原样写入终端，需用转义序列表示特殊键（\\r 回车、\\x1b Esc、\\x03 Ctrl+C）".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "input": { "type": "string", "description": "要发送到终端的按键/文本。原样写入 PTY，用转义序列表示特殊键：\\r=回车、\\x1b=Esc、\\x03=Ctrl+C、\\x1b[A=上方向键等" },
+                    "wait": { "type": "integer", "description": "发送后等待屏幕变化的秒数（给程序渲染时间），默认 3", "minimum": 1 }
+                },
+                "required": ["input"]
             }),
         },
         ToolSpec {

--- a/crates/tiangong-core/src/permission.rs
+++ b/crates/tiangong-core/src/permission.rs
@@ -296,9 +296,8 @@ pub(crate) fn classify_tool(tool_name: &str) -> PermissionLevel {
         // 标准：文件写入
         "write_file" | "replace_in_file" => PermissionLevel::Standard,
         // 高级：命令执行 + 浏览器操作
-        "run_command" | "run_shell" | "web_form_fill" | "web_click" | "web_load_html" => {
-            PermissionLevel::Elevated
-        }
+        "run_command" | "run_shell" | "terminal_send" | "web_form_fill" | "web_click"
+        | "web_load_html" => PermissionLevel::Elevated,
         // 关键：补丁、后台任务、多媒体
         "apply_patch" | "spawn_task" | "cancel_task" => PermissionLevel::Critical,
         // MCP 工具和未知工具默认为关键
@@ -504,7 +503,7 @@ fn infer_tool_name_scope(
         "read_file" | "write_file" | "replace_in_file" | "list_dir" | "tree_dir" => "path",
         "web_fetch" => "network",
         "analyze_attachment" | "generate_image" | "speech_to_text" | "text_to_speech" => "external",
-        "run_command" | "run_shell" => "command",
+        "run_command" | "run_shell" | "terminal_send" => "command",
         "web_form_extract" | "web_form_fill" | "web_click" | "web_load_html" => "browser",
         _ => return (None, summary),
     };

--- a/crates/tiangong-core/src/terminal_trait.rs
+++ b/crates/tiangong-core/src/terminal_trait.rs
@@ -26,6 +26,28 @@ pub trait TerminalProvider: Send + Sync + 'static {
         timeout_secs: Option<u64>,
     ) -> Pin<Box<dyn Future<Output = Option<TerminalExecResult>> + Send>>;
 
+    /// 在指定对话的终端会话中以交互模式启动命令（如 vi/nano/python REPL）。
+    ///
+    /// 与 `exec` 不同：不使用 marker 协议包裹命令，直接以 CR 提交命令行；
+    /// 等待 `wait_secs` 秒后收集初始输出并返回 `interactive_mode: true`，
+    /// 终端协作状态进入 `AgentInteractive`，前台交互进程继续运行。
+    /// 后续输入由用户在终端面板手动操作，或由 Agent 通过 `send_input` 驱动。
+    fn exec_interactive(
+        &self,
+        session_id: &str,
+        command: &str,
+        wait_secs: u64,
+    ) -> Pin<Box<dyn Future<Output = Option<TerminalExecResult>> + Send>>;
+
+    /// 在指定对话的终端会话中以交互模式启动原始命令（cmd + args）。
+    fn exec_command_interactive(
+        &self,
+        session_id: &str,
+        cmd: &str,
+        args: &[String],
+        wait_secs: u64,
+    ) -> Pin<Box<dyn Future<Output = Option<TerminalExecResult>> + Send>>;
+
     /// 获取指定对话终端最近的输出（环形缓冲区）。
     fn recent_output(
         &self,
@@ -43,6 +65,19 @@ pub trait TerminalProvider: Send + Sync + 'static {
         session_id: &str,
         input: &str,
     ) -> Pin<Box<dyn Future<Output = Option<()>> + Send>>;
+
+    /// 向已进入交互态的终端发送输入（按键/文本），并等待屏幕变化后返回新快照。
+    ///
+    /// 这是 Agent 持续操作交互程序（vi/nano/REPL）的核心能力：每发一次按键，
+    /// 自动等待屏幕渲染稳定，返回当前可见内容。Agent 据此观察程序对输入的反应，
+    /// 形成持续的"输入→观察→输入"闭环（如看到 swap 提示→发 d 删除→看 vi 界面）。
+    /// 与 `exec_interactive`（首次启动交互程序）配套使用。
+    fn send_interactive(
+        &self,
+        session_id: &str,
+        input: &str,
+        wait_secs: u64,
+    ) -> Pin<Box<dyn Future<Output = Option<TerminalExecResult>> + Send>>;
 
     /// 重置指定对话的终端会话（清理状态，重新初始化）。
     fn reset(&self, session_id: &str) -> Pin<Box<dyn Future<Output = Option<()>> + Send>>;

--- a/crates/tiangong-plugin-terminal/Cargo.toml
+++ b/crates/tiangong-plugin-terminal/Cargo.toml
@@ -16,6 +16,7 @@ portable-pty = "0.8"
 scru128 = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
+descape = "3"
 
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }

--- a/crates/tiangong-plugin-terminal/build.rs
+++ b/crates/tiangong-plugin-terminal/build.rs
@@ -8,12 +8,14 @@ const COMMANDS: &[&str] = &[
     "terminal_resize",
     "terminal_ensure_session",
     "terminal_destroy_session",
+    "terminal_attach_session",
     "terminal_session_send_input",
     "terminal_session_recent_output",
     "terminal_session_info",
     "terminal_session_set_cwd",
     "terminal_session_resize",
     "terminal_session_reset",
+    "terminal_session_update_screen",
     "terminal_panel_set_session",
 ];
 

--- a/crates/tiangong-plugin-terminal/permissions/autogenerated/commands/terminal_attach_session.toml
+++ b/crates/tiangong-plugin-terminal/permissions/autogenerated/commands/terminal_attach_session.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-terminal-attach-session"
+description = "Enables the terminal_attach_session command without any pre-configured scope."
+commands.allow = ["terminal_attach_session"]
+
+[[permission]]
+identifier = "deny-terminal-attach-session"
+description = "Denies the terminal_attach_session command without any pre-configured scope."
+commands.deny = ["terminal_attach_session"]

--- a/crates/tiangong-plugin-terminal/permissions/autogenerated/commands/terminal_session_update_screen.toml
+++ b/crates/tiangong-plugin-terminal/permissions/autogenerated/commands/terminal_session_update_screen.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-terminal-session-update-screen"
+description = "Enables the terminal_session_update_screen command without any pre-configured scope."
+commands.allow = ["terminal_session_update_screen"]
+
+[[permission]]
+identifier = "deny-terminal-session-update-screen"
+description = "Denies the terminal_session_update_screen command without any pre-configured scope."
+commands.deny = ["terminal_session_update_screen"]

--- a/crates/tiangong-plugin-terminal/permissions/autogenerated/reference.md
+++ b/crates/tiangong-plugin-terminal/permissions/autogenerated/reference.md
@@ -13,12 +13,14 @@
 - `allow-terminal-resize`
 - `allow-terminal-ensure-session`
 - `allow-terminal-destroy-session`
+- `allow-terminal-attach-session`
 - `allow-terminal-session-send-input`
 - `allow-terminal-session-recent-output`
 - `allow-terminal-session-info`
 - `allow-terminal-session-set-cwd`
 - `allow-terminal-session-resize`
 - `allow-terminal-session-reset`
+- `allow-terminal-session-update-screen`
 - `allow-terminal-panel-set-session`
 
 ## Permission Table
@@ -29,6 +31,32 @@
 <th>Description</th>
 </tr>
 
+
+<tr>
+<td>
+
+`tiangong-plugin-terminal:allow-terminal-attach-session`
+
+</td>
+<td>
+
+Enables the terminal_attach_session command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`tiangong-plugin-terminal:deny-terminal-attach-session`
+
+</td>
+<td>
+
+Denies the terminal_attach_session command without any pre-configured scope.
+
+</td>
+</tr>
 
 <tr>
 <td>
@@ -390,6 +418,32 @@ Enables the terminal_session_set_cwd command without any pre-configured scope.
 <td>
 
 Denies the terminal_session_set_cwd command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`tiangong-plugin-terminal:allow-terminal-session-update-screen`
+
+</td>
+<td>
+
+Enables the terminal_session_update_screen command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`tiangong-plugin-terminal:deny-terminal-session-update-screen`
+
+</td>
+<td>
+
+Denies the terminal_session_update_screen command without any pre-configured scope.
 
 </td>
 </tr>

--- a/crates/tiangong-plugin-terminal/permissions/default.toml
+++ b/crates/tiangong-plugin-terminal/permissions/default.toml
@@ -10,11 +10,13 @@ permissions = [
     "allow-terminal-resize",
     "allow-terminal-ensure-session",
     "allow-terminal-destroy-session",
+    "allow-terminal-attach-session",
     "allow-terminal-session-send-input",
     "allow-terminal-session-recent-output",
     "allow-terminal-session-info",
     "allow-terminal-session-set-cwd",
     "allow-terminal-session-resize",
     "allow-terminal-session-reset",
+    "allow-terminal-session-update-screen",
     "allow-terminal-panel-set-session",
 ]

--- a/crates/tiangong-plugin-terminal/permissions/schemas/schema.json
+++ b/crates/tiangong-plugin-terminal/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the terminal_attach_session command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-terminal-attach-session",
+          "markdownDescription": "Enables the terminal_attach_session command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the terminal_attach_session command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-terminal-attach-session",
+          "markdownDescription": "Denies the terminal_attach_session command without any pre-configured scope."
+        },
+        {
           "description": "Enables the terminal_destroy_session command without any pre-configured scope.",
           "type": "string",
           "const": "allow-terminal-destroy-session",
@@ -463,6 +475,18 @@
           "markdownDescription": "Denies the terminal_session_set_cwd command without any pre-configured scope."
         },
         {
+          "description": "Enables the terminal_session_update_screen command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-terminal-session-update-screen",
+          "markdownDescription": "Enables the terminal_session_update_screen command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the terminal_session_update_screen command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-terminal-session-update-screen",
+          "markdownDescription": "Denies the terminal_session_update_screen command without any pre-configured scope."
+        },
+        {
           "description": "Enables the terminal_set_cwd command without any pre-configured scope.",
           "type": "string",
           "const": "allow-terminal-set-cwd",
@@ -487,10 +511,10 @@
           "markdownDescription": "Denies the terminal_system_session_info command without any pre-configured scope."
         },
         {
-          "description": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-panel-set-session`",
+          "description": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-attach-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-session-update-screen`\n- `allow-terminal-panel-set-session`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-panel-set-session`"
+          "markdownDescription": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-attach-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-session-update-screen`\n- `allow-terminal-panel-set-session`"
         }
       ]
     }

--- a/crates/tiangong-plugin-terminal/src/collaboration.rs
+++ b/crates/tiangong-plugin-terminal/src/collaboration.rs
@@ -11,6 +11,8 @@ pub enum TerminalBusyState {
     UserActive,
     /// Agent 正在执行非交互命令
     AgentRunning { command_id: String },
+    /// 终端有前台交互进程（Agent 通过 exec_interactive 启动，如 vi/nano/REPL）
+    AgentInteractive { command_id: String },
 }
 
 /// 终端输入来源
@@ -46,7 +48,10 @@ impl TerminalActivityTracker {
         }
         // Agent 执行期间用户输入 → 标记干预
         if let Ok(state) = self.busy_state.lock() {
-            if matches!(&*state, TerminalBusyState::AgentRunning { .. }) {
+            if matches!(
+                &*state,
+                TerminalBusyState::AgentRunning { .. } | TerminalBusyState::AgentInteractive { .. }
+            ) {
                 if let Ok(mut flag) = self.user_intervened.lock() {
                     *flag = true;
                 }
@@ -102,6 +107,7 @@ impl TerminalBusyState {
             TerminalBusyState::Idle => "Idle",
             TerminalBusyState::UserActive => "UserActive",
             TerminalBusyState::AgentRunning { .. } => "Running",
+            TerminalBusyState::AgentInteractive { .. } => "Interactive",
         }
     }
 }

--- a/crates/tiangong-plugin-terminal/src/command_protocol.rs
+++ b/crates/tiangong-plugin-terminal/src/command_protocol.rs
@@ -554,6 +554,55 @@ pub(crate) async fn handle_exec(
 /// 返回内容：终端当前可见文本（ANSI 已处理）。交互程序进入任何状态
 ///（编辑页 / swap 提示 / 等待输入）都会在第一次渲染时被捕获，
 /// Agent 直接阅读返回内容即可判断当前状态，无需后端识别提示类型。
+/// 等待终端屏幕发生变化（双信号 + 稳定窗口），用于交互程序首屏/响应检测。
+///
+/// 双信号策略：
+/// - `screen_updates`（前端 xterm 快照）：最准确的屏幕内容，优先等此信号
+/// - `output_pushed`（后端 buffer）：可靠的后端信号，前端未回传时退到此信号
+///
+/// 稳定窗口：信号首次触发后，继续轮询 `stable_window`（300ms）确认无进一步变化，
+/// 认为屏幕已渲染稳定。快照信号用 1x 窗口，output 信号用 2x 窗口（精度较低等更久）。
+/// 超过 `wait_secs` 仍无信号则放弃等待（返回，调用方用当前快照兜底）。
+async fn wait_for_screen_change(
+    manager: &Arc<TerminalManager>,
+    baseline_pushed: usize,
+    baseline_updates: u64,
+    wait_secs: u64,
+) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs.max(1));
+    let stable_window = std::time::Duration::from_millis(300);
+    let poll_interval = std::time::Duration::from_millis(50);
+    let mut output_changed_at: Option<std::time::Instant> = None;
+    let mut screen_changed_at: Option<std::time::Instant> = None;
+
+    loop {
+        let now_pushed = manager.total_lines_pushed();
+        let now_updates = manager.screen_updates();
+        if output_changed_at.is_none() && now_pushed > baseline_pushed {
+            output_changed_at = Some(std::time::Instant::now());
+        }
+        if screen_changed_at.is_none() && now_updates > baseline_updates {
+            screen_changed_at = Some(std::time::Instant::now());
+        }
+        if let Some(change_time) = screen_changed_at {
+            if change_time.elapsed() >= stable_window {
+                break;
+            }
+        }
+        if screen_changed_at.is_none() {
+            if let Some(change_time) = output_changed_at {
+                if change_time.elapsed() >= stable_window * 2 {
+                    break;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
 pub(crate) async fn handle_exec_interactive(
     manager: &Arc<TerminalManager>,
     pty_state: &mut Option<PtyState>,
@@ -638,40 +687,8 @@ pub(crate) async fn handle_exec_interactive(
         });
     }
 
-    // 双信号等待：output_pushed 触发"程序已开始输出"，screen_updates 确认"快照已更新"。
-    // 优先等快照更新（最准确的屏幕内容），前端未回传时退到 output_pushed 变化。
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs.max(1));
-    let stable_window = std::time::Duration::from_millis(300);
-    let poll_interval = std::time::Duration::from_millis(50);
-    let mut output_changed_at: Option<std::time::Instant> = None;
-    let mut screen_changed_at: Option<std::time::Instant> = None;
-
-    loop {
-        let now_pushed = manager.total_lines_pushed();
-        let now_updates = manager.screen_updates();
-        if output_changed_at.is_none() && now_pushed > baseline_pushed {
-            output_changed_at = Some(std::time::Instant::now());
-        }
-        if screen_changed_at.is_none() && now_updates > baseline_updates {
-            screen_changed_at = Some(std::time::Instant::now());
-        }
-        if let Some(change_time) = screen_changed_at {
-            if change_time.elapsed() >= stable_window {
-                break;
-            }
-        }
-        if screen_changed_at.is_none() {
-            if let Some(change_time) = output_changed_at {
-                if change_time.elapsed() >= stable_window * 2 {
-                    break;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            break;
-        }
-        tokio::time::sleep(poll_interval).await;
-    }
+    // 双信号等待：交互程序首屏渲染（见 wait_for_screen_change）
+    wait_for_screen_change(manager, baseline_pushed, baseline_updates, wait_secs).await;
 
     // 返回终端当前可见内容：优先前端 xterm 回传的屏幕快照（与用户看到的画面一致，
     // vim/nano 全屏界面、swap 提示都能完整呈现），若前端尚未回传（面板未挂载等）
@@ -705,6 +722,8 @@ pub(crate) async fn handle_send_interactive(
     input: &str,
     wait_secs: u64,
     response_tx: oneshot::Sender<TerminalExecResponse>,
+    // _activity 不使用：send_interactive 发的是对已运行交互程序的按键，
+    // 此时协作状态在 exec_interactive 启动时已设为 AgentInteractive，无需重复设置。
     _activity: Option<&Arc<crate::collaboration::TerminalActivityTracker>>,
 ) {
     let ps = match pty_state {
@@ -752,40 +771,8 @@ pub(crate) async fn handle_send_interactive(
         return;
     }
 
-    // 双信号等待：output_pushed 触发"程序已响应"，screen_updates 确认"快照已更新"。
-    // 优先等快照更新（最准确），若前端未回传（面板未挂载）则退到 output_pushed 变化。
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs.max(1));
-    let stable_window = std::time::Duration::from_millis(300);
-    let poll_interval = std::time::Duration::from_millis(50);
-    let mut output_changed_at: Option<std::time::Instant> = None;
-    let mut screen_changed_at: Option<std::time::Instant> = None;
-
-    loop {
-        let now_pushed = manager.total_lines_pushed();
-        let now_updates = manager.screen_updates();
-        if output_changed_at.is_none() && now_pushed > baseline_pushed {
-            output_changed_at = Some(std::time::Instant::now());
-        }
-        if screen_changed_at.is_none() && now_updates > baseline_updates {
-            screen_changed_at = Some(std::time::Instant::now());
-        }
-        if let Some(change_time) = screen_changed_at {
-            if change_time.elapsed() >= stable_window {
-                break;
-            }
-        }
-        if screen_changed_at.is_none() {
-            if let Some(change_time) = output_changed_at {
-                if change_time.elapsed() >= stable_window * 2 {
-                    break;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            break;
-        }
-        tokio::time::sleep(poll_interval).await;
-    }
+    // 双信号等待：交互程序对输入的响应（见 wait_for_screen_change）
+    wait_for_screen_change(manager, baseline_pushed, baseline_updates, wait_secs).await;
 
     let stdout_text = manager
         .screen_snapshot()

--- a/crates/tiangong-plugin-terminal/src/command_protocol.rs
+++ b/crates/tiangong-plugin-terminal/src/command_protocol.rs
@@ -20,6 +20,33 @@ fn send_to_pty(writer: &mut Box<dyn std::io::Write + Send>, input: &str) -> anyh
     Ok(())
 }
 
+/// 解码 Agent 在 terminal_send input 中使用的转义序列为真实控制字节。
+///
+/// Agent 按工具规格用字面转义序列表示特殊键（如 `\x1b:wq\r`），但 JSON 字符串里
+/// `` 是 4 个字面字符（反斜杠+x+1+b）。写入 PTY 前需解码为真实控制字节（0x1b），
+/// 否则 vi 等程序会把它当普通文本插入而非 ESC 指令。
+///
+/// 转义在终端执行侧（写入 PTY 前）处理，而非 handler 发送侧——这样 handler 只负责
+/// 取参数原样传递，转义细节内聚在终端层。
+///
+/// 使用 descape 库解码（支持 \e/\x1b=ESC、\r=CR、\n=LF、\xHH=任意字节、
+/// \uXXXX=unicode 等完整 C 风格转义）。解码失败（含非法转义）时回退到原文，
+/// 保证不丢数据——最坏情况是字面字符写入 PTY（与修复前行为一致）。
+fn decode_terminal_escapes(input: &str) -> String {
+    use descape::UnescapeExt;
+    match input.to_unescaped() {
+        Ok(cow) => cow.into_owned(),
+        Err(e) => {
+            tracing::warn!(
+                index = e.index,
+                input_len = input.len(),
+                "terminal_send input 含非法转义序列，原样写入 PTY"
+            );
+            input.to_string()
+        }
+    }
+}
+
 /// 把 `total_lines_pushed` 轨道值换算为环形缓冲区当前索引。
 /// 环形缓冲区会从头部淘汰旧行，因此越早推入的行对应索引越小；
 /// 若该时刻的行已被淘汰则返回 0（从缓冲区开头兜底）。
@@ -702,11 +729,13 @@ pub(crate) async fn handle_send_interactive(
     let baseline_pushed = manager.total_lines_pushed();
     let baseline_updates = manager.screen_updates();
 
-    // 把输入写入 PTY。输入由 Agent 给出（vi 按键、REPL 命令等），原样写入。
+    // 把输入写入 PTY。输入由 Agent 给出（vi 按键、REPL 命令等）。
+    // Agent 用转义序列表示特殊键（\x1b=ESC、\r=CR），在终端执行侧解码为真实控制字节。
     // 不做 LF 转 CR：send_interactive 发的是对前台程序的原始输入，由 Agent 控制按键。
+    let decoded_input = decode_terminal_escapes(input);
     let send_result = {
         match ps.writer.lock() {
-            Ok(mut writer) => send_to_pty(&mut writer, input),
+            Ok(mut writer) => send_to_pty(&mut writer, &decoded_input),
             Err(e) => Err(anyhow::anyhow!("获取 writer 锁失败: {}", e)),
         }
     };
@@ -777,6 +806,61 @@ pub(crate) async fn handle_send_interactive(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decode_esc_sequence_for_vi_save_quit() {
+        // vi 保存退出：ESC + :wq + CR
+        let decoded = decode_terminal_escapes("\\x1b:wq\\r");
+        assert_eq!(decoded.as_bytes(), &[0x1b, b':', b'w', b'q', 0x0d]);
+    }
+
+    #[test]
+    fn decode_ctrl_c_as_etx() {
+        // Ctrl+C = ETX (0x03)
+        let decoded = decode_terminal_escapes("\\x03");
+        assert_eq!(decoded.as_bytes(), &[0x03]);
+    }
+
+    #[test]
+    fn decode_carriage_return_and_newline() {
+        let decoded = decode_terminal_escapes("abc\\r\\n");
+        assert_eq!(decoded.as_bytes(), &[b'a', b'b', b'c', 0x0d, 0x0a]);
+    }
+
+    #[test]
+    fn decode_escape_letter_e() {
+        // \e 也表示 ESC
+        let decoded = decode_terminal_escapes("\\e");
+        assert_eq!(decoded.as_bytes(), &[0x1b]);
+    }
+
+    #[test]
+    fn decode_preserves_plain_text() {
+        // 普通文本无转义，原样返回
+        let decoded = decode_terminal_escapes("hello world");
+        assert_eq!(decoded, "hello world");
+    }
+
+    #[test]
+    fn decode_unknown_escape_preserved() {
+        // 不识别的转义（如 \d）回退原文（保留反斜杠+字符）
+        let decoded = decode_terminal_escapes("a\\db");
+        assert_eq!(decoded, "a\\db");
+    }
+
+    #[test]
+    fn decode_literal_backslash() {
+        // \\ → 字面反斜杠
+        let decoded = decode_terminal_escapes("a\\\\b");
+        assert_eq!(decoded, "a\\b");
+    }
+
+    #[test]
+    fn decode_arrow_key_sequence() {
+        // 上方向键 = ESC[A
+        let decoded = decode_terminal_escapes("\\x1b[A");
+        assert_eq!(decoded.as_bytes(), &[0x1b, b'[', b'A']);
+    }
 
     fn make_manager_with_lines(lines: &[&str]) -> Arc<TerminalManager> {
         let manager = Arc::new(TerminalManager::new("test".to_string(), "/tmp".to_string()));

--- a/crates/tiangong-plugin-terminal/src/command_protocol.rs
+++ b/crates/tiangong-plugin-terminal/src/command_protocol.rs
@@ -514,6 +514,266 @@ pub(crate) async fn handle_exec(
     }
 }
 
+/// 交互式命令执行：不使用 marker 协议，直接以 CR 提交命令，
+/// 轮询等待终端"第一次变化"后返回完整可见内容。
+///
+/// 适用场景：vi/nano/python REPL 等需要持续键盘交互的程序。
+/// 与 `handle_exec` 的关键差异：
+/// - 不发 marker（交互程序前台时 marker 会污染屏幕甚至被读走）
+/// - 协作状态进入 `AgentInteractive` 而非 `AgentRunning`
+/// - 不轮询 marker，而是检测 output_buffer 相比基线是否出现增长（程序开始渲染）
+/// - 退出码恒为 0、不更新 cwd（交互程序不会回 end/cwd marker）
+///
+/// 返回内容：终端当前可见文本（ANSI 已处理）。交互程序进入任何状态
+///（编辑页 / swap 提示 / 等待输入）都会在第一次渲染时被捕获，
+/// Agent 直接阅读返回内容即可判断当前状态，无需后端识别提示类型。
+pub(crate) async fn handle_exec_interactive(
+    manager: &Arc<TerminalManager>,
+    pty_state: &mut Option<PtyState>,
+    app: &tauri::AppHandle,
+    command: &str,
+    wait_secs: u64,
+    response_tx: oneshot::Sender<TerminalExecResponse>,
+    activity: Option<&Arc<crate::collaboration::TerminalActivityTracker>>,
+) {
+    let ps = match pty_state {
+        Some(ps) => ps,
+        None => {
+            // PTY 不可用时尝试恢复一次，逻辑与 handle_exec 一致
+            match ensure_system_pty(manager, app) {
+                Some(new_ps) => {
+                    *pty_state = Some(new_ps);
+                    pty_state.as_mut().expect("PTY 刚写入，必然存在")
+                }
+                None => {
+                    let _ = response_tx.send(TerminalExecResponse {
+                        exit_code: -1,
+                        stdout: String::new(),
+                        stderr: "终端会话不可用".to_string(),
+                        timed_out: false,
+                        cwd_after: manager.cwd(),
+                        interrupted_by_user: false,
+                        interactive_mode: false,
+                    });
+                    return;
+                }
+            }
+        }
+    };
+
+    // 发送命令前记录双信号基线：
+    // - output_pushed：程序输出到达后端 buffer 的可靠信号（立即可知）
+    // - screen_updates：前端 xterm 渲染并回传快照的信号（最终屏幕内容来源）
+    let baseline_pushed = manager.total_lines_pushed();
+    let baseline_updates = manager.screen_updates();
+
+    // 清理残留进程 + 发送命令
+    // 注意：用 `\r`（CR）而非 `\n`（LF）作为回车键。zsh 的 ZLE、vim、less 等
+    // TUI 程序在 raw 模式下只识别 CR 作为"提交本行"，发 LF 会导致命令停留在
+    // 输入行不执行。
+    // 先发 \x03(Ctrl+C) 清理可能残留的前台进程，再发 \x15(Ctrl+U) 清空当前行，
+    // 最后以 CR 提交命令。
+    let send_result = {
+        match ps.writer.lock() {
+            Ok(mut writer) => {
+                let _ = writer.write_all(b"\x03");
+                let _ = writer.flush();
+                let _ = writer.write_all(b"\x15");
+                let _ = writer.flush();
+                let cmd = format!("{}\r", command);
+                send_to_pty(&mut writer, &cmd)
+            }
+            Err(e) => Err(anyhow::anyhow!("获取 writer 锁失败: {}", e)),
+        }
+    };
+    if let Err(e) = send_result {
+        if let Some(tracker) = activity {
+            tracker.set_busy_state(crate::collaboration::TerminalBusyState::Idle);
+        }
+        let _ = response_tx.send(TerminalExecResponse {
+            exit_code: -1,
+            stdout: String::new(),
+            stderr: format!("发送命令到终端失败: {}", e),
+            timed_out: false,
+            cwd_after: manager.cwd(),
+            interrupted_by_user: false,
+            interactive_mode: false,
+        });
+        return;
+    }
+
+    // 命令已成功发送，设置协作状态为 AgentInteractive：该 session 的 tracker
+    // 会被标记为"Agent 正在交互执行"，用户在面板输入会被记为干预。
+    let command_id = scru128::new().to_string();
+    if let Some(tracker) = activity {
+        tracker.set_busy_state(crate::collaboration::TerminalBusyState::AgentInteractive {
+            command_id: command_id.clone(),
+        });
+    }
+
+    // 双信号等待：output_pushed 触发"程序已开始输出"，screen_updates 确认"快照已更新"。
+    // 优先等快照更新（最准确的屏幕内容），前端未回传时退到 output_pushed 变化。
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs.max(1));
+    let stable_window = std::time::Duration::from_millis(300);
+    let poll_interval = std::time::Duration::from_millis(50);
+    let mut output_changed_at: Option<std::time::Instant> = None;
+    let mut screen_changed_at: Option<std::time::Instant> = None;
+
+    loop {
+        let now_pushed = manager.total_lines_pushed();
+        let now_updates = manager.screen_updates();
+        if output_changed_at.is_none() && now_pushed > baseline_pushed {
+            output_changed_at = Some(std::time::Instant::now());
+        }
+        if screen_changed_at.is_none() && now_updates > baseline_updates {
+            screen_changed_at = Some(std::time::Instant::now());
+        }
+        if let Some(change_time) = screen_changed_at {
+            if change_time.elapsed() >= stable_window {
+                break;
+            }
+        }
+        if screen_changed_at.is_none() {
+            if let Some(change_time) = output_changed_at {
+                if change_time.elapsed() >= stable_window * 2 {
+                    break;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    // 返回终端当前可见内容：优先前端 xterm 回传的屏幕快照（与用户看到的画面一致，
+    // vim/nano 全屏界面、swap 提示都能完整呈现），若前端尚未回传（面板未挂载等）
+    // 则回退到后端 output_buffer 的可见内容（recent_output 兜底，保证即时可见性）。
+    let stdout_text = manager
+        .screen_snapshot()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| manager.recent_output(80));
+
+    let _ = response_tx.send(TerminalExecResponse {
+        exit_code: 0,
+        stdout: stdout_text,
+        stderr: String::new(),
+        timed_out: false,
+        cwd_after: manager.cwd(),
+        interrupted_by_user: false,
+        interactive_mode: true,
+    });
+}
+
+/// 向已进入交互态的终端发送输入（按键/文本），等待屏幕变化后返回新快照。
+///
+/// 这是 Agent 持续操作交互程序的核心：每发一次按键，等待屏幕渲染稳定后返回
+/// 当前可见内容。Agent 据此观察程序反应，形成"输入→观察→输入"闭环。
+/// 不发 marker、不设置协作状态（交互程序启动时已是 AgentInteractive 态）。
+/// 复用 `handle_exec_interactive` 的"等待 screen_updates 变化 + 稳定窗口"轮询逻辑。
+pub(crate) async fn handle_send_interactive(
+    manager: &Arc<TerminalManager>,
+    pty_state: &mut Option<PtyState>,
+    _app: &tauri::AppHandle,
+    input: &str,
+    wait_secs: u64,
+    response_tx: oneshot::Sender<TerminalExecResponse>,
+    _activity: Option<&Arc<crate::collaboration::TerminalActivityTracker>>,
+) {
+    let ps = match pty_state {
+        Some(ps) => ps,
+        None => {
+            let _ = response_tx.send(TerminalExecResponse {
+                exit_code: -1,
+                stdout: String::new(),
+                stderr: "终端会话不可用".to_string(),
+                timed_out: false,
+                cwd_after: manager.cwd(),
+                interrupted_by_user: false,
+                interactive_mode: false,
+            });
+            return;
+        }
+    };
+
+    // 发送前记录双信号基线：
+    // - output_pushed：程序响应输出到达后端 buffer 的可靠信号（立即可知）
+    // - screen_updates：前端 xterm 渲染并回传快照的信号（最终屏幕内容来源）
+    let baseline_pushed = manager.total_lines_pushed();
+    let baseline_updates = manager.screen_updates();
+
+    // 把输入写入 PTY。输入由 Agent 给出（vi 按键、REPL 命令等），原样写入。
+    // 不做 LF 转 CR：send_interactive 发的是对前台程序的原始输入，由 Agent 控制按键。
+    let send_result = {
+        match ps.writer.lock() {
+            Ok(mut writer) => send_to_pty(&mut writer, input),
+            Err(e) => Err(anyhow::anyhow!("获取 writer 锁失败: {}", e)),
+        }
+    };
+    if let Err(e) = send_result {
+        let _ = response_tx.send(TerminalExecResponse {
+            exit_code: -1,
+            stdout: String::new(),
+            stderr: format!("发送输入到终端失败: {}", e),
+            timed_out: false,
+            cwd_after: manager.cwd(),
+            interrupted_by_user: false,
+            interactive_mode: false,
+        });
+        return;
+    }
+
+    // 双信号等待：output_pushed 触发"程序已响应"，screen_updates 确认"快照已更新"。
+    // 优先等快照更新（最准确），若前端未回传（面板未挂载）则退到 output_pushed 变化。
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs.max(1));
+    let stable_window = std::time::Duration::from_millis(300);
+    let poll_interval = std::time::Duration::from_millis(50);
+    let mut output_changed_at: Option<std::time::Instant> = None;
+    let mut screen_changed_at: Option<std::time::Instant> = None;
+
+    loop {
+        let now_pushed = manager.total_lines_pushed();
+        let now_updates = manager.screen_updates();
+        if output_changed_at.is_none() && now_pushed > baseline_pushed {
+            output_changed_at = Some(std::time::Instant::now());
+        }
+        if screen_changed_at.is_none() && now_updates > baseline_updates {
+            screen_changed_at = Some(std::time::Instant::now());
+        }
+        if let Some(change_time) = screen_changed_at {
+            if change_time.elapsed() >= stable_window {
+                break;
+            }
+        }
+        if screen_changed_at.is_none() {
+            if let Some(change_time) = output_changed_at {
+                if change_time.elapsed() >= stable_window * 2 {
+                    break;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    let stdout_text = manager
+        .screen_snapshot()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| manager.recent_output(80));
+
+    let _ = response_tx.send(TerminalExecResponse {
+        exit_code: 0,
+        stdout: stdout_text,
+        stderr: String::new(),
+        timed_out: false,
+        cwd_after: manager.cwd(),
+        interrupted_by_user: false,
+        interactive_mode: true,
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tiangong-plugin-terminal/src/commands.rs
+++ b/crates/tiangong-plugin-terminal/src/commands.rs
@@ -53,6 +53,23 @@ pub async fn terminal_destroy_session(
     Ok(())
 }
 
+/// 把草稿态临时 id 的 PTY 迁移到真实 session_id（草稿态转正时调用）。
+///
+/// 草稿态新对话用稳定临时 id 创建 PTY；首条消息创建后端 session 拿到真实 id 后，
+/// 调用此命令把 PTY 归属、日志迁移到真实 id。幂等：草稿 id 不存在或真实 id 已
+/// 存在时安全返回。
+#[tauri::command]
+pub async fn terminal_attach_session(
+    draft_session_id: String,
+    persistent_session_id: String,
+    state: State<'_, TerminalPluginState>,
+) -> Result<(), String> {
+    state
+        .registry
+        .attach_persistent_session_id(&draft_session_id, &persistent_session_id);
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn terminal_session_send_input(
     session_id: String,
@@ -169,5 +186,22 @@ pub async fn terminal_panel_set_session(
     _session_id: Option<String>,
     _state: State<'_, TerminalPluginState>,
 ) -> Result<(), String> {
+    Ok(())
+}
+
+/// 前端 xterm.js 回传当前屏幕快照。
+///
+/// 前端在终端内容变化时，把 xterm.js buffer.active 的可见区域序列化成文本回传。
+/// 后端缓存到对应 session 的 TerminalManager，`handle_exec_interactive` 读取此快照
+/// 返回给 Agent——这样 Agent 看到的是与用户一致的屏幕内容（含 vim/nano 全屏界面），
+/// 而非后端单行 processor 无法重建的碎片。
+#[tauri::command]
+pub async fn terminal_session_update_screen(
+    session_id: String,
+    snapshot: String,
+    state: State<'_, TerminalPluginState>,
+) -> Result<(), String> {
+    let pty = ensure_pty(&state, &session_id)?;
+    pty.manager.update_screen_snapshot(snapshot);
     Ok(())
 }

--- a/crates/tiangong-plugin-terminal/src/handler.rs
+++ b/crates/tiangong-plugin-terminal/src/handler.rs
@@ -63,13 +63,45 @@ fn is_interactive_program(word: &str) -> bool {
     )
 }
 
+/// 检测脚本是否使用 stdin 自动化（heredoc/管道/echo 注入）驱动交互程序。
+/// 这是反模式：即便交互式终端能力已启用，用 heredoc 自动化 vi 仍不可靠
+/// （vi 的 ex 模式行为不稳定、转义复杂），应拒绝并引导 Agent 分步操作。
+fn script_uses_stdin_automation(script: &str) -> bool {
+    let lower = script.to_ascii_lowercase();
+    script.contains("<<")
+        || script.contains('|')
+        || lower.contains("printf ")
+        || lower.contains("echo ")
+        || lower.contains(" -es")
+        || lower.contains(" -e ")
+        || lower.contains(" --cmd")
+}
+
 /// 拦截 Agent 发起的交互式终端程序。
 ///
-/// 当前基础终端分支不支持 Agent 自动操作交互式终端程序
-/// （terminal_input/output/reset 等交互能力在独立分支开发）。
-/// 一旦检测到脚本中出现 vi/vim/nano/ssh/python REPL 等交互程序，
-/// 无论是否伴随 stdin 自动化，都直接拒绝，避免 PTY 进入前台交互后卡死。
-fn reject_interactive_script(script: &str) -> Option<ToolResult> {
+/// 门禁策略随 `interactive` 参数分流：
+/// - `interactive=false`（默认，向后兼容）：无条件拒绝所有交互程序。LLM 未显式声明
+///   交互意图时，按基础终端分支语义处理，避免误用导致 PTY 卡死。
+/// - `interactive=true`：放行裸交互程序（如 `vi file.txt`、`python`），仅拦截
+///   stdin 自动化（heredoc/pipe/echo 驱动 vi 等）的反模式。Agent 必须通过
+///   `run_shell{interactive:true}` 显式声明，才能启动交互程序并进入 AgentInteractive 态。
+fn reject_interactive_script(script: &str, interactive: bool) -> Option<ToolResult> {
+    if interactive {
+        // 交互模式：只拦截 stdin 自动化反模式，放行裸交互程序
+        if script_uses_interactive_terminal_program(script) && script_uses_stdin_automation(script)
+        {
+            return Some(ToolResult {
+                ok: false,
+                summary: "不支持用 stdin 自动化驱动交互式终端程序".to_string(),
+                stdout: String::new(),
+                stderr: "检测到脚本试图通过 heredoc/管道/echo 自动化驱动 vi/vim/nano 等交互程序，这种用法不可靠。请直接以 `run_shell{interactive:true, script:\"vi <file>\"}` 启动，然后在终端面板手动操作，或改用 write_file / replace_in_file 完成编辑。".to_string(),
+                exit_code: 2,
+                execution: None,
+            });
+        }
+        return None;
+    }
+    // 非交互模式：无条件拒绝所有交互程序（保持基础终端分支语义）
     if !script_uses_interactive_terminal_program(script) {
         return None;
     }
@@ -77,7 +109,7 @@ fn reject_interactive_script(script: &str) -> Option<ToolResult> {
         ok: false,
         summary: "不支持 Agent 自动操作交互式终端程序".to_string(),
         stdout: String::new(),
-        stderr: "检测到脚本中包含 vi/vim/nano/ssh/python REPL 等交互式终端程序。当前基础终端分支不支持 Agent 自动操作交互式终端程序，请改用 write_file / replace_in_file 完成文件编辑，或使用非交互 shell 命令（如 sed、awk）。交互式终端能力在独立分支开发。".to_string(),
+        stderr: "检测到脚本中包含 vi/vim/nano/ssh/python REPL 等交互式终端程序。如需启动交互程序，请使用 `run_shell{interactive:true, script:\"<command>\"}` 显式声明交互意图。否则请改用 write_file / replace_in_file 完成文件编辑，或使用非交互 shell 命令（如 sed、awk）。".to_string(),
         exit_code: 2,
         execution: None,
     })
@@ -113,6 +145,13 @@ impl TerminalToolOverride {
             None => return Box::pin(async { None }),
         };
         let timeout_secs = call.arguments.get("timeout").and_then(|v| v.as_u64());
+        // 读取 interactive 标志：Agent 显式声明要启动交互程序（vi/nano/REPL）。
+        // true 时走 exec_interactive 进入 AgentInteractive 态；false 时保持基础终端语义。
+        let interactive = call
+            .arguments
+            .get("interactive")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         // 读取 agent 指定的工作目录（run_shell schema 含 cwd 字段）。
         // 与 run_command_via_pty 一致：cwd 与终端当前目录不同时，把 script
         // 包装成 `cd <cwd> && <script>`，避免命令在错误的目录执行。
@@ -122,7 +161,7 @@ impl TerminalToolOverride {
             .and_then(|v| v.as_str())
             .map(String::from);
 
-        if let Some(result) = reject_interactive_script(&command) {
+        if let Some(result) = reject_interactive_script(&command, interactive) {
             return Box::pin(async move { Some(result) });
         }
 
@@ -148,18 +187,32 @@ impl TerminalToolOverride {
                 }
                 _ => command,
             };
-            let result = match provider.exec(&session_id, &command, timeout_secs).await {
-                Some(r) => r,
-                None => return None, // 终端不可用，回退到默认 run_shell
+            let result = if interactive {
+                // 交互模式：以 CR 提交命令，等待初始渲染，进入 AgentInteractive 态。
+                // wait_secs=3 给 vi/nano 足够时间绘制界面。
+                match provider.exec_interactive(&session_id, &command, 3).await {
+                    Some(r) => r,
+                    None => return None, // 终端不可用，回退到默认 run_shell
+                }
+            } else {
+                match provider.exec(&session_id, &command, timeout_secs).await {
+                    Some(r) => r,
+                    None => return None, // 终端不可用，回退到默认 run_shell
+                }
             };
 
             let stdout = Self::truncate_text(&result.stdout, OUTPUT_THRESHOLD);
 
-            // 当前基础终端分支不支持 Agent 交互式终端：interactive_mode 为 true
-            // 时 PTY 前台进程仍在运行，必须报告失败，避免 Agent 误判成功后在卡住
-            // 的 PTY 上继续执行后续命令。
-            let mut summary = if result.interactive_mode {
-                "命令进入交互模式（当前不支持 Agent 交互式终端）".to_string()
+            // 成功判定随交互模式分流：
+            // - 交互模式：interactive_mode=true 是预期的成功（命令已进入交互态），
+            //   报告 ok=true。stdout 携带终端首次变化后的完整可见内容（vi 编辑页、
+            //   swap 提示 E325、REPL 提示符等），由 Agent 自行阅读判断当前状态。
+            // - 非交互模式：interactive_mode=true 意味着命令意外进入交互（兜底检测），
+            //   前台进程仍在运行，必须报告失败，避免 Agent 误判后在卡住的 PTY 继续操作。
+            let mut summary = if interactive && result.interactive_mode {
+                "命令已进入交互态（终端当前显示见 stdout）".to_string()
+            } else if result.interactive_mode {
+                "命令进入交互模式（未声明 interactive:true）".to_string()
             } else if result.timed_out {
                 "命令执行超时".to_string()
             } else if result.interrupted_by_user {
@@ -175,21 +228,101 @@ impl TerminalToolOverride {
             }
 
             let mut stderr = result.stderr.clone();
-            if result.interactive_mode {
+            if interactive && result.interactive_mode {
+                // stdout 携带终端首次变化后的完整可见内容。引导 Agent 阅读该内容，
+                // 据此判断交互程序所处状态（已进入编辑器 / 遇到 swap 提示 / 等待输入
+                // 等），并据此引导用户在终端面板手动操作或改用非交互方式。
                 stderr.push_str(
-                    "\n[提示] 命令似乎进入了交互模式（等待输入或未正常退出）。\
-当前基础终端分支不支持 Agent 自动操作交互式终端程序，请改用 write_file / \
-replace_in_file，或使用非交互 shell 命令完成。",
+                    "\n[提示] stdout 为终端当前显示内容，请阅读判断命令状态：\
+若已进入编辑器（vi/nano 编辑界面），可引导用户在其中操作；\
+若遇到提示（如 swap 恢复 E325、确认 [Y/n]），引导用户在终端面板按键选择；\
+若不便交互，可改用非交互方式（write_file / replace_in_file 等）。",
+                );
+            } else if result.interactive_mode {
+                stderr.push_str(
+                    "\n[提示] 命令似乎进入了交互模式（未通过 interactive:true 声明）。\
+如需启动交互程序，请使用 `run_shell{interactive:true}`。",
                 );
             } else if result.interrupted_by_user {
                 stderr.push_str("\n[提示] 命令被用户中断，建议询问用户是否需要调整执行计划");
             }
 
+            // 交互模式且成功进入交互态视为成功
+            let ok = if interactive && result.interactive_mode {
+                true
+            } else {
+                result.exit_code == 0 && !result.timed_out && !result.interactive_mode
+            };
+
             Some(ToolResult {
-                ok: result.exit_code == 0 && !result.timed_out && !result.interactive_mode,
+                ok,
                 summary,
                 stdout,
                 stderr,
+                exit_code: result.exit_code,
+                execution: None,
+            })
+        })
+    }
+
+    /// 处理 terminal_send：向已进入交互态的终端发送按键/文本，返回屏幕新快照。
+    ///
+    /// 这是 Agent 持续操作交互程序（vi/nano/REPL）的核心工具。每次调用完成
+    /// "发送输入 → 等待屏幕变化 → 返回新快照"的原子操作，Agent 据此观察程序
+    /// 反应并决定下一步输入，形成持续交互闭环。
+    fn handle_terminal_send(
+        provider: &std::sync::Arc<dyn tiangong_core::terminal_trait::TerminalProvider>,
+        call: &tiangong_core::model::ToolCall,
+        session_id: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<ToolResult>> + Send>> {
+        // input：要发送的按键/文本（原样写入 PTY，由 Agent 控制具体内容）
+        let input = match call.arguments.get("input").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => {
+                return Box::pin(async {
+                    Some(ToolResult {
+                        ok: false,
+                        summary: "terminal_send 缺少 input 参数".to_string(),
+                        stdout: String::new(),
+                        stderr: "input 参数为必填，指定要发送到终端的按键/文本".to_string(),
+                        exit_code: 2,
+                        execution: None,
+                    })
+                });
+            }
+        };
+        // wait_secs：发送后等待屏幕变化的秒数（默认 3，给程序渲染时间）
+        let wait_secs = call
+            .arguments
+            .get("wait")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(3);
+
+        let provider = provider.clone();
+        let session_id = session_id.to_string();
+        Box::pin(async move {
+            let result = match provider
+                .send_interactive(&session_id, &input, wait_secs)
+                .await
+            {
+                Some(r) => r,
+                None => return None, // 终端不可用，回退到默认逻辑
+            };
+
+            let stdout = Self::truncate_text(&result.stdout, OUTPUT_THRESHOLD);
+            let summary = if result.interactive_mode {
+                "终端已更新（当前显示见 stdout）".to_string()
+            } else if result.exit_code != 0 {
+                format!("终端输入失败（退出码 {}）", result.exit_code)
+            } else {
+                "终端输入已发送".to_string()
+            };
+
+            Some(ToolResult {
+                ok: true,
+                summary,
+                stdout,
+                stderr: String::new(),
                 exit_code: result.exit_code,
                 execution: None,
             })
@@ -205,6 +338,7 @@ impl tiangong_core::tool_override::ToolOverrideHandler for TerminalToolOverride 
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<ToolResult>> + Send>> {
         match call.name.as_str() {
             "run_shell" => Self::handle_run_shell(&self.provider, call, session_id),
+            "terminal_send" => Self::handle_terminal_send(&self.provider, call, session_id),
             _ => Box::pin(async { None }),
         }
     }
@@ -217,7 +351,8 @@ impl tiangong_core::tool_override::PromptSectionProvider for TerminalPromptSecti
     fn prompt_sections(&self) -> Vec<String> {
         vec![
             "当用户请求涉及命令行操作（安装依赖、创建项目、编译构建、文件操作等），必须逐步使用 `run_shell` 实际执行命令，不要仅以文本或代码块形式展示命令给用户。每步执行一条命令，根据执行结果决定下一步操作。回复中可以用代码块展示已执行的命令，但必须先通过 `run_shell` 实际执行。".to_string(),
-            "当前基础终端能力不支持 Agent 自动操作交互式终端程序（如 vi/vim/nano/ssh/python REPL）。遇到文件编辑应使用 write_file / replace_in_file，或使用非交互 shell 命令（如 sed、awk）完成。".to_string(),
+            "需要启动交互式终端程序（如 vi/vim/nano 编辑文件、python/node REPL）时，使用 `run_shell{interactive:true, script:\"<command>\"}` 显式声明。命令在终端首次渲染屏幕后返回，stdout 为终端当前显示内容（已过滤控制序列）。请阅读该内容判断命令状态，然后用 `terminal_send{input:\"<按键>\"}` 持续操作终端：每次发送按键后自动等待屏幕变化并返回新快照，据此观察程序反应决定下一步。例如遇到 vi 的 swap 恢复提示（E325）时，发 `terminal_send{input:\"d\"}` 删除 swap 文件，返回的快照会显示进入编辑器后的界面；在 vi 中编辑完成后发 `terminal_send{input:\"\\x1b:wq\\r\"}` 保存退出。禁止用 heredoc/管道/echo 自动化驱动交互程序。".to_string(),
+            "文件编辑优先使用 write_file / replace_in_file；仅当用户明确要求在终端编辑器（如 vi）中操作，或需要交互式程序（如 REPL 实验）时才用 `run_shell{interactive:true}`。".to_string(),
         ]
     }
 }
@@ -227,40 +362,52 @@ mod tests {
     use super::*;
 
     #[test]
-    fn rejects_heredoc_driven_vi() {
+    fn rejects_heredoc_driven_vi_non_interactive() {
         let script = "rm -f hello.txt\nvi -es hello.txt <<'EOF'\ni\nworld\n.\nwq\nEOF\n";
-        let result = reject_interactive_script(script);
+        // 非交互模式：无条件拒绝
+        let result = reject_interactive_script(script, false);
         assert!(result.is_some());
         let result = result.unwrap();
         assert!(!result.ok);
         assert_eq!(result.exit_code, 2);
+    }
+
+    #[test]
+    fn rejects_heredoc_driven_vi_even_interactive() {
+        // 交互模式下，stdin 自动化驱动 vi 仍被拒（反模式）
+        let script = "rm -f hello.txt\nvi -es hello.txt <<'EOF'\ni\nworld\n.\nwq\nEOF\n";
+        let result = reject_interactive_script(script, true);
+        assert!(result.is_some());
     }
 
     #[test]
     fn rejects_expect_driven_vi() {
         let script =
             "expect <<'EOF'\nset timeout 10\nspawn vi hello.txt\nsend \"iworld\\033:wq\\r\"\nexpect eof\nEOF";
-        let result = reject_interactive_script(script);
-        assert!(result.is_some());
+        // 两种模式都拒（heredoc 自动化）
+        assert!(reject_interactive_script(script, false).is_some());
+        assert!(reject_interactive_script(script, true).is_some());
     }
 
     #[test]
     fn rejects_pipe_driven_vi() {
         let script = "printf 'iworld\\033:wq\\n' | vi hello.txt";
-        let result = reject_interactive_script(script);
-        assert!(result.is_some());
+        // 管道自动化：两种模式都拒
+        assert!(reject_interactive_script(script, false).is_some());
+        assert!(reject_interactive_script(script, true).is_some());
     }
 
     #[test]
     fn allows_regular_shell_script() {
-        let result = reject_interactive_script("rm -f hello.txt\ncat hello.txt");
-        assert!(result.is_none());
+        // 普通脚本两种模式都放行
+        assert!(reject_interactive_script("rm -f hello.txt\ncat hello.txt", false).is_none());
+        assert!(reject_interactive_script("rm -f hello.txt\ncat hello.txt", true).is_none());
     }
 
     #[test]
-    fn rejects_plain_vi() {
-        // 裸 vi 调用（无 heredoc/pipe）也应被拒绝：当前分支不支持 Agent 操作交互式程序
-        let result = reject_interactive_script("vi hello.txt");
+    fn rejects_plain_vi_non_interactive() {
+        // 非交互模式：裸 vi 被拒（未声明交互意图）
+        let result = reject_interactive_script("vi hello.txt", false);
         assert!(result.is_some());
         let result = result.unwrap();
         assert!(!result.ok);
@@ -268,20 +415,33 @@ mod tests {
     }
 
     #[test]
-    fn rejects_python_repl() {
-        let result = reject_interactive_script("python");
+    fn allows_plain_vi_interactive() {
+        // 交互模式：裸 vi 放行（Agent 显式声明交互意图）
+        let result = reject_interactive_script("vi hello.txt", true);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn allows_python_repl_interactive() {
+        // 交互模式放行 REPL
+        assert!(reject_interactive_script("python", true).is_none());
+        assert!(reject_interactive_script("python3", true).is_none());
+    }
+
+    #[test]
+    fn rejects_python_repl_non_interactive() {
+        let result = reject_interactive_script("python", false);
         assert!(result.is_some());
     }
 
     #[test]
-    fn rejects_node_repl() {
-        let result = reject_interactive_script("node");
-        assert!(result.is_some());
+    fn allows_ssh_interactive() {
+        assert!(reject_interactive_script("ssh user@host", true).is_none());
     }
 
     #[test]
-    fn rejects_ssh() {
-        let result = reject_interactive_script("ssh user@host");
+    fn rejects_ssh_non_interactive() {
+        let result = reject_interactive_script("ssh user@host", false);
         assert!(result.is_some());
     }
 }

--- a/crates/tiangong-plugin-terminal/src/handler.rs
+++ b/crates/tiangong-plugin-terminal/src/handler.rs
@@ -7,30 +7,6 @@ use crate::util::shell_quote;
 
 const OUTPUT_THRESHOLD: usize = 2000;
 
-/// 解码 Agent 在 terminal_send input 中使用的转义序列。
-///
-/// Agent 按工具规格用字面转义序列表示特殊键（如 `\x1b:wq\r`），但 JSON 字符串里
-/// `` 是 4 个字面字符（反斜杠+x+1+b），写入 PTY 时需解码为真实控制字节（0x1b），
-/// 否则 vi 等程序会把它当普通文本插入而非 ESC 指令。
-///
-/// 使用 descape 库解码（支持 \e/\x1b=ESC、\r=CR、\n=LF、\xHH=任意字节、
-/// \uXXXX=unicode 等完整 C 风格转义）。解码失败（含非法转义）时回退到原文，
-/// 保证不丢数据——最坏情况是字面字符写入 PTY（与修复前行为一致）。
-fn decode_terminal_escapes(input: &str) -> String {
-    use descape::UnescapeExt;
-    match input.to_unescaped() {
-        Ok(cow) => cow.into_owned(),
-        Err(e) => {
-            tracing::warn!(
-                index = e.index,
-                input_len = input.len(),
-                "terminal_send input 含非法转义序列，原样写入 PTY"
-            );
-            input.to_string()
-        }
-    }
-}
-
 fn first_shell_word(line: &str) -> Option<&str> {
     let trimmed = line.trim_start();
     if trimmed.is_empty() || trimmed.starts_with('#') {
@@ -299,10 +275,9 @@ impl TerminalToolOverride {
         call: &tiangong_core::model::ToolCall,
         session_id: &str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<ToolResult>> + Send>> {
-        // input：要发送的按键/文本。Agent 用转义序列表示特殊键（\x1b=ESC、\r=CR），
-        // JSON 字符串里这些是字面字符，写入 PTY 前需解码为真实控制字节。
+        // input：要发送的按键/文本（原样传递，转义由终端执行侧 command_protocol 处理）。
         let input = match call.arguments.get("input").and_then(|v| v.as_str()) {
-            Some(s) => decode_terminal_escapes(s),
+            Some(s) => s.to_string(),
             None => {
                 return Box::pin(async {
                     Some(ToolResult {
@@ -385,61 +360,6 @@ impl tiangong_core::tool_override::PromptSectionProvider for TerminalPromptSecti
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn decode_esc_sequence_for_vi_save_quit() {
-        // vi 保存退出：ESC + :wq + CR
-        let decoded = decode_terminal_escapes("\\x1b:wq\\r");
-        assert_eq!(decoded.as_bytes(), &[0x1b, b':', b'w', b'q', 0x0d]);
-    }
-
-    #[test]
-    fn decode_ctrl_c_as_etx() {
-        // Ctrl+C = ETX (0x03)
-        let decoded = decode_terminal_escapes("\\x03");
-        assert_eq!(decoded.as_bytes(), &[0x03]);
-    }
-
-    #[test]
-    fn decode_carriage_return_and_newline() {
-        let decoded = decode_terminal_escapes("abc\\r\\n");
-        assert_eq!(decoded.as_bytes(), &[b'a', b'b', b'c', 0x0d, 0x0a]);
-    }
-
-    #[test]
-    fn decode_escape_letter_e() {
-        // \e 也表示 ESC
-        let decoded = decode_terminal_escapes("\\e");
-        assert_eq!(decoded.as_bytes(), &[0x1b]);
-    }
-
-    #[test]
-    fn decode_preserves_plain_text() {
-        // 普通文本无转义，原样返回
-        let decoded = decode_terminal_escapes("hello world");
-        assert_eq!(decoded, "hello world");
-    }
-
-    #[test]
-    fn decode_unknown_escape_preserved() {
-        // 不识别的转义（如 \d）保留反斜杠
-        let decoded = decode_terminal_escapes("a\\db");
-        assert_eq!(decoded, "a\\db");
-    }
-
-    #[test]
-    fn decode_literal_backslash() {
-        // \\ → 字面反斜杠
-        let decoded = decode_terminal_escapes("a\\\\b");
-        assert_eq!(decoded, "a\\b");
-    }
-
-    #[test]
-    fn decode_arrow_key_sequence() {
-        // 上方向键 = ESC[A
-        let decoded = decode_terminal_escapes("\\x1b[A");
-        assert_eq!(decoded.as_bytes(), &[0x1b, b'[', b'A']);
-    }
 
     #[test]
     fn rejects_heredoc_driven_vi_non_interactive() {

--- a/crates/tiangong-plugin-terminal/src/handler.rs
+++ b/crates/tiangong-plugin-terminal/src/handler.rs
@@ -66,6 +66,9 @@ fn is_interactive_program(word: &str) -> bool {
 /// 检测脚本是否使用 stdin 自动化（heredoc/管道/echo 注入）驱动交互程序。
 /// 这是反模式：即便交互式终端能力已启用，用 heredoc 自动化 vi 仍不可靠
 /// （vi 的 ex 模式行为不稳定、转义复杂），应拒绝并引导 Agent 分步操作。
+/// 注意：`|` 检测会匹配任意管道，`vi file | tee backup` 这类合法用法理论上会被误拒。
+/// 但本函数仅在 `script_uses_interactive_terminal_program` 也为 true 时才被调用
+///（双重条件），实际误判率极低，可接受。
 fn script_uses_stdin_automation(script: &str) -> bool {
     let lower = script.to_ascii_lowercase();
     script.contains("<<")
@@ -319,7 +322,9 @@ impl TerminalToolOverride {
             };
 
             Some(ToolResult {
-                ok: true,
+                // ok 与 exit_code 一致：send_interactive 在 PTY 不可用或写入失败时
+                // 返回 exit_code: -1，此时 ok 必须为 false，否则 Agent 会误以为成功
+                ok: result.exit_code == 0,
                 summary,
                 stdout,
                 stderr: String::new(),

--- a/crates/tiangong-plugin-terminal/src/handler.rs
+++ b/crates/tiangong-plugin-terminal/src/handler.rs
@@ -7,6 +7,30 @@ use crate::util::shell_quote;
 
 const OUTPUT_THRESHOLD: usize = 2000;
 
+/// 解码 Agent 在 terminal_send input 中使用的转义序列。
+///
+/// Agent 按工具规格用字面转义序列表示特殊键（如 `\x1b:wq\r`），但 JSON 字符串里
+/// `` 是 4 个字面字符（反斜杠+x+1+b），写入 PTY 时需解码为真实控制字节（0x1b），
+/// 否则 vi 等程序会把它当普通文本插入而非 ESC 指令。
+///
+/// 使用 descape 库解码（支持 \e/\x1b=ESC、\r=CR、\n=LF、\xHH=任意字节、
+/// \uXXXX=unicode 等完整 C 风格转义）。解码失败（含非法转义）时回退到原文，
+/// 保证不丢数据——最坏情况是字面字符写入 PTY（与修复前行为一致）。
+fn decode_terminal_escapes(input: &str) -> String {
+    use descape::UnescapeExt;
+    match input.to_unescaped() {
+        Ok(cow) => cow.into_owned(),
+        Err(e) => {
+            tracing::warn!(
+                index = e.index,
+                input_len = input.len(),
+                "terminal_send input 含非法转义序列，原样写入 PTY"
+            );
+            input.to_string()
+        }
+    }
+}
+
 fn first_shell_word(line: &str) -> Option<&str> {
     let trimmed = line.trim_start();
     if trimmed.is_empty() || trimmed.starts_with('#') {
@@ -275,9 +299,10 @@ impl TerminalToolOverride {
         call: &tiangong_core::model::ToolCall,
         session_id: &str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<ToolResult>> + Send>> {
-        // input：要发送的按键/文本（原样写入 PTY，由 Agent 控制具体内容）
+        // input：要发送的按键/文本。Agent 用转义序列表示特殊键（\x1b=ESC、\r=CR），
+        // JSON 字符串里这些是字面字符，写入 PTY 前需解码为真实控制字节。
         let input = match call.arguments.get("input").and_then(|v| v.as_str()) {
-            Some(s) => s.to_string(),
+            Some(s) => decode_terminal_escapes(s),
             None => {
                 return Box::pin(async {
                     Some(ToolResult {
@@ -360,6 +385,61 @@ impl tiangong_core::tool_override::PromptSectionProvider for TerminalPromptSecti
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decode_esc_sequence_for_vi_save_quit() {
+        // vi 保存退出：ESC + :wq + CR
+        let decoded = decode_terminal_escapes("\\x1b:wq\\r");
+        assert_eq!(decoded.as_bytes(), &[0x1b, b':', b'w', b'q', 0x0d]);
+    }
+
+    #[test]
+    fn decode_ctrl_c_as_etx() {
+        // Ctrl+C = ETX (0x03)
+        let decoded = decode_terminal_escapes("\\x03");
+        assert_eq!(decoded.as_bytes(), &[0x03]);
+    }
+
+    #[test]
+    fn decode_carriage_return_and_newline() {
+        let decoded = decode_terminal_escapes("abc\\r\\n");
+        assert_eq!(decoded.as_bytes(), &[b'a', b'b', b'c', 0x0d, 0x0a]);
+    }
+
+    #[test]
+    fn decode_escape_letter_e() {
+        // \e 也表示 ESC
+        let decoded = decode_terminal_escapes("\\e");
+        assert_eq!(decoded.as_bytes(), &[0x1b]);
+    }
+
+    #[test]
+    fn decode_preserves_plain_text() {
+        // 普通文本无转义，原样返回
+        let decoded = decode_terminal_escapes("hello world");
+        assert_eq!(decoded, "hello world");
+    }
+
+    #[test]
+    fn decode_unknown_escape_preserved() {
+        // 不识别的转义（如 \d）保留反斜杠
+        let decoded = decode_terminal_escapes("a\\db");
+        assert_eq!(decoded, "a\\db");
+    }
+
+    #[test]
+    fn decode_literal_backslash() {
+        // \\ → 字面反斜杠
+        let decoded = decode_terminal_escapes("a\\\\b");
+        assert_eq!(decoded, "a\\b");
+    }
+
+    #[test]
+    fn decode_arrow_key_sequence() {
+        // 上方向键 = ESC[A
+        let decoded = decode_terminal_escapes("\\x1b[A");
+        assert_eq!(decoded.as_bytes(), &[0x1b, b'[', b'A']);
+    }
 
     #[test]
     fn rejects_heredoc_driven_vi_non_interactive() {

--- a/crates/tiangong-plugin-terminal/src/lib.rs
+++ b/crates/tiangong-plugin-terminal/src/lib.rs
@@ -29,6 +29,7 @@ pub fn init(session_id: String, cwd: String) -> TauriPlugin<Wry> {
         .invoke_handler(tauri::generate_handler![
             commands::terminal_ensure_session,
             commands::terminal_destroy_session,
+            commands::terminal_attach_session,
             commands::terminal_session_send_input,
             commands::terminal_session_recent_output,
             commands::terminal_session_info,
@@ -37,6 +38,7 @@ pub fn init(session_id: String, cwd: String) -> TauriPlugin<Wry> {
             commands::terminal_session_set_cwd,
             commands::terminal_session_resize,
             commands::terminal_session_reset,
+            commands::terminal_session_update_screen,
             commands::terminal_panel_set_session,
         ])
         .setup(move |app, _api| {

--- a/crates/tiangong-plugin-terminal/src/manager.rs
+++ b/crates/tiangong-plugin-terminal/src/manager.rs
@@ -32,6 +32,16 @@ pub(crate) struct TerminalState {
     pub total_lines_pushed: usize,
     /// 当前尚未换行的屏幕行（如 Password:、Proceed? [Y/n] 等提示）
     pub current_line: String,
+    /// 前端 xterm.js 回传的屏幕快照（终端可见区域的文本序列化）。
+    ///
+    /// 后端的 `TerminalLineProcessor` 是单行模型，无法重建 vim/nano 等全屏 TUI 界面
+    ///（光标在屏幕各处定位、多行同时存在）。前端 xterm.js 维护了完整的二维屏幕缓冲区，
+    ///（正是它渲染了用户看到的终端画面），由前端在内容变化时序列化回传。
+    /// `handle_exec_interactive` 返回此快照，让 Agent 看到与用户一致的屏幕内容。
+    pub screen_snapshot: Option<String>,
+    /// 屏幕快照更新计数：每次前端回传新快照时递增。
+    /// `handle_exec_interactive` 用它检测"屏幕是否发生变化"（替代 output_buffer 计数）。
+    pub screen_updates: u64,
 }
 
 impl TerminalManager {
@@ -48,6 +58,8 @@ impl TerminalManager {
                 last_read_line: 0,
                 total_lines_pushed: 0,
                 current_line: String::new(),
+                screen_snapshot: None,
+                screen_updates: 0,
             })),
             logger: None,
         }
@@ -72,6 +84,41 @@ impl TerminalManager {
 
     pub fn session_id(&self) -> String {
         self.state.lock().unwrap().session_id.clone()
+    }
+
+    /// 更新 PTY 所属的 session_id（草稿态 PTY 转正时使用）。
+    ///
+    /// 草稿态用临时 id 创建 PTY，首条消息转正后调用此方法把 PTY 归属迁移到
+    /// 真实 session_id。更新后：
+    /// - 命令循环内通过 `manager.session_id()` 读取的操作（如 reset 重启 shell）
+    ///   会使用新 id
+    /// - 输出读取线程 emit 的事件会以新 session_id 推送（output_reader 动态读取）
+    /// - 配合 `SessionPtyRegistry::attach_persistent_session_id` 重命名注册表 key
+    ///   和日志文件，完成完整迁移
+    pub(crate) fn set_session_id(&self, session_id: String) {
+        self.state.lock().unwrap().session_id = session_id;
+    }
+
+    /// 更新前端 xterm.js 回传的屏幕快照（前端内容变化时调用）。
+    pub(crate) fn update_screen_snapshot(&self, snapshot: String) {
+        let mut state = self.state.lock().unwrap();
+        state.screen_snapshot = Some(snapshot);
+        state.screen_updates = state.screen_updates.saturating_add(1);
+    }
+
+    /// 获取当前屏幕快照（前端回传的可见区域文本）。
+    pub fn screen_snapshot(&self) -> Option<String> {
+        self.state.lock().unwrap().screen_snapshot.clone()
+    }
+
+    /// 获取屏幕快照更新计数（用于检测变化）。
+    pub fn screen_updates(&self) -> u64 {
+        self.state.lock().unwrap().screen_updates
+    }
+
+    /// 获取累计输出行数（程序向终端写数据的可靠信号，用于检测交互程序响应）。
+    pub fn total_lines_pushed(&self) -> usize {
+        self.state.lock().unwrap().total_lines_pushed
     }
 
     pub fn cwd(&self) -> String {
@@ -205,6 +252,22 @@ pub(crate) async fn spawn_command_loop(
                 )
                 .await;
             }
+            TerminalCommand::ExecInteractive {
+                command,
+                wait_secs,
+                response_tx,
+            } => {
+                command_protocol::handle_exec_interactive(
+                    &manager,
+                    &mut pty_state,
+                    &app,
+                    &command,
+                    wait_secs,
+                    response_tx,
+                    activity.as_ref(),
+                )
+                .await;
+            }
             TerminalCommand::RecentOutput { lines, response_tx } => {
                 let output = manager.recent_output(lines);
                 let _ = response_tx.send(output);
@@ -246,6 +309,22 @@ pub(crate) async fn spawn_command_loop(
                     }
                 }
                 let _ = response_tx.send(());
+            }
+            TerminalCommand::SendInteractive {
+                input,
+                wait_secs,
+                response_tx,
+            } => {
+                command_protocol::handle_send_interactive(
+                    &manager,
+                    &mut pty_state,
+                    &app,
+                    &input,
+                    wait_secs,
+                    response_tx,
+                    activity.as_ref(),
+                )
+                .await;
             }
             TerminalCommand::SetCwd { cwd } => {
                 {
@@ -403,6 +482,8 @@ mod tests {
             last_read_line: 0,
             total_lines_pushed: 0,
             current_line: String::new(),
+            screen_snapshot: None,
+            screen_updates: 0,
         };
 
         for i in 0..8 {

--- a/crates/tiangong-plugin-terminal/src/output_processor.rs
+++ b/crates/tiangong-plugin-terminal/src/output_processor.rs
@@ -448,8 +448,14 @@ pub(crate) fn spawn_output_reader(
                 if let Some(ref logger) = logger {
                     logger.append(&filtered);
                 }
+                // session_id 从 state 动态读取：草稿态 PTY 转正时会更新 state.session_id，
+                // 这样事件能以新（真实）session_id 推送，前端按 session_id 分发能正确命中。
+                let current_session_id = state
+                    .lock()
+                    .map(|s| s.session_id.clone())
+                    .unwrap_or_else(|_| session_id.clone());
                 let event = TerminalOutputEvent {
-                    session_id: session_id.clone(),
+                    session_id: current_session_id,
                     text: filtered,
                     is_echo: false,
                 };

--- a/crates/tiangong-plugin-terminal/src/session_pty.rs
+++ b/crates/tiangong-plugin-terminal/src/session_pty.rs
@@ -139,6 +139,68 @@ impl SessionPtyRegistry {
         }
     }
 
+    /// 把临时草稿 id 的 PTY 迁移到真实 session_id（草稿态转正时调用）。
+    ///
+    /// 草稿态新对话用稳定临时 id 创建 PTY（如 `__draft_<n>`），首条消息创建后端
+    /// session 拿到真实 id 后调用此方法完成迁移：
+    /// - 注册表 key：临时 id → 真实 id
+    /// - manager 内部 session_id：更新（命令循环/输出线程后续用新 id）
+    /// - 持久化日志文件：临时目录 → 真实目录（rename，保留草稿期已产生的历史）
+    ///
+    /// 幂等：真实 id 已存在或临时 id 不存在时安全返回（不破坏已有状态）。
+    /// 前端调用前应保证真实 id 尚未创建 PTY（否则会与转正迁移冲突）。
+    pub fn attach_persistent_session_id(&self, draft_id: &str, persistent_id: &str) {
+        if draft_id == persistent_id {
+            return;
+        }
+        let slot = {
+            let mut sessions = self.sessions.lock().unwrap();
+            // 真实 id 已存在：说明 session 已有自己的 PTY，无需迁移
+            if sessions.contains_key(persistent_id) {
+                info!(
+                    draft_id,
+                    persistent_id, "真实 session 已有 PTY，跳过草稿迁移"
+                );
+                return;
+            }
+            sessions.remove(draft_id)
+        };
+
+        let Some(slot) = slot else {
+            // 草稿 id 不存在（用户草稿态没打开终端就没创建），无需迁移
+            return;
+        };
+
+        // 更新 manager 内部 session_id（命令循环/输出线程动态读取，自动生效）
+        slot.manager.set_session_id(persistent_id.to_string());
+
+        // 迁移持久化日志：草稿目录 → 真实目录
+        let draft_log = terminal_log_path(draft_id);
+        let real_log = terminal_log_path(persistent_id);
+        if draft_log.exists() {
+            if let Some(parent) = real_log.parent() {
+                if let Err(e) = std::fs::create_dir_all(parent) {
+                    error!(
+                        draft_id, persistent_id, error = %e,
+                        "迁移终端日志：创建真实 session 目录失败"
+                    );
+                }
+            }
+            if let Err(e) = std::fs::rename(&draft_log, &real_log) {
+                // rename 失败不阻塞迁移：日志是辅助的，PTY 本身已就绪
+                error!(
+                    draft_id, persistent_id, error = %e,
+                    "迁移终端日志文件失败（PTY 已迁移，日志保留在草稿目录）"
+                );
+            }
+        }
+
+        // 重新 insert 到真实 key
+        let mut sessions = self.sessions.lock().unwrap();
+        sessions.insert(persistent_id.to_string(), slot);
+        info!(draft_id, persistent_id, "草稿 PTY 已转正迁移到真实 session");
+    }
+
     /// 列出所有 session 的状态摘要（phase 取自各对话的协作状态机）
     pub fn list_statuses(&self) -> Vec<crate::types::TerminalSessionStatus> {
         let sessions = self.sessions.lock().unwrap();
@@ -290,6 +352,61 @@ impl tiangong_core::terminal_trait::TerminalProvider for SessionAwareTerminalPro
         self.exec(session_id, &command, timeout_secs)
     }
 
+    fn exec_interactive(
+        &self,
+        session_id: &str,
+        command: &str,
+        wait_secs: u64,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Option<tiangong_core::terminal_trait::TerminalExecResult>,
+                > + Send,
+        >,
+    > {
+        let tx = match self.tx(session_id) {
+            Some(tx) => tx,
+            None => return Box::pin(async { None }),
+        };
+        let command = command.to_string();
+        Box::pin(async move {
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+            let resp: crate::types::TerminalExecResponse = send_and_wait!(
+                tx,
+                TerminalCommand::ExecInteractive {
+                    command,
+                    wait_secs,
+                    response_tx,
+                },
+                response_rx,
+                180
+            );
+            Some(resp.into())
+        })
+    }
+
+    fn exec_command_interactive(
+        &self,
+        session_id: &str,
+        cmd: &str,
+        args: &[String],
+        wait_secs: u64,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Option<tiangong_core::terminal_trait::TerminalExecResult>,
+                > + Send,
+        >,
+    > {
+        // 拼装命令字符串，委托给 exec_interactive
+        let mut parts = vec![cmd.to_string()];
+        for arg in args {
+            parts.push(shell_quote(arg));
+        }
+        let command = parts.join(" ");
+        self.exec_interactive(session_id, &command, wait_secs)
+    }
+
     fn recent_output(
         &self,
         session_id: &str,
@@ -336,6 +453,39 @@ impl tiangong_core::terminal_trait::TerminalProvider for SessionAwareTerminalPro
                 5
             );
             Some(())
+        })
+    }
+
+    fn send_interactive(
+        &self,
+        session_id: &str,
+        input: &str,
+        wait_secs: u64,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Option<tiangong_core::terminal_trait::TerminalExecResult>,
+                > + Send,
+        >,
+    > {
+        let tx = match self.tx(session_id) {
+            Some(tx) => tx,
+            None => return Box::pin(async { None }),
+        };
+        let input = input.to_string();
+        Box::pin(async move {
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+            let resp: crate::types::TerminalExecResponse = send_and_wait!(
+                tx,
+                TerminalCommand::SendInteractive {
+                    input,
+                    wait_secs,
+                    response_tx,
+                },
+                response_rx,
+                180
+            );
+            Some(resp.into())
         })
     }
 

--- a/crates/tiangong-plugin-terminal/src/types.rs
+++ b/crates/tiangong-plugin-terminal/src/types.rs
@@ -40,6 +40,12 @@ pub enum TerminalCommand {
         timeout_secs: Option<u64>,
         response_tx: oneshot::Sender<TerminalExecResponse>,
     },
+    /// 交互式命令执行（vi/nano/REPL 等），不使用 marker 协议，直接 CR 提交并等待初始输出
+    ExecInteractive {
+        command: String,
+        wait_secs: u64,
+        response_tx: oneshot::Sender<TerminalExecResponse>,
+    },
     RecentOutput {
         lines: usize,
         response_tx: oneshot::Sender<String>,
@@ -51,6 +57,12 @@ pub enum TerminalCommand {
         input: String,
         source: crate::collaboration::InputSource,
         response_tx: oneshot::Sender<()>,
+    },
+    /// 交互式输入：向已进入交互态的终端发送按键/文本，等待屏幕变化后返回快照
+    SendInteractive {
+        input: String,
+        wait_secs: u64,
+        response_tx: oneshot::Sender<TerminalExecResponse>,
     },
     Reset {
         response_tx: oneshot::Sender<()>,

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -865,6 +865,16 @@ export const api = {
   terminalEnsureSession: (sessionId: string, cwd: string): Promise<boolean> =>
     invoke('plugin:terminal|terminal_ensure_session', { sessionId, cwd }),
 
+  // 把草稿态临时 id 的 PTY 迁移到真实 session_id（草稿态转正时调用）
+  terminalAttachSession: (
+    draftSessionId: string,
+    persistentSessionId: string,
+  ): Promise<void> =>
+    invoke('plugin:terminal|terminal_attach_session', {
+      draftSessionId,
+      persistentSessionId,
+    }),
+
   terminalSessionSendInput: (sessionId: string, input: string): Promise<void> =>
     invoke('plugin:terminal|terminal_session_send_input', { sessionId, input }),
 
@@ -887,6 +897,10 @@ export const api = {
 
   terminalSessionReset: (sessionId: string): Promise<void> =>
     invoke('plugin:terminal|terminal_session_reset', { sessionId }),
+
+  // 前端 xterm.js 把当前屏幕可见区域序列化回传后端（供 handle_exec_interactive 返回给 Agent）
+  terminalSessionUpdateScreen: (sessionId: string, snapshot: string): Promise<void> =>
+    invoke('plugin:terminal|terminal_session_update_screen', { sessionId, snapshot }),
 
   terminalDestroySession: (sessionId: string): Promise<void> =>
     invoke('plugin:terminal|terminal_destroy_session', { sessionId }),

--- a/frontend/src/components/TerminalPanel.tsx
+++ b/frontend/src/components/TerminalPanel.tsx
@@ -18,6 +18,34 @@ interface TerminalEntry {
 
 const MAX_POOL_SIZE = 5;
 
+// 草稿态终端的稳定临时 id（与 store 中 createSession 生成的一致）。
+// 草稿态用此 id 创建 PTY；转正后前端把 pool 的 key 从此 id 迁移到真实 session_id。
+const DRAFT_TERMINAL_ID = '__draft_terminal__';
+// 屏幕快照回传节流间隔（毫秒）：xterm 每次输出后都序列化屏幕会过于频繁，
+// 用此间隔合并短时间内的多次输出为一次回传。
+const SCREEN_SNAPSHOT_THROTTLE_MS = 50;
+
+/**
+ * 序列化 xterm.js 当前可见屏幕（baseY..baseY+rows）为纯文本。
+ * 这是终端真正渲染的画面（含 vim/nano 全屏界面），后端单行 processor 无法重建，
+ * 由前端回传供 handle_exec_interactive 返回给 Agent。
+ */
+function snapshotVisibleScreen(term: Terminal): string {
+  const buffer = term.buffer.active;
+  const start = buffer.baseY;
+  const end = start + term.rows;
+  const lines: string[] = [];
+  for (let y = start; y < end; y++) {
+    const line = buffer.getLine(y);
+    lines.push(line ? line.translateToString(true) : '');
+  }
+  // 裁掉尾部空行（vim 底部的 ~ 占位行保留，但纯空白行精简输出）
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+  return lines.join('\n');
+}
+
 const TERMINAL_CONFIG = {
   cursorBlink: true,
   fontSize: 13,
@@ -42,6 +70,7 @@ const TERMINAL_CONFIG = {
  */
 export function TerminalPanel({ onClose }: { onClose: () => void }) {
   const activeSessionId = useStore((s) => s.activeSessionId);
+  const draftTerminalId = useStore((s) => s.draftTerminalId);
   const sessionCwd = useStore((s) => s.sessionCwd);
   const workspaceDir = useStore((s) => s.workspaceDir);
 
@@ -52,6 +81,8 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const pendingCreateRef = useRef<Set<string>>(new Set());
   const createdTimeRef = useRef<number>(0);
+  // 上次屏幕快照回传时间戳（节流用）
+  const lastSnapshotPushRef = useRef<number>(0);
 
   const [displayInfo, setDisplayInfo] = useState<{
     cwd: string;
@@ -62,8 +93,10 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
     alive: false,
   });
 
-  // 按对话 PTY 模型：effectiveId 为当前对话 id，每个对话有独立终端会话
-  const effectiveId = activeSessionId || null;
+  // 按对话 PTY 模型：effectiveId 为当前对话 id。
+  // 草稿态（activeSessionId=null）用 draftTerminalId 作为临时 id 创建草稿 PTY，
+  // 转正后切换为真实 session_id（后端 PTY 已通过 terminalAttachSession 迁移归属）。
+  const effectiveId = activeSessionId || draftTerminalId || null;
 
   // 全局 output listener（按 session_id 分发）
   useEffect(() => {
@@ -78,6 +111,16 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
           const entry = poolRef.current.get(session_id);
           if (entry) {
             entry.term.write(text);
+            // write 是同步的，写完 buffer 立即可读。节流后把当前可见屏幕回传后端，
+            // 供 handle_exec_interactive 检测变化并返回给 Agent（vi/nano 全屏界面）。
+            const now = Date.now();
+            if (now - lastSnapshotPushRef.current >= SCREEN_SNAPSHOT_THROTTLE_MS) {
+              lastSnapshotPushRef.current = now;
+              const snapshot = snapshotVisibleScreen(entry.term);
+              api
+                .terminalSessionUpdateScreen(session_id, snapshot)
+                .catch(() => {});
+            }
           }
         },
       );
@@ -120,6 +163,24 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
   useEffect(() => {
     // 按对话 PTY 模型：effectiveId 即当前对话 id，尚未就绪时跳过
     if (!effectiveId) return;
+
+    // 草稿态转正过渡：effectiveId 从 DRAFT_TERMINAL_ID 切换到真实 session_id 时，
+    // 把前端 pool 里的 xterm entry key 从草稿 id 迁移到真实 id。
+    // 后端 PTY 已通过 terminalAttachSession 改名，前端 pool 同步改名后，
+    // 输出 listener（按 session_id 分发）和后续 ensure（命中后端已迁移的 PTY）
+    // 都能用真实 id 正确工作，避免重建 xterm 丢失草稿期已渲染的内容。
+    if (
+      effectiveId !== DRAFT_TERMINAL_ID &&
+      effectiveId !== currentIdRef.current &&
+      poolRef.current.has(DRAFT_TERMINAL_ID)
+    ) {
+      const draftEntry = poolRef.current.get(DRAFT_TERMINAL_ID);
+      if (draftEntry) {
+        poolRef.current.delete(DRAFT_TERMINAL_ID);
+        poolRef.current.set(effectiveId, draftEntry);
+      }
+    }
+
     if (effectiveId === currentIdRef.current && poolRef.current.has(effectiveId)) {
       return;
     }

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -141,6 +141,14 @@ interface AppState {
   // 状态
   sessions: Session[];
   activeSessionId: string | null;
+  /**
+   * 草稿态终端的稳定临时 id。
+   * 草稿态（activeSessionId=null）无法用真实 session_id 创建 PTY，
+   * 用此临时 id 先创建一个草稿 PTY 供用户在终端面板操作；
+   * 首条消息转正后，该 PTY 会迁移归属到真实 session_id。
+   * 转正完成（或切换/删除对话）时清空。
+   */
+  draftTerminalId: string | null;
   messages: Message[];
   runStatus: string;
   runSummary: string;
@@ -225,6 +233,7 @@ export const useStore = create<AppState>((set, get) => ({
   // 初始状态
   sessions: [],
   activeSessionId: null as string | null,
+  draftTerminalId: null as string | null,
   messages: [],
   runStatus: 'idle',
   runSummary: '',
@@ -316,9 +325,13 @@ export const useStore = create<AppState>((set, get) => ({
     const workspaceDir = get().workspaceDir;
     const { reasoningEffortPerSession } = get();
     const draftEffort = reasoningEffortPerSession['__draft__'] || 'medium';
+    // 为草稿态终端生成稳定临时 id：同一时刻只有一个草稿，用固定常量即可。
+    // TerminalPanel 草稿态会以此 id 创建 PTY；转正时迁移归属到真实 session_id。
+    const draftTerminalId = '__draft_terminal__';
     set({
       isDraft: true,
       activeSessionId: null,
+      draftTerminalId,
       messages: [],
       inputContent: '',
       runStatus: 'idle',
@@ -350,6 +363,7 @@ export const useStore = create<AppState>((set, get) => ({
       set({
         isDraft: false,
         activeSessionId: id,
+        draftTerminalId: null,
         messages: snapshot.messages,
         inputContent: snapshot.input_draft,
         runStatus: snapshot.status,
@@ -384,6 +398,7 @@ export const useStore = create<AppState>((set, get) => ({
         sessions,
         isDraft: false,
         activeSessionId: snapshot.messages.length > 0 ? snapshot.messages[0].id : null,
+        draftTerminalId: null,
         messages: snapshot.messages,
         inputContent: snapshot.input_draft,
         runStatus: snapshot.status,
@@ -413,11 +428,29 @@ export const useStore = create<AppState>((set, get) => ({
         if (draftCwd) {
           await api.setSessionCwd(draftCwd).catch(console.error);
         }
+        // 草稿 PTY 转正：把草稿态临时 id 的 PTY 迁移归属到真实 session_id。
+        // 草稿态若用户打开过终端，已用 draftTerminalId 创建了 PTY，这里迁移它
+        // （PTY 内 shell 历史、cwd 一并保留）；若草稿态没开终端（draftTerminalId
+        // 不存在或未创建），迁移是幂等的 no-op。
+        const draftId = get().draftTerminalId;
+        if (draftId) {
+          await api
+            .terminalAttachSession(draftId, session.id)
+            .catch(e => console.error('草稿终端 PTY 转正迁移失败:', e));
+        }
         set(state => ({
           sessions: [session, ...state.sessions],
           activeSessionId: session.id,
           isDraft: false,
+          draftTerminalId: null,
         }));
+        // 兜底：确保转正后真实 session 一定有 PTY。
+        // 草稿态未开终端时迁移是 no-op，这里补建；草稿态开过终端时迁移已完成，
+        // ensure 命中已存在直接返回 true，不会重复创建。
+        const ensureCwd = draftCwd || get().workspaceDir || '';
+        await api
+          .terminalEnsureSession(session.id, ensureCwd)
+          .catch(e => console.error('新会话终端 PTY 创建失败:', e));
       } catch (error) {
         console.error('创建会话失败:', error);
         return;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -301,7 +301,10 @@ fn run_gui() {
                 state.set_terminal_provider(provider.clone());
                 let terminal_override = tiangong_plugin_terminal::get_tool_override(app.handle());
                 if let Some(handler) = terminal_override {
-                    state.register_tool_override("run_shell", handler);
+                    // 同一 TerminalToolOverride 分发 run_shell（执行命令/启动交互程序）
+                    // 和 terminal_send（持续操作交互程序：发送按键+返回屏幕快照）
+                    state.register_tool_override("run_shell", handler.clone());
+                    state.register_tool_override("terminal_send", handler);
                 }
                 state.register_prompt_section_provider(
                     tiangong_plugin_terminal::get_prompt_section_provider(),


### PR DESCRIPTION
## 概述

基于已有的按对话独立 PTY 架构，新增 Agent 对交互式终端程序（vi/vim/nano 编辑、python/node REPL）的启动和持续操作能力。

## 核心能力

- **run_shell interactive 模式**：显式声明进入交互程序，命令以 CR 提交，双信号等待首屏渲染后返回当前可见屏幕
- **terminal_send 工具**：向已进入交互态的终端发送按键/文本，等待屏幕变化后返回新快照，形成"输入→观察→输入"闭环
- **转义解码**：Agent 用转义序列表示特殊键（`\x1b`=ESC、`\r`=CR、`\x03`=Ctrl+C、`\x1b[A`=方向键），在终端执行侧（PTY 写入前）用 descape 库解码为真实控制字节

## 关键设计

- **双信号等待**：`output_pushed`（后端 buffer 即时信号）+ `screen_updates`（前端 xterm 快照准确信号），优先等快照、退到 output。抽取为 `wait_for_screen_change` 共享函数
- **门禁分流**：`reject_interactive_script` 按 interactive 标志分流——`false` 拒绝所有交互程序（向后兼容），`true` 仅拦截 stdin 自动化反模式（heredoc/pipe/echo 驱动 vi），放行裸交互程序
- **草稿态 PTY 迁移**：新对话未发首条消息前用临时 id，发送时迁移到真实 session_id（registry key + manager + 日志 rename），幂等设计
- **错误状态正确传递**：`handle_terminal_send` 的 `ok` 标志根据 `exit_code` 判断，写入失败时 Agent 正确感知

## 提交

| 提交 | 内容 |
|---|---|
| `79c81a2` | 交互式终端持续操作能力（vi/nano/REPL + swap 处理） |
| `adf2c81` | terminal_send 正确解码转义序列（ESC/Ctrl+C/方向键等） |
| `789d375` | decode_terminal_escapes 下沉到终端执行侧 |
| `534f45b` | review 修正（ok 标志 + 轮询抽取 + 注释） |

## 测试

- 369 测试全过（含转义解码 8 个单元测试）
- fmt / clippy（-D warnings）零警告
- 转义解码测试覆盖：vi 保存退出、Ctrl+C、CR/LF、ESC、方向键、普通文本保留、字面反斜杠、未知转义回退