### PR TITLE
fix(terminal): Windows 平台 PTY 启动失败（issue #151）

### DIFF
--- a/crates/tiangong-plugin-terminal/src/manager.rs
+++ b/crates/tiangong-plugin-terminal/src/manager.rs
@@ -46,7 +46,7 @@ pub(crate) struct TerminalState {
 
 impl TerminalManager {
     pub fn new(session_id: String, cwd: String) -> Self {
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+        let shell = default_shell();
         Self {
             state: Arc::new(Mutex::new(TerminalState {
                 session_id,
@@ -425,6 +425,23 @@ pub(crate) async fn spawn_command_loop(
         state.alive = false;
     }
     info!(session_id = %session_id, "终端命令处理器退出");
+}
+
+/// 解析默认 shell 可执行文件路径。
+///
+/// 与 `tiangong_core::tool::common::derive_shell_exec_args` 的跨平台约定保持一致：
+///
+/// - **非 Windows**：读取 `SHELL` 环境变量，缺失时 fallback 到 `/bin/bash`。
+/// - **Windows**：`SHELL` 是 Unix 概念，Windows 几乎从不设置，且即使设置也通常指向
+///   Git Bash 之类的非标准 shell。Windows 默认走 `powershell.exe`（通过 PATH 解析）。
+///   旧版 `SHELL` fallback 到 `/bin/bash` 在 Windows 上不存在该路径，会导致
+///   `spawn_command` 失败、终端面板提示"PTY 启动失败"（见 issue #151）。
+fn default_shell() -> String {
+    if cfg!(target_os = "windows") {
+        "powershell.exe".to_string()
+    } else {
+        std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string())
+    }
 }
 
 pub(crate) fn start_pty(session_id: &str, cwd: &str, shell: &str) -> anyhow::Result<PtyState> {

--- a/crates/tiangong-plugin-terminal/src/util.rs
+++ b/crates/tiangong-plugin-terminal/src/util.rs
@@ -2,13 +2,30 @@
 
 /// 对单个 shell 参数进行安全引用。
 ///
-/// 若字符串为空或包含任何 shell 元字符（空白、引号、`$`、`` ` ``、`!`、通配符、
-/// 控制操作符等），则用单引号包裹并对内部单引号做 `'\\''` 转义；否则原样返回。
+/// 行为按目标平台区分（与 `common.rs::derive_shell_exec_args` 的跨平台 shell 选择一致）：
+///
+/// - **非 Windows**（bash/sh 等 POSIX shell）：若字符串为空或包含任何 shell 元字符
+///   （空白、引号、`$`、`` ` ``、`!`、通配符、控制操作符等），则用单引号包裹并对
+///   内部单引号做 `'\\''` 转义；否则原样返回。
+/// - **Windows**（PowerShell/cmd）：Windows 路径天然含反斜杠 `\`，POSIX 单引号转义
+///   在 PowerShell/cmd 下不工作。这里仅对含空格或双引号的参数用双引号包裹并对
+///   内部双引号做 `""` 转义（cmd 兼容写法，PowerShell 同样接受）。反斜杠、`$` 等
+///   不视为需要引用的元字符，避免把合法的 `C:\Users\...` 路径整体包进引号导致
+///   `cd` 失败。
 ///
 /// 该函数同时服务于：
 /// - `handler.rs` 的 `format_command`（普通命令参数拼装）
 /// - `manager.rs` 的 `SetCwd`（`cd <path>` 路径引用）
 pub(crate) fn shell_quote(s: &str) -> String {
+    if cfg!(target_os = "windows") {
+        windows_quote(s)
+    } else {
+        posix_quote(s)
+    }
+}
+
+/// POSIX shell（bash/sh）参数引用：单引号包裹，内部单引号转义为 `'\''`。
+fn posix_quote(s: &str) -> String {
     if s.is_empty()
         || s.contains(|c: char| {
             c.is_whitespace()
@@ -37,5 +54,62 @@ pub(crate) fn shell_quote(s: &str) -> String {
         format!("'{}'", s.replace('\'', "'\\''"))
     } else {
         s.to_string()
+    }
+}
+
+/// Windows shell（PowerShell/cmd）参数引用：仅当含空格或双引号时用双引号包裹。
+///
+/// 不引用反斜杠：Windows 路径（`C:\Users\foo`）大量使用反斜杠，若按 POSIX 规则
+/// 把含反斜杠的参数整体包进单引号，PowerShell 会原样保留单引号导致 `cd` 找不到路径。
+/// 双引号在 cmd 下为转义标准（内部 `"` → `""`），PowerShell 同样接受。
+fn windows_quote(s: &str) -> String {
+    if s.is_empty() || s.contains(' ') || s.contains('"') {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn posix_simple_path_not_quoted() {
+        assert_eq!(posix_quote("/usr/bin"), "/usr/bin");
+    }
+
+    #[test]
+    fn posix_path_with_space_single_quoted() {
+        assert_eq!(posix_quote("/path with space"), "'/path with space'");
+    }
+
+    #[test]
+    fn posix_single_quote_escaped() {
+        assert_eq!(posix_quote("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn windows_drive_path_not_quoted() {
+        // 关键回归点：Windows 路径含反斜杠不应被引用，否则 cd 会失败
+        assert_eq!(windows_quote(r"C:\Users\foo"), r"C:\Users\foo");
+    }
+
+    #[test]
+    fn windows_path_with_space_double_quoted() {
+        assert_eq!(
+            windows_quote(r"C:\Program Files\foo"),
+            r#""C:\Program Files\foo""#
+        );
+    }
+
+    #[test]
+    fn windows_inner_double_quote_escaped() {
+        assert_eq!(windows_quote(r#"a"b"#), r#""a""b""#);
+    }
+
+    #[test]
+    fn windows_empty_quoted() {
+        assert_eq!(windows_quote(""), "\"\"");
     }
 }


### PR DESCRIPTION
## 背景

Cherry-pick \`v0.9.1\` 的紧急修复回主干。已在 \`v0.9.1\` 发布并经 Windows 设备验证。

Closes #151

## 问题

Windows 平台点击"打开终端"提示 **"PTY 启动失败"**。

### 根因

\`crates/tiangong-plugin-terminal/src/manager.rs:49\`：

\`\`\`rust
let shell = std::env::var(\"SHELL\").unwrap_or_else(|_| \"/bin/bash\".to_string());
\`\`\`

\`SHELL\` 是 Unix 概念，Windows 几乎从不设置 → fallback 到 \`/bin/bash\`（Windows 无此路径）→ \`slave.spawn_command(cmd)\` 失败 → \`session_pty\` 返回 false → 前端 \`TerminalPanel.tsx:210\` 显示 \"PTY 启动失败\"。

## 修复

1. **\`manager.rs\`**：新增 \`default_shell()\`，Windows 默认 \`powershell.exe\`（走 PATH 解析），与 \`common.rs::derive_shell_exec_args\` 的跨平台约定一致。
2. **\`util.rs\`**：\`shell_quote\` 拆为平台感知。\`posix_quote\`（单引号 + \`'\\''\` 转义）与 \`windows_quote\`（仅含空格/双引号时用双引号包裹，\`\"\` → \`\"\"\"\`）。关键修正：Windows 路径 \`C:\\Users\\foo\` 不再被整体引用，否则 PowerShell/cmd 的 \`cd\` 找不到路径。

新增 7 个单元测试覆盖 POSIX 与 Windows 引用路径。

## 验证

- [x] 本机 fmt / clippy / nextest（52/52）全绿
- [x] \`v0.9.1\` 已发布，Windows 设备验证通过（用户确认）
- [x] cherry-pick 到 main 零冲突（main 上该代码段与 v0.9.0 完全一致）

## 关联

- 发版标签：\`v0.9.1\`（commit \`4e9be96\`）
- hotfix 分支：\`hotfix/v0.9-pty-windows\`