### PR TITLE
chore(release): 将 v0.9.1 发版 commit 并入 main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "发布标签，留空时使用 v0.9.0"
+        description: "发布标签，留空时使用 v0.9.1"
         required: false
         type: string
       release_draft:
@@ -66,7 +66,7 @@ jobs:
           else
             tag="${{ inputs.tag }}"
             if [[ -z "$tag" ]]; then
-              tag="v0.9.0"
+              tag="v0.9.1"
             fi
             draft="${{ inputs.release_draft }}"
           fi
@@ -219,7 +219,7 @@ jobs:
         with:
           projectPath: .
           tagName: ${{ steps.release.outputs.tag }}
-          releaseName: "天工 v0.9.0"
+          releaseName: "天工 v0.9.1"
           releaseBody: ${{ steps.release_notes.outputs.body }}
           releaseDraft: ${{ steps.release.outputs.draft }}
           prerelease: false
@@ -245,7 +245,7 @@ jobs:
           else
             tag="${{ inputs.tag }}"
             if [[ -z "$tag" ]]; then
-              tag="v0.9.0"
+              tag="v0.9.1"
             fi
           fi
           # Strip leading 'v' or 'app-v' to get bare version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9409,7 +9409,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "tiangong-config",
@@ -9418,7 +9418,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-anthropic"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "eventsource-stream",
  "futures-util",
@@ -9430,7 +9430,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-app"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -9490,7 +9490,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -9503,7 +9503,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -9550,7 +9550,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-entry"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -9565,7 +9565,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-llm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -9585,7 +9585,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-media"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9598,7 +9598,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-memory"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9625,7 +9625,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-browser"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64-url",
  "scru128",
@@ -9641,7 +9641,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-terminal"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "descape",
@@ -9659,7 +9659,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-scheduler"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9676,7 +9676,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -9707,7 +9707,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "scru128",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 
 [workspace.dependencies]
 tiangong-anthropic = { path = "crates/tiangong-anthropic" }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiangong-frontend",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "天工",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "identifier": "com.silent.tiangong",
   "build": {
     "beforeDevCommand": "yarn --cwd ../frontend dev",


### PR DESCRIPTION
## 背景

\`v0.9.1\` 紧急修复发布时，发版 commit \`4e9be96\`（版本号 0.9.0→0.9.1）仅存在于 \`hotfix/v0.9-pty-windows\` 分支与 \`v0.9.1\` 标签上，未随修复 commit 一起并入 main。本 PR 补齐该发版记录。

> 此前 PR #154 已合入修复本身（\`fix(terminal): Windows 平台 PTY 启动失败\`），但只 cherry-pick 了修复 commit，遗漏了发版 commit。

## 改动

cherry-pick \`4e9be96\`，零冲突。仅版本相关文件：

| 文件 | 改动 |
|------|------|
| \`Cargo.toml\` / \`Cargo.lock\` | workspace 版本 0.9.0 → 0.9.1 |
| \`src-tauri/tauri.conf.json\` | 0.9.0 → 0.9.1 |
| \`frontend/package.json\` | 0.9.0 → 0.9.1 |
| \`.github/workflows/release.yml\` | 默认标签/release name 指向 v0.9.1 |

PLAN/TODO 文档沿用发布时的选择，不在本 PR 范围。

## 验证

- [x] 基于 \`origin/main\` (\`0750c1ed\`) cherry-pick，零冲突
- [x] fmt / clippy / nextest（全量）/ yarn build / yarn test 全绿
- [x] \`v0.9.1\` 标签内容与 main 合并后一致（版本号 0.9.1）

## 关联

- 发版标签：\`v0.9.1\` → \`4e9be96\`
- 修复 PR：#154（已合并）
- 原始发版 commit：\`4e9be96\` on \`hotfix/v0.9-pty-windows\`