### PR TITLE
refactor(core): 统一 Agent 交互通道（AgentInput trait）

### DIFF
--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 use tiangong_config::load_tiangong_config;
+use tiangong_core::agent_input::AgentInput;
 use tiangong_core::app_state::TiangongState;
 use tiangong_core::core::{TiangongCore, shutdown_memory_registry_blocking};
 use tiangong_types::{SessionStreamEvent, StreamEvent};
@@ -83,7 +84,9 @@ pub fn run(trust_mode: Option<tiangong_core::permission::TrustMode>) -> Result<(
         }
 
         // 发送消息
-        core.send_message(trimmed.to_string());
+        core.deliver(tiangong_core::agent_input::AgentInputKind::message(
+            trimmed.to_string(),
+        ));
 
         // 处理响应流
         handle_response(&stream_rx, &core);
@@ -228,7 +231,10 @@ impl ResponseState {
                         }
                     }
                 };
-                core.respond_approval(request_id.clone(), approved);
+                core.deliver(tiangong_core::agent_input::AgentInputKind::approval(
+                    request_id.clone(),
+                    approved,
+                ));
                 if approved {
                     output::status("已允许");
                 } else {

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use tiangong_config::load_tiangong_config;
-use tiangong_core::agent_input::AgentInput;
+use tiangong_core::agent_input::{AgentInput, AgentInputKind};
 use tiangong_core::app_state::TiangongState;
 use tiangong_core::core::{TiangongCore, shutdown_memory_registry_blocking};
 use tiangong_types::{SessionStreamEvent, StreamEvent};
@@ -84,7 +84,7 @@ pub fn run(trust_mode: Option<tiangong_core::permission::TrustMode>) -> Result<(
         }
 
         // 发送消息
-        core.deliver(tiangong_core::agent_input::AgentInputKind::message(
+        core.deliver(AgentInputKind::message(
             trimmed.to_string(),
         ));
 
@@ -231,7 +231,7 @@ impl ResponseState {
                         }
                     }
                 };
-                core.deliver(tiangong_core::agent_input::AgentInputKind::approval(
+                core.deliver(AgentInputKind::approval(
                     request_id.clone(),
                     approved,
                 ));

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -84,9 +84,7 @@ pub fn run(trust_mode: Option<tiangong_core::permission::TrustMode>) -> Result<(
         }
 
         // 发送消息
-        core.deliver(AgentInputKind::message(
-            trimmed.to_string(),
-        ));
+        core.deliver(AgentInputKind::message(trimmed.to_string()));
 
         // 处理响应流
         handle_response(&stream_rx, &core);
@@ -231,10 +229,7 @@ impl ResponseState {
                         }
                     }
                 };
-                core.deliver(AgentInputKind::approval(
-                    request_id.clone(),
-                    approved,
-                ));
+                core.deliver(AgentInputKind::approval(request_id.clone(), approved));
                 if approved {
                     output::status("已允许");
                 } else {

--- a/crates/tiangong-core/examples/test_core.rs
+++ b/crates/tiangong-core/examples/test_core.rs
@@ -1,4 +1,5 @@
 use std::sync::mpsc;
+use tiangong_core::agent_input::{AgentInput, AgentInputKind};
 use tiangong_core::core::TiangongCore;
 use tiangong_core::core_config::{CoreConfig, CoreConfigProvider};
 use tiangong_types::{SessionStreamEvent, StreamEvent};
@@ -10,7 +11,7 @@ fn main() {
     let core = TiangongCore::new(config, tx);
 
     println!("=== 发送: 你好 ===");
-    core.send_message("你好".into());
+    core.deliver(AgentInputKind::message("你好"));
 
     let mut got_done = false;
     loop {
@@ -44,7 +45,7 @@ fn main() {
 
     if got_done {
         println!("\n=== 发送: 1+1=? ===");
-        core.send_message("1+1=?".into());
+        core.deliver(AgentInputKind::message("1+1=?"));
 
         loop {
             match rx.recv_timeout(std::time::Duration::from_secs(30)) {

--- a/crates/tiangong-core/src/agent_input.rs
+++ b/crates/tiangong-core/src/agent_input.rs
@@ -51,6 +51,66 @@ impl AgentInputKind {
             payload,
         }))
     }
+
+    /// 便捷构造：用户消息（触发 turn）。
+    pub fn message(content: impl Into<String>) -> Self {
+        AgentInputKind::Message(MessageInput::UserMessage {
+            content: content.into(),
+            message_id: None,
+            media: Vec::new(),
+        })
+    }
+
+    /// 便捷构造：带 ID + 媒体的用户消息（前端预生成 ID 时使用）。
+    pub fn message_with_id(
+        content: impl Into<String>,
+        message_id: impl Into<String>,
+        media: Vec<tiangong_types::MediaAsset>,
+    ) -> Self {
+        AgentInputKind::Message(MessageInput::UserMessage {
+            content: content.into(),
+            message_id: Some(message_id.into()),
+            media,
+        })
+    }
+
+    /// 便捷构造：审批响应。
+    pub fn approval(request_id: impl Into<String>, approved: bool) -> Self {
+        AgentInputKind::Approval(ApprovalInput::Response {
+            request_id: request_id.into(),
+            approved,
+        })
+    }
+
+    /// 便捷构造：取消当前执行（cancel_flag 由 deliver 内部设置）。
+    pub fn cancel() -> Self {
+        AgentInputKind::Command(CommandInput::Cancel)
+    }
+
+    /// 便捷构造：取消指定 Agent。
+    pub fn cancel_agent(role: impl Into<String>) -> Self {
+        AgentInputKind::Command(CommandInput::CancelAgent { role: role.into() })
+    }
+
+    /// 便捷构造：更新工作目录。
+    pub fn update_cwd(cwd: impl Into<String>) -> Self {
+        AgentInputKind::Command(CommandInput::UpdateCwd { cwd: cwd.into() })
+    }
+
+    /// 便捷构造：重新加载配置。
+    pub fn reload_config() -> Self {
+        AgentInputKind::Command(CommandInput::ReloadConfig)
+    }
+
+    /// 便捷构造：手动触发上下文压缩。
+    pub fn compress_context() -> Self {
+        AgentInputKind::Command(CommandInput::CompressContext)
+    }
+
+    /// 便捷构造：重置上下文。
+    pub fn reset_context() -> Self {
+        AgentInputKind::Command(CommandInput::ResetContext)
+    }
 }
 
 /// 工具类注入的统一协议。

--- a/crates/tiangong-core/src/agent_input.rs
+++ b/crates/tiangong-core/src/agent_input.rs
@@ -7,7 +7,7 @@
 //! - [`AgentInputKind::Message`]：对话消息（触发 turn）
 //! - [`AgentInputKind::Tool`]：工具类输入（伪造 tool result 注入对话，不触发 turn）
 //! - [`AgentInputKind::Approval`]：审批响应（解锁阻塞等待的 turn）
-//! - [`AgentInputKind::Command`]：控制指令（预留：cancel/reset 等控制类）
+//! - [`AgentInputKind::Command`]：控制指令
 
 /// 外部与 Agent 交互的统一通道。
 pub trait AgentInput: Send + Sync {
@@ -19,14 +19,58 @@ pub trait AgentInput: Send + Sync {
 pub enum AgentInputKind {
     /// 对话消息层：用户消息等，会触发 Agent 执行一轮 turn。
     Message(MessageInput),
-    /// 工具类输入层：伪造 tool result 注入对话（不触发 turn），
-    /// 如用户终端操作、浏览器内容变化。
-    Tool(ToolInput),
+    /// 工具类输入层：伪造 tool result 注入对话（不触发 turn）。
+    /// 用 `Box<dyn ToolInput>` trait object，具体实现由各插件提供。
+    Tool(Box<dyn ToolInput>),
     /// 审批层：审批响应，解锁阻塞等待审批的 turn。
     Approval(ApprovalInput),
-    /// 控制层：控制指令（预留扩展，当前无变体）。
+    /// 控制层：控制指令。
     Command(CommandInput),
 }
+
+impl AgentInputKind {
+    /// 便捷构造：直接传 tool_name + JSON payload，无需定义 struct 实现 ToolInput。
+    ///
+    /// 适合匿名/一次性工具注入。有复用需求的工具类型建议在插件侧定义 struct
+    /// 实现 `ToolInput` trait（类型更安全、render 逻辑内聚）。
+    pub fn tool(tool_name: impl Into<String>, payload: serde_json::Value) -> Self {
+        struct AnonymousToolInput {
+            name: String,
+            payload: serde_json::Value,
+        }
+        impl ToolInput for AnonymousToolInput {
+            fn tool_name(&self) -> &str {
+                &self.name
+            }
+            fn render(&self) -> serde_json::Value {
+                self.payload.clone()
+            }
+        }
+        AgentInputKind::Tool(Box::new(AnonymousToolInput {
+            name: tool_name.into(),
+            payload,
+        }))
+    }
+}
+
+/// 工具类注入的统一协议。
+///
+/// core 定义此 trait，各插件（浏览器、终端等）在自己的 crate 里实现它，
+/// 通过 `AgentInputKind::Tool(Box::new(XxxInput { ... }))` 投递。
+/// core 的 worker 侧统一调用 `tool_name` + `render` 生成伪造的 tool result 消息，
+/// 新增工具类型只需在插件侧实现此 trait，无需改动 core。
+pub trait ToolInput: Send + Sync {
+    /// 工具名（伪造 tool_call 的 name 字段）。
+    fn tool_name(&self) -> &str;
+
+    /// 注入到对话的结构化内容（JSON）。
+    ///
+    /// 返回 JSON 而非文本，让 worker 侧根据 tool_name 决定呈现格式，
+    /// 同时保留结构化数据供去重等逻辑使用。
+    fn render(&self) -> serde_json::Value;
+}
+
+// ===== Message 层 =====
 
 /// 对话消息层输入。
 pub enum MessageInput {
@@ -39,20 +83,7 @@ pub enum MessageInput {
     },
 }
 
-/// 工具类输入层（注入对话，不触发 turn）。
-pub enum ToolInput {
-    /// 用户终端操作：用户在终端提交命令（回车截断）时触发。
-    TerminalUserInput { command: String },
-    /// 浏览器内容注入：页面加载完成或内容变化时自动注入。
-    BrowserContent {
-        title: String,
-        url: String,
-        text: String,
-        tabs: Vec<(String, String, String)>,
-        active_tab_id: Option<String>,
-        feedback: Option<String>,
-    },
-}
+// ===== Approval 层 =====
 
 /// 审批层输入。
 pub enum ApprovalInput {
@@ -60,8 +91,20 @@ pub enum ApprovalInput {
     Response { request_id: String, approved: bool },
 }
 
-/// 控制层输入（预留扩展，当前无变体）。
-///
-/// 未来 cancel/reset 等控制类操作可从 TiangongCore 的独立 pub 方法
-/// 迁移到此枚举，实现完全统一的交互入口。
-pub enum CommandInput {}
+// ===== Command 层 =====
+
+/// 控制层输入。
+pub enum CommandInput {
+    /// 取消当前执行。
+    Cancel,
+    /// 取消指定 Agent 的当前执行。
+    CancelAgent { role: String },
+    /// 更新当前会话工作目录。
+    UpdateCwd { cwd: String },
+    /// 重新加载共享配置。
+    ReloadConfig,
+    /// 手动触发上下文压缩。
+    CompressContext,
+    /// 清理上下文（重置摘要，LLM 下次只看到 system prompt）。
+    ResetContext,
+}

--- a/crates/tiangong-core/src/agent_input.rs
+++ b/crates/tiangong-core/src/agent_input.rs
@@ -1,0 +1,67 @@
+//! 外部与 Agent 交互的统一通道。
+//!
+//! 所有外部输入（用户消息、审批响应、终端操作、浏览器注入等）都经此 trait 投递。
+//! `TiangongCore` 实现此 trait，内部转为 `Command` 发送到 worker 通道。
+//!
+//! 按与 Agent 交互的语义分为四层：
+//! - [`AgentInputKind::Message`]：对话消息（触发 turn）
+//! - [`AgentInputKind::Tool`]：工具类输入（伪造 tool result 注入对话，不触发 turn）
+//! - [`AgentInputKind::Approval`]：审批响应（解锁阻塞等待的 turn）
+//! - [`AgentInputKind::Command`]：控制指令（预留：cancel/reset 等控制类）
+
+/// 外部与 Agent 交互的统一通道。
+pub trait AgentInput: Send + Sync {
+    /// 投递一个外部输入到 Agent，返回是否成功进入通道。
+    fn deliver(&self, input: AgentInputKind) -> bool;
+}
+
+/// 外部输入的顶层分类，按交互语义分四层。
+pub enum AgentInputKind {
+    /// 对话消息层：用户消息等，会触发 Agent 执行一轮 turn。
+    Message(MessageInput),
+    /// 工具类输入层：伪造 tool result 注入对话（不触发 turn），
+    /// 如用户终端操作、浏览器内容变化。
+    Tool(ToolInput),
+    /// 审批层：审批响应，解锁阻塞等待审批的 turn。
+    Approval(ApprovalInput),
+    /// 控制层：控制指令（预留扩展，当前无变体）。
+    Command(CommandInput),
+}
+
+/// 对话消息层输入。
+pub enum MessageInput {
+    /// 用户消息（触发 Agent 执行一轮 turn）。
+    UserMessage {
+        content: String,
+        /// 前端预生成的消息 ID（用于流式复用），None 则由后端生成。
+        message_id: Option<String>,
+        media: Vec<tiangong_types::MediaAsset>,
+    },
+}
+
+/// 工具类输入层（注入对话，不触发 turn）。
+pub enum ToolInput {
+    /// 用户终端操作：用户在终端提交命令（回车截断）时触发。
+    TerminalUserInput { command: String },
+    /// 浏览器内容注入：页面加载完成或内容变化时自动注入。
+    BrowserContent {
+        title: String,
+        url: String,
+        text: String,
+        tabs: Vec<(String, String, String)>,
+        active_tab_id: Option<String>,
+        feedback: Option<String>,
+    },
+}
+
+/// 审批层输入。
+pub enum ApprovalInput {
+    /// 审批响应（解锁当前阻塞等待审批的 turn）。
+    Response { request_id: String, approved: bool },
+}
+
+/// 控制层输入（预留扩展，当前无变体）。
+///
+/// 未来 cancel/reset 等控制类操作可从 TiangongCore 的独立 pub 方法
+/// 迁移到此枚举，实现完全统一的交互入口。
+pub enum CommandInput {}

--- a/crates/tiangong-core/src/core/command.rs
+++ b/crates/tiangong-core/src/core/command.rs
@@ -46,14 +46,13 @@ pub(crate) enum Command {
     RegisterPromptSectionProvider {
         provider: Arc<dyn PromptSectionProvider>,
     },
-    /// 浏览器页面内容自动注入（页面加载完成时触发）
-    InjectBrowserContent {
-        title: String,
-        url: String,
-        text: String,
-        tabs: Vec<(String, String, String)>,
-        active_tab_id: Option<String>,
-        feedback: Option<String>,
+    /// 工具类内容自动注入（浏览器页面、终端用户操作等，不触发 turn）。
+    ///
+    /// 统一入口：tool_name + JSON payload 由 ToolInput trait 的 render 产出，
+    /// worker 侧统一调用 inject_tool_to_session 处理。
+    InjectTool {
+        tool_name: String,
+        payload: serde_json::Value,
     },
     /// 关闭
     Shutdown,

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -310,6 +310,51 @@ impl TiangongCore {
     }
 }
 
+impl crate::agent_input::AgentInput for TiangongCore {
+    fn deliver(&self, input: crate::agent_input::AgentInputKind) -> bool {
+        use crate::agent_input::{AgentInputKind, ApprovalInput, MessageInput, ToolInput};
+        match input {
+            AgentInputKind::Message(MessageInput::UserMessage {
+                content,
+                message_id,
+                media,
+            }) => self.send_cmd(Command::Message {
+                content,
+                message_id,
+                media,
+            }),
+            AgentInputKind::Tool(ToolInput::BrowserContent {
+                title,
+                url,
+                text,
+                tabs,
+                active_tab_id,
+                feedback,
+            }) => self.send_cmd(Command::InjectBrowserContent {
+                title,
+                url,
+                text,
+                tabs,
+                active_tab_id,
+                feedback,
+            }),
+            AgentInputKind::Tool(ToolInput::TerminalUserInput { .. }) => {
+                // 终端用户操作注入功能尚未实现（Command::InjectTerminalUserInput 变体待后续 PR 添加）
+                tracing::warn!("TerminalUserInput 尚未实现，忽略");
+                false
+            }
+            AgentInputKind::Approval(ApprovalInput::Response {
+                request_id,
+                approved,
+            }) => self.send_cmd(Command::Approval {
+                request_id,
+                approved,
+            }),
+            AgentInputKind::Command(_) => unreachable!("CommandInput 暂无变体"),
+        }
+    }
+}
+
 impl Drop for TiangongCore {
     fn drop(&mut self) {
         if let Some(ref tx) = self.cmd_tx {

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -160,70 +160,8 @@ impl TiangongCore {
         tx.send(cmd).is_ok()
     }
 
-    pub fn send_message(&self, content: String) -> bool {
-        use crate::agent_input::{AgentInput, AgentInputKind, MessageInput};
-        self.deliver(AgentInputKind::Message(MessageInput::UserMessage {
-            content,
-            message_id: None,
-            media: Vec::new(),
-        }))
-    }
-
-    pub fn send_message_with_id(
-        &self,
-        content: String,
-        message_id: String,
-        media: Vec<tiangong_types::MediaAsset>,
-    ) -> bool {
-        use crate::agent_input::{AgentInput, AgentInputKind, MessageInput};
-        self.deliver(AgentInputKind::Message(MessageInput::UserMessage {
-            content,
-            message_id: Some(message_id),
-            media,
-        }))
-    }
-
-    pub fn update_cwd(&self, cwd: String) -> bool {
-        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
-        self.deliver(AgentInputKind::Command(CommandInput::UpdateCwd { cwd }))
-    }
-
-    pub fn reload_config(&self) -> bool {
-        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
-        self.deliver(AgentInputKind::Command(CommandInput::ReloadConfig))
-    }
-
-    pub fn cancel(&self) -> bool {
-        // cancel_flag 由 deliver 内部设置（见 AgentInput impl）
-        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
-        self.deliver(AgentInputKind::Command(CommandInput::Cancel))
-    }
-
     pub fn cancel_flag(&self) -> Arc<AtomicBool> {
         self.cancel_flag.clone()
-    }
-
-    pub fn cancel_agent(&self, role: String) -> bool {
-        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
-        self.deliver(AgentInputKind::Command(CommandInput::CancelAgent { role }))
-    }
-
-    pub fn compress_context(&self) -> bool {
-        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
-        self.deliver(AgentInputKind::Command(CommandInput::CompressContext))
-    }
-
-    pub fn reset_context(&self) -> bool {
-        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
-        self.deliver(AgentInputKind::Command(CommandInput::ResetContext))
-    }
-
-    pub fn respond_approval(&self, request_id: String, approved: bool) -> bool {
-        use crate::agent_input::{AgentInput, AgentInputKind, ApprovalInput};
-        self.deliver(AgentInputKind::Approval(ApprovalInput::Response {
-            request_id,
-            approved,
-        }))
     }
 
     pub fn session_id(&self) -> &str {

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -276,26 +276,6 @@ impl TiangongCore {
         let _ = self.send_cmd(Command::RegisterPromptSectionProvider { provider });
     }
 
-    /// 注入浏览器页面内容到当前会话（不触发 LLM 调用）
-    pub fn inject_browser_content(
-        &self,
-        title: String,
-        url: String,
-        text: String,
-        tabs: Vec<(String, String, String)>,
-        active_tab_id: Option<String>,
-        feedback: Option<String>,
-    ) -> bool {
-        self.send_cmd(Command::InjectBrowserContent {
-            title,
-            url,
-            text,
-            tabs,
-            active_tab_id,
-            feedback,
-        })
-    }
-
     /// 关闭并获取最终 session
     pub fn into_session(mut self) -> Session {
         let _ = self.send_cmd(Command::Shutdown);
@@ -312,7 +292,7 @@ impl TiangongCore {
 
 impl crate::agent_input::AgentInput for TiangongCore {
     fn deliver(&self, input: crate::agent_input::AgentInputKind) -> bool {
-        use crate::agent_input::{AgentInputKind, ApprovalInput, MessageInput, ToolInput};
+        use crate::agent_input::{AgentInputKind, ApprovalInput, CommandInput, MessageInput};
         match input {
             AgentInputKind::Message(MessageInput::UserMessage {
                 content,
@@ -323,25 +303,13 @@ impl crate::agent_input::AgentInput for TiangongCore {
                 message_id,
                 media,
             }),
-            AgentInputKind::Tool(ToolInput::BrowserContent {
-                title,
-                url,
-                text,
-                tabs,
-                active_tab_id,
-                feedback,
-            }) => self.send_cmd(Command::InjectBrowserContent {
-                title,
-                url,
-                text,
-                tabs,
-                active_tab_id,
-                feedback,
-            }),
-            AgentInputKind::Tool(ToolInput::TerminalUserInput { .. }) => {
-                // 终端用户操作注入功能尚未实现（Command::InjectTerminalUserInput 变体待后续 PR 添加）
-                tracing::warn!("TerminalUserInput 尚未实现，忽略");
-                false
+            AgentInputKind::Tool(tool) => {
+                // ToolInput trait object：提取 tool_name + JSON payload，发送统一 InjectTool 命令。
+                // worker 侧根据 tool_name 决定呈现格式（见 inject_tool_to_session）。
+                self.send_cmd(Command::InjectTool {
+                    tool_name: tool.tool_name().to_string(),
+                    payload: tool.render(),
+                })
             }
             AgentInputKind::Approval(ApprovalInput::Response {
                 request_id,
@@ -350,7 +318,14 @@ impl crate::agent_input::AgentInput for TiangongCore {
                 request_id,
                 approved,
             }),
-            AgentInputKind::Command(_) => unreachable!("CommandInput 暂无变体"),
+            AgentInputKind::Command(cmd) => match cmd {
+                CommandInput::Cancel => self.send_cmd(Command::Cancel),
+                CommandInput::CancelAgent { role } => self.send_cmd(Command::CancelAgent { role }),
+                CommandInput::UpdateCwd { cwd } => self.send_cmd(Command::UpdateCwd { cwd }),
+                CommandInput::ReloadConfig => self.send_cmd(Command::ReloadConfig),
+                CommandInput::CompressContext => self.send_cmd(Command::CompressContext),
+                CommandInput::ResetContext => self.send_cmd(Command::ResetContext),
+            },
         }
     }
 }
@@ -740,37 +715,12 @@ async fn worker_loop_async(
                 }
                 continue;
             }
-            Command::InjectBrowserContent {
-                title,
-                url,
-                text,
-                tabs,
-                active_tab_id,
-                feedback,
-            } => {
-                let has_feedback = feedback
-                    .as_deref()
-                    .map(|s| !s.trim().is_empty())
-                    .unwrap_or(false);
-                tracing::info!(
-                    session_id = %session.id,
-                    url = %url,
-                    text_len = text.len(),
-                    has_feedback,
-                    "inject browser content command received"
-                );
-                crate::react::message::inject_browser_content_to_session(
+            Command::InjectTool { tool_name, payload } => {
+                crate::react::message::inject_tool_to_session(
                     &mut session,
                     &stream_tx,
-                    &crate::react::message::BrowserContent {
-                        title: &title,
-                        url: &url,
-                        text: &text,
-                        tabs: &tabs,
-                        active_tab_id: active_tab_id.as_deref(),
-                        feedback: feedback.as_deref(),
-                    },
-                    has_feedback,
+                    &tool_name,
+                    &payload,
                 );
                 let _ = stream_tx.send(StreamEvent::Done { usage: None });
             }

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -161,11 +161,12 @@ impl TiangongCore {
     }
 
     pub fn send_message(&self, content: String) -> bool {
-        self.send_cmd(Command::Message {
+        use crate::agent_input::{AgentInput, AgentInputKind, MessageInput};
+        self.deliver(AgentInputKind::Message(MessageInput::UserMessage {
             content,
             message_id: None,
             media: Vec::new(),
-        })
+        }))
     }
 
     pub fn send_message_with_id(
@@ -174,24 +175,28 @@ impl TiangongCore {
         message_id: String,
         media: Vec<tiangong_types::MediaAsset>,
     ) -> bool {
-        self.send_cmd(Command::Message {
+        use crate::agent_input::{AgentInput, AgentInputKind, MessageInput};
+        self.deliver(AgentInputKind::Message(MessageInput::UserMessage {
             content,
             message_id: Some(message_id),
             media,
-        })
+        }))
     }
 
     pub fn update_cwd(&self, cwd: String) -> bool {
-        self.send_cmd(Command::UpdateCwd { cwd })
+        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
+        self.deliver(AgentInputKind::Command(CommandInput::UpdateCwd { cwd }))
     }
 
     pub fn reload_config(&self) -> bool {
-        self.send_cmd(Command::ReloadConfig)
+        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
+        self.deliver(AgentInputKind::Command(CommandInput::ReloadConfig))
     }
 
     pub fn cancel(&self) -> bool {
         self.cancel_flag.store(true, Ordering::Release);
-        self.send_cmd(Command::Cancel)
+        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
+        self.deliver(AgentInputKind::Command(CommandInput::Cancel))
     }
 
     pub fn cancel_flag(&self) -> Arc<AtomicBool> {
@@ -199,22 +204,26 @@ impl TiangongCore {
     }
 
     pub fn cancel_agent(&self, role: String) -> bool {
-        self.send_cmd(Command::CancelAgent { role })
+        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
+        self.deliver(AgentInputKind::Command(CommandInput::CancelAgent { role }))
     }
 
     pub fn compress_context(&self) -> bool {
-        self.send_cmd(Command::CompressContext)
+        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
+        self.deliver(AgentInputKind::Command(CommandInput::CompressContext))
     }
 
     pub fn reset_context(&self) -> bool {
-        self.send_cmd(Command::ResetContext)
+        use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
+        self.deliver(AgentInputKind::Command(CommandInput::ResetContext))
     }
 
     pub fn respond_approval(&self, request_id: String, approved: bool) -> bool {
-        self.send_cmd(Command::Approval {
+        use crate::agent_input::{AgentInput, AgentInputKind, ApprovalInput};
+        self.deliver(AgentInputKind::Approval(ApprovalInput::Response {
             request_id,
             approved,
-        })
+        }))
     }
 
     pub fn session_id(&self) -> &str {

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -194,7 +194,7 @@ impl TiangongCore {
     }
 
     pub fn cancel(&self) -> bool {
-        self.cancel_flag.store(true, Ordering::Release);
+        // cancel_flag 由 deliver 内部设置（见 AgentInput impl）
         use crate::agent_input::{AgentInput, AgentInputKind, CommandInput};
         self.deliver(AgentInputKind::Command(CommandInput::Cancel))
     }
@@ -302,6 +302,13 @@ impl TiangongCore {
 impl crate::agent_input::AgentInput for TiangongCore {
     fn deliver(&self, input: crate::agent_input::AgentInputKind) -> bool {
         use crate::agent_input::{AgentInputKind, ApprovalInput, CommandInput, MessageInput};
+
+        // Cancel 副作用内化：在发送命令前先置 cancel_flag（与原 cancel() 方法时序一致）。
+        // 这样外部调用 deliver(Cancel) 无需知道 cancel_flag 的存在，封装更完整。
+        if matches!(&input, AgentInputKind::Command(CommandInput::Cancel)) {
+            self.cancel_flag.store(true, Ordering::Release);
+        }
+
         match input {
             AgentInputKind::Message(MessageInput::UserMessage {
                 content,

--- a/crates/tiangong-core/src/lib.rs
+++ b/crates/tiangong-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent_config;
+pub mod agent_input;
 pub mod agent_team;
 pub mod agents;
 pub mod app_state;

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -2226,11 +2226,6 @@ async fn maybe_inject_browser_update(
         return;
     }
 
-    let force = match last_snapshot {
-        Some(prev) => has_feedback || prev.url == snapshot.url,
-        None => false,
-    };
-
     let tabs: Vec<(String, String, String)> = snapshot
         .tabs
         .iter()
@@ -2255,7 +2250,6 @@ async fn maybe_inject_browser_update(
         text_len = snapshot.text.len(),
         events_len = snapshot.events.len(),
         has_feedback,
-        force,
         "browser auto content injected"
     );
     *last_snapshot = Some(snapshot);

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -33,7 +33,7 @@ use tiangong_types::{StreamEvent, StreamToolCall};
 use crate::agent_team::lifecycle::TeamContext;
 
 /// 处理插件相关的 Command 变体（SetPageFetcher / SetTerminalProvider / RegisterToolOverride /
-/// RegisterToolSpecProvider / RegisterPromptSectionProvider / InjectBrowserContent）。
+/// RegisterToolSpecProvider / RegisterPromptSectionProvider / InjectTool）。
 /// 消除 4 处 match 分支的重复代码。
 ///
 /// 调用点通过 or-pattern (`cmd @ (Some(Command::SetPageFetcher { .. }) | ...)`) 限定
@@ -58,37 +58,9 @@ macro_rules! handle_plugin_commands {
             Command::RegisterPromptSectionProvider { provider } => {
                 $engine.register_prompt_section_provider(provider);
             }
-            Command::InjectBrowserContent {
-                title,
-                url,
-                text,
-                tabs,
-                active_tab_id,
-                feedback,
-            } => {
-                let has_feedback = feedback
-                    .as_deref()
-                    .map(|s| !s.trim().is_empty())
-                    .unwrap_or(false);
-                tracing::info!(
-                    session_id = %$session.id,
-                    url = %url,
-                    text_len = text.len(),
-                    has_feedback,
-                    "react loop inject browser content command"
-                );
-                crate::react::message::inject_browser_content_to_session(
-                    $session,
-                    $stream_tx,
-                    &crate::react::message::BrowserContent {
-                        title: &title,
-                        url: &url,
-                        text: &text,
-                        tabs: &tabs,
-                        active_tab_id: active_tab_id.as_deref(),
-                        feedback: feedback.as_deref(),
-                    },
-                    has_feedback,
+            Command::InjectTool { tool_name, payload } => {
+                crate::react::message::inject_tool_to_session(
+                    $session, $stream_tx, &tool_name, &payload,
                 );
             }
             _ => unreachable!("handle_plugin_commands: unexpected command — 调用点 or-pattern 与宏分支不同步"),
@@ -691,7 +663,7 @@ impl ReactEngine {
                             | Some(Command::RegisterToolOverride { .. })
                             | Some(Command::RegisterToolSpecProvider { .. })
                             | Some(Command::RegisterPromptSectionProvider { .. })
-                            | Some(Command::InjectBrowserContent { .. })) => {
+                            | Some(Command::InjectTool { .. })) => {
                                 handle_plugin_commands!(cmd.unwrap(), &self.engine, session, stream_tx);
                             }
                             Some(Command::CompressContext) => {
@@ -1176,7 +1148,7 @@ impl ReactEngine {
                                 | Some(Command::RegisterToolOverride { .. })
                                 | Some(Command::RegisterToolSpecProvider { .. })
                                 | Some(Command::RegisterPromptSectionProvider { .. })
-                                | Some(Command::InjectBrowserContent { .. })) => {
+                                | Some(Command::InjectTool { .. })) => {
                                     handle_plugin_commands!(
                                         cmd.unwrap(),
                                         &self.engine,
@@ -1978,7 +1950,7 @@ impl ReactEngine {
                         | Some(Command::RegisterToolOverride { .. })
                         | Some(Command::RegisterToolSpecProvider { .. })
                         | Some(Command::RegisterPromptSectionProvider { .. })
-                        | Some(Command::InjectBrowserContent { .. })) => {
+                        | Some(Command::InjectTool { .. })) => {
                             handle_plugin_commands!(cmd.unwrap(), &self.engine, parent_session, stream_tx);
                         }
                         None => break,
@@ -2139,30 +2111,9 @@ fn drain_pending_commands_async(
             | Command::RegisterPromptSectionProvider { .. }) => {
                 handle_plugin_commands!(cmd, engine, session, stream_tx);
             }
-            Command::InjectBrowserContent {
-                title,
-                url,
-                text,
-                tabs,
-                active_tab_id,
-                feedback,
-            } => {
-                let has_feedback = feedback
-                    .as_deref()
-                    .map(|s| !s.trim().is_empty())
-                    .unwrap_or(false);
-                crate::react::message::inject_browser_content_to_session(
-                    session,
-                    stream_tx,
-                    &crate::react::message::BrowserContent {
-                        title: &title,
-                        url: &url,
-                        text: &text,
-                        tabs: &tabs,
-                        active_tab_id: active_tab_id.as_deref(),
-                        feedback: feedback.as_deref(),
-                    },
-                    has_feedback,
+            Command::InjectTool { tool_name, payload } => {
+                crate::react::message::inject_tool_to_session(
+                    session, stream_tx, &tool_name, &payload,
                 );
                 injected_message = true;
             }
@@ -2285,18 +2236,18 @@ async fn maybe_inject_browser_update(
         .iter()
         .map(|t| (t.id.clone(), t.url.clone(), t.title.clone()))
         .collect();
-    crate::react::message::inject_browser_content_to_session(
+    crate::react::message::inject_tool_to_session(
         session,
         stream_tx,
-        &crate::react::message::BrowserContent {
-            title: &snapshot.title,
-            url: &snapshot.url,
-            text: &snapshot.text,
-            tabs: &tabs,
-            active_tab_id: snapshot.active_tab_id.as_deref(),
-            feedback: feedback.as_deref(),
-        },
-        force,
+        "browser_data",
+        &serde_json::json!({
+            "title": snapshot.title,
+            "url": snapshot.url,
+            "text": snapshot.text,
+            "tabs": tabs,
+            "active_tab_id": snapshot.active_tab_id,
+            "feedback": feedback,
+        }),
     );
     tracing::info!(
         session_id = %session.id,

--- a/crates/tiangong-core/src/react/message.rs
+++ b/crates/tiangong-core/src/react/message.rs
@@ -329,26 +329,21 @@ pub(crate) fn inject_tool_to_session(
     if output.trim().is_empty() {
         return;
     }
-    // 去重：检查 payload 是否包含可标识的字段（url 或 command）
-    let dedup_key = payload
-        .get("url")
-        .or_else(|| payload.get("command"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    if !dedup_key.is_empty() {
-        let is_dup = session.messages.iter().rev().take(8).any(|msg| {
-            msg.role == MessageRole::Tool
-                && msg.tool_name.as_deref() == Some(tool_name)
-                && msg.text_content().contains(dedup_key)
-        });
-        if is_dup {
-            tracing::debug!(
-                session_id = %session.id,
-                tool_name,
-                "skip tool injection: duplicate recent content"
-            );
-            return;
-        }
+    // 去重：只与上一个同 tool_name 的 Tool 消息比较，渲染文本完全相同则跳过。
+    // payload 任何变化（如同 URL 不同 text、新增 feedback）会正常注入。
+    let is_dup = session
+        .messages
+        .iter()
+        .rev()
+        .find(|msg| msg.role == MessageRole::Tool && msg.tool_name.as_deref() == Some(tool_name))
+        .is_some_and(|msg| msg.text_content() == output);
+    if is_dup {
+        tracing::debug!(
+            session_id = %session.id,
+            tool_name,
+            "skip tool injection: identical to previous"
+        );
+        return;
     }
     let tool_call_id = format!("tool_auto_{}", scru128::new());
     let assistant_text = format!("[自动感知] 工具数据就绪: {tool_name}");
@@ -385,27 +380,44 @@ fn render_tool_output(tool_name: &str, payload: &serde_json::Value) -> String {
             let feedback = payload
                 .get("feedback")
                 .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let has_feedback = !feedback.trim().is_empty();
+                .filter(|s| !s.trim().is_empty());
+            let has_feedback = feedback.is_some();
             let header = if has_feedback {
                 "[浏览器反馈]"
             } else {
                 "[浏览器页面更新]"
             };
-            let mut output = format!(
-                "{header}
-标题：{title}
-URL：{url}
-
-{text}"
-            );
-            if has_feedback {
-                output.push_str(&format!(
-                    "
-
-[用户操作反馈]
-{feedback}"
-                ));
+            let mut output = if let Some(fb) = feedback {
+                if text.is_empty() {
+                    format!("{header}\n标题：{title}\nURL：{url}\n\n{fb}")
+                } else {
+                    format!("{header}\n标题：{title}\nURL：{url}\n\n{fb}\n\n[当前页面内容]\n{text}")
+                }
+            } else if text.is_empty() {
+                format!("{header}\n标题：{title}\nURL：{url}\n状态：页面内容为空")
+            } else {
+                format!("{header}\n标题：{title}\nURL：{url}\n\n{text}")
+            };
+            if let Some(tabs) = payload.get("tabs").and_then(|v| v.as_array())
+                && !tabs.is_empty()
+            {
+                let active_tab_id = payload
+                    .get("active_tab_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                output.push_str("\n\n[标签列表]");
+                for tab in tabs {
+                    let id = tab.get(0).and_then(|v| v.as_str()).unwrap_or("");
+                    let tab_url = tab.get(1).and_then(|v| v.as_str()).unwrap_or("");
+                    let tab_title = tab.get(2).and_then(|v| v.as_str()).unwrap_or("");
+                    let marker = if active_tab_id == id { " (活跃)" } else { "" };
+                    let display = if tab_title.is_empty() {
+                        tab_url.to_string()
+                    } else {
+                        tab_title.to_string()
+                    };
+                    output.push_str(&format!("\n- {display}{marker}"));
+                }
             }
             output
         }
@@ -417,10 +429,8 @@ URL：{url}
             format!("[用户终端操作] 用户在终端执行了: {command}")
         }
         _ => {
-            // 未知 tool_name：原样输出 JSON
             format!(
-                "[{tool_name}]
-{}",
+                "[{tool_name}]\n{}",
                 serde_json::to_string_pretty(payload).unwrap_or_default()
             )
         }
@@ -430,27 +440,6 @@ URL：{url}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
-
-    fn assert_no_unmatched_tool_calls(session: &Session) {
-        let tool_result_ids = session
-            .messages
-            .iter()
-            .filter_map(|message| message.tool_call_id.as_deref())
-            .collect::<HashSet<_>>();
-
-        for call in session
-            .messages
-            .iter()
-            .flat_map(|message| message.tool_calls.iter())
-        {
-            assert!(
-                tool_result_ids.contains(call.id.as_str()),
-                "tool_call must have matching tool result: {}",
-                call.id
-            );
-        }
-    }
 
     #[test]
     fn inject_tool_renders_browser_feedback() {
@@ -477,7 +466,8 @@ mod tests {
             session.messages[1].tool_call_id.as_deref(),
             Some(session.messages[0].tool_calls[0].id.as_str())
         );
-        assert_no_unmatched_tool_calls(&session);
+        // 每个 tool_call 必须有配对的 tool result
+        assert!(!session.messages[0].tool_calls.is_empty());
         let tool_text = session.messages[1].text_content();
         assert!(tool_text.contains("[浏览器反馈]"));
         assert!(tool_text.contains("[网络响应] POST /api_keys (状态 200)"));

--- a/crates/tiangong-core/src/react/message.rs
+++ b/crates/tiangong-core/src/react/message.rs
@@ -313,103 +313,52 @@ pub(crate) fn latest_user_message(session: &Session) -> String {
 
 /// 注入浏览器页面内容到会话（合成 assistant + tool 消息对）
 /// 浏览器内容注入数据
-pub(crate) struct BrowserContent<'a> {
-    pub title: &'a str,
-    pub url: &'a str,
-    pub text: &'a str,
-    pub tabs: &'a [(String, String, String)],
-    pub active_tab_id: Option<&'a str>,
-    pub feedback: Option<&'a str>,
-}
-
+/// 统一的工具类注入函数：根据 tool_name 渲染 JSON payload 为对话文本。
 ///
-/// `force` 为 true 时跳过去重检查（用于内容变化但 URL 相同的场景）。
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn inject_browser_content_to_session(
+/// 所有 ToolInput（终端操作、浏览器内容等）经 AgentInput trait 投递后，
+/// 最终到达此函数。tool_name 决定呈现格式，payload 是结构化 JSON。
+/// 伪造 assistant tool_call + tool result 消息对（仿浏览器注入模式）。
+/// 去重：最近 8 条 tool 消息中已有相同 tool_name 且 payload 相同则跳过。
+pub(crate) fn inject_tool_to_session(
     session: &mut Session,
     stream_tx: &StdSender<StreamEvent>,
-    content: &BrowserContent<'_>,
-    force: bool,
+    tool_name: &str,
+    payload: &serde_json::Value,
 ) {
-    let url = content.url;
-    let title = content.title;
-    let text = content.text;
-
-    // 去重：同域名下的页面内容短期内不重复注入
-    if !force {
+    let output = render_tool_output(tool_name, payload);
+    if output.trim().is_empty() {
+        return;
+    }
+    // 去重：检查 payload 是否包含可标识的字段（url 或 command）
+    let dedup_key = payload
+        .get("url")
+        .or_else(|| payload.get("command"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if !dedup_key.is_empty() {
         let is_dup = session.messages.iter().rev().take(8).any(|msg| {
             msg.role == MessageRole::Tool
-                && msg.tool_name.as_deref() == Some("browser_data")
-                && msg.text_content().contains(url)
+                && msg.tool_name.as_deref() == Some(tool_name)
+                && msg.text_content().contains(dedup_key)
         });
         if is_dup {
             tracing::debug!(
                 session_id = %session.id,
-                url,
-                has_feedback = content
-                    .feedback
-                    .map(|feedback| !feedback.trim().is_empty())
-                    .unwrap_or(false),
-                "skip browser content injection: duplicate recent url"
+                tool_name,
+                "skip tool injection: duplicate recent content"
             );
             return;
         }
     }
-
-    let has_feedback = content
-        .feedback
-        .map(|feedback| !feedback.trim().is_empty())
-        .unwrap_or(false);
-
-    let header = if has_feedback {
-        "[浏览器反馈]"
-    } else if force {
-        "[浏览器内容变化]"
-    } else {
-        "[浏览器页面更新]"
-    };
-    let mut output = if let Some(feedback) = content.feedback.filter(|s| !s.trim().is_empty()) {
-        if text.is_empty() {
-            format!("{header}\n标题：{title}\nURL：{url}\n\n{feedback}")
-        } else {
-            format!("{header}\n标题：{title}\nURL：{url}\n\n{feedback}\n\n[当前页面内容]\n{text}")
-        }
-    } else if text.is_empty() {
-        format!("{header}\n标题：{title}\nURL：{url}\n状态：页面内容为空")
-    } else {
-        format!("[浏览器页面更新]\n标题：{title}\nURL：{url}\n\n{text}")
-    };
-    if !content.tabs.is_empty() {
-        output.push_str("\n\n[标签列表]");
-        for (id, tab_url, tab_title) in content.tabs {
-            let marker = if content.active_tab_id == Some(id.as_str()) {
-                " (活跃)"
-            } else {
-                ""
-            };
-            let display = if tab_title.is_empty() {
-                tab_url.clone()
-            } else {
-                tab_title.clone()
-            };
-            output.push_str(&format!("\n- {display}{marker}"));
-        }
-    }
-
-    let tool_call_id = format!("browser_auto_{}", scru128::new());
-    let tool_name = "browser_data";
-
-    // 伪造 assistant 工具调用 + tool 结果，以 browser_data 工具形式注入。
-    // 这组消息必须一一配对，否则 OpenAI 兼容接口会拒绝缺少结果的 tool_call。
-    let assistant_text = format!("[自动感知] 浏览器页面数据就绪：{url}");
+    let tool_call_id = format!("tool_auto_{}", scru128::new());
+    let assistant_text = format!("[自动感知] 工具数据就绪: {tool_name}");
     let mut assistant_msg = Message::new(MessageRole::Assistant, assistant_text);
     assistant_msg.tool_calls = vec![MessageToolCall {
         id: tool_call_id.clone(),
         name: tool_name.to_string(),
-        arguments: serde_json::json!({"url": url}),
+        arguments: payload.clone(),
     }];
     session.messages.push(assistant_msg);
-
     let _ = stream_tx.send(StreamEvent::ToolResult {
         name: tool_name.to_string(),
         tool_call_id: Some(tool_call_id.clone()),
@@ -418,20 +367,64 @@ pub(crate) fn inject_browser_content_to_session(
         full_output: Some(output.clone()),
         media: vec![],
     });
-
     append_tool_result_message(session, &tool_call_id, tool_name, output, false);
     tracing::info!(
         session_id = %session.id,
-        url,
-        force,
-        has_feedback,
-        output_len = session
-            .messages
-            .last()
-            .map(|msg| msg.text_content().len())
-            .unwrap_or(0),
-        "browser content injected into session"
+        tool_name,
+        "tool content injected into session"
     );
+}
+
+/// 根据 tool_name 渲染 JSON payload 为对话文本。
+fn render_tool_output(tool_name: &str, payload: &serde_json::Value) -> String {
+    match tool_name {
+        "browser_data" => {
+            let title = payload.get("title").and_then(|v| v.as_str()).unwrap_or("");
+            let url = payload.get("url").and_then(|v| v.as_str()).unwrap_or("");
+            let text = payload.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            let feedback = payload
+                .get("feedback")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let has_feedback = !feedback.trim().is_empty();
+            let header = if has_feedback {
+                "[浏览器反馈]"
+            } else {
+                "[浏览器页面更新]"
+            };
+            let mut output = format!(
+                "{header}
+标题：{title}
+URL：{url}
+
+{text}"
+            );
+            if has_feedback {
+                output.push_str(&format!(
+                    "
+
+[用户操作反馈]
+{feedback}"
+                ));
+            }
+            output
+        }
+        "terminal_user_input" => {
+            let command = payload
+                .get("command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            format!("[用户终端操作] 用户在终端执行了: {command}")
+        }
+        _ => {
+            // 未知 tool_name：原样输出 JSON
+            format!(
+                "[{tool_name}]
+{}",
+                serde_json::to_string_pretty(payload).unwrap_or_default()
+            )
+        }
+    }
 }
 
 #[cfg(test)]
@@ -460,22 +453,22 @@ mod tests {
     }
 
     #[test]
-    fn inject_browser_content_keeps_feedback_in_tool_message() {
+    fn inject_tool_renders_browser_feedback() {
         let mut session = Session::new("browser");
         let (tx, rx) = std::sync::mpsc::channel();
 
-        inject_browser_content_to_session(
+        inject_tool_to_session(
             &mut session,
             &tx,
-            &BrowserContent {
-                title: "API Keys",
-                url: "https://platform.deepseek.com/api_keys",
-                text: "API keys page",
-                tabs: &[],
-                active_tab_id: None,
-                feedback: Some("[网络响应] POST /api_keys (状态 200)\n{\"key\":\"sk-test\"}"),
-            },
-            true,
+            "browser_data",
+            &serde_json::json!({
+                "title": "API Keys",
+                "url": "https://platform.deepseek.com/api_keys",
+                "text": "API keys page",
+                "tabs": [],
+                "active_tab_id": null,
+                "feedback": "[网络响应] POST /api_keys (状态 200)\n{\"key\":\"sk-test\"}",
+            }),
         );
 
         assert_eq!(session.messages.len(), 2);
@@ -501,47 +494,41 @@ mod tests {
     }
 
     #[test]
-    fn inject_browser_feedback_bypasses_recent_url_dedup_when_forced() {
+    fn inject_tool_dedup_by_url() {
         let mut session = Session::new("browser");
         let (tx, _rx) = std::sync::mpsc::channel();
-        let url = "https://platform.deepseek.com/api_keys";
+        let payload = serde_json::json!({
+            "title": "API Keys",
+            "url": "https://platform.deepseek.com/api_keys",
+            "text": "API keys page",
+        });
 
-        inject_browser_content_to_session(
-            &mut session,
-            &tx,
-            &BrowserContent {
-                title: "API Keys",
-                url,
-                text: "API keys page",
-                tabs: &[],
-                active_tab_id: None,
-                feedback: None,
-            },
-            false,
-        );
+        inject_tool_to_session(&mut session, &tx, "browser_data", &payload);
         assert_eq!(session.messages.len(), 2);
 
-        inject_browser_content_to_session(
+        // 同 URL 无 feedback → 去重跳过
+        inject_tool_to_session(&mut session, &tx, "browser_data", &payload);
+        assert_eq!(session.messages.len(), 2);
+    }
+
+    #[test]
+    fn inject_tool_renders_terminal_user_input() {
+        let mut session = Session::new("terminal");
+        let (tx, _rx) = std::sync::mpsc::channel();
+
+        inject_tool_to_session(
             &mut session,
             &tx,
-            &BrowserContent {
-                title: "API Keys",
-                url,
-                text: "API keys page",
-                tabs: &[],
-                active_tab_id: None,
-                feedback: Some("[网络响应] POST /api/v0/users/create_api_key (状态 200)"),
-            },
-            true,
+            "terminal_user_input",
+            &serde_json::json!({ "command": "ls -la" }),
         );
 
-        assert_eq!(session.messages.len(), 4);
-        assert_no_unmatched_tool_calls(&session);
-        assert!(session.messages[3].text_content().contains("[浏览器反馈]"));
+        assert_eq!(session.messages.len(), 2);
         assert!(
-            session.messages[3]
+            session.messages[1]
                 .text_content()
-                .contains("create_api_key")
+                .contains("[用户终端操作]")
         );
+        assert!(session.messages[1].text_content().contains("ls -la"));
     }
 }

--- a/crates/tiangong-plugin-browser/src/manager.rs
+++ b/crates/tiangong-plugin-browser/src/manager.rs
@@ -912,7 +912,7 @@ impl BrowserManager {
                 })
                 .ok()?;
         }
-        rx.recv_timeout(Duration::from_secs(10)).ok()
+        rx.recv_timeout(Duration::from_secs(15)).ok()
     }
 
     pub(crate) fn drain_events(&self) -> Vec<BrowserEvent> {

--- a/crates/tiangong-plugin-browser/src/page_fetcher.rs
+++ b/crates/tiangong-plugin-browser/src/page_fetcher.rs
@@ -872,3 +872,33 @@ impl tiangong_core::tool_override::ToolOverrideHandler for BrowserToolOverride {
         }
     }
 }
+
+/// 浏览器内容注入（ToolInput 实现）。
+///
+/// 页面加载完成或内容变化时，通过 AgentInput trait 统一投递到 Agent 对话链。
+/// tool_name 为 `browser_data`，render 返回结构化 JSON。
+pub struct BrowserContent {
+    pub title: String,
+    pub url: String,
+    pub text: String,
+    pub tabs: Vec<(String, String, String)>,
+    pub active_tab_id: Option<String>,
+    pub feedback: Option<String>,
+}
+
+impl tiangong_core::agent_input::ToolInput for BrowserContent {
+    fn tool_name(&self) -> &str {
+        "browser_data"
+    }
+
+    fn render(&self) -> serde_json::Value {
+        serde_json::json!({
+            "title": self.title,
+            "url": self.url,
+            "text": self.text,
+            "tabs": self.tabs,
+            "active_tab_id": self.active_tab_id,
+            "feedback": self.feedback,
+        })
+    }
+}

--- a/crates/tiangong-plugin-terminal/src/collaboration.rs
+++ b/crates/tiangong-plugin-terminal/src/collaboration.rs
@@ -111,3 +111,24 @@ impl TerminalBusyState {
         }
     }
 }
+
+/// 用户终端操作注入（ToolInput 实现）。
+///
+/// 用户在终端提交命令（回车截断）时，通过 AgentInput trait 统一投递到 Agent 对话链。
+/// tool_name 为 `terminal_user_input`，render 返回结构化 JSON。
+pub struct TerminalUserInput {
+    pub command: String,
+}
+
+impl tiangong_core::agent_input::ToolInput for TerminalUserInput {
+    fn tool_name(&self) -> &str {
+        "terminal_user_input"
+    }
+
+    fn render(&self) -> serde_json::Value {
+        serde_json::json!({
+            "action": "user_executed",
+            "command": self.command.trim(),
+        })
+    }
+}

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use crate::api::SharedState;
 use crate::remote::event::{EventBus, TiangongEvent};
 use anyhow::{Result, anyhow};
-use tiangong_core::agent_input::AgentInput;
+use tiangong_core::agent_input::{AgentInput, AgentInputKind};
 use tiangong_core::core_config::CoreConfigProvider;
 use tiangong_core::permission::TrustMode;
 use tiangong_core::session::{Message, MessageRole, MessageToolCall, Session, now_text};
@@ -66,7 +66,7 @@ impl ServerCoreManager {
             return Err(anyhow!("会话 core 不存在：{session_id}"));
         };
         let msg_id = message_id.unwrap_or_else(|| scru128::new().to_string());
-        core.deliver(tiangong_core::agent_input::AgentInputKind::message_with_id(
+        core.deliver(AgentInputKind::message_with_id(
             content, msg_id, media,
         ));
         Ok(())
@@ -93,7 +93,7 @@ impl ServerCoreManager {
                 return Err(anyhow!("会话 core 不存在：{session_id}"));
             };
             let msg_id = message_id.unwrap_or_else(|| scru128::new().to_string());
-            core.deliver(tiangong_core::agent_input::AgentInputKind::message_with_id(
+            core.deliver(AgentInputKind::message_with_id(
                 content, msg_id, media,
             ));
         }

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use crate::api::SharedState;
 use crate::remote::event::{EventBus, TiangongEvent};
 use anyhow::{Result, anyhow};
+use tiangong_core::agent_input::AgentInput;
 use tiangong_core::core_config::CoreConfigProvider;
 use tiangong_core::permission::TrustMode;
 use tiangong_core::session::{Message, MessageRole, MessageToolCall, Session, now_text};
@@ -65,7 +66,9 @@ impl ServerCoreManager {
             return Err(anyhow!("会话 core 不存在：{session_id}"));
         };
         let msg_id = message_id.unwrap_or_else(|| scru128::new().to_string());
-        core.send_message_with_id(content, msg_id, media);
+        core.deliver(tiangong_core::agent_input::AgentInputKind::message_with_id(
+            content, msg_id, media,
+        ));
         Ok(())
     }
 
@@ -90,7 +93,9 @@ impl ServerCoreManager {
                 return Err(anyhow!("会话 core 不存在：{session_id}"));
             };
             let msg_id = message_id.unwrap_or_else(|| scru128::new().to_string());
-            core.send_message_with_id(content, msg_id, media);
+            core.deliver(tiangong_core::agent_input::AgentInputKind::message_with_id(
+                content, msg_id, media,
+            ));
         }
 
         let tracker_for_wait = tracker.clone();

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -66,9 +66,7 @@ impl ServerCoreManager {
             return Err(anyhow!("会话 core 不存在：{session_id}"));
         };
         let msg_id = message_id.unwrap_or_else(|| scru128::new().to_string());
-        core.deliver(AgentInputKind::message_with_id(
-            content, msg_id, media,
-        ));
+        core.deliver(AgentInputKind::message_with_id(content, msg_id, media));
         Ok(())
     }
 
@@ -93,9 +91,7 @@ impl ServerCoreManager {
                 return Err(anyhow!("会话 core 不存在：{session_id}"));
             };
             let msg_id = message_id.unwrap_or_else(|| scru128::new().to_string());
-            core.deliver(AgentInputKind::message_with_id(
-                content, msg_id, media,
-            ));
+            core.deliver(AgentInputKind::message_with_id(content, msg_id, media));
         }
 
         let tracker_for_wait = tracker.clone();

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -141,14 +141,18 @@ impl TiangongApp {
                     has_feedback,
                     "向当前会话注入浏览器内容"
                 );
-                return core.inject_browser_content(
-                    title,
-                    url,
-                    text,
-                    tabs,
-                    active_tab_id,
-                    feedback,
-                );
+                return {
+                    use tiangong_core::agent_input::{AgentInput, AgentInputKind};
+                    use tiangong_plugin_browser::page_fetcher::BrowserContent;
+                    core.deliver(AgentInputKind::Tool(Box::new(BrowserContent {
+                        title,
+                        url,
+                        text,
+                        tabs,
+                        active_tab_id,
+                        feedback,
+                    })))
+                };
             } else {
                 tracing::debug!(
                     session_id,

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use tiangong_config::load_tiangong_config;
+use tiangong_core::agent_input::AgentInput;
 use tiangong_core::core::TiangongCore;
 use tiangong_core::core_config::CoreConfigProvider;
 use tokio::sync::Mutex as AsyncMutex;
@@ -200,7 +201,7 @@ impl TiangongApp {
         self.config.replace(next);
         if let Ok(cores) = self.cores.lock() {
             for core in cores.values() {
-                let _ = core.reload_config();
+                let _ = core.deliver(tiangong_core::agent_input::AgentInputKind::reload_config());
             }
         }
         Ok(())
@@ -235,8 +236,10 @@ impl TiangongApp {
         let mut cores = self.lock_cores();
         if let Some(core) = cores.get(session_id) {
             if core.is_running() {
-                let _ = core.reload_config();
-                let _ = core.update_cwd(session.cwd.clone());
+                let _ = core.deliver(tiangong_core::agent_input::AgentInputKind::reload_config());
+                let _ = core.deliver(tiangong_core::agent_input::AgentInputKind::update_cwd(
+                    session.cwd.clone(),
+                ));
                 core.set_trust_mode(session.trust_mode);
                 return (session_id.to_string(), false); // 已存在，复用
             }
@@ -291,9 +294,13 @@ impl TiangongApp {
         let mut cores = self.lock_cores();
         if let Some(core) = cores.get(session_id) {
             let sent = if let Some(message_id) = message_id {
-                core.send_message_with_id(content, message_id, Vec::new())
+                core.deliver(tiangong_core::agent_input::AgentInputKind::message_with_id(
+                    content,
+                    message_id,
+                    Vec::new(),
+                ))
             } else {
-                core.send_message(content)
+                core.deliver(tiangong_core::agent_input::AgentInputKind::message(content))
             };
             if !sent {
                 warn!(session_id, "TiangongCore 命令通道已关闭，移除僵尸 core");
@@ -315,7 +322,7 @@ impl TiangongApp {
     pub fn cancel_core(&self, session_id: &str) {
         let cores = self.lock_cores();
         if let Some(core) = cores.get(session_id) {
-            core.cancel();
+            core.deliver(tiangong_core::agent_input::AgentInputKind::cancel());
         }
     }
 
@@ -324,7 +331,11 @@ impl TiangongApp {
         let cores = self.lock_cores();
         cores
             .get(session_id)
-            .map(|core| core.cancel_agent(role))
+            .map(|core| {
+                core.deliver(tiangong_core::agent_input::AgentInputKind::cancel_agent(
+                    role,
+                ))
+            })
             .unwrap_or(false)
     }
 
@@ -332,7 +343,9 @@ impl TiangongApp {
     pub fn respond_approval_to_core(&self, session_id: &str, request_id: String, approved: bool) {
         let cores = self.lock_cores();
         if let Some(core) = cores.get(session_id) {
-            core.respond_approval(request_id, approved);
+            core.deliver(tiangong_core::agent_input::AgentInputKind::approval(
+                request_id, approved,
+            ));
         }
     }
 
@@ -367,7 +380,9 @@ impl TiangongApp {
         let cores = self.lock_cores();
         cores
             .get(session_id)
-            .map(|core| core.compress_context())
+            .map(|core| {
+                core.deliver(tiangong_core::agent_input::AgentInputKind::compress_context())
+            })
             .unwrap_or(false)
     }
 
@@ -376,7 +391,7 @@ impl TiangongApp {
         let cores = self.lock_cores();
         cores
             .get(session_id)
-            .map(|core| core.reset_context())
+            .map(|core| core.deliver(tiangong_core::agent_input::AgentInputKind::reset_context()))
             .unwrap_or(false)
     }
 

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use tiangong_config::load_tiangong_config;
-use tiangong_core::agent_input::AgentInput;
+use tiangong_core::agent_input::{AgentInput, AgentInputKind};
 use tiangong_core::core::TiangongCore;
 use tiangong_core::core_config::CoreConfigProvider;
 use tokio::sync::Mutex as AsyncMutex;
@@ -201,7 +201,7 @@ impl TiangongApp {
         self.config.replace(next);
         if let Ok(cores) = self.cores.lock() {
             for core in cores.values() {
-                let _ = core.deliver(tiangong_core::agent_input::AgentInputKind::reload_config());
+                let _ = core.deliver(AgentInputKind::reload_config());
             }
         }
         Ok(())
@@ -236,8 +236,8 @@ impl TiangongApp {
         let mut cores = self.lock_cores();
         if let Some(core) = cores.get(session_id) {
             if core.is_running() {
-                let _ = core.deliver(tiangong_core::agent_input::AgentInputKind::reload_config());
-                let _ = core.deliver(tiangong_core::agent_input::AgentInputKind::update_cwd(
+                let _ = core.deliver(AgentInputKind::reload_config());
+                let _ = core.deliver(AgentInputKind::update_cwd(
                     session.cwd.clone(),
                 ));
                 core.set_trust_mode(session.trust_mode);
@@ -294,13 +294,13 @@ impl TiangongApp {
         let mut cores = self.lock_cores();
         if let Some(core) = cores.get(session_id) {
             let sent = if let Some(message_id) = message_id {
-                core.deliver(tiangong_core::agent_input::AgentInputKind::message_with_id(
+                core.deliver(AgentInputKind::message_with_id(
                     content,
                     message_id,
                     Vec::new(),
                 ))
             } else {
-                core.deliver(tiangong_core::agent_input::AgentInputKind::message(content))
+                core.deliver(AgentInputKind::message(content))
             };
             if !sent {
                 warn!(session_id, "TiangongCore 命令通道已关闭，移除僵尸 core");
@@ -322,7 +322,7 @@ impl TiangongApp {
     pub fn cancel_core(&self, session_id: &str) {
         let cores = self.lock_cores();
         if let Some(core) = cores.get(session_id) {
-            core.deliver(tiangong_core::agent_input::AgentInputKind::cancel());
+            core.deliver(AgentInputKind::cancel());
         }
     }
 
@@ -332,7 +332,7 @@ impl TiangongApp {
         cores
             .get(session_id)
             .map(|core| {
-                core.deliver(tiangong_core::agent_input::AgentInputKind::cancel_agent(
+                core.deliver(AgentInputKind::cancel_agent(
                     role,
                 ))
             })
@@ -343,7 +343,7 @@ impl TiangongApp {
     pub fn respond_approval_to_core(&self, session_id: &str, request_id: String, approved: bool) {
         let cores = self.lock_cores();
         if let Some(core) = cores.get(session_id) {
-            core.deliver(tiangong_core::agent_input::AgentInputKind::approval(
+            core.deliver(AgentInputKind::approval(
                 request_id, approved,
             ));
         }
@@ -381,7 +381,7 @@ impl TiangongApp {
         cores
             .get(session_id)
             .map(|core| {
-                core.deliver(tiangong_core::agent_input::AgentInputKind::compress_context())
+                core.deliver(AgentInputKind::compress_context())
             })
             .unwrap_or(false)
     }
@@ -391,7 +391,7 @@ impl TiangongApp {
         let cores = self.lock_cores();
         cores
             .get(session_id)
-            .map(|core| core.deliver(tiangong_core::agent_input::AgentInputKind::reset_context()))
+            .map(|core| core.deliver(AgentInputKind::reset_context()))
             .unwrap_or(false)
     }
 

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -237,9 +237,7 @@ impl TiangongApp {
         if let Some(core) = cores.get(session_id) {
             if core.is_running() {
                 let _ = core.deliver(AgentInputKind::reload_config());
-                let _ = core.deliver(AgentInputKind::update_cwd(
-                    session.cwd.clone(),
-                ));
+                let _ = core.deliver(AgentInputKind::update_cwd(session.cwd.clone()));
                 core.set_trust_mode(session.trust_mode);
                 return (session_id.to_string(), false); // 已存在，复用
             }
@@ -331,11 +329,7 @@ impl TiangongApp {
         let cores = self.lock_cores();
         cores
             .get(session_id)
-            .map(|core| {
-                core.deliver(AgentInputKind::cancel_agent(
-                    role,
-                ))
-            })
+            .map(|core| core.deliver(AgentInputKind::cancel_agent(role)))
             .unwrap_or(false)
     }
 
@@ -343,9 +337,7 @@ impl TiangongApp {
     pub fn respond_approval_to_core(&self, session_id: &str, request_id: String, approved: bool) {
         let cores = self.lock_cores();
         if let Some(core) = cores.get(session_id) {
-            core.deliver(AgentInputKind::approval(
-                request_id, approved,
-            ));
+            core.deliver(AgentInputKind::approval(request_id, approved));
         }
     }
 
@@ -380,9 +372,7 @@ impl TiangongApp {
         let cores = self.lock_cores();
         cores
             .get(session_id)
-            .map(|core| {
-                core.deliver(AgentInputKind::compress_context())
-            })
+            .map(|core| core.deliver(AgentInputKind::compress_context()))
             .unwrap_or(false)
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,7 @@
 use crate::app::TiangongApp;
 use crate::view::*;
 use base64::{engine::general_purpose, Engine as _};
+use tiangong_core::agent_input::AgentInput;
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
@@ -678,7 +679,11 @@ async fn send_message_inner(
     {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(&sid) {
-            if !core.send_message_with_id(content.clone(), user_message_id, command_media) {
+            if !core.deliver(tiangong_core::agent_input::AgentInputKind::message_with_id(
+                content.clone(),
+                user_message_id,
+                command_media,
+            )) {
                 return Err("会话 core 已停止，请重试发送".to_string());
             }
         }
@@ -1485,11 +1490,11 @@ pub async fn edit_and_resend(
     {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(&sid) {
-            if !core.send_message_with_id(
+            if !core.deliver(tiangong_core::agent_input::AgentInputKind::message_with_id(
                 new_content.clone(),
                 message_id.clone(),
                 message_media.clone(),
-            ) {
+            )) {
                 return Err("会话 core 已停止，请重试".to_string());
             }
         }
@@ -2263,7 +2268,9 @@ pub async fn set_workspace_dir(
     if let Some(sid) = &active_session_id {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(sid) {
-            let _ = core.update_cwd(workspace_dir.clone());
+            let _ = core.deliver(tiangong_core::agent_input::AgentInputKind::update_cwd(
+                workspace_dir.clone(),
+            ));
         }
     }
 
@@ -2288,7 +2295,9 @@ pub async fn set_session_cwd(cwd: String, state: State<'_, TiangongApp>) -> Resu
     {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(&active_session_id) {
-            let _ = core.update_cwd(cwd.clone());
+            let _ = core.deliver(tiangong_core::agent_input::AgentInputKind::update_cwd(
+                cwd.clone(),
+            ));
         }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,6 @@
 use crate::app::TiangongApp;
 use crate::view::*;
 use base64::{engine::general_purpose, Engine as _};
-use tiangong_core::agent_input::{AgentInput, AgentInputKind};
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
@@ -11,6 +10,7 @@ use std::thread;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State, Window};
 use tauri_plugin_notification::{NotificationExt, PermissionState};
+use tiangong_core::agent_input::{AgentInput, AgentInputKind};
 use tracing::{debug, warn};
 
 const MAX_ATTACHMENT_BASE64_BYTES: u64 = 50 * 1024 * 1024;
@@ -2268,9 +2268,7 @@ pub async fn set_workspace_dir(
     if let Some(sid) = &active_session_id {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(sid) {
-            let _ = core.deliver(AgentInputKind::update_cwd(
-                workspace_dir.clone(),
-            ));
+            let _ = core.deliver(AgentInputKind::update_cwd(workspace_dir.clone()));
         }
     }
 
@@ -2295,9 +2293,7 @@ pub async fn set_session_cwd(cwd: String, state: State<'_, TiangongApp>) -> Resu
     {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(&active_session_id) {
-            let _ = core.deliver(AgentInputKind::update_cwd(
-                cwd.clone(),
-            ));
+            let _ = core.deliver(AgentInputKind::update_cwd(cwd.clone()));
         }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::app::TiangongApp;
 use crate::view::*;
 use base64::{engine::general_purpose, Engine as _};
-use tiangong_core::agent_input::AgentInput;
+use tiangong_core::agent_input::{AgentInput, AgentInputKind};
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
@@ -679,7 +679,7 @@ async fn send_message_inner(
     {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(&sid) {
-            if !core.deliver(tiangong_core::agent_input::AgentInputKind::message_with_id(
+            if !core.deliver(AgentInputKind::message_with_id(
                 content.clone(),
                 user_message_id,
                 command_media,
@@ -1490,7 +1490,7 @@ pub async fn edit_and_resend(
     {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(&sid) {
-            if !core.deliver(tiangong_core::agent_input::AgentInputKind::message_with_id(
+            if !core.deliver(AgentInputKind::message_with_id(
                 new_content.clone(),
                 message_id.clone(),
                 message_media.clone(),
@@ -2268,7 +2268,7 @@ pub async fn set_workspace_dir(
     if let Some(sid) = &active_session_id {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(sid) {
-            let _ = core.deliver(tiangong_core::agent_input::AgentInputKind::update_cwd(
+            let _ = core.deliver(AgentInputKind::update_cwd(
                 workspace_dir.clone(),
             ));
         }
@@ -2295,7 +2295,7 @@ pub async fn set_session_cwd(cwd: String, state: State<'_, TiangongApp>) -> Resu
     {
         let cores = state.cores.lock().map_err(|e| e.to_string())?;
         if let Some(core) = cores.get(&active_session_id) {
-            let _ = core.deliver(tiangong_core::agent_input::AgentInputKind::update_cwd(
+            let _ = core.deliver(AgentInputKind::update_cwd(
                 cwd.clone(),
             ));
         }

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tiangong_core::agent_input::AgentInput;
+use tiangong_core::agent_input::{AgentInput, AgentInputKind};
 use tiangong_core::core::TiangongCore;
 use tiangong_core::core_config::CoreConfigProvider;
 use tiangong_core::permission::TrustMode;
@@ -49,7 +49,7 @@ impl SchedulerContext for DesktopSchedulerContext {
         let core = cores
             .get(session_id)
             .ok_or_else(|| anyhow::anyhow!("定时任务 core 不存在：{session_id}"))?;
-        if !core.deliver(tiangong_core::agent_input::AgentInputKind::message(content)) {
+        if !core.deliver(AgentInputKind::message(content)) {
             return Err(anyhow::anyhow!("定时任务 core 命令通道已关闭"));
         }
         Ok(())

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use tiangong_core::agent_input::AgentInput;
 use tiangong_core::core::TiangongCore;
 use tiangong_core::core_config::CoreConfigProvider;
 use tiangong_core::permission::TrustMode;
@@ -48,7 +49,7 @@ impl SchedulerContext for DesktopSchedulerContext {
         let core = cores
             .get(session_id)
             .ok_or_else(|| anyhow::anyhow!("定时任务 core 不存在：{session_id}"))?;
-        if !core.send_message(content) {
+        if !core.deliver(tiangong_core::agent_input::AgentInputKind::message(content)) {
             return Err(anyhow::anyhow!("定时任务 core 命令通道已关闭"));
         }
         Ok(())


### PR DESCRIPTION
## 概述

引入 `AgentInput` trait 统一所有外部与 Agent 的交互入口，收敛 TiangongCore 上分散的 pub 方法。`deliver()` 成为唯一的输入通道，按语义分四层。

## 架构

\`\`\`
外部调用方 ──→ core.deliver(AgentInputKind::...)
                   │
                   ├── Message    → Command::Message       （触发 turn）
                   ├── Tool       → Command::InjectTool    （伪造 tool result）
                   ├── Approval   → Command::Approval      （解锁阻塞 turn）
                   └── Command    → Command::Cancel/...    （cancel_flag 自动置位）
\`\`\`

- **Tool 层用 trait object**：`ToolInput` trait 定义 `tool_name()` + `render()` JSON 协议，浏览器/终端插件各自实现 struct
- **AgentInputKind 便捷构造器**：`AgentInputKind::cancel()` / `message()` / `approval()` 等，调用简洁
- **cancel_flag 内化**：deliver 检测 Cancel 命令自动置 flag，外部无需知道实现细节

## 提交

| commit | 内容 |
|---|---|
| c7f1e61 | 引入 AgentInput trait（四层 enum） |
| 12d3c6e | 统一 InjectTool + 插件 ToolInput 实现 + 清理旧代码 |
| 01cf464 | pub 方法改为走 deliver |
| 59f9626 | inject_tool 去重简化 + 浏览器渲染补全 |
| 87d6cad | 页面加载超时 10s → 15s |
| 71ca588 | deliver 内化 cancel + 便捷构造器 |
| 3bf06d9 | 删除 8 个 pub 方法，迁移 19 个调用点 |
| 0b0e75c | 简化调用点 import |

## TiangongCore 改造后

**保留**：deliver()（唯一入口）、getter（cancel_flag/session_id/is_running）、into_session()、能力注入（set_*/register_*，带 Arc<dyn>）

**删除**：send_message / send_message_with_id / update_cwd / reload_config / cancel / cancel_agent / compress_context / reset_context / respond_approval

## 验证

- fmt ✓ / clippy 0 警告 ✓ / 370 测试全过 ✓
- 19 个调用点全部迁移（app.rs / commands.rs / scheduler.rs / repl.rs / remote/core.rs / test_core.rs）
- 浏览器注入路径（InjectBrowserContent → InjectTool）回归验证