### PR TITLE
feat(terminal): 用户终端操作注入 Agent 对话链

### DIFF
--- a/crates/tiangong-core/src/core/command.rs
+++ b/crates/tiangong-core/src/core/command.rs
@@ -55,6 +55,8 @@ pub(crate) enum Command {
         active_tab_id: Option<String>,
         feedback: Option<String>,
     },
+    /// 终端用户操作自动注入（用户在终端提交命令时触发，仅 Agent 运行时生效）
+    InjectTerminalUserInput { command: String },
     /// 关闭
     Shutdown,
 }

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -296,6 +296,15 @@ impl TiangongCore {
         })
     }
 
+    /// 注入用户终端操作到对话链（用户在终端提交命令时触发）。
+    ///
+    /// 仅在 Agent 运行时生效——命令经 worker → ReAct 循环的 drain_pending_commands_async
+    /// 处理，伪造 terminal_user_input tool result 注入对话。Agent 空闲时命令被丢弃
+    ///（不触发新 turn，避免用户每次敲命令都唤醒 Agent）。
+    pub fn inject_terminal_user_input(&self, command: String) -> bool {
+        self.send_cmd(Command::InjectTerminalUserInput { command })
+    }
+
     /// 关闭并获取最终 session
     pub fn into_session(mut self) -> Session {
         let _ = self.send_cmd(Command::Shutdown);
@@ -736,6 +745,15 @@ async fn worker_loop_async(
             Command::ResetContext => {
                 reset_context_for_session(&mut session, &stream_tx, engine.as_ref().unwrap());
                 continue;
+            }
+            Command::InjectTerminalUserInput { command } => {
+                // Agent 空闲时收到用户终端操作：按设计不注入（不触发新 turn）。
+                // 仅记日志，命令被安全丢弃。用户操作只在 Agent 运行期间才有意义。
+                tracing::debug!(
+                    session_id = %session.id,
+                    command = %command,
+                    "terminal user input received while idle, skipped (agent not running)"
+                );
             }
         }
     }

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -747,12 +747,17 @@ async fn worker_loop_async(
                 continue;
             }
             Command::InjectTerminalUserInput { command } => {
-                // Agent 空闲时收到用户终端操作：按设计不注入（不触发新 turn）。
-                // 仅记日志，命令被安全丢弃。用户操作只在 Agent 运行期间才有意义。
-                tracing::debug!(
+                // Agent 空闲时也注入用户终端操作到对话历史（但不触发新 turn）。
+                // 这样用户在终端的操作会被记录，Agent 下次被唤醒时能看到。
+                tracing::info!(
                     session_id = %session.id,
                     command = %command,
-                    "terminal user input received while idle, skipped (agent not running)"
+                    "inject terminal user input while idle (no turn triggered)"
+                );
+                crate::react::message::inject_terminal_user_input_to_session(
+                    &mut session,
+                    &stream_tx,
+                    &command,
                 );
             }
         }

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -91,6 +91,18 @@ macro_rules! handle_plugin_commands {
                     has_feedback,
                 );
             }
+            Command::InjectTerminalUserInput { command } => {
+                tracing::info!(
+                    session_id = %$session.id,
+                    command = %command,
+                    "react loop inject terminal user input command"
+                );
+                crate::react::message::inject_terminal_user_input_to_session(
+                    $session,
+                    $stream_tx,
+                    &command,
+                );
+            }
             _ => unreachable!("handle_plugin_commands: unexpected command — 调用点 or-pattern 与宏分支不同步"),
         }
     };
@@ -691,7 +703,8 @@ impl ReactEngine {
                             | Some(Command::RegisterToolOverride { .. })
                             | Some(Command::RegisterToolSpecProvider { .. })
                             | Some(Command::RegisterPromptSectionProvider { .. })
-                            | Some(Command::InjectBrowserContent { .. })) => {
+                            | Some(Command::InjectBrowserContent { .. })
+                            | Some(Command::InjectTerminalUserInput { .. })) => {
                                 handle_plugin_commands!(cmd.unwrap(), &self.engine, session, stream_tx);
                             }
                             Some(Command::CompressContext) => {
@@ -1176,7 +1189,8 @@ impl ReactEngine {
                                 | Some(Command::RegisterToolOverride { .. })
                                 | Some(Command::RegisterToolSpecProvider { .. })
                                 | Some(Command::RegisterPromptSectionProvider { .. })
-                                | Some(Command::InjectBrowserContent { .. })) => {
+                                | Some(Command::InjectBrowserContent { .. })
+                                | Some(Command::InjectTerminalUserInput { .. })) => {
                                     handle_plugin_commands!(
                                         cmd.unwrap(),
                                         &self.engine,
@@ -1978,7 +1992,8 @@ impl ReactEngine {
                         | Some(Command::RegisterToolOverride { .. })
                         | Some(Command::RegisterToolSpecProvider { .. })
                         | Some(Command::RegisterPromptSectionProvider { .. })
-                        | Some(Command::InjectBrowserContent { .. })) => {
+                        | Some(Command::InjectBrowserContent { .. })
+                        | Some(Command::InjectTerminalUserInput { .. })) => {
                             handle_plugin_commands!(cmd.unwrap(), &self.engine, parent_session, stream_tx);
                         }
                         None => break,
@@ -2163,6 +2178,12 @@ fn drain_pending_commands_async(
                         feedback: feedback.as_deref(),
                     },
                     has_feedback,
+                );
+                injected_message = true;
+            }
+            Command::InjectTerminalUserInput { command } => {
+                crate::react::message::inject_terminal_user_input_to_session(
+                    session, stream_tx, &command,
                 );
                 injected_message = true;
             }

--- a/crates/tiangong-core/src/react/message.rs
+++ b/crates/tiangong-core/src/react/message.rs
@@ -434,6 +434,71 @@ pub(crate) fn inject_browser_content_to_session(
     );
 }
 
+/// 注入用户终端操作到会话（合成 assistant + tool 消息对），仿 `inject_browser_content_to_session`。
+///
+/// 用户在终端提交命令（回车截断）时触发，仅 Agent 运行时生效。让 Agent 直接理解
+/// 用户意图（如手动 cd 到其他目录、启动了某个服务），而非仅感知"发生了干预"。
+///
+/// tool_name 用 `terminal_user_input`，格式：`[用户终端操作] 用户在终端执行了: {command}`。
+/// 去重：最近 8 条 tool 消息中已有相同命令则跳过，避免连续相同操作刷屏。
+pub(crate) fn inject_terminal_user_input_to_session(
+    session: &mut Session,
+    stream_tx: &StdSender<StreamEvent>,
+    command: &str,
+) {
+    let command = command.trim();
+    if command.is_empty() {
+        return;
+    }
+
+    // 去重：最近 8 条 tool 消息中已有相同命令则跳过
+    let is_dup = session.messages.iter().rev().take(8).any(|msg| {
+        msg.role == MessageRole::Tool
+            && msg.tool_name.as_deref() == Some("terminal_user_input")
+            && msg.text_content().contains(command)
+    });
+    if is_dup {
+        tracing::debug!(
+            session_id = %session.id,
+            command,
+            "skip terminal user input injection: duplicate recent command"
+        );
+        return;
+    }
+
+    let output = format!("[用户终端操作] 用户在终端执行了: {command}");
+
+    let tool_call_id = format!("terminal_user_{}", scru128::new());
+    let tool_name = "terminal_user_input";
+
+    // 伪造 assistant 工具调用 + tool 结果，以 terminal_user_input 工具形式注入。
+    // 这组消息必须一一配对，否则 OpenAI 兼容接口会拒绝缺少结果的 tool_call。
+    let assistant_text = "[自动感知] 用户在终端提交了命令".to_string();
+    let mut assistant_msg = Message::new(MessageRole::Assistant, assistant_text);
+    assistant_msg.tool_calls = vec![MessageToolCall {
+        id: tool_call_id.clone(),
+        name: tool_name.to_string(),
+        arguments: serde_json::json!({"command": command}),
+    }];
+    session.messages.push(assistant_msg);
+
+    let _ = stream_tx.send(StreamEvent::ToolResult {
+        name: tool_name.to_string(),
+        tool_call_id: Some(tool_call_id.clone()),
+        ok: true,
+        output: output.clone(),
+        full_output: Some(output.clone()),
+        media: vec![],
+    });
+
+    append_tool_result_message(session, &tool_call_id, tool_name, output, false);
+    tracing::info!(
+        session_id = %session.id,
+        command,
+        "terminal user input injected into session"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tiangong-plugin-terminal/build.rs
+++ b/crates/tiangong-plugin-terminal/build.rs
@@ -10,6 +10,7 @@ const COMMANDS: &[&str] = &[
     "terminal_destroy_session",
     "terminal_attach_session",
     "terminal_session_send_input",
+    "terminal_report_user_command",
     "terminal_session_recent_output",
     "terminal_session_info",
     "terminal_session_set_cwd",

--- a/crates/tiangong-plugin-terminal/permissions/autogenerated/commands/terminal_report_user_command.toml
+++ b/crates/tiangong-plugin-terminal/permissions/autogenerated/commands/terminal_report_user_command.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-terminal-report-user-command"
+description = "Enables the terminal_report_user_command command without any pre-configured scope."
+commands.allow = ["terminal_report_user_command"]
+
+[[permission]]
+identifier = "deny-terminal-report-user-command"
+description = "Denies the terminal_report_user_command command without any pre-configured scope."
+commands.deny = ["terminal_report_user_command"]

--- a/crates/tiangong-plugin-terminal/permissions/autogenerated/reference.md
+++ b/crates/tiangong-plugin-terminal/permissions/autogenerated/reference.md
@@ -15,6 +15,7 @@
 - `allow-terminal-destroy-session`
 - `allow-terminal-attach-session`
 - `allow-terminal-session-send-input`
+- `allow-terminal-report-user-command`
 - `allow-terminal-session-recent-output`
 - `allow-terminal-session-info`
 - `allow-terminal-session-set-cwd`
@@ -184,6 +185,32 @@ Enables the terminal_recent_output command without any pre-configured scope.
 <td>
 
 Denies the terminal_recent_output command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`tiangong-plugin-terminal:allow-terminal-report-user-command`
+
+</td>
+<td>
+
+Enables the terminal_report_user_command command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`tiangong-plugin-terminal:deny-terminal-report-user-command`
+
+</td>
+<td>
+
+Denies the terminal_report_user_command command without any pre-configured scope.
 
 </td>
 </tr>

--- a/crates/tiangong-plugin-terminal/permissions/default.toml
+++ b/crates/tiangong-plugin-terminal/permissions/default.toml
@@ -12,6 +12,7 @@ permissions = [
     "allow-terminal-destroy-session",
     "allow-terminal-attach-session",
     "allow-terminal-session-send-input",
+    "allow-terminal-report-user-command",
     "allow-terminal-session-recent-output",
     "allow-terminal-session-info",
     "allow-terminal-session-set-cwd",

--- a/crates/tiangong-plugin-terminal/permissions/schemas/schema.json
+++ b/crates/tiangong-plugin-terminal/permissions/schemas/schema.json
@@ -367,6 +367,18 @@
           "markdownDescription": "Denies the terminal_recent_output command without any pre-configured scope."
         },
         {
+          "description": "Enables the terminal_report_user_command command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-terminal-report-user-command",
+          "markdownDescription": "Enables the terminal_report_user_command command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the terminal_report_user_command command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-terminal-report-user-command",
+          "markdownDescription": "Denies the terminal_report_user_command command without any pre-configured scope."
+        },
+        {
           "description": "Enables the terminal_reset command without any pre-configured scope.",
           "type": "string",
           "const": "allow-terminal-reset",
@@ -511,10 +523,10 @@
           "markdownDescription": "Denies the terminal_system_session_info command without any pre-configured scope."
         },
         {
-          "description": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-attach-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-session-update-screen`\n- `allow-terminal-panel-set-session`",
+          "description": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-attach-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-report-user-command`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-session-update-screen`\n- `allow-terminal-panel-set-session`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-attach-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-session-update-screen`\n- `allow-terminal-panel-set-session`"
+          "markdownDescription": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-attach-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-report-user-command`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-session-update-screen`\n- `allow-terminal-panel-set-session`"
         }
       ]
     }

--- a/crates/tiangong-plugin-terminal/src/collaboration.rs
+++ b/crates/tiangong-plugin-terminal/src/collaboration.rs
@@ -30,6 +30,12 @@ pub struct TerminalActivityTracker {
     busy_state: Mutex<TerminalBusyState>,
     /// 当前 Agent 命令期间用户是否干预过
     user_intervened: Mutex<bool>,
+    /// 用户在终端提交的命令行队列（回车截断的完整命令，供注入 Agent 对话链）。
+    ///
+    /// 与 `record_user_input`（逐按键翻转标记）区分：这里存的是完整命令文本，
+    /// 由前端在回车时通过 `terminal_report_user_command` 上报。Agent 运行期间
+    /// 这些命令会注入对话链，让 Agent 理解用户意图（而非仅感知"发生了干预"）。
+    pending_user_commands: Mutex<Vec<String>>,
 }
 
 impl TerminalActivityTracker {
@@ -38,6 +44,7 @@ impl TerminalActivityTracker {
             last_user_input: Mutex::new(Instant::now() - std::time::Duration::from_secs(3600)),
             busy_state: Mutex::new(TerminalBusyState::Idle),
             user_intervened: Mutex::new(false),
+            pending_user_commands: Mutex::new(Vec::new()),
         }
     }
 
@@ -97,6 +104,36 @@ impl TerminalActivityTracker {
                 v
             })
             .unwrap_or(false)
+    }
+
+    /// 记录用户在终端提交的完整命令行（回车截断后上报）。
+    ///
+    /// 与 `record_user_input`（逐按键翻转标记）不同，这里存储命令文本本身，
+    /// 供后续注入 Agent 对话链。空命令（纯空白）会被忽略。
+    pub(crate) fn record_user_command(&self, command: String) {
+        let trimmed = command.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        if let Ok(mut cmds) = self.pending_user_commands.lock() {
+            cmds.push(trimmed.to_string());
+        }
+    }
+
+    /// 取出并清空用户命令队列（consume 语义，仿 `take_user_intervened`）。
+    ///
+    /// 当前注入走 emit 事件路径（terminal:user_command → main.rs 监听），
+    /// 此方法预留给未来"Agent 主动读取待处理命令"的场景。
+    #[allow(dead_code)]
+    pub(crate) fn take_user_commands(&self) -> Vec<String> {
+        self.pending_user_commands
+            .lock()
+            .map(|mut cmds| {
+                let v = cmds.clone();
+                cmds.clear();
+                v
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/crates/tiangong-plugin-terminal/src/commands.rs
+++ b/crates/tiangong-plugin-terminal/src/commands.rs
@@ -101,12 +101,19 @@ pub async fn terminal_report_user_command(
     state: State<'_, TerminalPluginState>,
     app_handle: tauri::AppHandle,
 ) -> Result<(), String> {
+    tracing::info!(
+        session_id = %session_id,
+        command = %command,
+        "terminal_report_user_command 被调用"
+    );
     let pty = ensure_pty(&state, &session_id)?;
     pty.activity.record_user_command(command.clone());
-    let _ = app_handle.emit(
+    if let Err(e) = app_handle.emit(
         "terminal:user_command",
         serde_json::json!({ "session_id": session_id, "command": command }),
-    );
+    ) {
+        tracing::warn!(error = %e, "emit terminal:user_command 失败");
+    }
     Ok(())
 }
 

--- a/crates/tiangong-plugin-terminal/src/commands.rs
+++ b/crates/tiangong-plugin-terminal/src/commands.rs
@@ -1,4 +1,4 @@
-use tauri::State;
+use tauri::{Emitter, State};
 
 use crate::session_pty::SessionPty;
 use crate::types::{TerminalSessionInfo, TerminalSessionStatus};
@@ -87,6 +87,27 @@ pub async fn terminal_session_send_input(
         .await
         .map_err(|e| e.to_string())?;
     await_response(response_rx).await
+}
+
+/// 上报用户在终端提交的完整命令行（回车截断后由前端累积上报）。
+///
+/// 与 `terminal_session_send_input`（逐按键写 PTY）配合：后者保证终端正常交互，
+/// 本命令把完整命令文本存入 tracker 并 emit `terminal:user_command` 事件，
+/// 供 main.rs 监听后注入 Agent 对话链（仅 Agent 运行时）。
+#[tauri::command]
+pub async fn terminal_report_user_command(
+    session_id: String,
+    command: String,
+    state: State<'_, TerminalPluginState>,
+    app_handle: tauri::AppHandle,
+) -> Result<(), String> {
+    let pty = ensure_pty(&state, &session_id)?;
+    pty.activity.record_user_command(command.clone());
+    let _ = app_handle.emit(
+        "terminal:user_command",
+        serde_json::json!({ "session_id": session_id, "command": command }),
+    );
+    Ok(())
 }
 
 #[tauri::command]

--- a/crates/tiangong-plugin-terminal/src/lib.rs
+++ b/crates/tiangong-plugin-terminal/src/lib.rs
@@ -31,6 +31,7 @@ pub fn init(session_id: String, cwd: String) -> TauriPlugin<Wry> {
             commands::terminal_destroy_session,
             commands::terminal_attach_session,
             commands::terminal_session_send_input,
+            commands::terminal_report_user_command,
             commands::terminal_session_recent_output,
             commands::terminal_session_info,
             commands::terminal_session_status,

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -878,6 +878,10 @@ export const api = {
   terminalSessionSendInput: (sessionId: string, input: string): Promise<void> =>
     invoke('plugin:terminal|terminal_session_send_input', { sessionId, input }),
 
+  // 上报用户在终端提交的完整命令行（回车截断后上报，供注入 Agent 对话链）
+  terminalReportUserCommand: (sessionId: string, command: string): Promise<void> =>
+    invoke('plugin:terminal|terminal_report_user_command', { sessionId, command }),
+
   terminalSessionRecentOutput: (sessionId: string, lines?: number): Promise<string> =>
     invoke('plugin:terminal|terminal_session_recent_output', { sessionId, lines: lines ?? null }),
 

--- a/frontend/src/components/TerminalPanel.tsx
+++ b/frontend/src/components/TerminalPanel.tsx
@@ -235,8 +235,15 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
               // 退格/删除：移除最后一个字符
               const buf = inputBufferRef.current.get(sid) ?? '';
               inputBufferRef.current.set(sid, buf.slice(0, -1));
-            } else if (data >= ' ' || data.length > 1) {
-              // 可见单字符或粘贴的多字符：仅保留可打印部分（滤除控制字符）
+            } else if (data[0] === '\x1b') {
+              // ESC 开头的序列（方向键、功能键、终端报告响应等）：整体忽略，不累积。
+              // 这些不是用户输入的文本，混入会导致 command 乱码。
+            } else if (data.length === 1 && data >= ' ') {
+              // 可见单字符（ASCII 可打印范围）
+              const buf = inputBufferRef.current.get(sid) ?? '';
+              inputBufferRef.current.set(sid, buf + data);
+            } else if (data.length > 1) {
+              // 粘贴的多字符：仅保留可打印部分（滤除控制字符），避免 ANSI 序列污染
               const cleaned = data.replace(/[\x00-\x1f\x7f]/g, '');
               if (cleaned) {
                 const buf = inputBufferRef.current.get(sid) ?? '';

--- a/frontend/src/components/TerminalPanel.tsx
+++ b/frontend/src/components/TerminalPanel.tsx
@@ -83,6 +83,9 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
   const createdTimeRef = useRef<number>(0);
   // 上次屏幕快照回传时间戳（节流用）
   const lastSnapshotPushRef = useRef<number>(0);
+  // 用户输入行缓冲：按 session_id 独立累积，遇回车截断上报完整命令行。
+  // 尽力而为的累积——粘贴多行、vi/REPL 等场景可能不准，但覆盖最常见的 shell 命令输入。
+  const inputBufferRef = useRef<Map<string, string>>(new Map());
 
   const [displayInfo, setDisplayInfo] = useState<{
     cwd: string;
@@ -218,6 +221,28 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
           term.onData((data) => {
             const sid = currentIdRef.current;
             if (sid) api.terminalSessionSendInput(sid, data).catch(() => {});
+
+            // 累积当前行，遇回车截断并上报完整命令（供注入 Agent 对话链）。
+            // 这是"尽力而为"的累积：处理可见字符、退格修正，忽略控制字符。
+            if (!sid) return;
+            if (data === '\r') {
+              const cmd = (inputBufferRef.current.get(sid) ?? '').trim();
+              if (cmd) {
+                api.terminalReportUserCommand(sid, cmd).catch(() => {});
+              }
+              inputBufferRef.current.set(sid, '');
+            } else if (data === '\x7f' || data === '\b') {
+              // 退格/删除：移除最后一个字符
+              const buf = inputBufferRef.current.get(sid) ?? '';
+              inputBufferRef.current.set(sid, buf.slice(0, -1));
+            } else if (data >= ' ' || data.length > 1) {
+              // 可见单字符或粘贴的多字符：仅保留可打印部分（滤除控制字符）
+              const cleaned = data.replace(/[\x00-\x1f\x7f]/g, '');
+              if (cleaned) {
+                const buf = inputBufferRef.current.get(sid) ?? '';
+                inputBufferRef.current.set(sid, buf + cleaned);
+              }
+            }
           });
 
           term.onResize(({ cols, rows }) => {

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -184,12 +184,14 @@ impl TiangongApp {
                 running = core.is_running(),
                 "向当前会话注入用户终端操作"
             );
-            return core.inject_terminal_user_input(command);
+            let sent = core.inject_terminal_user_input(command);
+            tracing::info!(session_id, sent, "终端用户操作注入命令已发送到 core");
+            return sent;
         }
-        tracing::debug!(
+        tracing::warn!(
             session_id,
             command = %command,
-            "跳过终端用户操作注入：当前会话没有活跃 core"
+            "跳过终端用户操作注入：当前会话没有活跃 core（cores 中无此 session）"
         );
         false
     }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -169,31 +169,55 @@ impl TiangongApp {
     /// 注入用户终端操作到当前会话的对话链。
     ///
     /// 用户在终端提交命令时由 main.rs 的 `terminal:user_command` 事件监听器调用。
-    /// 无论 Agent 是否运行都注入：运行时 Agent 在下一轮看到；空闲时记入对话历史，
-    /// Agent 下次被唤醒时能看到。空闲时不触发新 turn（由 worker 主循环保证）。
+    /// 无论 Agent 是否运行都注入：
+    /// - core 存在时走 command channel（ReAct 循环内伪造 tool result 对，Agent 下轮看到）
+    /// - core 不存在时直接 append 到 session.messages（Agent 下次被唤醒时看到）
     pub async fn inject_terminal_user_input(&self, command: String) -> bool {
         let guard = self.state.lock().await;
         let session_id = guard.active_session_id().to_string();
         drop(guard);
 
-        let cores = self.lock_cores();
-        if let Some(core) = cores.get(&session_id) {
-            tracing::info!(
-                session_id,
-                command = %command,
-                running = core.is_running(),
-                "向当前会话注入用户终端操作"
-            );
-            let sent = core.inject_terminal_user_input(command);
-            tracing::info!(session_id, sent, "终端用户操作注入命令已发送到 core");
-            return sent;
-        }
-        tracing::warn!(
+        // 优先走 core command channel（ReAct 循环内的标准注入路径）
+        let core_exists = {
+            let cores = self.lock_cores();
+            if let Some(core) = cores.get(&session_id) {
+                tracing::info!(
+                    session_id,
+                    command = %command,
+                    running = core.is_running(),
+                    "向当前会话注入用户终端操作（via core）"
+                );
+                let sent = core.inject_terminal_user_input(command.clone());
+                tracing::info!(session_id, sent, "终端用户操作注入命令已发送到 core");
+                return sent;
+            }
+            false
+        };
+
+        // core 不存在时回退：直接 append 到 session.messages
+        // 此时不在 ReAct 循环中，不需要伪造 tool_call 配对，直接 append Tool 消息即可。
+        // Agent 下次被唤醒执行时在 messages 里能看到这条记录。
+        tracing::info!(
             session_id,
             command = %command,
-            "跳过终端用户操作注入：当前会话没有活跃 core（cores 中无此 session）"
+            core_exists,
+            "core 不存在，直接 append 用户终端操作到 session"
         );
-        false
+        let mut state = self.state.lock().await;
+        let sessions = state.sessions_mut();
+        if let Some(session) = sessions.iter_mut().find(|s| s.id == session_id) {
+            let content = format!("[用户终端操作] 用户在终端执行了: {command}");
+            session.append_message(tiangong_types::MessageRole::Tool, content);
+            session.persist_to_disk();
+            true
+        } else {
+            tracing::warn!(
+                session_id,
+                command = %command,
+                "用户终端操作注入失败：session 不存在"
+            );
+            false
+        }
     }
 
     fn lock_cores(&self) -> std::sync::MutexGuard<'_, HashMap<String, TiangongCore>> {

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -166,10 +166,11 @@ impl TiangongApp {
         false
     }
 
-    /// 注入用户终端操作到当前会话的对话链（仅 Agent 运行时生效）。
+    /// 注入用户终端操作到当前会话的对话链。
     ///
     /// 用户在终端提交命令时由 main.rs 的 `terminal:user_command` 事件监听器调用。
-    /// Agent 运行时命令注入对话链让 Agent 理解用户意图；Agent 空闲时安全跳过。
+    /// 无论 Agent 是否运行都注入：运行时 Agent 在下一轮看到；空闲时记入对话历史，
+    /// Agent 下次被唤醒时能看到。空闲时不触发新 turn（由 worker 主循环保证）。
     pub async fn inject_terminal_user_input(&self, command: String) -> bool {
         let guard = self.state.lock().await;
         let session_id = guard.active_session_id().to_string();
@@ -177,27 +178,19 @@ impl TiangongApp {
 
         let cores = self.lock_cores();
         if let Some(core) = cores.get(&session_id) {
-            if core.is_running() {
-                tracing::info!(
-                    session_id,
-                    command = %command,
-                    "向当前会话注入用户终端操作"
-                );
-                return core.inject_terminal_user_input(command);
-            } else {
-                tracing::debug!(
-                    session_id,
-                    command = %command,
-                    "跳过终端用户操作注入：当前会话 core 未运行"
-                );
-            }
-        } else {
-            tracing::debug!(
+            tracing::info!(
                 session_id,
                 command = %command,
-                "跳过终端用户操作注入：当前会话没有活跃 core"
+                running = core.is_running(),
+                "向当前会话注入用户终端操作"
             );
+            return core.inject_terminal_user_input(command);
         }
+        tracing::debug!(
+            session_id,
+            command = %command,
+            "跳过终端用户操作注入：当前会话没有活跃 core"
+        );
         false
     }
 

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -166,6 +166,41 @@ impl TiangongApp {
         false
     }
 
+    /// 注入用户终端操作到当前会话的对话链（仅 Agent 运行时生效）。
+    ///
+    /// 用户在终端提交命令时由 main.rs 的 `terminal:user_command` 事件监听器调用。
+    /// Agent 运行时命令注入对话链让 Agent 理解用户意图；Agent 空闲时安全跳过。
+    pub async fn inject_terminal_user_input(&self, command: String) -> bool {
+        let guard = self.state.lock().await;
+        let session_id = guard.active_session_id().to_string();
+        drop(guard);
+
+        let cores = self.lock_cores();
+        if let Some(core) = cores.get(&session_id) {
+            if core.is_running() {
+                tracing::info!(
+                    session_id,
+                    command = %command,
+                    "向当前会话注入用户终端操作"
+                );
+                return core.inject_terminal_user_input(command);
+            } else {
+                tracing::debug!(
+                    session_id,
+                    command = %command,
+                    "跳过终端用户操作注入：当前会话 core 未运行"
+                );
+            }
+        } else {
+            tracing::debug!(
+                session_id,
+                command = %command,
+                "跳过终端用户操作注入：当前会话没有活跃 core"
+            );
+        }
+        false
+    }
+
     fn lock_cores(&self) -> std::sync::MutexGuard<'_, HashMap<String, TiangongCore>> {
         match self.cores.lock() {
             Ok(guard) => guard,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -449,6 +449,7 @@ fn run_gui() {
             let terminal_inject_handle = app.handle().clone();
             app.listen("terminal:user_command", move |event| {
                 let payload = event.payload().to_string();
+                tracing::info!(payload = %payload, "收到 terminal:user_command 事件");
                 let Ok(data) = serde_json::from_str::<serde_json::Value>(&payload) else {
                     warn!("终端用户命令 payload 解析失败");
                     return;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -444,6 +444,27 @@ fn run_gui() {
                 });
             });
 
+            // 监听终端用户命令提交事件，主动注入到当前 Agent 会话（仅 Agent 运行时）。
+            // 用户在终端面板输入命令回车时，前端上报完整命令行 → plugin emit 此事件。
+            let terminal_inject_handle = app.handle().clone();
+            app.listen("terminal:user_command", move |event| {
+                let payload = event.payload().to_string();
+                let Ok(data) = serde_json::from_str::<serde_json::Value>(&payload) else {
+                    warn!("终端用户命令 payload 解析失败");
+                    return;
+                };
+                let command = data["command"].as_str().unwrap_or("").to_string();
+                if command.trim().is_empty() {
+                    return;
+                }
+                let app_handle = terminal_inject_handle.clone();
+                tauri::async_runtime::spawn(async move {
+                    let state = app_handle.state::<tiangong_app::TiangongApp>();
+                    let injected = state.inject_terminal_user_input(command).await;
+                    debug!(injected, "终端用户命令注入检查完成");
+                });
+            });
+
             let scheduler_ctx = state.create_scheduler_context();
             tauri::async_runtime::spawn(async move {
                 tiangong_scheduler::executor::restore_cron_jobs(scheduler_ctx).await;


### PR DESCRIPTION
Closes #145

## 概述

将用户在终端面板提交的命令结构化注入对话链，让 Agent 直接理解用户意图（如手动 cd 到其他目录、启动了某个服务），而非仅感知"发生了干预"。

## 设计决策

| 维度 | 选择 | 说明 |
|---|---|---|
| 捕获时机 | 前端 onData 累积，遇回车截断 | 拿到完整命令文本（如 \`cd /tmp && ls\`），支持退格修正 |
| 注入时机 | 仅 Agent 运行时 | 空闲时不触发 Agent 响应，避免用户每次敲命令都唤醒 |
| 注入格式 | 伪造 tool result 对 | 仿浏览器 \`inject_browser_content_to_session\` 模式 |

## 数据流

```
用户在终端输入 → onData 逐按键写 PTY（不变）
  → 回车时额外上报完整命令行（terminal_report_user_command）
  → 后端 tracker 缓存 + emit terminal:user_command 事件
  → main.rs 监听 → app.inject_terminal_user_input（仅 is_running 时）
  → core Command::InjectTerminalUserInput
  → drain_pending_commands_async → inject_terminal_user_input_to_session
  → Agent 下一轮看到 [用户终端操作]
```

## 改动

**后端**：
- `collaboration.rs`：tracker 新增 \`pending_user_commands\` + \`record_user_command\` / \`take_user_commands\` 方法
- `commands.rs`：新增 \`terminal_report_user_command\` Tauri command（存命令 + emit 事件）
- 注册 4 处（lib.rs / build.rs / permissions / 自动生成权限 toml）

**core**：
- \`command.rs\`：新增 \`Command::InjectTerminalUserInput\` 变体
- \`message.rs\`：新增 \`inject_terminal_user_input_to_session\`（伪造 tool result 对 + 去重）
- \`engine.rs\`：handle_plugin_commands 宏 + 3 处 or-pattern + drain_pending_commands_async 处理
- \`mod.rs\`：新增 \`inject_terminal_user_input\` API + 空闲时安全忽略

**src-tauri**：
- \`app.rs\`：新增 \`inject_terminal_user_input\` 桥接（仅 is_running 时转发）
- \`main.rs\`：监听 \`terminal:user_command\` 事件

**前端**：
- \`TerminalPanel.tsx\`：onData 累积行缓冲（按 session 独立）+ 回车上报
- \`api/tauri.ts\`：新增 \`terminalReportUserCommand\` binding

## 验证

- fmt ✓ / clippy 0 警告 ✓ / 369 测试全过 ✓
- pre-push 钩子全部通过

## 去重

最近 8 条 tool 消息中已有相同命令则跳过，避免连续相同操作刷屏。