### PR TITLE
feat(terminal): 用户终端操作注入 Agent 对话链

### DIFF
--- a/crates/tiangong-core/src/core/command.rs
+++ b/crates/tiangong-core/src/core/command.rs
@@ -55,6 +55,8 @@ pub(crate) enum Command {
         active_tab_id: Option<String>,
         feedback: Option<String>,
     },
+    /// 终端用户操作自动注入（用户在终端提交命令时触发）
+    InjectTerminalUserInput { command: String },
     /// 关闭
     Shutdown,
 }

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -296,6 +296,11 @@ impl TiangongCore {
         })
     }
 
+    /// 注入用户终端操作到对话链（用户在终端提交命令时触发）。
+    pub fn inject_terminal_user_input(&self, command: String) -> bool {
+        self.send_cmd(Command::InjectTerminalUserInput { command })
+    }
+
     /// 关闭并获取最终 session
     pub fn into_session(mut self) -> Session {
         let _ = self.send_cmd(Command::Shutdown);
@@ -736,6 +741,14 @@ async fn worker_loop_async(
             Command::ResetContext => {
                 reset_context_for_session(&mut session, &stream_tx, engine.as_ref().unwrap());
                 continue;
+            }
+            Command::InjectTerminalUserInput { command } => {
+                // Agent 空闲时也注入到对话历史（不触发新 turn）。
+                crate::react::message::inject_terminal_user_input_to_session(
+                    &mut session,
+                    &stream_tx,
+                    &command,
+                );
             }
         }
     }

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -91,6 +91,11 @@ macro_rules! handle_plugin_commands {
                     has_feedback,
                 );
             }
+            Command::InjectTerminalUserInput { command } => {
+                crate::react::message::inject_terminal_user_input_to_session(
+                    $session, $stream_tx, &command,
+                );
+            }
             _ => unreachable!("handle_plugin_commands: unexpected command — 调用点 or-pattern 与宏分支不同步"),
         }
     };
@@ -691,7 +696,8 @@ impl ReactEngine {
                             | Some(Command::RegisterToolOverride { .. })
                             | Some(Command::RegisterToolSpecProvider { .. })
                             | Some(Command::RegisterPromptSectionProvider { .. })
-                            | Some(Command::InjectBrowserContent { .. })) => {
+                            | Some(Command::InjectBrowserContent { .. })
+                            | Some(Command::InjectTerminalUserInput { .. })) => {
                                 handle_plugin_commands!(cmd.unwrap(), &self.engine, session, stream_tx);
                             }
                             Some(Command::CompressContext) => {
@@ -1176,7 +1182,8 @@ impl ReactEngine {
                                 | Some(Command::RegisterToolOverride { .. })
                                 | Some(Command::RegisterToolSpecProvider { .. })
                                 | Some(Command::RegisterPromptSectionProvider { .. })
-                                | Some(Command::InjectBrowserContent { .. })) => {
+                                | Some(Command::InjectBrowserContent { .. })
+                                | Some(Command::InjectTerminalUserInput { .. })) => {
                                     handle_plugin_commands!(
                                         cmd.unwrap(),
                                         &self.engine,
@@ -1978,7 +1985,8 @@ impl ReactEngine {
                         | Some(Command::RegisterToolOverride { .. })
                         | Some(Command::RegisterToolSpecProvider { .. })
                         | Some(Command::RegisterPromptSectionProvider { .. })
-                        | Some(Command::InjectBrowserContent { .. })) => {
+                        | Some(Command::InjectBrowserContent { .. })
+                            | Some(Command::InjectTerminalUserInput { .. })) => {
                             handle_plugin_commands!(cmd.unwrap(), &self.engine, parent_session, stream_tx);
                         }
                         None => break,
@@ -2163,6 +2171,12 @@ fn drain_pending_commands_async(
                         feedback: feedback.as_deref(),
                     },
                     has_feedback,
+                );
+                injected_message = true;
+            }
+            Command::InjectTerminalUserInput { command } => {
+                crate::react::message::inject_terminal_user_input_to_session(
+                    session, stream_tx, &command,
                 );
                 injected_message = true;
             }

--- a/crates/tiangong-core/src/react/message.rs
+++ b/crates/tiangong-core/src/react/message.rs
@@ -434,6 +434,61 @@ pub(crate) fn inject_browser_content_to_session(
     );
 }
 
+/// 注入用户终端操作到会话（合成 assistant + tool 消息对），仿浏览器注入。
+///
+/// 用户在终端提交命令时触发。让 Agent 直接理解用户意图（如手动 cd 到其他目录、
+/// 启动了某个服务），而非仅感知"发生了干预"。
+/// tool_name 用 `terminal_user_input`，格式：`[用户终端操作] 用户在终端执行了: {command}`。
+/// 去重：最近 8 条 tool 消息中已有相同命令则跳过。
+pub(crate) fn inject_terminal_user_input_to_session(
+    session: &mut Session,
+    stream_tx: &StdSender<StreamEvent>,
+    command: &str,
+) {
+    let command = command.trim();
+    if command.is_empty() {
+        return;
+    }
+    let is_dup = session.messages.iter().rev().take(8).any(|msg| {
+        msg.role == MessageRole::Tool
+            && msg.tool_name.as_deref() == Some("terminal_user_input")
+            && msg.text_content().contains(command)
+    });
+    if is_dup {
+        tracing::debug!(
+            session_id = %session.id,
+            command,
+            "skip terminal user input injection: duplicate recent command"
+        );
+        return;
+    }
+    let output = format!("[用户终端操作] 用户在终端执行了: {command}");
+    let tool_call_id = format!("terminal_user_{}", scru128::new());
+    let tool_name = "terminal_user_input";
+    let assistant_text = "[自动感知] 用户在终端提交了命令".to_string();
+    let mut assistant_msg = Message::new(MessageRole::Assistant, assistant_text);
+    assistant_msg.tool_calls = vec![MessageToolCall {
+        id: tool_call_id.clone(),
+        name: tool_name.to_string(),
+        arguments: serde_json::json!({"command": command}),
+    }];
+    session.messages.push(assistant_msg);
+    let _ = stream_tx.send(StreamEvent::ToolResult {
+        name: tool_name.to_string(),
+        tool_call_id: Some(tool_call_id.clone()),
+        ok: true,
+        output: output.clone(),
+        full_output: Some(output.clone()),
+        media: vec![],
+    });
+    append_tool_result_message(session, &tool_call_id, tool_name, output, false);
+    tracing::info!(
+        session_id = %session.id,
+        command,
+        "terminal user input injected into session"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tiangong-plugin-terminal/build.rs
+++ b/crates/tiangong-plugin-terminal/build.rs
@@ -10,6 +10,7 @@ const COMMANDS: &[&str] = &[
     "terminal_destroy_session",
     "terminal_attach_session",
     "terminal_session_send_input",
+    "terminal_report_user_command",
     "terminal_session_recent_output",
     "terminal_session_info",
     "terminal_session_set_cwd",

--- a/crates/tiangong-plugin-terminal/permissions/autogenerated/commands/terminal_report_user_command.toml
+++ b/crates/tiangong-plugin-terminal/permissions/autogenerated/commands/terminal_report_user_command.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-terminal-report-user-command"
+description = "Enables the terminal_report_user_command command without any pre-configured scope."
+commands.allow = ["terminal_report_user_command"]
+
+[[permission]]
+identifier = "deny-terminal-report-user-command"
+description = "Denies the terminal_report_user_command command without any pre-configured scope."
+commands.deny = ["terminal_report_user_command"]

--- a/crates/tiangong-plugin-terminal/permissions/autogenerated/reference.md
+++ b/crates/tiangong-plugin-terminal/permissions/autogenerated/reference.md
@@ -15,6 +15,7 @@
 - `allow-terminal-destroy-session`
 - `allow-terminal-attach-session`
 - `allow-terminal-session-send-input`
+- `allow-terminal-report-user-command`
 - `allow-terminal-session-recent-output`
 - `allow-terminal-session-info`
 - `allow-terminal-session-set-cwd`
@@ -184,6 +185,32 @@ Enables the terminal_recent_output command without any pre-configured scope.
 <td>
 
 Denies the terminal_recent_output command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`tiangong-plugin-terminal:allow-terminal-report-user-command`
+
+</td>
+<td>
+
+Enables the terminal_report_user_command command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`tiangong-plugin-terminal:deny-terminal-report-user-command`
+
+</td>
+<td>
+
+Denies the terminal_report_user_command command without any pre-configured scope.
 
 </td>
 </tr>

--- a/crates/tiangong-plugin-terminal/permissions/default.toml
+++ b/crates/tiangong-plugin-terminal/permissions/default.toml
@@ -12,6 +12,7 @@ permissions = [
     "allow-terminal-destroy-session",
     "allow-terminal-attach-session",
     "allow-terminal-session-send-input",
+    "allow-terminal-report-user-command",
     "allow-terminal-session-recent-output",
     "allow-terminal-session-info",
     "allow-terminal-session-set-cwd",

--- a/crates/tiangong-plugin-terminal/permissions/schemas/schema.json
+++ b/crates/tiangong-plugin-terminal/permissions/schemas/schema.json
@@ -367,6 +367,18 @@
           "markdownDescription": "Denies the terminal_recent_output command without any pre-configured scope."
         },
         {
+          "description": "Enables the terminal_report_user_command command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-terminal-report-user-command",
+          "markdownDescription": "Enables the terminal_report_user_command command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the terminal_report_user_command command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-terminal-report-user-command",
+          "markdownDescription": "Denies the terminal_report_user_command command without any pre-configured scope."
+        },
+        {
           "description": "Enables the terminal_reset command without any pre-configured scope.",
           "type": "string",
           "const": "allow-terminal-reset",
@@ -511,10 +523,10 @@
           "markdownDescription": "Denies the terminal_system_session_info command without any pre-configured scope."
         },
         {
-          "description": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-attach-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-session-update-screen`\n- `allow-terminal-panel-set-session`",
+          "description": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-attach-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-report-user-command`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-session-update-screen`\n- `allow-terminal-panel-set-session`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-attach-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-session-update-screen`\n- `allow-terminal-panel-set-session`"
+          "markdownDescription": "允许使用终端面板的全部功能。\n#### This default permission set includes:\n\n- `allow-terminal-exec`\n- `allow-terminal-recent-output`\n- `allow-terminal-send-input`\n- `allow-terminal-reset`\n- `allow-terminal-system-session-info`\n- `allow-terminal-set-cwd`\n- `allow-terminal-resize`\n- `allow-terminal-ensure-session`\n- `allow-terminal-destroy-session`\n- `allow-terminal-attach-session`\n- `allow-terminal-session-send-input`\n- `allow-terminal-report-user-command`\n- `allow-terminal-session-recent-output`\n- `allow-terminal-session-info`\n- `allow-terminal-session-set-cwd`\n- `allow-terminal-session-resize`\n- `allow-terminal-session-reset`\n- `allow-terminal-session-update-screen`\n- `allow-terminal-panel-set-session`"
         }
       ]
     }

--- a/crates/tiangong-plugin-terminal/src/collaboration.rs
+++ b/crates/tiangong-plugin-terminal/src/collaboration.rs
@@ -30,6 +30,8 @@ pub struct TerminalActivityTracker {
     busy_state: Mutex<TerminalBusyState>,
     /// 当前 Agent 命令期间用户是否干预过
     user_intervened: Mutex<bool>,
+    /// 用户在终端提交的命令行队列（回车截断的完整命令，供注入 Agent 对话链）。
+    pending_user_commands: Mutex<Vec<String>>,
 }
 
 impl TerminalActivityTracker {
@@ -38,6 +40,7 @@ impl TerminalActivityTracker {
             last_user_input: Mutex::new(Instant::now() - std::time::Duration::from_secs(3600)),
             busy_state: Mutex::new(TerminalBusyState::Idle),
             user_intervened: Mutex::new(false),
+            pending_user_commands: Mutex::new(Vec::new()),
         }
     }
 
@@ -97,6 +100,30 @@ impl TerminalActivityTracker {
                 v
             })
             .unwrap_or(false)
+    }
+
+    /// 记录用户在终端提交的完整命令行（回车截断后上报）。
+    pub(crate) fn record_user_command(&self, command: String) {
+        let trimmed = command.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        if let Ok(mut cmds) = self.pending_user_commands.lock() {
+            cmds.push(trimmed.to_string());
+        }
+    }
+
+    /// 取出并清空用户命令队列（consume 语义）。
+    #[allow(dead_code)]
+    pub(crate) fn take_user_commands(&self) -> Vec<String> {
+        self.pending_user_commands
+            .lock()
+            .map(|mut cmds| {
+                let v = cmds.clone();
+                cmds.clear();
+                v
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/crates/tiangong-plugin-terminal/src/commands.rs
+++ b/crates/tiangong-plugin-terminal/src/commands.rs
@@ -1,4 +1,4 @@
-use tauri::State;
+use tauri::{Emitter, State};
 
 use crate::session_pty::SessionPty;
 use crate::types::{TerminalSessionInfo, TerminalSessionStatus};
@@ -87,6 +87,26 @@ pub async fn terminal_session_send_input(
         .await
         .map_err(|e| e.to_string())?;
     await_response(response_rx).await
+}
+
+/// 上报用户在终端提交的完整命令行（回车截断后由前端累积上报）。
+///
+/// 存入 tracker 并 emit `terminal:user_command` 事件（携带 session_id + command），
+/// 供 main.rs 监听后注入 Agent 对话链。
+#[tauri::command]
+pub async fn terminal_report_user_command(
+    session_id: String,
+    command: String,
+    state: State<'_, TerminalPluginState>,
+    app_handle: tauri::AppHandle,
+) -> Result<(), String> {
+    let pty = ensure_pty(&state, &session_id)?;
+    pty.activity.record_user_command(command.clone());
+    let _ = app_handle.emit(
+        "terminal:user_command",
+        serde_json::json!({ "session_id": session_id, "command": command }),
+    );
+    Ok(())
 }
 
 #[tauri::command]

--- a/crates/tiangong-plugin-terminal/src/lib.rs
+++ b/crates/tiangong-plugin-terminal/src/lib.rs
@@ -31,6 +31,7 @@ pub fn init(session_id: String, cwd: String) -> TauriPlugin<Wry> {
             commands::terminal_destroy_session,
             commands::terminal_attach_session,
             commands::terminal_session_send_input,
+            commands::terminal_report_user_command,
             commands::terminal_session_recent_output,
             commands::terminal_session_info,
             commands::terminal_session_status,

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -878,6 +878,10 @@ export const api = {
   terminalSessionSendInput: (sessionId: string, input: string): Promise<void> =>
     invoke('plugin:terminal|terminal_session_send_input', { sessionId, input }),
 
+  // 上报用户在终端提交的完整命令行（回车截断后上报，供注入 Agent 对话链）
+  terminalReportUserCommand: (sessionId: string, command: string): Promise<void> =>
+    invoke('plugin:terminal|terminal_report_user_command', { sessionId, command }),
+
   terminalSessionRecentOutput: (sessionId: string, lines?: number): Promise<string> =>
     invoke('plugin:terminal|terminal_session_recent_output', { sessionId, lines: lines ?? null }),
 

--- a/frontend/src/components/TerminalPanel.tsx
+++ b/frontend/src/components/TerminalPanel.tsx
@@ -83,6 +83,8 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
   const createdTimeRef = useRef<number>(0);
   // 上次屏幕快照回传时间戳（节流用）
   const lastSnapshotPushRef = useRef<number>(0);
+  // 用户输入行缓冲：按 session_id 独立累积，遇回车截断上报完整命令行。
+  const inputBufferRef = useRef<Map<string, string>>(new Map());
 
   const [displayInfo, setDisplayInfo] = useState<{
     cwd: string;
@@ -218,6 +220,31 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
           term.onData((data) => {
             const sid = currentIdRef.current;
             if (sid) api.terminalSessionSendInput(sid, data).catch(() => {});
+
+            // 累积当前行，遇回车截断并上报完整命令（供注入 Agent 对话链）。
+            if (!sid) return;
+            if (data === '\r') {
+              const cmd = (inputBufferRef.current.get(sid) ?? '').trim();
+              if (cmd) {
+                api.terminalReportUserCommand(sid, cmd).catch(() => {});
+              }
+              inputBufferRef.current.set(sid, '');
+            } else if (data === '\x7f' || data === '\b') {
+              const buf = inputBufferRef.current.get(sid) ?? '';
+              inputBufferRef.current.set(sid, buf.slice(0, -1));
+            } else if (data[0] === '\x1b') {
+              // ESC 开头的序列（方向键/功能键/终端报告）：整体忽略，不累积
+            } else if (data.length === 1 && data >= ' ') {
+              const buf = inputBufferRef.current.get(sid) ?? '';
+              inputBufferRef.current.set(sid, buf + data);
+            } else if (data.length > 1) {
+              // 粘贴的多字符：仅保留可打印部分
+              const cleaned = data.replace(/[\x00-\x1f\x7f]/g, '');
+              if (cleaned) {
+                const buf = inputBufferRef.current.get(sid) ?? '';
+                inputBufferRef.current.set(sid, buf + cleaned);
+              }
+            }
           });
 
           term.onResize(({ cols, rows }) => {

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -166,6 +166,54 @@ impl TiangongApp {
         false
     }
 
+    /// 注入用户终端操作到指定会话的对话链。
+    ///
+    /// 用传入的 session_id 路由（来自终端操作的 session，而非 active session）。
+    /// - core 存在：走 command channel（ReAct 循环内或空闲时都注入到 core session）
+    /// - core 不存在：直接 append 到 state session（下次 ensure_core 会取快照）
+    pub async fn inject_terminal_user_input(&self, session_id: String, command: String) -> bool {
+        // 优先走 core command channel
+        let core_sent = {
+            let cores = self.lock_cores();
+            if let Some(core) = cores.get(&session_id) {
+                tracing::info!(
+                    session_id,
+                    command = %command,
+                    running = core.is_running(),
+                    "注入用户终端操作 via core"
+                );
+                core.inject_terminal_user_input(command.clone())
+            } else {
+                false
+            }
+        };
+        if core_sent {
+            return true;
+        }
+
+        // core 不存在：直接 append 到 state session
+        tracing::info!(
+            session_id,
+            command = %command,
+            "core 不存在，直接 append 用户终端操作到 state session"
+        );
+        let mut state = self.state.lock().await;
+        let sessions = state.sessions_mut();
+        if let Some(session) = sessions.iter_mut().find(|s| s.id == session_id) {
+            let content = format!("[用户终端操作] 用户在终端执行了: {command}");
+            session.append_message(tiangong_types::MessageRole::Tool, content);
+            session.persist_to_disk();
+            true
+        } else {
+            tracing::warn!(
+                session_id,
+                command = %command,
+                "用户终端操作注入失败：session 不存在"
+            );
+            false
+        }
+    }
+
     fn lock_cores(&self) -> std::sync::MutexGuard<'_, HashMap<String, TiangongCore>> {
         match self.cores.lock() {
             Ok(guard) => guard,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -444,6 +444,28 @@ fn run_gui() {
                 });
             });
 
+            // 监听终端用户命令提交事件，注入到对应会话的对话链。
+            // 用 payload 里的 session_id 路由（终端操作的 session，而非 active session）。
+            let terminal_inject_handle = app.handle().clone();
+            app.listen("terminal:user_command", move |event| {
+                let payload = event.payload().to_string();
+                let Ok(data) = serde_json::from_str::<serde_json::Value>(&payload) else {
+                    warn!("终端用户命令 payload 解析失败");
+                    return;
+                };
+                let session_id = data["session_id"].as_str().unwrap_or("").to_string();
+                let command = data["command"].as_str().unwrap_or("").to_string();
+                if session_id.is_empty() || command.trim().is_empty() {
+                    return;
+                }
+                let app_handle = terminal_inject_handle.clone();
+                tauri::async_runtime::spawn(async move {
+                    let state = app_handle.state::<tiangong_app::TiangongApp>();
+                    let injected = state.inject_terminal_user_input(session_id, command).await;
+                    debug!(injected, "终端用户命令注入完成");
+                });
+            });
+
             let scheduler_ctx = state.create_scheduler_context();
             tauri::async_runtime::spawn(async move {
                 tiangong_scheduler::executor::restore_cron_jobs(scheduler_ctx).await;


### PR DESCRIPTION
Closes #145

## 概述

将用户在终端面板提交的命令结构化注入对话链，让 Agent 直接理解用户意图（如手动 cd 到其他目录、启动了某个服务），而非仅感知"发生了干预"。

## 设计

| 维度 | 选择 |
|---|---|
| 捕获时机 | 前端 onData 累积当前行（ESC 序列过滤），遇回车截断上报 |
| 注入时机 | 无论 Agent 是否运行都注入（运行时下轮看到；空闲时记入历史） |
| 注入格式 | 伪造 terminal_user_input tool_call + tool result 对 |
| session 路由 | 用 payload 的 session_id（终端操作的 session），不用 active session |
| 回退路径 | core 不存在时直接 append 到 state session |

## 数据流

```
用户终端输入 → onData 逐按键写 PTY（不变）
  → 回车截断完整命令 → terminal_report_user_command
  → emit terminal:user_command（带 session_id）
  → main.rs 监听 → app.inject_terminal_user_input（用 payload session_id）
  → core 存在走 command channel；不存在直接 append state session
  → Agent 看到 [用户终端操作]
```

## 验证

- fmt ✓ / clippy 0 警告 ✓ / 369 测试全过 ✓ / pre-push 钩子全过 ✓