### PR TITLE
fix(memory): 修复 deep_recall 集成测试 flaky 问题

### DIFF
--- a/crates/tiangong-memory/tests/runtime_integration.rs
+++ b/crates/tiangong-memory/tests/runtime_integration.rs
@@ -93,24 +93,19 @@ impl MockMemoryLlmServer {
                     break;
                 }
                 match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let request = read_http_request(&mut stream);
-                        let body = request
-                            .as_deref()
-                            .map(memory_llm_mock_response)
-                            .unwrap_or_else(|| serde_json::json!({"error": "bad request"}));
-                        let payload = body.to_string();
-                        let response = format!(
-                            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
-                            payload.len(),
-                            payload
-                        );
-                        let _ = stream.write_all(response.as_bytes());
+                    Ok((stream, _)) => {
+                        // per-request 多线程：每个连接独立处理，避免 Deep Recall 的多轮
+                        // LLM 调用因串行排队而超时。Mock 响应是纯计算（无 IO），线程开销可忽略。
+                        std::thread::spawn(move || handle_mock_request(stream));
                     }
                     Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
                         std::thread::sleep(Duration::from_millis(10));
                     }
-                    Err(_) => break,
+                    Err(err) => {
+                        // accept 错误不终止服务器：瞬时 socket 错误不应让后续 LLM 调用全部失败
+                        eprintln!("[mock-llm] accept 错误，继续轮询: {err}");
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
                 }
             }
         });
@@ -124,6 +119,22 @@ impl MockMemoryLlmServer {
     fn base_url(&self) -> String {
         self.base_url.clone()
     }
+}
+
+/// 处理单个 Mock LLM 请求（在独立线程中运行）。
+fn handle_mock_request(mut stream: std::net::TcpStream) {
+    let request = read_http_request(&mut stream);
+    let body = request
+        .as_deref()
+        .map(memory_llm_mock_response)
+        .unwrap_or_else(|| serde_json::json!({"error": "bad request"}));
+    let payload = body.to_string();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        payload.len(),
+        payload
+    );
+    let _ = stream.write_all(response.as_bytes());
 }
 
 impl Drop for MockMemoryLlmServer {
@@ -1246,8 +1257,11 @@ async fn deep_recall_fixed_scenario_traces_cross_session_artifact_entity_and_dec
         base_url: mock_llm.base_url(),
         model: "memory-deep-recall-mock".to_string(),
         protocol: ProviderProtocol::OpenAiCompatible,
-        timeout: Duration::from_secs(5),
-        max_retries: 0,
+        // Deep Recall 会触发 5-7 轮 LLM 调用（裁决器 + 锚点规划器 + 整理器），
+        // CI 慢环境下累积延迟可能超过 5s。加大超时并允许 1 次重试，避免瞬时超时
+        // 导致 LLM 返回空 → deep→Normal 降级。
+        timeout: Duration::from_secs(15),
+        max_retries: 1,
     };
     let handle = start_with_options(MemoryOptions::new().with_model(model))
         .expect("启动带 mock Memory LLM 的 memory 失败");


### PR DESCRIPTION
## 问题

`deep_recall_fixed_scenario_traces_cross_session_artifact_entity_and_decision` 测试间歇性失败，曾导致 pre-push 钩子拦截推送（需 \`--no-verify\` 绕过）。

**失败现象**：stderr 显示 LLM 返回空内容 → Deep Recall 降级为 Normal Recall → \`response.recall_depth != Deep\` 断言失败。

## 根因

Mock LLM 服务器（\`MockMemoryLlmServer\`）**串行处理请求**——主线程 accept 后同步处理。Deep Recall 会触发 5-7 轮 LLM 调用（深度回忆裁决器 + 3 次锚点规划器 + 结果整理器），全部排队串行处理。CI 慢环境下累积延迟超过 5s timeout（且 \`max_retries: 0\` 不重试），导致单次调用超时返回空。

## 修复

| # | 修复 | 说明 |
|---|---|---|
| 1 | Mock 服务器改 per-request 多线程 | 主线程只 accept，每连接 spawn 独立线程处理。根治串行排队 |
| 2 | timeout 5s → 15s，max_retries 0 → 1 | CI 慢环境容错，允许瞬时超时重试 |
| 3 | accept 错误 break → continue | 避免瞬时 socket 错误静默终止服务器，导致后续 LLM 调用全失败 |

## 验证

- 连续 5 次重跑 flaky 测试：**全部通过**（每次约 0.7s）
- 全工作区 369 测试：**零失败**
- pre-push 钩子（fmt + clippy + tests）：**全部通过**