### PR TITLE
feat(llm): 新增 OpenAI Responses provider，拆分 Chat Completions，修复 reasoning 流式截断

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,5 +170,6 @@ pub fn now_text() -> String {
 | `API_BASE_URL` | API 基础 URL |
 | `API_TIMEOUT_MS` | 请求超时（毫秒） |
 | `API_MODEL` | 模型名称 |
+| `API_PROTOCOL` | LLM 协议：`openai`（Responses）/ `openai_chatcompletions`（Chat Completions，默认）/ `anthropic` / `deepseek` |
 | `API_STREAM` | 是否启用流式输出（默认 true） |
 | `API_CLI_COMMAND` | CLI 模式命令 |

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -15,7 +15,10 @@ use tiangong_llm::message::{
 use tiangong_llm::provider::LlmProvider;
 use tiangong_llm::providers::anthropic::{AnthropicConfig, AnthropicProvider};
 use tiangong_llm::providers::deepseek::{DeepSeekConfig, DeepSeekProvider};
-use tiangong_llm::providers::openai::{OpenAiCompatibleConfig, OpenAiCompatibleProvider};
+use tiangong_llm::providers::openai::{OpenAiResponsesConfig, OpenAiResponsesProvider};
+use tiangong_llm::providers::openai_chatcompletions::{
+    OpenAiChatCompletionsProvider, OpenAiChatConfig,
+};
 use tiangong_llm::request::ProviderRequest;
 use tiangong_llm::response::{ProviderResponse, StopReason};
 use tiangong_llm::stream::{ProviderStream, ProviderStreamEvent};
@@ -252,6 +255,13 @@ impl SingleProviderClient {
                 .await
                 .map(|items| items.into_iter().map(|item| item.id).collect::<Vec<_>>())
                 .map_err(map_llm_error)?
+        } else if cfg.api_protocol == ProviderProtocol::OpenAi {
+            let provider = build_openai_responses_provider_from_config(cfg, timeout_ms, None)?;
+            provider
+                .list_models()
+                .await
+                .map(|items| items.into_iter().map(|item| item.id).collect::<Vec<_>>())
+                .map_err(map_llm_error)?
         } else {
             let provider = build_openai_provider_from_config(cfg, timeout_ms, None)?;
             provider
@@ -300,6 +310,20 @@ impl SingleProviderClient {
             models.dedup();
             return Ok(models);
         }
+        if cfg.api_protocol == ProviderProtocol::OpenAi {
+            let provider = build_openai_responses_provider_from_config(cfg, timeout_ms, None)?;
+            let runtime = TokioRuntimeBuilder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("初始化异步运行时失败")?;
+            let mut models = runtime
+                .block_on(provider.list_models())
+                .map(|items| items.into_iter().map(|item| item.id).collect::<Vec<_>>())
+                .map_err(map_llm_error)?;
+            models.sort();
+            models.dedup();
+            return Ok(models);
+        }
         let provider = build_openai_provider_from_config(cfg, timeout_ms, None)?;
         let runtime = TokioRuntimeBuilder::new_current_thread()
             .enable_all()
@@ -322,12 +346,43 @@ impl SingleProviderClient {
         build_anthropic_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())
     }
 
+    /// 根据协议构建 OpenAI 变体 provider（Responses 或 Chat Completions）。
+    ///
+    /// 用于非流式 complete 路径：Anthropic/DeepSeek 已在各方法内单独处理，
+    /// 此处仅覆盖 OpenAI 两种变体。
+    fn build_openai_variant_provider(&self, timeout_ms: u64) -> Result<Box<dyn LlmProvider>> {
+        match self.protocol() {
+            ProviderProtocol::OpenAi => Ok(Box::new(build_openai_responses_provider_from_config(
+                &self.cfg,
+                timeout_ms,
+                self.on_retry.clone(),
+            )?)),
+            // Chat Completions（含旧 openai_compatible 别名）。
+            ProviderProtocol::OpenAiChatCompletions => Ok(Box::new(
+                build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?,
+            )),
+            // 其它协议（Anthropic/DeepSeek）不应进入此方法，给出明确错误。
+            protocol => Err(anyhow!(
+                "build_openai_variant_provider 不支持协议 {}",
+                protocol.as_str()
+            )),
+        }
+    }
+
     fn build_provider_dispatch(&self, timeout_ms: u64) -> Result<ProviderDispatch> {
         match self.protocol() {
             ProviderProtocol::Anthropic => Ok(ProviderDispatch::Anthropic(Box::new(
                 self.build_anthropic_provider(timeout_ms)?,
             ))),
-            ProviderProtocol::OpenAiCompatible => Ok(ProviderDispatch::OpenAi(Box::new(
+            ProviderProtocol::OpenAi => Ok(ProviderDispatch::OpenAiResponses(Box::new(
+                build_openai_responses_provider_from_config(
+                    &self.cfg,
+                    timeout_ms,
+                    self.on_retry.clone(),
+                )?,
+            ))),
+            // Chat Completions（含旧 openai_compatible 别名）。
+            ProviderProtocol::OpenAiChatCompletions => Ok(ProviderDispatch::OpenAi(Box::new(
                 build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?,
             ))),
             ProviderProtocol::DeepSeek => {
@@ -498,8 +553,7 @@ impl SingleProviderClient {
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起轻量级模型请求"));
         }
-        let provider =
-            build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?;
+        let provider = self.build_openai_variant_provider(timeout_ms)?;
         let request = ProviderRequest {
             model: model.to_string(),
             system: Some(
@@ -556,8 +610,7 @@ impl SingleProviderClient {
                 .trim()
                 .to_string());
         }
-        let provider =
-            build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?;
+        let provider = self.build_openai_variant_provider(timeout_ms)?;
         let response = self.block_on_llm(provider.complete(request))?;
         Ok(collect_provider_text(&response).trim().to_string())
     }
@@ -792,8 +845,7 @@ impl SingleProviderClient {
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起工具模型请求"));
         }
-        let provider =
-            build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?;
+        let provider = self.build_openai_variant_provider(timeout_ms)?;
         let request = build_provider_request(req, model, MAX_TOKENS_MAIN, functions, tool_choice);
         let response = self.block_on_llm(provider.complete(request))?;
         convert_provider_response_to_function_response(response)
@@ -888,8 +940,7 @@ impl ModelClient for SingleProviderClient {
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起模型请求"));
         }
-        let provider =
-            build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?;
+        let provider = self.build_openai_variant_provider(timeout_ms)?;
         let request = build_provider_request(req, model, MAX_TOKENS_MAIN, &[], None);
         let response = self.block_on_llm(provider.complete(request))?;
         Ok(ModelResponse {
@@ -955,16 +1006,34 @@ fn build_openai_provider_from_config(
     cfg: &ModelProviderConfig,
     timeout_ms: u64,
     on_retry: Option<OnRetryCallback>,
-) -> Result<OpenAiCompatibleProvider> {
+) -> Result<OpenAiChatCompletionsProvider> {
     let token = cfg.api_auth_token.trim();
     if token.is_empty() {
         return Err(anyhow!("API_AUTH_TOKEN 不能为空，无法发起 OpenAI 兼容请求"));
     }
-    let mut config = OpenAiCompatibleConfig::new(token.to_string(), cfg.api_base_url.clone());
+    let mut config = OpenAiChatConfig::new(token.to_string(), cfg.api_base_url.clone());
     config.timeout = Duration::from_millis(timeout_ms);
     config.max_retries = MAX_RETRIES;
     config.retry_notifier = on_retry;
-    Ok(OpenAiCompatibleProvider::new(config))
+    Ok(OpenAiChatCompletionsProvider::new(config))
+}
+
+fn build_openai_responses_provider_from_config(
+    cfg: &ModelProviderConfig,
+    timeout_ms: u64,
+    on_retry: Option<OnRetryCallback>,
+) -> Result<OpenAiResponsesProvider> {
+    let token = cfg.api_auth_token.trim();
+    if token.is_empty() {
+        return Err(anyhow!(
+            "API_AUTH_TOKEN 不能为空，无法发起 OpenAI Responses 请求"
+        ));
+    }
+    let mut config = OpenAiResponsesConfig::new(token.to_string(), cfg.api_base_url.clone());
+    config.timeout = Duration::from_millis(timeout_ms);
+    config.max_retries = MAX_RETRIES;
+    config.retry_notifier = on_retry;
+    Ok(OpenAiResponsesProvider::new(config))
 }
 
 fn build_deepseek_provider_from_config(
@@ -1773,7 +1842,8 @@ async fn consume_provider_stream_events_async(
 
 enum ProviderDispatch {
     Anthropic(Box<AnthropicProvider>),
-    OpenAi(Box<OpenAiCompatibleProvider>),
+    OpenAi(Box<OpenAiChatCompletionsProvider>),
+    OpenAiResponses(Box<OpenAiResponsesProvider>),
     DeepSeek(Box<DeepSeekProvider>),
 }
 
@@ -1785,6 +1855,7 @@ impl ProviderDispatch {
         match self {
             ProviderDispatch::Anthropic(provider) => provider.stream(request).await,
             ProviderDispatch::OpenAi(provider) => provider.stream(request).await,
+            ProviderDispatch::OpenAiResponses(provider) => provider.stream(request).await,
             ProviderDispatch::DeepSeek(provider) => provider.stream(request).await,
         }
     }

--- a/crates/tiangong-core/src/models_config.rs
+++ b/crates/tiangong-core/src/models_config.rs
@@ -778,7 +778,7 @@ mod tests {
                 base_url: "https://api.test.com".to_string(),
                 api_key: "key".to_string(),
                 timeout_ms: 60_000,
-                protocol: ProviderProtocol::OpenAiCompatible,
+                protocol: ProviderProtocol::OpenAiChatCompletions,
             },
         );
         config.models.insert(
@@ -816,7 +816,7 @@ mod tests {
                 base_url: "https://api.test.com".to_string(),
                 api_key: "key".to_string(),
                 timeout_ms: 60_000,
-                protocol: ProviderProtocol::OpenAiCompatible,
+                protocol: ProviderProtocol::OpenAiChatCompletions,
             },
         );
         config.routing.insert(
@@ -905,7 +905,7 @@ mod tests {
                 base_url: "https://api.test.com".to_string(),
                 api_key: "key".to_string(),
                 timeout_ms: 60_000,
-                protocol: ProviderProtocol::OpenAiCompatible,
+                protocol: ProviderProtocol::OpenAiChatCompletions,
             },
         );
         config.models.insert(
@@ -954,7 +954,7 @@ mod tests {
                 base_url: "https://api.test.com".to_string(),
                 api_key: "k".to_string(),
                 timeout_ms: 60_000,
-                protocol: ProviderProtocol::OpenAiCompatible,
+                protocol: ProviderProtocol::OpenAiChatCompletions,
             },
         );
         config.routing.insert(

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -82,7 +82,9 @@ impl CancelStrategy {
             tiangong_llm::model::ProviderProtocol::Anthropic => {
                 CancelStrategy::AbortWithStreamingUsage
             }
-            tiangong_llm::model::ProviderProtocol::OpenAiCompatible
+            // Responses 与 Chat Completions 的 usage 均在流式末尾返回，需等请求完成。
+            tiangong_llm::model::ProviderProtocol::OpenAi
+            | tiangong_llm::model::ProviderProtocol::OpenAiChatCompletions
             | tiangong_llm::model::ProviderProtocol::DeepSeek => CancelStrategy::WaitForUsage,
         }
     }

--- a/crates/tiangong-llm/Cargo.toml
+++ b/crates/tiangong-llm/Cargo.toml
@@ -13,7 +13,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
-async-openai = { workspace = true, features = ["byot", "chat-completion", "model"] }
+async-openai = { workspace = true, features = ["byot", "chat-completion", "model", "responses"] }
 backoff = { workspace = true }
 tokio = { workspace = true, features = ["rt", "time"] }
 reqwest = { workspace = true, default-features = false, features = ["json", "rustls"] }

--- a/crates/tiangong-llm/src/client.rs
+++ b/crates/tiangong-llm/src/client.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use crate::model::ProviderProtocol;
-use crate::providers::openai::{OpenAiCompatibleConfig, OpenAiCompatibleRerankProvider};
+use crate::providers::openai_chatcompletions::{OpenAiChatConfig, OpenAiChatRerankProvider};
 use crate::rerank::{RerankEndpointConfig, RerankProvider};
 
 /// 根据端点配置创建 RerankProvider。
@@ -13,11 +13,12 @@ pub fn rerank_provider_from_config(
     config: &RerankEndpointConfig,
 ) -> Result<Arc<dyn RerankProvider>> {
     match config.protocol {
-        ProviderProtocol::OpenAiCompatible => {
+        // Rerank 端点（/rerank）与 OpenAI 两种协议变体兼容。
+        ProviderProtocol::OpenAi | ProviderProtocol::OpenAiChatCompletions => {
             let mut provider_config =
-                OpenAiCompatibleConfig::new(config.api_key.clone(), config.base_url.clone());
+                OpenAiChatConfig::new(config.api_key.clone(), config.base_url.clone());
             provider_config.timeout = config.timeout;
-            Ok(Arc::new(OpenAiCompatibleRerankProvider::new(
+            Ok(Arc::new(OpenAiChatRerankProvider::new(
                 provider_config,
                 config.model.clone(),
             )))

--- a/crates/tiangong-llm/src/embedding.rs
+++ b/crates/tiangong-llm/src/embedding.rs
@@ -42,7 +42,8 @@ pub fn embedding_provider_from_config(
     config: &EmbeddingEndpointConfig,
 ) -> Result<Arc<dyn EmbeddingProvider>> {
     match config.protocol {
-        ProviderProtocol::OpenAiCompatible => {
+        // Embedding 端点（/v1/embeddings）与 OpenAI 两种协议变体兼容。
+        ProviderProtocol::OpenAi | ProviderProtocol::OpenAiChatCompletions => {
             Ok(Arc::new(OpenAiEmbeddingProvider::from_config(config)?))
         }
         protocol => anyhow::bail!(
@@ -104,7 +105,10 @@ impl OpenAiEmbeddingProvider {
 
     /// 从统一 Embedding 端点配置创建 provider。
     pub fn from_config(config: &EmbeddingEndpointConfig) -> Result<Self> {
-        if config.protocol != ProviderProtocol::OpenAiCompatible {
+        if !matches!(
+            config.protocol,
+            ProviderProtocol::OpenAi | ProviderProtocol::OpenAiChatCompletions
+        ) {
             anyhow::bail!(
                 "OpenAI Embedding Provider 不支持 {} 协议",
                 config.protocol.as_str()

--- a/crates/tiangong-llm/src/lib.rs
+++ b/crates/tiangong-llm/src/lib.rs
@@ -19,6 +19,7 @@ pub use embedding::{
     embedding_provider_from_config,
 };
 pub use model::{ProviderModelInfo, ProviderProtocol};
+pub use providers::openai::{OpenAiResponsesConfig, OpenAiResponsesProvider};
 pub use request::ReasoningEffort;
 pub use rerank::{
     RerankEndpointConfig, RerankProvider, RerankRequest, RerankResponse, RerankResult,

--- a/crates/tiangong-llm/src/model.rs
+++ b/crates/tiangong-llm/src/model.rs
@@ -4,10 +4,17 @@ use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 
 /// Provider 协议类型。
+///
+/// `OpenAi` 走 OpenAI Responses API（`/responses`，需显式选择）；`OpenAiChatCompletions`
+/// 走 Chat Completions API（`/chat/completions`），是默认协议，适用于官方 OpenAI 端点以及
+/// vLLM/Ollama/智谱等第三方 OpenAI 兼容端点。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ProviderProtocol {
+    /// OpenAI Responses API（`/responses`）。
+    OpenAi,
+    /// OpenAI Chat Completions API（`/chat/completions`）。
     #[default]
-    OpenAiCompatible,
+    OpenAiChatCompletions,
     Anthropic,
     DeepSeek,
 }
@@ -28,7 +35,8 @@ impl<'de> Deserialize<'de> for ProviderProtocol {
 impl ProviderProtocol {
     pub fn as_str(&self) -> &'static str {
         match self {
-            ProviderProtocol::OpenAiCompatible => "openai",
+            ProviderProtocol::OpenAi => "openai",
+            ProviderProtocol::OpenAiChatCompletions => "openai_chatcompletions",
             ProviderProtocol::Anthropic => "anthropic",
             ProviderProtocol::DeepSeek => "deepseek",
         }
@@ -40,8 +48,19 @@ impl FromStr for ProviderProtocol {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim() {
-            "" | "openai" | "openai_compatible" | "open_ai_compatible" => {
-                Ok(ProviderProtocol::OpenAiCompatible)
+            // 空值回退到默认协议（Chat Completions），避免未配置端点误走 Responses。
+            "" => Ok(ProviderProtocol::OpenAiChatCompletions),
+            "openai" => Ok(ProviderProtocol::OpenAi),
+            "openai_responses" | "openai-responses" | "responses" => Ok(ProviderProtocol::OpenAi),
+            "openai_chatcompletions"
+            | "openai_chat_completions"
+            | "openai_chat"
+            | "openai-chat"
+            | "chat_completions"
+            | "chat-completions" => Ok(ProviderProtocol::OpenAiChatCompletions),
+            // 历史别名：旧的 "openai_compatible" 归入 Chat Completions。
+            "openai_compatible" | "open_ai_compatible" => {
+                Ok(ProviderProtocol::OpenAiChatCompletions)
             }
             "anthropic" => Ok(ProviderProtocol::Anthropic),
             "deepseek" | "deep_seek" => Ok(ProviderProtocol::DeepSeek),

--- a/crates/tiangong-llm/src/providers/mod.rs
+++ b/crates/tiangong-llm/src/providers/mod.rs
@@ -1,3 +1,4 @@
 pub mod anthropic;
 pub mod deepseek;
 pub mod openai;
+pub mod openai_chatcompletions;

--- a/crates/tiangong-llm/src/providers/openai/client.rs
+++ b/crates/tiangong-llm/src/providers/openai/client.rs
@@ -1,214 +1,66 @@
 use std::time::Duration;
 
-use anyhow::Context;
 use futures_util::Stream;
-use serde_json::{Value, json};
+use serde_json::Value;
 use tokio::time::timeout;
 
 use crate::error::LlmError;
 use crate::model::ProviderModelInfo;
-use crate::rerank::RerankRequest;
 
-use super::config::OpenAiCompatibleConfig;
-use super::error::{is_retryable_openai_error, map_openai_error};
+use super::config::OpenAiResponsesConfig;
+use super::error::{is_retryable_responses_error, map_responses_error};
 use super::mapping::normalize_api_base;
 
-type OpenAiByotStream =
+type ResponsesByotStream =
     std::pin::Pin<Box<dyn Stream<Item = Result<Value, async_openai::error::OpenAIError>> + Send>>;
 
-const MAX_RETRIES: u32 = 3;
 const INITIAL_RETRY_DELAY_MS: u64 = 1000;
 
 #[derive(Clone)]
-pub struct OpenAiClient {
-    config: OpenAiCompatibleConfig,
+pub struct ResponsesClient {
+    config: OpenAiResponsesConfig,
 }
 
-impl OpenAiClient {
-    pub fn new(config: OpenAiCompatibleConfig) -> Self {
+impl ResponsesClient {
+    pub fn new(config: OpenAiResponsesConfig) -> Self {
         Self { config }
     }
 
     pub async fn complete(&self, model: &str, payload: Value) -> Result<Value, LlmError> {
         let client = self.build_client();
-        let chat = client.chat();
+        let responses = client.responses();
         timeout(
             self.config.timeout,
             self.with_retry("openai_complete", model, false, || {
-                chat.create_byot::<_, Value>(payload.clone())
+                responses.create_byot::<_, Value>(payload.clone())
             }),
         )
         .await
         .map_err(|_| LlmError::Timeout(self.config.timeout.as_millis() as u64))?
     }
 
-    pub async fn stream(&self, model: &str, payload: Value) -> Result<OpenAiByotStream, LlmError> {
+    pub async fn stream(
+        &self,
+        model: &str,
+        payload: Value,
+    ) -> Result<ResponsesByotStream, LlmError> {
         let client = self.build_client();
-        let chat = client.chat();
+        let responses = client.responses();
         self.with_retry("openai_stream", model, true, || {
-            chat.create_stream_byot::<_, Value>(payload.clone())
+            responses.create_stream_byot::<_, Value>(payload.clone())
         })
         .await
     }
 
-    pub async fn rerank(&self, model: &str, request: &RerankRequest) -> Result<Value, LlmError> {
-        if request.documents.is_empty() {
-            return Ok(json!({ "results": [] }));
-        }
-
-        let base = normalize_rerank_api_base(&self.config.base_url)
-            .map_err(|err| LlmError::Configuration(err.to_string()))?;
-        let url = format!("{base}/rerank");
-        let payload = json!({
-            "model": model,
-            "query": &request.query,
-            "documents": &request.documents,
-            "top_n": request.top_n.max(1).min(request.documents.len()),
-        });
-        let client = reqwest::Client::builder()
-            .timeout(self.config.timeout)
-            .build()
-            .map_err(|err| LlmError::Transport(err.to_string()))?;
-
-        let mut req = client.post(&url).json(&payload);
-        if !self.config.api_key.trim().is_empty() {
-            req = req.bearer_auth(&self.config.api_key);
-        }
-
-        let start = std::time::Instant::now();
-        tracing::info!(
-            operation = "openai_rerank",
-            provider = "openai",
-            model,
-            stream = false,
-            attempt = 0,
-            "开始 OpenAI 兼容请求"
-        );
-        let response = req
-            .send()
-            .await
-            .with_context(|| format!("Rerank 请求失败：{url}"))
-            .map_err(|err| LlmError::Transport(err.to_string()))?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            tracing::warn!(
-                operation = "openai_rerank",
-                provider = "openai",
-                model,
-                stream = false,
-                attempt = 0,
-                latency_ms = start.elapsed().as_millis() as u64,
-                status = status.as_u16(),
-                "OpenAI 兼容请求失败"
-            );
-            return Err(LlmError::Provider {
-                provider: "openai",
-                message: format!("Rerank API 返回错误 {status}: {body}"),
-            });
-        }
-
-        let body = response
-            .json::<Value>()
-            .await
-            .map_err(|err| LlmError::Serialization(err.to_string()))?;
-        tracing::info!(
-            operation = "openai_rerank",
-            provider = "openai",
-            model,
-            stream = false,
-            attempt = 0,
-            latency_ms = start.elapsed().as_millis() as u64,
-            "OpenAI 兼容请求完成"
-        );
-        Ok(body)
-    }
-
     pub async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
-        let start = std::time::Instant::now();
-        tracing::info!(
-            operation = "openai_list_models",
-            provider = "openai",
-            model = "<list_models>",
-            stream = false,
-            attempt = 0,
-            "开始 OpenAI 兼容请求"
-        );
-        let base = normalize_api_base(&self.config.base_url)
-            .map_err(|err| LlmError::Configuration(err.to_string()))?;
-        let url = format!("{base}/models");
-        let client = reqwest::Client::builder()
-            .timeout(self.config.timeout)
-            .build()
-            .map_err(|err| LlmError::Transport(err.to_string()))?;
-        let response = client
-            .get(&url)
-            .header("Authorization", format!("Bearer {}", self.config.api_key))
-            .send()
-            .await
-            .with_context(|| format!("请求模型列表失败：{url}"))
-            .map_err(|err| LlmError::Transport(err.to_string()))?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            tracing::warn!(
-                operation = "openai_list_models",
-                provider = "openai",
-                model = "<list_models>",
-                stream = false,
-                attempt = 0,
-                latency_ms = start.elapsed().as_millis() as u64,
-                status = status.as_u16(),
-                "OpenAI 兼容请求失败"
-            );
-            let message = format!("获取模型列表失败：HTTP {status}，响应：{body}");
-            if status.as_u16() == 429
-                || status.as_u16() == 529
-                || body.to_ascii_lowercase().contains("rate limit")
-                || body.to_ascii_lowercase().contains("too many requests")
-                || body.to_ascii_lowercase().contains("overloaded_error")
-            {
-                return Err(LlmError::RateLimited(message));
-            }
-            return Err(LlmError::Provider {
-                provider: "openai",
-                message,
-            });
-        }
-        #[derive(serde::Deserialize)]
-        struct ModelEntry {
-            id: String,
-        }
-        #[derive(serde::Deserialize)]
-        struct ModelsResponse {
-            data: Vec<ModelEntry>,
-        }
-        let body = response
-            .text()
-            .await
-            .map_err(|err| LlmError::Transport(err.to_string()))?;
-        let parsed: ModelsResponse =
-            serde_json::from_str(&body).map_err(|err| LlmError::Provider {
-                provider: "openai",
-                message: format!("failed to deserialize api response: {err}: {body}"),
-            })?;
-        tracing::info!(
-            operation = "openai_list_models",
-            provider = "openai",
-            model = "<list_models>",
-            stream = false,
-            attempt = 0,
-            latency_ms = start.elapsed().as_millis() as u64,
-            "OpenAI 兼容请求完成"
-        );
-        Ok(parsed
-            .data
-            .into_iter()
-            .map(|entry| ProviderModelInfo {
-                id: entry.id,
-                display_name: None,
-            })
-            .collect())
+        // Responses 与 Chat 共用 /models 端点，复用 Chat Completions 的实现。
+        crate::providers::openai_chatcompletions::client::list_models_via_config(
+            &self.config.api_key,
+            &self.config.base_url,
+            self.config.timeout,
+            "openai",
+        )
+        .await
     }
 
     fn build_client(&self) -> async_openai::Client<async_openai::config::OpenAIConfig> {
@@ -234,7 +86,7 @@ impl OpenAiClient {
     {
         let mut attempt = 0u32;
         let mut delay_ms = INITIAL_RETRY_DELAY_MS;
-        let max_retries = self.config.max_retries.max(MAX_RETRIES);
+        let max_retries = self.config.max_retries;
         loop {
             let start = std::time::Instant::now();
             tracing::info!(
@@ -243,7 +95,7 @@ impl OpenAiClient {
                 model,
                 stream,
                 attempt,
-                "开始 OpenAI 兼容请求"
+                "开始 OpenAI Responses 请求"
             );
             match f().await {
                 Ok(value) => {
@@ -254,11 +106,11 @@ impl OpenAiClient {
                         stream,
                         attempt,
                         latency_ms = start.elapsed().as_millis() as u64,
-                        "OpenAI 兼容请求完成"
+                        "OpenAI Responses 请求完成"
                     );
                     return Ok(value);
                 }
-                Err(err) if attempt < max_retries && is_retryable_openai_error(&err) => {
+                Err(err) if attempt < max_retries && is_retryable_responses_error(&err) => {
                     attempt += 1;
                     if let Some(notifier) = &self.config.retry_notifier {
                         notifier(attempt, max_retries, delay_ms, &err.to_string());
@@ -271,7 +123,7 @@ impl OpenAiClient {
                         attempt,
                         delay_ms,
                         error = %err,
-                        "OpenAI 兼容请求失败，准备重试"
+                        "OpenAI Responses 请求失败，准备重试"
                     );
                     tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                     delay_ms *= 2;
@@ -285,39 +137,11 @@ impl OpenAiClient {
                         attempt,
                         latency_ms = start.elapsed().as_millis() as u64,
                         error = %err,
-                        "OpenAI 兼容请求失败"
+                        "OpenAI Responses 请求失败"
                     );
-                    return Err(map_openai_error(&err));
+                    return Err(map_responses_error(&err));
                 }
             }
         }
-    }
-}
-
-fn normalize_rerank_api_base(base_url: &str) -> anyhow::Result<String> {
-    let base = normalize_api_base(base_url)?;
-    let cleaned = base.trim_end_matches('/');
-    let cleaned = cleaned.strip_suffix("/rerank").unwrap_or(cleaned);
-    Ok(cleaned.to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::normalize_rerank_api_base;
-
-    #[test]
-    fn normalizes_openai_compatible_rerank_api_base() {
-        assert_eq!(
-            normalize_rerank_api_base("http://127.0.0.1:8000/v1").unwrap(),
-            "http://127.0.0.1:8000/v1"
-        );
-        assert_eq!(
-            normalize_rerank_api_base("http://127.0.0.1:8000/v1/rerank").unwrap(),
-            "http://127.0.0.1:8000/v1"
-        );
-        assert_eq!(
-            normalize_rerank_api_base("http://127.0.0.1:8000/rerank").unwrap(),
-            "http://127.0.0.1:8000"
-        );
     }
 }

--- a/crates/tiangong-llm/src/providers/openai/error.rs
+++ b/crates/tiangong-llm/src/providers/openai/error.rs
@@ -1,38 +1,8 @@
-use crate::error::LlmError;
+//! Responses API 错误映射。
+//!
+//! 与 Chat Completions 共用 `async-openai` 错误类型，直接复用 Chat Completions 模块的映射逻辑。
 
-pub fn map_openai_error(error: &async_openai::error::OpenAIError) -> LlmError {
-    let text = error.to_string();
-    if text.contains("401") {
-        return LlmError::Authentication(text);
-    }
-    if is_rate_limited_text(&text) {
-        return LlmError::RateLimited(text);
-    }
-    if text.contains("400") {
-        return LlmError::InvalidRequest(text);
-    }
-    if text.contains("timeout") {
-        return LlmError::Timeout(0);
-    }
-    LlmError::Transport(text)
-}
-
-pub fn is_retryable_openai_error(err: &async_openai::error::OpenAIError) -> bool {
-    let text = err.to_string();
-    is_rate_limited_text(&text)
-        || text.contains("500 Internal Server Error")
-        || text.contains("502 Bad Gateway")
-        || text.contains("503 Service Unavailable")
-        || text.contains("504 Gateway Timeout")
-        || text.contains("connection reset")
-        || text.contains("connection refused")
-}
-
-fn is_rate_limited_text(text: &str) -> bool {
-    let lower = text.to_ascii_lowercase();
-    text.contains("429")
-        || text.contains("529")
-        || lower.contains("rate limit")
-        || lower.contains("too many requests")
-        || lower.contains("overloaded_error")
-}
+pub(super) use crate::providers::openai_chatcompletions::error::{
+    is_retryable_openai_error as is_retryable_responses_error,
+    map_openai_error as map_responses_error,
+};

--- a/crates/tiangong-llm/src/providers/openai/mapping.rs
+++ b/crates/tiangong-llm/src/providers/openai/mapping.rs
@@ -62,21 +62,31 @@ pub fn build_request_json(req: &ProviderRequest, stream: bool) -> Result<Value> 
     }
 
     // 思考/推理配置：优先 reasoning_effort，其次 thinking。
+    // 注意：Responses API 的 reasoning summary 必须显式请求（summary: "auto"），
+    // 否则服务端不会返回可展示的思考摘要，前端 thinking 链路将无内容。
     if let Some(effort) = &req.reasoning_effort {
         payload.insert(
             "reasoning".to_string(),
-            json!({ "effort": effort_to_str(effort) }),
+            build_reasoning(effort_to_str(effort)),
         );
     } else if req.thinking_disabled {
         // Responses API 没有 disabled 语义，省略 reasoning 字段即不强制思考。
     } else if let Some(thinking) = &req.thinking {
         payload.insert(
             "reasoning".to_string(),
-            json!({ "effort": budget_to_effort(thinking.budget_tokens) }),
+            build_reasoning(budget_to_effort(thinking.budget_tokens)),
         );
     }
 
     Ok(Value::Object(payload))
+}
+
+/// 构建 reasoning 请求字段。
+///
+/// `summary: "auto"` 让模型返回 reasoning summary（思考摘要），是 Responses API
+/// 暴露 reasoning 内容的必要条件；缺省时模型不会输出可展示的思考链。
+fn build_reasoning(effort: &str) -> Value {
+    json!({ "effort": effort, "summary": "auto" })
 }
 
 fn effort_to_str(effort: &ReasoningEffort) -> &'static str {
@@ -353,7 +363,7 @@ pub fn parse_complete_response(payload: &Value) -> Result<ProviderResponse> {
     })
 }
 
-fn extract_reasoning_text(item: &Value) -> String {
+pub(super) fn extract_reasoning_text(item: &Value) -> String {
     // 优先取 content[].text（reasoning_text），其次取 summary[].text。
     if let Some(content) = item.get("content").and_then(Value::as_array)
         && !content.is_empty()
@@ -603,6 +613,75 @@ mod tests {
         assert_eq!(payload["tools"][0]["name"], "get_weather");
         assert_eq!(payload["tool_choice"], "required");
         assert_eq!(payload["stream"], true);
+    }
+
+    #[test]
+    fn reasoning_effort_requests_summary_auto() {
+        // reasoning_effort 分支必须带上 summary: "auto"，否则服务端不返回思考摘要。
+        let req = ProviderRequest {
+            model: "o3".to_string(),
+            system: None,
+            messages: vec![crate::message::ChatMessage::text(MessageRole::User, "hi")],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: 0,
+            temperature: None,
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+            thinking: None,
+            reasoning_effort: Some(ReasoningEffort::High),
+            thinking_disabled: false,
+        };
+        let payload = build_request_json(&req, false).unwrap();
+        assert_eq!(payload["reasoning"]["effort"], "high");
+        assert_eq!(payload["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn thinking_budget_requests_summary_auto() {
+        // thinking 分支（通过 budget_tokens 映射 effort）同样必须带上 summary。
+        let req = ProviderRequest {
+            model: "o3".to_string(),
+            system: None,
+            messages: vec![crate::message::ChatMessage::text(MessageRole::User, "hi")],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: 0,
+            temperature: None,
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+            thinking: Some(crate::request::ThinkingConfig {
+                budget_tokens: 8_192,
+            }),
+            reasoning_effort: None,
+            thinking_disabled: false,
+        };
+        let payload = build_request_json(&req, false).unwrap();
+        assert_eq!(payload["reasoning"]["effort"], "medium");
+        assert_eq!(payload["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn thinking_disabled_omits_reasoning() {
+        let req = ProviderRequest {
+            model: "gpt-4o".to_string(),
+            system: None,
+            messages: vec![crate::message::ChatMessage::text(MessageRole::User, "hi")],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: 0,
+            temperature: None,
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+            thinking: None,
+            reasoning_effort: None,
+            thinking_disabled: true,
+        };
+        let payload = build_request_json(&req, false).unwrap();
+        assert!(payload.get("reasoning").is_none());
     }
 
     #[test]

--- a/crates/tiangong-llm/src/providers/openai/mapping.rs
+++ b/crates/tiangong-llm/src/providers/openai/mapping.rs
@@ -1,10 +1,15 @@
-use anyhow::{Context, Result, anyhow};
-use async_openai::types::chat::{
-    ChatCompletionMessageToolCall, ChatCompletionMessageToolCalls,
-    ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
-    ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestToolMessage,
-    ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs, FunctionCall,
-};
+//! Responses API 请求/响应映射。
+//!
+//! Responses API 与 Chat Completions 在结构上差异较大：
+//! - 顶层用 `input`（items 列表）替代 `messages`
+//! - 系统提示放入 `instructions`
+//! - 工具定义为 `{type:"function", name, description, parameters}`
+//! - 响应输出为 `output` items 列表（message/function_call/reasoning）
+//!
+//! 为避免 SDK 强类型泄漏并保持与 Chat Completions 一致的实现风格，
+//! 这里直接在 `serde_json::Value` 层操作。
+
+use anyhow::Result;
 use serde_json::{Value, json};
 
 use crate::message::{ChatMessage, MessageContent, MessageRole};
@@ -13,68 +18,170 @@ use crate::response::{ProviderResponse, StopReason};
 use crate::tool::{ToolChoice, ToolSpec};
 use crate::usage::TokenUsageData;
 
+/// 复用 Chat Completions 的 base_url 规范化逻辑。
 pub fn normalize_api_base(base_url: &str) -> Result<String> {
-    let trimmed = base_url.trim();
-    if trimmed.is_empty() {
-        return Err(anyhow!("API_BASE_URL 不能为空"));
-    }
-    let cleaned = trimmed.trim_end_matches('/');
-    let cleaned = cleaned.strip_suffix("/chat/completions").unwrap_or(cleaned);
-    Ok(cleaned.to_string())
+    crate::providers::openai_chatcompletions::mapping::normalize_api_base(base_url)
 }
 
+/// 构建 Responses API 请求 JSON。
 pub fn build_request_json(req: &ProviderRequest, stream: bool) -> Result<Value> {
-    let messages = build_openai_messages(req)?;
-    let mut request_args_binding = CreateChatCompletionRequestArgs::default();
-    let mut request_args = request_args_binding
-        .model(req.model.clone())
-        .messages(messages)
-        .stream(stream);
-    if let Some(temperature) = req.temperature {
-        request_args = request_args.temperature(temperature);
-    }
-    let request = request_args.build().context("构建 OpenAI 请求失败")?;
+    let mut payload = serde_json::Map::new();
+    payload.insert("model".to_string(), json!(req.model));
 
-    let mut payload = serde_json::to_value(request).context("序列化 OpenAI 请求失败")?;
-    inject_max_tokens_config(&mut payload, req.max_tokens);
+    // Responses API 的 instructions 只能承载单个系统提示，而消息流中可能
+    // 插入额外 System 消息（记忆检索结果、错误提示等）。将主 system 与流中
+    // System 消息按出现顺序拼接到 instructions，避免静默丢弃。
+    let instructions = collect_instructions(req);
+    if !instructions.trim().is_empty() {
+        payload.insert("instructions".to_string(), json!(instructions));
+    }
+
+    payload.insert("input".to_string(), build_input_items(req)?);
+
     if stream {
-        inject_stream_usage_option(&mut payload);
+        payload.insert("stream".to_string(), json!(true));
+    }
+
+    if req.max_tokens > 0 {
+        payload.insert("max_output_tokens".to_string(), json!(req.max_tokens));
     }
     if let Some(temperature) = req.temperature {
-        inject_temperature_config(&mut payload, temperature)?;
+        payload.insert("temperature".to_string(), json!(temperature));
     }
-    if !req.tools.is_empty() {
-        inject_function_tools(&mut payload, &req.tools, req.tool_choice.as_ref());
+    if let Some(top_p) = req.top_p {
+        payload.insert("top_p".to_string(), json!(top_p));
     }
-    if let Some(effort) = &req.reasoning_effort {
-        inject_reasoning_effort(&mut payload, effort);
-    }
-    if req.thinking_disabled {
-        inject_thinking_disabled(&mut payload);
-    } else if let Some(thinking) = &req.thinking {
-        inject_thinking_enabled(&mut payload, thinking.budget_tokens);
-    }
-    Ok(payload)
-}
 
-fn build_openai_messages(req: &ProviderRequest) -> Result<Vec<ChatCompletionRequestMessage>> {
-    let mut messages = Vec::new();
-    if let Some(system) = req.system.as_ref().filter(|value| !value.trim().is_empty()) {
-        messages.push(
-            ChatCompletionRequestSystemMessageArgs::default()
-                .content(system.clone())
-                .build()
-                .context("构建 system 消息失败")?
-                .into(),
+    if !req.tools.is_empty() {
+        payload.insert("tools".to_string(), build_tools(&req.tools));
+        if let Some(choice) = req.tool_choice.as_ref()
+            && let Some(tool_choice) = build_tool_choice(choice)
+        {
+            payload.insert("tool_choice".to_string(), tool_choice);
+        }
+    }
+
+    // 思考/推理配置：优先 reasoning_effort，其次 thinking。
+    if let Some(effort) = &req.reasoning_effort {
+        payload.insert(
+            "reasoning".to_string(),
+            json!({ "effort": effort_to_str(effort) }),
+        );
+    } else if req.thinking_disabled {
+        // Responses API 没有 disabled 语义，省略 reasoning 字段即不强制思考。
+    } else if let Some(thinking) = &req.thinking {
+        payload.insert(
+            "reasoning".to_string(),
+            json!({ "effort": budget_to_effort(thinking.budget_tokens) }),
         );
     }
 
+    Ok(Value::Object(payload))
+}
+
+fn effort_to_str(effort: &ReasoningEffort) -> &'static str {
+    match effort {
+        ReasoningEffort::Low => "low",
+        ReasoningEffort::Medium => "medium",
+        ReasoningEffort::High => "high",
+        // Responses API 的 reasoning.effort 目前仅支持 low/medium/high，
+        // Max 暂降级为 high；若 OpenAI 后续开放 "max" 级别需同步更新此处。
+        ReasoningEffort::Max => "high",
+    }
+}
+
+/// 根据 thinking budget_tokens 粗略映射到 reasoning effort。
+fn budget_to_effort(budget_tokens: u32) -> &'static str {
+    if budget_tokens >= 16_384 {
+        "high"
+    } else if budget_tokens >= 4_096 {
+        "medium"
+    } else {
+        "low"
+    }
+}
+
+/// 收集主 system 与消息流中的 System 消息，按顺序拼接为 instructions。
+///
+/// Responses API 的 instructions 仅支持单个字符串，故将对话中插入的 System
+/// 消息（如记忆检索结果、错误提示）追加到主系统提示之后。
+fn collect_instructions(req: &ProviderRequest) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(system) = req
+        .system
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|v| !v.is_empty())
+    {
+        parts.push(system.to_string());
+    }
+    for message in &req.messages {
+        if !matches!(message.role, MessageRole::System) {
+            continue;
+        }
+        let text = collect_text(message);
+        if !text.trim().is_empty() {
+            parts.push(text.trim().to_string());
+        }
+    }
+    parts.join("\n\n")
+}
+
+fn build_tools(specs: &[ToolSpec]) -> Value {
+    let tools = specs
+        .iter()
+        .map(|spec| {
+            json!({
+                "type": "function",
+                "name": spec.name,
+                "description": spec.description,
+                "parameters": spec.input_schema,
+            })
+        })
+        .collect::<Vec<_>>();
+    Value::Array(tools)
+}
+
+fn build_tool_choice(choice: &ToolChoice) -> Option<Value> {
+    match choice {
+        ToolChoice::Auto => Some(json!("auto")),
+        ToolChoice::Any => Some(json!("required")),
+        ToolChoice::Tool(name) => Some(json!({ "type": "function", "name": name })),
+    }
+}
+
+fn build_input_items(req: &ProviderRequest) -> Result<Value> {
+    let mut items = Vec::new();
     for message in &req.messages {
         match message.role {
-            MessageRole::System => {}
+            MessageRole::System => {
+                // System 消息已由 collect_instructions 拼入 instructions，此处不重复入 input。
+            }
             MessageRole::User => {
-                if let Some(message) = build_openai_user_message(message)? {
-                    messages.push(message);
+                if let Some(item) = build_user_item(message)? {
+                    items.push(item);
+                }
+            }
+            MessageRole::Assistant => {
+                // 助手文本与工具调用分别作为独立 input items 推入历史。
+                let text = collect_text(message);
+                if !text.trim().is_empty() {
+                    items.push(json!({
+                        "type": "message",
+                        "role": "assistant",
+                        "content": text,
+                    }));
+                }
+                for tool_call in message.content.iter().filter_map(|content| match content {
+                    MessageContent::ToolCall(tool_call) => Some(tool_call),
+                    _ => None,
+                }) {
+                    items.push(json!({
+                        "type": "function_call",
+                        "call_id": tool_call.id,
+                        "name": tool_call.name,
+                        "arguments": tool_call.arguments.to_string(),
+                    }));
                 }
             }
             MessageRole::Tool => {
@@ -82,58 +189,23 @@ fn build_openai_messages(req: &ProviderRequest) -> Result<Vec<ChatCompletionRequ
                     MessageContent::ToolResult(result) => Some(result),
                     _ => None,
                 }) {
-                    let content = match &result.content {
+                    let output = match &result.content {
                         crate::tool::ToolResultContent::Text(text) => text.clone(),
                         crate::tool::ToolResultContent::Json(value) => value.to_string(),
                     };
-                    messages.push(ChatCompletionRequestMessage::Tool(
-                        ChatCompletionRequestToolMessage {
-                            content: content.into(),
-                            tool_call_id: result.tool_call_id.clone(),
-                        },
-                    ));
-                }
-            }
-            MessageRole::Assistant => {
-                let text = extract_message_text(message);
-                let tool_calls = message
-                    .content
-                    .iter()
-                    .filter_map(|content| match content {
-                        MessageContent::ToolCall(tool_call) => {
-                            Some(ChatCompletionMessageToolCalls::Function(
-                                ChatCompletionMessageToolCall {
-                                    id: tool_call.id.clone(),
-                                    function: FunctionCall {
-                                        name: tool_call.name.clone(),
-                                        arguments: tool_call.arguments.to_string(),
-                                    },
-                                },
-                            ))
-                        }
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>();
-                if !text.is_empty() || !tool_calls.is_empty() {
-                    let mut args = ChatCompletionRequestAssistantMessageArgs::default();
-                    if !text.is_empty() {
-                        args.content(text);
-                    }
-                    if !tool_calls.is_empty() {
-                        args.tool_calls(tool_calls);
-                    }
-                    messages.push(args.build().context("构建 assistant 消息失败")?.into());
+                    items.push(json!({
+                        "type": "function_call_output",
+                        "call_id": result.tool_call_id,
+                        "output": output,
+                    }));
                 }
             }
         }
     }
-
-    Ok(messages)
+    Ok(Value::Array(items))
 }
 
-fn build_openai_user_message(
-    message: &ChatMessage,
-) -> Result<Option<ChatCompletionRequestMessage>> {
+fn build_user_item(message: &ChatMessage) -> Result<Option<Value>> {
     let images = message
         .content
         .iter()
@@ -142,40 +214,37 @@ fn build_openai_user_message(
             _ => None,
         })
         .collect::<Vec<_>>();
-    let text = extract_message_text(message);
+    let text = collect_text(message);
+
     if images.is_empty() {
-        if text.is_empty() {
+        if text.trim().is_empty() {
             return Ok(None);
         }
-        return Ok(Some(
-            ChatCompletionRequestUserMessageArgs::default()
-                .content(text)
-                .build()
-                .context("构建 user 消息失败")?
-                .into(),
-        ));
+        return Ok(Some(json!({
+            "type": "message",
+            "role": "user",
+            "content": text,
+        })));
     }
 
     let mut content = Vec::new();
-    if !text.is_empty() {
-        content.push(json!({ "type": "text", "text": text }));
+    if !text.trim().is_empty() {
+        content.push(json!({ "type": "input_text", "text": text }));
     }
     for image in images {
         content.push(json!({
-            "type": "image_url",
-            "image_url": { "url": image.data }
+            "type": "input_image",
+            "image_url": image.data,
         }));
     }
-    Ok(Some(
-        serde_json::from_value(json!({
-            "role": "user",
-            "content": content
-        }))
-        .context("构建 OpenAI 多模态 user 消息失败")?,
-    ))
+    Ok(Some(json!({
+        "type": "message",
+        "role": "user",
+        "content": content,
+    })))
 }
 
-fn extract_message_text(message: &ChatMessage) -> String {
+fn collect_text(message: &ChatMessage) -> String {
     message
         .content
         .iter()
@@ -197,230 +266,351 @@ fn extract_message_text(message: &ChatMessage) -> String {
         .join("\n")
 }
 
+/// 解析 Responses API 完整响应。
 pub fn parse_complete_response(payload: &Value) -> Result<ProviderResponse> {
-    let choice = payload
-        .get("choices")
-        .and_then(Value::as_array)
-        .and_then(|choices| choices.first())
-        .ok_or_else(|| anyhow!("OpenAI 响应缺少 choices"))?;
-
-    let text = choice
-        .get("message")
-        .and_then(|message| message.get("content"))
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
-    let reasoning_content = choice
-        .get("message")
-        .and_then(|message| message.get("reasoning_content"))
-        .and_then(Value::as_str)
-        .map(|value| value.to_string());
-
-    let tool_calls = choice
-        .get("message")
-        .and_then(|message| message.get("tool_calls"))
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-
     let mut content = Vec::new();
-    if !text.trim().is_empty() {
-        content.push(MessageContent::Text(strip_think_tags(text.trim())));
-    }
-    for tool_call in tool_calls {
-        let id = tool_call
-            .get("id")
-            .and_then(Value::as_str)
-            .unwrap_or_default();
-        let name = tool_call
-            .get("function")
-            .and_then(|v| v.get("name"))
-            .and_then(Value::as_str)
-            .unwrap_or_default();
-        let arguments = tool_call
-            .get("function")
-            .and_then(|v| v.get("arguments"))
-            .and_then(Value::as_str)
-            .and_then(|raw| serde_json::from_str(raw).ok())
-            .unwrap_or_else(|| json!({}));
-        if !name.is_empty() {
-            content.push(MessageContent::ToolCall(crate::tool::ToolCall {
-                id: id.to_string(),
-                name: name.to_string(),
-                arguments,
-            }));
+    let mut reasoning_content: Option<String> = None;
+
+    if let Some(output) = payload.get("output").and_then(Value::as_array) {
+        for item in output {
+            match item.get("type").and_then(Value::as_str) {
+                Some("message") => {
+                    let text = item
+                        .get("content")
+                        .and_then(Value::as_array)
+                        .map(|parts| {
+                            parts
+                                .iter()
+                                .filter_map(|part| {
+                                    let part_type = part.get("type").and_then(Value::as_str);
+                                    if part_type == Some("output_text")
+                                        || part_type == Some("reasoning_text")
+                                        || part_type == Some("text")
+                                    {
+                                        part.get("text").and_then(Value::as_str).map(String::from)
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                                .join("")
+                        })
+                        .unwrap_or_default();
+                    if !text.trim().is_empty() {
+                        content.push(MessageContent::Text(strip_think(text.trim())));
+                    }
+                }
+                Some("function_call") => {
+                    let call_id = item
+                        .get("call_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let name = item
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let arguments = item
+                        .get("arguments")
+                        .and_then(Value::as_str)
+                        .and_then(|raw| serde_json::from_str(raw).ok())
+                        .unwrap_or_else(|| json!({}));
+                    if !name.is_empty() {
+                        content.push(MessageContent::ToolCall(crate::tool::ToolCall {
+                            id: call_id,
+                            name,
+                            arguments,
+                        }));
+                    }
+                }
+                Some("reasoning") if reasoning_content.is_none() => {
+                    reasoning_content = Some(extract_reasoning_text(item));
+                }
+                _ => {}
+            }
         }
     }
 
     let usage = payload.get("usage").map(parse_usage);
+    let status = payload.get("status").and_then(Value::as_str).unwrap_or("");
+    let stop_reason = map_status_to_stop_reason(status, &content);
 
     Ok(ProviderResponse {
-        id: payload
-            .get("id")
-            .and_then(Value::as_str)
-            .map(|v| v.to_string()),
+        id: payload.get("id").and_then(Value::as_str).map(String::from),
         model: payload
             .get("model")
             .and_then(Value::as_str)
-            .map(|v| v.to_string()),
+            .map(String::from),
         assistant_message: ChatMessage {
             role: MessageRole::Assistant,
             content,
         },
         reasoning_content,
-        stop_reason: choice
-            .get("finish_reason")
-            .and_then(Value::as_str)
-            .map(map_stop_reason),
+        stop_reason,
         usage,
         raw: Some(payload.clone()),
     })
 }
 
-fn map_stop_reason(reason: &str) -> StopReason {
-    match reason {
-        "stop" => StopReason::EndTurn,
-        "tool_calls" => StopReason::ToolUse,
-        "length" => StopReason::MaxTokens,
-        other => StopReason::Other(other.to_string()),
+fn extract_reasoning_text(item: &Value) -> String {
+    // 优先取 content[].text（reasoning_text），其次取 summary[].text。
+    if let Some(content) = item.get("content").and_then(Value::as_array)
+        && !content.is_empty()
+    {
+        let text = content
+            .iter()
+            .filter_map(|part| part.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("");
+        if !text.trim().is_empty() {
+            return text;
+        }
+    }
+    item.get("summary")
+        .and_then(Value::as_array)
+        .map(|parts| {
+            parts
+                .iter()
+                .filter_map(|part| part.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default()
+}
+
+fn map_status_to_stop_reason(status: &str, content: &[MessageContent]) -> Option<StopReason> {
+    match status {
+        "completed" => {
+            if content
+                .iter()
+                .any(|c| matches!(c, MessageContent::ToolCall(_)))
+            {
+                Some(StopReason::ToolUse)
+            } else {
+                Some(StopReason::EndTurn)
+            }
+        }
+        "incomplete" => Some(StopReason::MaxTokens),
+        "failed" | "cancelled" => Some(StopReason::Other(status.to_string())),
+        _ => None,
     }
 }
 
+/// 解析 Responses 用量。
 pub fn parse_usage(usage: &Value) -> TokenUsageData {
     let prompt = usage
-        .get("prompt_tokens")
+        .get("input_tokens")
         .and_then(Value::as_u64)
         .unwrap_or(0) as usize;
     let completion = usage
-        .get("completion_tokens")
+        .get("output_tokens")
         .and_then(Value::as_u64)
         .unwrap_or(0) as usize;
     let total = usage
         .get("total_tokens")
         .and_then(Value::as_u64)
         .unwrap_or((prompt + completion) as u64) as usize;
+    let cached = usage
+        .get("input_tokens_details")
+        .and_then(|d| d.get("cached_tokens"))
+        .and_then(Value::as_u64)
+        .map(|v| v as usize);
     TokenUsageData {
         prompt_tokens: prompt,
         completion_tokens: completion,
         total_tokens: total,
-        prompt_cache_hit_tokens: None,
-        prompt_cache_miss_tokens: None,
+        prompt_cache_hit_tokens: cached,
+        prompt_cache_miss_tokens: cached.map(|c| prompt.saturating_sub(c)),
     }
 }
 
-fn inject_stream_usage_option(payload: &mut Value) {
-    let Some(obj) = payload.as_object_mut() else {
-        return;
-    };
-    obj.insert("stream_options".to_string(), json!({"include_usage": true}));
+/// 去除 `<think>...</think>` 标签，复用 Chat Completions 的实现。
+fn strip_think(text: &str) -> String {
+    crate::providers::openai_chatcompletions::mapping::strip_think_tags(text)
 }
 
-fn inject_max_tokens_config(payload: &mut Value, max_tokens: u32) {
-    let Some(obj) = payload.as_object_mut() else {
-        return;
-    };
-    obj.insert("max_tokens".to_string(), json!(max_tokens));
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
 
-fn inject_temperature_config(payload: &mut Value, temperature: f32) -> Result<()> {
-    let Some(obj) = payload.as_object_mut() else {
-        return Ok(());
-    };
-    let number = serde_json::Number::from_f64(temperature as f64)
-        .ok_or_else(|| anyhow!("temperature 无效"))?;
-    obj.insert("temperature".to_string(), Value::Number(number));
-    Ok(())
-}
-
-fn inject_function_tools(
-    payload: &mut Value,
-    functions: &[ToolSpec],
-    tool_choice: Option<&ToolChoice>,
-) {
-    let Some(obj) = payload.as_object_mut() else {
-        return;
-    };
-    let tools = functions
-        .iter()
-        .map(|spec| {
-            json!({
-                "type": "function",
-                "function": {
-                    "name": spec.name,
-                    "description": spec.description,
-                    "parameters": spec.input_schema,
+    #[test]
+    fn parses_text_response() {
+        let payload = json!({
+            "id": "resp_1",
+            "model": "gpt-4o",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        { "type": "output_text", "text": "你好" }
+                    ]
                 }
-            })
-        })
-        .collect::<Vec<_>>();
-    obj.insert("tools".to_string(), Value::Array(tools));
-    match tool_choice {
-        Some(ToolChoice::Any) => {
-            obj.insert(
-                "tool_choice".to_string(),
-                Value::String("required".to_string()),
-            );
+            ],
+            "usage": {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "total_tokens": 7
+            }
+        });
+        let resp = parse_complete_response(&payload).unwrap();
+        assert_eq!(resp.id.as_deref(), Some("resp_1"));
+        assert_eq!(resp.assistant_message.content.len(), 1);
+        match &resp.assistant_message.content[0] {
+            MessageContent::Text(text) => assert_eq!(text, "你好"),
+            other => panic!("expected text, got {other:?}"),
         }
-        Some(ToolChoice::Tool(name)) => {
-            obj.insert(
-                "tool_choice".to_string(),
-                json!({
-                    "type": "function",
-                    "function": { "name": name },
-                }),
-            );
-        }
-        // 兼容 vLLM / 部分 OpenAI-compatible 后端：
-        // 显式 `tool_choice: "auto"` 可能要求服务端开启
-        // --enable-auto-tool-choice 和 --tool-call-parser。
-        // 省略该字段时，OpenAI Chat Completions 语义仍会在提供 tools 后
-        // 使用默认自动选择策略，且不会触发这些后端的 400。
-        Some(ToolChoice::Auto) => {}
-        None => {}
+        let usage = resp.usage.unwrap();
+        assert_eq!(usage.total_tokens, 7);
+        assert_eq!(resp.stop_reason, Some(StopReason::EndTurn));
     }
-}
 
-fn inject_reasoning_effort(payload: &mut Value, effort: &ReasoningEffort) {
-    let Some(obj) = payload.as_object_mut() else {
-        return;
-    };
-    let effort_str = match effort {
-        ReasoningEffort::Low => "low",
-        ReasoningEffort::Medium => "medium",
-        ReasoningEffort::High => "high",
-        ReasoningEffort::Max => "max",
-    };
-    obj.insert("reasoning_effort".to_string(), json!(effort_str));
-}
-
-fn inject_thinking_disabled(payload: &mut Value) {
-    let Some(obj) = payload.as_object_mut() else {
-        return;
-    };
-    obj.insert("thinking".to_string(), json!({"type": "disabled"}));
-}
-
-fn inject_thinking_enabled(payload: &mut Value, budget_tokens: u32) {
-    let Some(obj) = payload.as_object_mut() else {
-        return;
-    };
-    obj.insert(
-        "thinking".to_string(),
-        json!({"type": "enabled", "budget_tokens": budget_tokens}),
-    );
-}
-
-pub fn strip_think_tags(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    let mut remaining = text;
-    while let Some(start) = remaining.find("<think>") {
-        result.push_str(&remaining[..start]);
-        if let Some(end) = remaining[start..].find("</think>") {
-            remaining = &remaining[start + end + 8..];
-        } else {
-            return result;
+    #[test]
+    fn parses_function_call_response() {
+        let payload = json!({
+            "id": "resp_2",
+            "model": "gpt-4o",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "get_weather",
+                    "arguments": "{\"city\":\"北京\"}"
+                }
+            ],
+            "usage": null
+        });
+        let resp = parse_complete_response(&payload).unwrap();
+        match &resp.assistant_message.content[0] {
+            MessageContent::ToolCall(call) => {
+                assert_eq!(call.id, "call_1");
+                assert_eq!(call.name, "get_weather");
+                assert_eq!(call.arguments["city"], "北京");
+            }
+            other => panic!("expected tool call, got {other:?}"),
         }
+        assert_eq!(resp.stop_reason, Some(StopReason::ToolUse));
     }
-    result.push_str(remaining);
-    result
+
+    #[test]
+    fn parses_reasoning_text() {
+        let payload = json!({
+            "id": "resp_3",
+            "model": "o3",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "reasoning",
+                    "summary": [{ "type": "summary_text", "text": "思考中" }]
+                },
+                {
+                    "type": "message",
+                    "content": [{ "type": "output_text", "text": "答案" }]
+                }
+            ],
+            "usage": {}
+        });
+        let resp = parse_complete_response(&payload).unwrap();
+        assert_eq!(resp.reasoning_content.as_deref(), Some("思考中"));
+    }
+
+    #[test]
+    fn builds_request_payload() {
+        let req = ProviderRequest {
+            model: "gpt-4o".to_string(),
+            system: Some("你是助手".to_string()),
+            messages: vec![crate::message::ChatMessage::text(MessageRole::User, "你好")],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: 1024,
+            temperature: Some(0.5),
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+            thinking: None,
+            reasoning_effort: None,
+            thinking_disabled: false,
+        };
+        let payload = build_request_json(&req, false).unwrap();
+        assert_eq!(payload["model"], "gpt-4o");
+        assert_eq!(payload["instructions"], "你是助手");
+        assert_eq!(payload["max_output_tokens"], 1024);
+        assert_eq!(payload["temperature"], 0.5);
+        assert_eq!(payload["input"][0]["type"], "message");
+        assert_eq!(payload["input"][0]["role"], "user");
+        assert_eq!(payload["input"][0]["content"], "你好");
+    }
+
+    #[test]
+    fn collects_stream_system_messages_into_instructions() {
+        // 消息流中的 System 消息（如记忆检索结果）应拼入 instructions，
+        // 而非静默丢弃。
+        let req = ProviderRequest {
+            model: "gpt-4o".to_string(),
+            system: Some("主系统提示".to_string()),
+            messages: vec![
+                crate::message::ChatMessage::text(MessageRole::System, "[记忆] 相关上下文"),
+                crate::message::ChatMessage::text(MessageRole::User, "你好"),
+            ],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: 100,
+            temperature: None,
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+            thinking: None,
+            reasoning_effort: None,
+            thinking_disabled: false,
+        };
+        let payload = build_request_json(&req, false).unwrap();
+        let instructions = payload["instructions"].as_str().unwrap();
+        assert!(instructions.contains("主系统提示"));
+        assert!(instructions.contains("[记忆] 相关上下文"));
+        // System 消息不应出现在 input 中。
+        let input = payload["input"].as_array().unwrap();
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+    }
+
+    #[test]
+    fn builds_request_with_tools() {
+        let req = ProviderRequest {
+            model: "gpt-4o".to_string(),
+            system: None,
+            messages: vec![crate::message::ChatMessage::text(MessageRole::User, "天气")],
+            tools: vec![ToolSpec {
+                name: "get_weather".to_string(),
+                description: "获取天气".to_string(),
+                input_schema: json!({"type": "object"}),
+            }],
+            tool_choice: Some(ToolChoice::Any),
+            max_tokens: 512,
+            temperature: None,
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+            thinking: None,
+            reasoning_effort: None,
+            thinking_disabled: false,
+        };
+        let payload = build_request_json(&req, true).unwrap();
+        assert_eq!(payload["tools"][0]["type"], "function");
+        assert_eq!(payload["tools"][0]["name"], "get_weather");
+        assert_eq!(payload["tool_choice"], "required");
+        assert_eq!(payload["stream"], true);
+    }
+
+    #[test]
+    fn normalizes_base_url_strips_chat_completions() {
+        // 复用 openai mapping 的 normalize_api_base。
+        let base = normalize_api_base("https://api.openai.com/v1/chat/completions").unwrap();
+        assert_eq!(base, "https://api.openai.com/v1");
+        let err = normalize_api_base("  ");
+        assert!(err.is_err(), "空 base_url 应报错：{err:?}");
+    }
 }

--- a/crates/tiangong-llm/src/providers/openai/mod.rs
+++ b/crates/tiangong-llm/src/providers/openai/mod.rs
@@ -1,3 +1,8 @@
+//! OpenAI Responses API（`/responses`）适配层。
+//!
+//! 与 `providers/openai_chatcompletions`（Chat Completions）并列，二者共享 `async-openai`
+//! 客户端与重试/错误映射基础能力，但请求/响应/流式结构各自独立实现。
+
 mod client;
 mod config;
 mod error;
@@ -5,5 +10,5 @@ mod mapping;
 mod provider;
 mod stream;
 
-pub use config::OpenAiCompatibleConfig;
-pub use provider::{OpenAiCompatibleProvider, OpenAiCompatibleRerankProvider};
+pub use config::OpenAiResponsesConfig;
+pub use provider::OpenAiResponsesProvider;

--- a/crates/tiangong-llm/src/providers/openai/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai/provider.rs
@@ -1,63 +1,34 @@
 use async_trait::async_trait;
 use futures_util::{StreamExt, stream};
-use serde::Deserialize;
 
 use crate::error::LlmError;
 use crate::model::ProviderModelInfo;
 use crate::provider::{LlmProvider, ProviderCapabilities};
 use crate::request::ProviderRequest;
-use crate::rerank::{RerankProvider, RerankRequest, RerankResponse, RerankResult};
 use crate::response::ProviderResponse;
 use crate::stream::ProviderStream;
 
-use super::client::OpenAiClient;
-use super::config::OpenAiCompatibleConfig;
-use super::error::map_openai_error;
+use super::client::ResponsesClient;
+use super::config::OpenAiResponsesConfig;
+use super::error::map_responses_error;
 use super::mapping::{build_request_json, parse_complete_response};
+use super::stream::parse_stream_event;
 
 #[derive(Clone)]
-pub struct OpenAiCompatibleProvider {
-    client: OpenAiClient,
+pub struct OpenAiResponsesProvider {
+    client: ResponsesClient,
 }
 
-#[derive(Clone)]
-pub struct OpenAiCompatibleRerankProvider {
-    client: OpenAiClient,
-    model: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct OpenAiRerankResponse {
-    #[serde(default)]
-    results: Vec<OpenAiRerankResult>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OpenAiRerankResult {
-    index: usize,
-    #[serde(alias = "score")]
-    relevance_score: f64,
-}
-
-impl OpenAiCompatibleProvider {
-    pub fn new(config: OpenAiCompatibleConfig) -> Self {
+impl OpenAiResponsesProvider {
+    pub fn new(config: OpenAiResponsesConfig) -> Self {
         Self {
-            client: OpenAiClient::new(config),
-        }
-    }
-}
-
-impl OpenAiCompatibleRerankProvider {
-    pub fn new(config: OpenAiCompatibleConfig, model: impl Into<String>) -> Self {
-        Self {
-            client: OpenAiClient::new(config),
-            model: model.into(),
+            client: ResponsesClient::new(config),
         }
     }
 }
 
 #[async_trait]
-impl LlmProvider for OpenAiCompatibleProvider {
+impl LlmProvider for OpenAiResponsesProvider {
     fn capabilities(&self) -> ProviderCapabilities {
         ProviderCapabilities {
             streaming: true,
@@ -85,8 +56,8 @@ impl LlmProvider for OpenAiCompatibleProvider {
         let stream = self.client.stream(&model, payload).await?;
         let mapped = stream
             .map(|item| match item {
-                Ok(payload) => super::stream::parse_stream_payload(&payload),
-                Err(err) => vec![Err(map_openai_error(&err))],
+                Ok(payload) => parse_stream_event(&payload),
+                Err(err) => vec![Err(map_responses_error(&err))],
             })
             .flat_map(stream::iter);
         Ok(Box::pin(mapped))
@@ -94,27 +65,5 @@ impl LlmProvider for OpenAiCompatibleProvider {
 
     async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
         self.client.list_models().await
-    }
-}
-
-#[async_trait]
-impl RerankProvider for OpenAiCompatibleRerankProvider {
-    async fn rerank(&self, request: RerankRequest) -> anyhow::Result<RerankResponse> {
-        let response = self.client.rerank(&self.model, &request).await?;
-        let parsed: OpenAiRerankResponse = serde_json::from_value(response)?;
-        Ok(RerankResponse {
-            results: parsed
-                .results
-                .into_iter()
-                .map(|item| RerankResult {
-                    index: item.index,
-                    relevance_score: item.relevance_score,
-                })
-                .collect(),
-        })
-    }
-
-    fn model(&self) -> &str {
-        &self.model
     }
 }

--- a/crates/tiangong-llm/src/providers/openai/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai/provider.rs
@@ -1,18 +1,19 @@
 use async_trait::async_trait;
 use futures_util::{StreamExt, stream};
+use serde_json::Value;
 
 use crate::error::LlmError;
 use crate::model::ProviderModelInfo;
 use crate::provider::{LlmProvider, ProviderCapabilities};
 use crate::request::ProviderRequest;
 use crate::response::ProviderResponse;
-use crate::stream::ProviderStream;
+use crate::stream::{ProviderStream, ProviderStreamEvent};
 
 use super::client::ResponsesClient;
 use super::config::OpenAiResponsesConfig;
 use super::error::map_responses_error;
 use super::mapping::{build_request_json, parse_complete_response};
-use super::stream::parse_stream_event;
+use super::stream::{extract_completed_reasoning, parse_stream_event};
 
 #[derive(Clone)]
 pub struct OpenAiResponsesProvider {
@@ -25,6 +26,25 @@ impl OpenAiResponsesProvider {
             client: ResponsesClient::new(config),
         }
     }
+}
+
+/// 对 completed 事件的 reasoning 兜底做条件去重。
+///
+/// OpenAI Responses 的思考内容主要靠流式增量事件（`reasoning_summary_text.delta` 等）
+/// 多段拼接，这些增量**必须全部保留**。只有当整个流式过程**完全没有收到任何 reasoning
+/// delta** 时，才从 `response.completed` 的最终 `output[]` 中兜底提取 reasoning。
+///
+/// 因此去重只针对 completed 兜底：`received_delta` 为 true 时跳过兜底 reasoning。
+fn maybe_completed_reasoning(
+    completed_payload: &Value,
+    received_delta: bool,
+) -> Option<ProviderStreamEvent> {
+    if received_delta {
+        return None;
+    }
+    extract_completed_reasoning(completed_payload)
+        .filter(|text| !text.trim().is_empty())
+        .map(ProviderStreamEvent::ReasoningDelta)
 }
 
 #[async_trait]
@@ -54,16 +74,93 @@ impl LlmProvider for OpenAiResponsesProvider {
         let payload = build_request_json(&req, true)
             .map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
         let stream = self.client.stream(&model, payload).await?;
-        let mapped = stream
-            .map(|item| match item {
-                Ok(payload) => parse_stream_event(&payload),
-                Err(err) => vec![Err(map_responses_error(&err))],
-            })
-            .flat_map(stream::iter);
+
+        // 维护流式状态：记录是否收到过 reasoning delta 增量。
+        // 流式增量一律保留；仅在全程无 delta 时，从 completed 兜底补发 reasoning。
+        let mut received_reasoning_delta = false;
+        let mapped = stream.flat_map(move |item| {
+            let raw_payload = match item {
+                Ok(payload) => payload,
+                Err(err) => {
+                    return stream::iter(vec![Err(map_responses_error(&err))]);
+                }
+            };
+
+            // 记录本条事件是否产生 reasoning delta（用于 completed 兜底判断）。
+            let is_completed = raw_payload
+                .get("type")
+                .and_then(Value::as_str)
+                .map(|t| t == "response.completed")
+                .unwrap_or(false);
+
+            let mut events = parse_stream_event(&raw_payload);
+
+            if is_completed {
+                // 仅当流式过程未收到任何 reasoning delta 时，兜底补发最终 reasoning。
+                if let Some(fallback) =
+                    maybe_completed_reasoning(&raw_payload, received_reasoning_delta)
+                {
+                    events.insert(0, Ok(fallback));
+                }
+            } else if events
+                .iter()
+                .any(|e| matches!(e, Ok(ProviderStreamEvent::ReasoningDelta(_))))
+            {
+                received_reasoning_delta = true;
+            }
+
+            stream::iter(events)
+        });
         Ok(Box::pin(mapped))
     }
 
     async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
         self.client.list_models().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_emitted_when_no_delta_received() {
+        let completed = serde_json::json!({
+            "response": {
+                "output": [
+                    { "type": "reasoning", "summary": [{ "type": "summary_text", "text": "最终思考" }] }
+                ]
+            }
+        });
+        let event = maybe_completed_reasoning(&completed, false);
+        let ok = matches!(
+            event.as_ref(),
+            Some(ProviderStreamEvent::ReasoningDelta(t)) if t == "最终思考"
+        );
+        assert!(ok, "无 delta 时应兜底: {event:?}");
+    }
+
+    #[test]
+    fn fallback_skipped_when_delta_received() {
+        // 已通过流式 delta 收到思考，completed 兜底应跳过，避免重复（关键 bug 修复）。
+        let completed = serde_json::json!({
+            "response": {
+                "output": [
+                    { "type": "reasoning", "summary": [{ "type": "summary_text", "text": "最终思考" }] }
+                ]
+            }
+        });
+        let event = maybe_completed_reasoning(&completed, true);
+        assert!(event.is_none(), "已收到 delta 时不应兜底重复: {event:?}");
+    }
+
+    #[test]
+    fn fallback_none_when_completed_has_no_reasoning() {
+        let completed = serde_json::json!({
+            "response": {
+                "output": [{ "type": "message", "content": [{ "type": "output_text", "text": "答案" }] }]
+            }
+        });
+        assert!(maybe_completed_reasoning(&completed, false).is_none());
     }
 }

--- a/crates/tiangong-llm/src/providers/openai/stream.rs
+++ b/crates/tiangong-llm/src/providers/openai/stream.rs
@@ -1,67 +1,108 @@
+//! Responses API 流式事件映射。
+//!
+//! Responses SSE 事件以 `type` 字段区分，解析为统一 `ProviderStreamEvent`。
+
 use serde_json::Value;
 
 use crate::stream::ProviderStreamEvent;
+use crate::tool::ToolCall;
 
-pub fn parse_stream_payload(
+use super::mapping::parse_usage;
+
+/// 解析单条 Responses 流式事件（已反序列化为 `Value`）。
+///
+/// 返回零到多个统一事件：文本增量、思考增量、工具调用增量、用量与结束。
+pub fn parse_stream_event(
     payload: &Value,
 ) -> Vec<Result<ProviderStreamEvent, crate::error::LlmError>> {
     let mut events = Vec::new();
-    if let Some(usage) = payload.get("usage") {
-        events.push(Ok(ProviderStreamEvent::Usage(super::mapping::parse_usage(
-            usage,
-        ))));
-    }
-    if let Some(choices) = payload.get("choices").and_then(Value::as_array) {
-        for choice in choices {
-            let delta = choice.get("delta").unwrap_or(&Value::Null);
-            if let Some(reasoning) = delta.get("reasoning_content").and_then(Value::as_str)
-                && !reasoning.is_empty()
+    let event_type = payload.get("type").and_then(Value::as_str).unwrap_or("");
+    match event_type {
+        "response.created" | "response.in_progress" => {
+            events.push(Ok(ProviderStreamEvent::MessageStart));
+        }
+        "response.output_text.delta" => {
+            if let Some(delta) = payload.get("delta").and_then(Value::as_str)
+                && !delta.is_empty()
             {
-                events.push(Ok(ProviderStreamEvent::ReasoningDelta(
-                    reasoning.to_string(),
-                )));
-            }
-            if let Some(content) = delta.get("content").and_then(Value::as_str)
-                && !content.is_empty()
-            {
-                events.push(Ok(ProviderStreamEvent::TextDelta(content.to_string())));
-            }
-            if let Some(tool_calls) = delta.get("tool_calls").and_then(Value::as_array) {
-                for tool_call in tool_calls {
-                    let id = tool_call
-                        .get("id")
-                        .and_then(Value::as_str)
-                        .filter(|s| !s.is_empty())
-                        .unwrap_or_default()
-                        .to_string();
-                    let index = tool_call
-                        .get("index")
-                        .and_then(Value::as_u64)
-                        .map(|i| i.to_string())
-                        .unwrap_or_default();
-                    if let Some(function) = tool_call.get("function") {
-                        if let Some(name) = function.get("name").and_then(Value::as_str) {
-                            events.push(Ok(ProviderStreamEvent::ToolCallStart(
-                                crate::tool::ToolCall {
-                                    id: id.clone(),
-                                    name: name.to_string(),
-                                    arguments: serde_json::json!({}),
-                                },
-                            )));
-                        }
-                        if let Some(arguments) = function.get("arguments").and_then(Value::as_str)
-                            && !arguments.is_empty()
-                        {
-                            let call_id = if !id.is_empty() { id } else { index };
-                            events.push(Ok(ProviderStreamEvent::ToolCallDelta {
-                                call_id,
-                                partial_json: arguments.to_string(),
-                            }));
-                        }
-                    }
-                }
+                events.push(Ok(ProviderStreamEvent::TextDelta(delta.to_string())));
             }
         }
+        "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
+            if let Some(delta) = payload.get("delta").and_then(Value::as_str)
+                && !delta.is_empty()
+            {
+                events.push(Ok(ProviderStreamEvent::ReasoningDelta(delta.to_string())));
+            }
+        }
+        "response.function_call_arguments.delta" => {
+            let call_id = payload
+                .get("item_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            if let Some(partial) = payload.get("delta").and_then(Value::as_str)
+                && !partial.is_empty()
+            {
+                events.push(Ok(ProviderStreamEvent::ToolCallDelta {
+                    call_id,
+                    partial_json: partial.to_string(),
+                }));
+            }
+        }
+        "response.output_item.added" => {
+            if let Some(item) = payload.get("item")
+                && item.get("type").and_then(Value::as_str) == Some("function_call")
+                && let Some(call) = parse_function_call_item(item)
+            {
+                events.push(Ok(ProviderStreamEvent::ToolCallStart(ToolCall {
+                    id: call.call_id,
+                    name: call.name,
+                    arguments: serde_json::json!({}),
+                })));
+            }
+        }
+        "response.function_call_arguments.done" => {
+            let item_id = payload
+                .get("item_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            if !item_id.is_empty() {
+                events.push(Ok(ProviderStreamEvent::ToolCallEnd { call_id: item_id }));
+            }
+        }
+        "response.completed" => {
+            if let Some(response) = payload.get("response")
+                && let Some(usage) = response.get("usage")
+            {
+                events.push(Ok(ProviderStreamEvent::Usage(parse_usage(usage))));
+            }
+            events.push(Ok(ProviderStreamEvent::MessageEnd));
+        }
+        "response.failed" | "response.incomplete" => {
+            let message = payload
+                .get("response")
+                .and_then(|r| r.get("error"))
+                .and_then(|e| e.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("Responses 请求失败")
+                .to_string();
+            events.push(Ok(ProviderStreamEvent::Error(message)));
+            events.push(Ok(ProviderStreamEvent::MessageEnd));
+        }
+        _ => {}
     }
     events
+}
+
+pub(super) struct ParsedFunctionCall {
+    pub(super) call_id: String,
+    pub(super) name: String,
+}
+
+pub(super) fn parse_function_call_item(item: &Value) -> Option<ParsedFunctionCall> {
+    let call_id = item.get("call_id").and_then(Value::as_str)?.to_string();
+    let name = item.get("name").and_then(Value::as_str)?.to_string();
+    Some(ParsedFunctionCall { call_id, name })
 }

--- a/crates/tiangong-llm/src/providers/openai/stream.rs
+++ b/crates/tiangong-llm/src/providers/openai/stream.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use crate::stream::ProviderStreamEvent;
 use crate::tool::ToolCall;
 
-use super::mapping::parse_usage;
+use super::mapping::{extract_reasoning_text, parse_usage};
 
 /// 解析单条 Responses 流式事件（已反序列化为 `Value`）。
 ///
@@ -28,11 +28,33 @@ pub fn parse_stream_event(
                 events.push(Ok(ProviderStreamEvent::TextDelta(delta.to_string())));
             }
         }
+        // 思考摘要增量（summary_text.delta 是主要事件；reasoning_text.delta 为
+        // 部分模型的完整思考文本增量）。
         "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
             if let Some(delta) = payload.get("delta").and_then(Value::as_str)
                 && !delta.is_empty()
             {
                 events.push(Ok(ProviderStreamEvent::ReasoningDelta(delta.to_string())));
+            }
+        }
+        // 部分模型通过 reasoning_summary_part 携带思考文本，part.text 为完整段落。
+        "response.reasoning_summary_part.added" | "response.reasoning_summary_part.done" => {
+            if let Some(text) = payload
+                .get("part")
+                .and_then(|p| p.get("text"))
+                .and_then(Value::as_str)
+                && !text.is_empty()
+            {
+                events.push(Ok(ProviderStreamEvent::ReasoningDelta(text.to_string())));
+            }
+        }
+        // reasoning_text.done / reasoning_summary_text.done 携带累积文本，仅在为
+        // 非空且尚未通过 delta 流出时作为兜底（多数情况下 delta 已覆盖，此处跳过）。
+        "response.reasoning_summary_text.done" | "response.reasoning_text.done" => {
+            if let Some(text) = payload.get("text").and_then(Value::as_str)
+                && !text.trim().is_empty()
+            {
+                events.push(Ok(ProviderStreamEvent::ReasoningDelta(text.to_string())));
             }
         }
         "response.function_call_arguments.delta" => {
@@ -78,6 +100,8 @@ pub fn parse_stream_event(
             {
                 events.push(Ok(ProviderStreamEvent::Usage(parse_usage(usage))));
             }
+            // 兜底解析 reasoning 由 provider 层根据"是否收到过 delta"决定，
+            // 避免此处无条件补发导致与流式增量重复。
             events.push(Ok(ProviderStreamEvent::MessageEnd));
         }
         "response.failed" | "response.incomplete" => {
@@ -91,9 +115,37 @@ pub fn parse_stream_event(
             events.push(Ok(ProviderStreamEvent::Error(message)));
             events.push(Ok(ProviderStreamEvent::MessageEnd));
         }
+        // P2：未处理的 reasoning 事件打 debug 日志，便于确认服务端实际返回结构。
+        _ if event_type.contains("reasoning") => {
+            tracing::debug!(event_type, payload = %payload, "未处理的 Responses reasoning 事件");
+        }
         _ => {}
     }
     events
+}
+
+/// 从 `response.completed` 事件的 payload 中提取最终 reasoning 文本。
+///
+/// 由 provider 层在有状态 stream mapper 中调用：仅当本次流式过程中
+/// **未收到任何 reasoning delta** 时，才用此兜底补发思考内容，避免与
+/// 流式增量重复。
+pub(super) fn extract_completed_reasoning(payload: &Value) -> Option<String> {
+    let response = payload.get("response")?;
+    let output = response.get("output").and_then(Value::as_array)?;
+    let mut parts = Vec::new();
+    for item in output {
+        if item.get("type").and_then(Value::as_str) == Some("reasoning") {
+            let text = extract_reasoning_text(item);
+            if !text.trim().is_empty() {
+                parts.push(text);
+            }
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n"))
+    }
 }
 
 pub(super) struct ParsedFunctionCall {
@@ -105,4 +157,131 @@ pub(super) fn parse_function_call_item(item: &Value) -> Option<ParsedFunctionCal
     let call_id = item.get("call_id").and_then(Value::as_str)?.to_string();
     let name = item.get("name").and_then(Value::as_str)?.to_string();
     Some(ParsedFunctionCall { call_id, name })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stream::ProviderStreamEvent;
+    use serde_json::json;
+
+    fn reasoning_delta(text: &str) -> bool {
+        matches!(text, "思考中")
+    }
+
+    #[test]
+    fn parses_reasoning_summary_delta() {
+        let payload = json!({
+            "type": "response.reasoning_summary_text.delta",
+            "delta": "思考中"
+        });
+        let events = parse_stream_event(&payload);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Ok(ProviderStreamEvent::ReasoningDelta(text)) => assert!(reasoning_delta(text)),
+            other => panic!("expected reasoning delta, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_reasoning_summary_part() {
+        // reasoning_summary_part.added 通过 part.text 携带思考段落。
+        let payload = json!({
+            "type": "response.reasoning_summary_part.added",
+            "part": { "type": "summary_text", "text": "思考中" }
+        });
+        let events = parse_stream_event(&payload);
+        match &events[0] {
+            Ok(ProviderStreamEvent::ReasoningDelta(text)) => assert!(reasoning_delta(text)),
+            other => panic!("expected reasoning delta, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn completed_event_emits_usage_and_end_only() {
+        // completed 事件本身只发 usage + end，reasoning 兜底由 provider 层根据
+        // 是否收到过 delta 决定（调用 extract_completed_reasoning）。
+        let payload = json!({
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "reasoning",
+                        "summary": [{ "type": "summary_text", "text": "最终思考" }]
+                    },
+                    {
+                        "type": "message",
+                        "content": [{ "type": "output_text", "text": "答案" }]
+                    }
+                ],
+                "usage": { "input_tokens": 1, "output_tokens": 1, "total_tokens": 2 }
+            }
+        });
+        let events = parse_stream_event(&payload);
+        // completed 事件不应自动输出 reasoning（避免与流式增量重复）。
+        let no_reasoning = !events
+            .iter()
+            .any(|e| matches!(e, Ok(ProviderStreamEvent::ReasoningDelta(_))));
+        assert!(
+            no_reasoning,
+            "completed 事件不应自动输出 reasoning: {events:?}"
+        );
+        let has_usage = events
+            .iter()
+            .any(|e| matches!(e, Ok(ProviderStreamEvent::Usage(_))));
+        assert!(has_usage);
+        let has_end = events
+            .iter()
+            .any(|e| matches!(e, Ok(ProviderStreamEvent::MessageEnd)));
+        assert!(has_end);
+    }
+
+    #[test]
+    fn extract_completed_reasoning_collects_summary() {
+        let payload = json!({
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "reasoning",
+                        "summary": [{ "type": "summary_text", "text": "最终思考" }]
+                    }
+                ]
+            }
+        });
+        let reasoning = extract_completed_reasoning(&payload).unwrap();
+        assert_eq!(reasoning, "最终思考");
+    }
+
+    #[test]
+    fn extract_completed_reasoning_returns_none_when_no_reasoning() {
+        let payload = json!({
+            "type": "response.completed",
+            "response": {
+                "output": [{ "type": "message", "content": [{ "type": "output_text", "text": "答案" }] }]
+            }
+        });
+        assert!(extract_completed_reasoning(&payload).is_none());
+    }
+
+    #[test]
+    fn completed_without_reasoning_emits_only_usage_and_end() {
+        let payload = json!({
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{ "type": "output_text", "text": "答案" }]
+                    }
+                ],
+                "usage": { "input_tokens": 1, "output_tokens": 1, "total_tokens": 2 }
+            }
+        });
+        let events = parse_stream_event(&payload);
+        let no_reasoning = !events
+            .iter()
+            .any(|e| matches!(e, Ok(ProviderStreamEvent::ReasoningDelta(_))));
+        assert!(no_reasoning, "无 reasoning item 时不应输出 reasoning");
+    }
 }

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/client.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/client.rs
@@ -1,0 +1,341 @@
+use std::time::Duration;
+
+use anyhow::Context;
+use futures_util::Stream;
+use serde_json::{Value, json};
+use tokio::time::timeout;
+
+use crate::error::LlmError;
+use crate::model::ProviderModelInfo;
+use crate::rerank::RerankRequest;
+
+use super::config::OpenAiChatConfig;
+use super::error::{is_retryable_openai_error, map_openai_error};
+use super::mapping::normalize_api_base;
+
+type OpenAiByotStream =
+    std::pin::Pin<Box<dyn Stream<Item = Result<Value, async_openai::error::OpenAIError>> + Send>>;
+
+const MAX_RETRIES: u32 = 3;
+const INITIAL_RETRY_DELAY_MS: u64 = 1000;
+
+#[derive(Clone)]
+pub struct OpenAiClient {
+    config: OpenAiChatConfig,
+}
+
+impl OpenAiClient {
+    pub fn new(config: OpenAiChatConfig) -> Self {
+        Self { config }
+    }
+
+    pub async fn complete(&self, model: &str, payload: Value) -> Result<Value, LlmError> {
+        let client = self.build_client();
+        let chat = client.chat();
+        timeout(
+            self.config.timeout,
+            self.with_retry("openai_complete", model, false, || {
+                chat.create_byot::<_, Value>(payload.clone())
+            }),
+        )
+        .await
+        .map_err(|_| LlmError::Timeout(self.config.timeout.as_millis() as u64))?
+    }
+
+    pub async fn stream(&self, model: &str, payload: Value) -> Result<OpenAiByotStream, LlmError> {
+        let client = self.build_client();
+        let chat = client.chat();
+        self.with_retry("openai_stream", model, true, || {
+            chat.create_stream_byot::<_, Value>(payload.clone())
+        })
+        .await
+    }
+
+    pub async fn rerank(&self, model: &str, request: &RerankRequest) -> Result<Value, LlmError> {
+        if request.documents.is_empty() {
+            return Ok(json!({ "results": [] }));
+        }
+
+        let base = normalize_rerank_api_base(&self.config.base_url)
+            .map_err(|err| LlmError::Configuration(err.to_string()))?;
+        let url = format!("{base}/rerank");
+        let payload = json!({
+            "model": model,
+            "query": &request.query,
+            "documents": &request.documents,
+            "top_n": request.top_n.max(1).min(request.documents.len()),
+        });
+        let client = reqwest::Client::builder()
+            .timeout(self.config.timeout)
+            .build()
+            .map_err(|err| LlmError::Transport(err.to_string()))?;
+
+        let mut req = client.post(&url).json(&payload);
+        if !self.config.api_key.trim().is_empty() {
+            req = req.bearer_auth(&self.config.api_key);
+        }
+
+        let start = std::time::Instant::now();
+        tracing::info!(
+            operation = "openai_rerank",
+            provider = "openai",
+            model,
+            stream = false,
+            attempt = 0,
+            "开始 OpenAI 兼容请求"
+        );
+        let response = req
+            .send()
+            .await
+            .with_context(|| format!("Rerank 请求失败：{url}"))
+            .map_err(|err| LlmError::Transport(err.to_string()))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            tracing::warn!(
+                operation = "openai_rerank",
+                provider = "openai",
+                model,
+                stream = false,
+                attempt = 0,
+                latency_ms = start.elapsed().as_millis() as u64,
+                status = status.as_u16(),
+                "OpenAI 兼容请求失败"
+            );
+            return Err(LlmError::Provider {
+                provider: "openai",
+                message: format!("Rerank API 返回错误 {status}: {body}"),
+            });
+        }
+
+        let body = response
+            .json::<Value>()
+            .await
+            .map_err(|err| LlmError::Serialization(err.to_string()))?;
+        tracing::info!(
+            operation = "openai_rerank",
+            provider = "openai",
+            model,
+            stream = false,
+            attempt = 0,
+            latency_ms = start.elapsed().as_millis() as u64,
+            "OpenAI 兼容请求完成"
+        );
+        Ok(body)
+    }
+
+    pub async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
+        list_models_via_config(
+            &self.config.api_key,
+            &self.config.base_url,
+            self.config.timeout,
+            "openai",
+        )
+        .await
+    }
+
+    fn build_client(&self) -> async_openai::Client<async_openai::config::OpenAIConfig> {
+        let config = async_openai::config::OpenAIConfig::new()
+            .with_api_key(self.config.api_key.clone())
+            .with_api_base(
+                normalize_api_base(&self.config.base_url)
+                    .unwrap_or_else(|_| self.config.base_url.clone()),
+            );
+        async_openai::Client::with_config(config)
+    }
+
+    async fn with_retry<F, Fut, T>(
+        &self,
+        operation: &'static str,
+        model: &str,
+        stream: bool,
+        mut f: F,
+    ) -> Result<T, LlmError>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<T, async_openai::error::OpenAIError>>,
+    {
+        let mut attempt = 0u32;
+        let mut delay_ms = INITIAL_RETRY_DELAY_MS;
+        let max_retries = self.config.max_retries.max(MAX_RETRIES);
+        loop {
+            let start = std::time::Instant::now();
+            tracing::info!(
+                operation,
+                provider = "openai",
+                model,
+                stream,
+                attempt,
+                "开始 OpenAI 兼容请求"
+            );
+            match f().await {
+                Ok(value) => {
+                    tracing::info!(
+                        operation,
+                        provider = "openai",
+                        model,
+                        stream,
+                        attempt,
+                        latency_ms = start.elapsed().as_millis() as u64,
+                        "OpenAI 兼容请求完成"
+                    );
+                    return Ok(value);
+                }
+                Err(err) if attempt < max_retries && is_retryable_openai_error(&err) => {
+                    attempt += 1;
+                    if let Some(notifier) = &self.config.retry_notifier {
+                        notifier(attempt, max_retries, delay_ms, &err.to_string());
+                    }
+                    tracing::warn!(
+                        operation,
+                        provider = "openai",
+                        model,
+                        stream,
+                        attempt,
+                        delay_ms,
+                        error = %err,
+                        "OpenAI 兼容请求失败，准备重试"
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                    delay_ms *= 2;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        operation,
+                        provider = "openai",
+                        model,
+                        stream,
+                        attempt,
+                        latency_ms = start.elapsed().as_millis() as u64,
+                        error = %err,
+                        "OpenAI 兼容请求失败"
+                    );
+                    return Err(map_openai_error(&err));
+                }
+            }
+        }
+    }
+}
+
+/// 通过 `/models` 端点拉取模型列表。
+///
+/// OpenAI Chat Completions 与 Responses 共用此端点，故抽为 crate 内公共函数。
+pub(crate) async fn list_models_via_config(
+    api_key: &str,
+    base_url: &str,
+    timeout: Duration,
+    provider_label: &'static str,
+) -> Result<Vec<ProviderModelInfo>, LlmError> {
+    let operation = "openai_list_models";
+    let start = std::time::Instant::now();
+    tracing::info!(
+        operation,
+        provider = provider_label,
+        model = "<list_models>",
+        stream = false,
+        attempt = 0,
+        "开始 OpenAI 兼容请求"
+    );
+    let base =
+        normalize_api_base(base_url).map_err(|err| LlmError::Configuration(err.to_string()))?;
+    let url = format!("{base}/models");
+    let client = reqwest::Client::builder()
+        .timeout(timeout)
+        .build()
+        .map_err(|err| LlmError::Transport(err.to_string()))?;
+    let response = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+        .with_context(|| format!("请求模型列表失败：{url}"))
+        .map_err(|err| LlmError::Transport(err.to_string()))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        tracing::warn!(
+            operation,
+            provider = provider_label,
+            model = "<list_models>",
+            stream = false,
+            attempt = 0,
+            latency_ms = start.elapsed().as_millis() as u64,
+            status = status.as_u16(),
+            "OpenAI 兼容请求失败"
+        );
+        let message = format!("获取模型列表失败：HTTP {status}，响应：{body}");
+        if status.as_u16() == 429
+            || status.as_u16() == 529
+            || body.to_ascii_lowercase().contains("rate limit")
+            || body.to_ascii_lowercase().contains("too many requests")
+            || body.to_ascii_lowercase().contains("overloaded_error")
+        {
+            return Err(LlmError::RateLimited(message));
+        }
+        return Err(LlmError::Provider {
+            provider: provider_label,
+            message,
+        });
+    }
+    #[derive(serde::Deserialize)]
+    struct ModelEntry {
+        id: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct ModelsResponse {
+        data: Vec<ModelEntry>,
+    }
+    let body = response
+        .text()
+        .await
+        .map_err(|err| LlmError::Transport(err.to_string()))?;
+    let parsed: ModelsResponse = serde_json::from_str(&body).map_err(|err| LlmError::Provider {
+        provider: provider_label,
+        message: format!("failed to deserialize api response: {err}: {body}"),
+    })?;
+    tracing::info!(
+        operation,
+        provider = provider_label,
+        model = "<list_models>",
+        stream = false,
+        attempt = 0,
+        latency_ms = start.elapsed().as_millis() as u64,
+        "OpenAI 兼容请求完成"
+    );
+    Ok(parsed
+        .data
+        .into_iter()
+        .map(|entry| ProviderModelInfo {
+            id: entry.id,
+            display_name: None,
+        })
+        .collect())
+}
+
+fn normalize_rerank_api_base(base_url: &str) -> anyhow::Result<String> {
+    let base = normalize_api_base(base_url)?;
+    let cleaned = base.trim_end_matches('/');
+    let cleaned = cleaned.strip_suffix("/rerank").unwrap_or(cleaned);
+    Ok(cleaned.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_rerank_api_base;
+
+    #[test]
+    fn normalizes_openai_compatible_rerank_api_base() {
+        assert_eq!(
+            normalize_rerank_api_base("http://127.0.0.1:8000/v1").unwrap(),
+            "http://127.0.0.1:8000/v1"
+        );
+        assert_eq!(
+            normalize_rerank_api_base("http://127.0.0.1:8000/v1/rerank").unwrap(),
+            "http://127.0.0.1:8000/v1"
+        );
+        assert_eq!(
+            normalize_rerank_api_base("http://127.0.0.1:8000/rerank").unwrap(),
+            "http://127.0.0.1:8000"
+        );
+    }
+}

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/config.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/config.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-/// 重试通知回调。
 pub type RetryNotifier = Arc<dyn Fn(u32, u32, u64, &str) + Send + Sync>;
 
-/// OpenAI Responses provider 配置。
 #[derive(Clone)]
-pub struct OpenAiResponsesConfig {
+pub struct OpenAiChatConfig {
     pub api_key: String,
     pub base_url: String,
     pub timeout: Duration,
@@ -14,7 +12,7 @@ pub struct OpenAiResponsesConfig {
     pub retry_notifier: Option<RetryNotifier>,
 }
 
-impl OpenAiResponsesConfig {
+impl OpenAiChatConfig {
     pub fn new(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
         Self {
             api_key: api_key.into(),
@@ -26,9 +24,9 @@ impl OpenAiResponsesConfig {
     }
 }
 
-impl std::fmt::Debug for OpenAiResponsesConfig {
+impl std::fmt::Debug for OpenAiChatConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpenAiResponsesConfig")
+        f.debug_struct("OpenAiChatConfig")
             .field("api_key", &(!self.api_key.is_empty()))
             .field("base_url", &self.base_url)
             .field("timeout", &self.timeout)

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/error.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/error.rs
@@ -1,0 +1,38 @@
+use crate::error::LlmError;
+
+pub fn map_openai_error(error: &async_openai::error::OpenAIError) -> LlmError {
+    let text = error.to_string();
+    if text.contains("401") {
+        return LlmError::Authentication(text);
+    }
+    if is_rate_limited_text(&text) {
+        return LlmError::RateLimited(text);
+    }
+    if text.contains("400") {
+        return LlmError::InvalidRequest(text);
+    }
+    if text.contains("timeout") {
+        return LlmError::Timeout(0);
+    }
+    LlmError::Transport(text)
+}
+
+pub fn is_retryable_openai_error(err: &async_openai::error::OpenAIError) -> bool {
+    let text = err.to_string();
+    is_rate_limited_text(&text)
+        || text.contains("500 Internal Server Error")
+        || text.contains("502 Bad Gateway")
+        || text.contains("503 Service Unavailable")
+        || text.contains("504 Gateway Timeout")
+        || text.contains("connection reset")
+        || text.contains("connection refused")
+}
+
+fn is_rate_limited_text(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    text.contains("429")
+        || text.contains("529")
+        || lower.contains("rate limit")
+        || lower.contains("too many requests")
+        || lower.contains("overloaded_error")
+}

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/mapping.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/mapping.rs
@@ -1,0 +1,426 @@
+use anyhow::{Context, Result, anyhow};
+use async_openai::types::chat::{
+    ChatCompletionMessageToolCall, ChatCompletionMessageToolCalls,
+    ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
+    ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestToolMessage,
+    ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs, FunctionCall,
+};
+use serde_json::{Value, json};
+
+use crate::message::{ChatMessage, MessageContent, MessageRole};
+use crate::request::{ProviderRequest, ReasoningEffort};
+use crate::response::{ProviderResponse, StopReason};
+use crate::tool::{ToolChoice, ToolSpec};
+use crate::usage::TokenUsageData;
+
+pub fn normalize_api_base(base_url: &str) -> Result<String> {
+    let trimmed = base_url.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("API_BASE_URL 不能为空"));
+    }
+    let cleaned = trimmed.trim_end_matches('/');
+    let cleaned = cleaned.strip_suffix("/chat/completions").unwrap_or(cleaned);
+    Ok(cleaned.to_string())
+}
+
+pub fn build_request_json(req: &ProviderRequest, stream: bool) -> Result<Value> {
+    let messages = build_openai_messages(req)?;
+    let mut request_args_binding = CreateChatCompletionRequestArgs::default();
+    let mut request_args = request_args_binding
+        .model(req.model.clone())
+        .messages(messages)
+        .stream(stream);
+    if let Some(temperature) = req.temperature {
+        request_args = request_args.temperature(temperature);
+    }
+    let request = request_args.build().context("构建 OpenAI 请求失败")?;
+
+    let mut payload = serde_json::to_value(request).context("序列化 OpenAI 请求失败")?;
+    inject_max_tokens_config(&mut payload, req.max_tokens);
+    if stream {
+        inject_stream_usage_option(&mut payload);
+    }
+    if let Some(temperature) = req.temperature {
+        inject_temperature_config(&mut payload, temperature)?;
+    }
+    if !req.tools.is_empty() {
+        inject_function_tools(&mut payload, &req.tools, req.tool_choice.as_ref());
+    }
+    if let Some(effort) = &req.reasoning_effort {
+        inject_reasoning_effort(&mut payload, effort);
+    }
+    if req.thinking_disabled {
+        inject_thinking_disabled(&mut payload);
+    } else if let Some(thinking) = &req.thinking {
+        inject_thinking_enabled(&mut payload, thinking.budget_tokens);
+    }
+    Ok(payload)
+}
+
+fn build_openai_messages(req: &ProviderRequest) -> Result<Vec<ChatCompletionRequestMessage>> {
+    let mut messages = Vec::new();
+    if let Some(system) = req.system.as_ref().filter(|value| !value.trim().is_empty()) {
+        messages.push(
+            ChatCompletionRequestSystemMessageArgs::default()
+                .content(system.clone())
+                .build()
+                .context("构建 system 消息失败")?
+                .into(),
+        );
+    }
+
+    for message in &req.messages {
+        match message.role {
+            MessageRole::System => {}
+            MessageRole::User => {
+                if let Some(message) = build_openai_user_message(message)? {
+                    messages.push(message);
+                }
+            }
+            MessageRole::Tool => {
+                for result in message.content.iter().filter_map(|content| match content {
+                    MessageContent::ToolResult(result) => Some(result),
+                    _ => None,
+                }) {
+                    let content = match &result.content {
+                        crate::tool::ToolResultContent::Text(text) => text.clone(),
+                        crate::tool::ToolResultContent::Json(value) => value.to_string(),
+                    };
+                    messages.push(ChatCompletionRequestMessage::Tool(
+                        ChatCompletionRequestToolMessage {
+                            content: content.into(),
+                            tool_call_id: result.tool_call_id.clone(),
+                        },
+                    ));
+                }
+            }
+            MessageRole::Assistant => {
+                let text = extract_message_text(message);
+                let tool_calls = message
+                    .content
+                    .iter()
+                    .filter_map(|content| match content {
+                        MessageContent::ToolCall(tool_call) => {
+                            Some(ChatCompletionMessageToolCalls::Function(
+                                ChatCompletionMessageToolCall {
+                                    id: tool_call.id.clone(),
+                                    function: FunctionCall {
+                                        name: tool_call.name.clone(),
+                                        arguments: tool_call.arguments.to_string(),
+                                    },
+                                },
+                            ))
+                        }
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                if !text.is_empty() || !tool_calls.is_empty() {
+                    let mut args = ChatCompletionRequestAssistantMessageArgs::default();
+                    if !text.is_empty() {
+                        args.content(text);
+                    }
+                    if !tool_calls.is_empty() {
+                        args.tool_calls(tool_calls);
+                    }
+                    messages.push(args.build().context("构建 assistant 消息失败")?.into());
+                }
+            }
+        }
+    }
+
+    Ok(messages)
+}
+
+fn build_openai_user_message(
+    message: &ChatMessage,
+) -> Result<Option<ChatCompletionRequestMessage>> {
+    let images = message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            MessageContent::Image(image) => Some(image),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let text = extract_message_text(message);
+    if images.is_empty() {
+        if text.is_empty() {
+            return Ok(None);
+        }
+        return Ok(Some(
+            ChatCompletionRequestUserMessageArgs::default()
+                .content(text)
+                .build()
+                .context("构建 user 消息失败")?
+                .into(),
+        ));
+    }
+
+    let mut content = Vec::new();
+    if !text.is_empty() {
+        content.push(json!({ "type": "text", "text": text }));
+    }
+    for image in images {
+        content.push(json!({
+            "type": "image_url",
+            "image_url": { "url": image.data }
+        }));
+    }
+    Ok(Some(
+        serde_json::from_value(json!({
+            "role": "user",
+            "content": content
+        }))
+        .context("构建 OpenAI 多模态 user 消息失败")?,
+    ))
+}
+
+fn extract_message_text(message: &ChatMessage) -> String {
+    message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            MessageContent::Text(text) => Some(text.clone()),
+            MessageContent::ToolResult(result) => Some(match &result.content {
+                crate::tool::ToolResultContent::Text(text) => text.clone(),
+                crate::tool::ToolResultContent::Json(value) => value.to_string(),
+            }),
+            MessageContent::File(file) => Some(format!(
+                "<attachment title=\"{}\" mime_type=\"{}\">\n{}\n</attachment>",
+                file.title.as_deref().unwrap_or("attachment"),
+                file.mime_type,
+                file.data
+            )),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn parse_complete_response(payload: &Value) -> Result<ProviderResponse> {
+    let choice = payload
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|choices| choices.first())
+        .ok_or_else(|| anyhow!("OpenAI 响应缺少 choices"))?;
+
+    let text = choice
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let reasoning_content = choice
+        .get("message")
+        .and_then(|message| message.get("reasoning_content"))
+        .and_then(Value::as_str)
+        .map(|value| value.to_string());
+
+    let tool_calls = choice
+        .get("message")
+        .and_then(|message| message.get("tool_calls"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut content = Vec::new();
+    if !text.trim().is_empty() {
+        content.push(MessageContent::Text(strip_think_tags(text.trim())));
+    }
+    for tool_call in tool_calls {
+        let id = tool_call
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let name = tool_call
+            .get("function")
+            .and_then(|v| v.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let arguments = tool_call
+            .get("function")
+            .and_then(|v| v.get("arguments"))
+            .and_then(Value::as_str)
+            .and_then(|raw| serde_json::from_str(raw).ok())
+            .unwrap_or_else(|| json!({}));
+        if !name.is_empty() {
+            content.push(MessageContent::ToolCall(crate::tool::ToolCall {
+                id: id.to_string(),
+                name: name.to_string(),
+                arguments,
+            }));
+        }
+    }
+
+    let usage = payload.get("usage").map(parse_usage);
+
+    Ok(ProviderResponse {
+        id: payload
+            .get("id")
+            .and_then(Value::as_str)
+            .map(|v| v.to_string()),
+        model: payload
+            .get("model")
+            .and_then(Value::as_str)
+            .map(|v| v.to_string()),
+        assistant_message: ChatMessage {
+            role: MessageRole::Assistant,
+            content,
+        },
+        reasoning_content,
+        stop_reason: choice
+            .get("finish_reason")
+            .and_then(Value::as_str)
+            .map(map_stop_reason),
+        usage,
+        raw: Some(payload.clone()),
+    })
+}
+
+fn map_stop_reason(reason: &str) -> StopReason {
+    match reason {
+        "stop" => StopReason::EndTurn,
+        "tool_calls" => StopReason::ToolUse,
+        "length" => StopReason::MaxTokens,
+        other => StopReason::Other(other.to_string()),
+    }
+}
+
+pub fn parse_usage(usage: &Value) -> TokenUsageData {
+    let prompt = usage
+        .get("prompt_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let completion = usage
+        .get("completion_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let total = usage
+        .get("total_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or((prompt + completion) as u64) as usize;
+    TokenUsageData {
+        prompt_tokens: prompt,
+        completion_tokens: completion,
+        total_tokens: total,
+        prompt_cache_hit_tokens: None,
+        prompt_cache_miss_tokens: None,
+    }
+}
+
+fn inject_stream_usage_option(payload: &mut Value) {
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    obj.insert("stream_options".to_string(), json!({"include_usage": true}));
+}
+
+fn inject_max_tokens_config(payload: &mut Value, max_tokens: u32) {
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    obj.insert("max_tokens".to_string(), json!(max_tokens));
+}
+
+fn inject_temperature_config(payload: &mut Value, temperature: f32) -> Result<()> {
+    let Some(obj) = payload.as_object_mut() else {
+        return Ok(());
+    };
+    let number = serde_json::Number::from_f64(temperature as f64)
+        .ok_or_else(|| anyhow!("temperature 无效"))?;
+    obj.insert("temperature".to_string(), Value::Number(number));
+    Ok(())
+}
+
+fn inject_function_tools(
+    payload: &mut Value,
+    functions: &[ToolSpec],
+    tool_choice: Option<&ToolChoice>,
+) {
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    let tools = functions
+        .iter()
+        .map(|spec| {
+            json!({
+                "type": "function",
+                "function": {
+                    "name": spec.name,
+                    "description": spec.description,
+                    "parameters": spec.input_schema,
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    obj.insert("tools".to_string(), Value::Array(tools));
+    match tool_choice {
+        Some(ToolChoice::Any) => {
+            obj.insert(
+                "tool_choice".to_string(),
+                Value::String("required".to_string()),
+            );
+        }
+        Some(ToolChoice::Tool(name)) => {
+            obj.insert(
+                "tool_choice".to_string(),
+                json!({
+                    "type": "function",
+                    "function": { "name": name },
+                }),
+            );
+        }
+        // 兼容 vLLM / 部分 OpenAI-compatible 后端：
+        // 显式 `tool_choice: "auto"` 可能要求服务端开启
+        // --enable-auto-tool-choice 和 --tool-call-parser。
+        // 省略该字段时，OpenAI Chat Completions 语义仍会在提供 tools 后
+        // 使用默认自动选择策略，且不会触发这些后端的 400。
+        Some(ToolChoice::Auto) => {}
+        None => {}
+    }
+}
+
+fn inject_reasoning_effort(payload: &mut Value, effort: &ReasoningEffort) {
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    let effort_str = match effort {
+        ReasoningEffort::Low => "low",
+        ReasoningEffort::Medium => "medium",
+        ReasoningEffort::High => "high",
+        ReasoningEffort::Max => "max",
+    };
+    obj.insert("reasoning_effort".to_string(), json!(effort_str));
+}
+
+fn inject_thinking_disabled(payload: &mut Value) {
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    obj.insert("thinking".to_string(), json!({"type": "disabled"}));
+}
+
+fn inject_thinking_enabled(payload: &mut Value, budget_tokens: u32) {
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    obj.insert(
+        "thinking".to_string(),
+        json!({"type": "enabled", "budget_tokens": budget_tokens}),
+    );
+}
+
+pub fn strip_think_tags(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut remaining = text;
+    while let Some(start) = remaining.find("<think>") {
+        result.push_str(&remaining[..start]);
+        if let Some(end) = remaining[start..].find("</think>") {
+            remaining = &remaining[start + end + 8..];
+        } else {
+            return result;
+        }
+    }
+    result.push_str(remaining);
+    result
+}

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/mod.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/mod.rs
@@ -1,0 +1,9 @@
+pub(crate) mod client;
+mod config;
+pub(crate) mod error;
+pub(crate) mod mapping;
+mod provider;
+mod stream;
+
+pub use config::OpenAiChatConfig;
+pub use provider::{OpenAiChatCompletionsProvider, OpenAiChatRerankProvider};

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/provider.rs
@@ -1,0 +1,120 @@
+use async_trait::async_trait;
+use futures_util::{StreamExt, stream};
+use serde::Deserialize;
+
+use crate::error::LlmError;
+use crate::model::ProviderModelInfo;
+use crate::provider::{LlmProvider, ProviderCapabilities};
+use crate::request::ProviderRequest;
+use crate::rerank::{RerankProvider, RerankRequest, RerankResponse, RerankResult};
+use crate::response::ProviderResponse;
+use crate::stream::ProviderStream;
+
+use super::client::OpenAiClient;
+use super::config::OpenAiChatConfig;
+use super::error::map_openai_error;
+use super::mapping::{build_request_json, parse_complete_response};
+
+#[derive(Clone)]
+pub struct OpenAiChatCompletionsProvider {
+    client: OpenAiClient,
+}
+
+#[derive(Clone)]
+pub struct OpenAiChatRerankProvider {
+    client: OpenAiClient,
+    model: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiRerankResponse {
+    #[serde(default)]
+    results: Vec<OpenAiRerankResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiRerankResult {
+    index: usize,
+    #[serde(alias = "score")]
+    relevance_score: f64,
+}
+
+impl OpenAiChatCompletionsProvider {
+    pub fn new(config: OpenAiChatConfig) -> Self {
+        Self {
+            client: OpenAiClient::new(config),
+        }
+    }
+}
+
+impl OpenAiChatRerankProvider {
+    pub fn new(config: OpenAiChatConfig, model: impl Into<String>) -> Self {
+        Self {
+            client: OpenAiClient::new(config),
+            model: model.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenAiChatCompletionsProvider {
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            streaming: true,
+            tool_calling: true,
+            system_prompt: true,
+            list_models: true,
+        }
+    }
+
+    async fn complete(&self, req: ProviderRequest) -> Result<ProviderResponse, LlmError> {
+        let model = req.model.clone();
+        let payload = build_request_json(&req, false)
+            .map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
+        let response = self.client.complete(&model, payload).await?;
+        parse_complete_response(&response).map_err(|err| LlmError::Provider {
+            provider: "openai",
+            message: err.to_string(),
+        })
+    }
+
+    async fn stream(&self, req: ProviderRequest) -> Result<ProviderStream, LlmError> {
+        let model = req.model.clone();
+        let payload = build_request_json(&req, true)
+            .map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
+        let stream = self.client.stream(&model, payload).await?;
+        let mapped = stream
+            .map(|item| match item {
+                Ok(payload) => super::stream::parse_stream_payload(&payload),
+                Err(err) => vec![Err(map_openai_error(&err))],
+            })
+            .flat_map(stream::iter);
+        Ok(Box::pin(mapped))
+    }
+
+    async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
+        self.client.list_models().await
+    }
+}
+
+#[async_trait]
+impl RerankProvider for OpenAiChatRerankProvider {
+    async fn rerank(&self, request: RerankRequest) -> anyhow::Result<RerankResponse> {
+        let response = self.client.rerank(&self.model, &request).await?;
+        let parsed: OpenAiRerankResponse = serde_json::from_value(response)?;
+        Ok(RerankResponse {
+            results: parsed
+                .results
+                .into_iter()
+                .map(|item| RerankResult {
+                    index: item.index,
+                    relevance_score: item.relevance_score,
+                })
+                .collect(),
+        })
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+}

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/stream.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/stream.rs
@@ -1,0 +1,67 @@
+use serde_json::Value;
+
+use crate::stream::ProviderStreamEvent;
+
+pub fn parse_stream_payload(
+    payload: &Value,
+) -> Vec<Result<ProviderStreamEvent, crate::error::LlmError>> {
+    let mut events = Vec::new();
+    if let Some(usage) = payload.get("usage") {
+        events.push(Ok(ProviderStreamEvent::Usage(super::mapping::parse_usage(
+            usage,
+        ))));
+    }
+    if let Some(choices) = payload.get("choices").and_then(Value::as_array) {
+        for choice in choices {
+            let delta = choice.get("delta").unwrap_or(&Value::Null);
+            if let Some(reasoning) = delta.get("reasoning_content").and_then(Value::as_str)
+                && !reasoning.is_empty()
+            {
+                events.push(Ok(ProviderStreamEvent::ReasoningDelta(
+                    reasoning.to_string(),
+                )));
+            }
+            if let Some(content) = delta.get("content").and_then(Value::as_str)
+                && !content.is_empty()
+            {
+                events.push(Ok(ProviderStreamEvent::TextDelta(content.to_string())));
+            }
+            if let Some(tool_calls) = delta.get("tool_calls").and_then(Value::as_array) {
+                for tool_call in tool_calls {
+                    let id = tool_call
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_default()
+                        .to_string();
+                    let index = tool_call
+                        .get("index")
+                        .and_then(Value::as_u64)
+                        .map(|i| i.to_string())
+                        .unwrap_or_default();
+                    if let Some(function) = tool_call.get("function") {
+                        if let Some(name) = function.get("name").and_then(Value::as_str) {
+                            events.push(Ok(ProviderStreamEvent::ToolCallStart(
+                                crate::tool::ToolCall {
+                                    id: id.clone(),
+                                    name: name.to_string(),
+                                    arguments: serde_json::json!({}),
+                                },
+                            )));
+                        }
+                        if let Some(arguments) = function.get("arguments").and_then(Value::as_str)
+                            && !arguments.is_empty()
+                        {
+                            let call_id = if !id.is_empty() { id } else { index };
+                            events.push(Ok(ProviderStreamEvent::ToolCallDelta {
+                                call_id,
+                                partial_json: arguments.to_string(),
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    events
+}

--- a/crates/tiangong-llm/src/text.rs
+++ b/crates/tiangong-llm/src/text.rs
@@ -11,7 +11,8 @@ use crate::model::ProviderProtocol;
 use crate::provider::LlmProvider;
 use crate::providers::anthropic::{AnthropicConfig, AnthropicProvider};
 use crate::providers::deepseek::{DeepSeekConfig, DeepSeekProvider};
-use crate::providers::openai::{OpenAiCompatibleConfig, OpenAiCompatibleProvider};
+use crate::providers::openai::{OpenAiResponsesConfig, OpenAiResponsesProvider};
+use crate::providers::openai_chatcompletions::{OpenAiChatCompletionsProvider, OpenAiChatConfig};
 use crate::request::ProviderRequest;
 
 #[derive(Debug, Clone)]
@@ -90,12 +91,22 @@ pub async fn complete_text_with_usage(
 
 fn build_provider(config: &LlmEndpointConfig) -> Result<Box<dyn LlmProvider>, LlmError> {
     match config.protocol {
-        ProviderProtocol::OpenAiCompatible => {
+        ProviderProtocol::OpenAi => {
             let mut provider_config =
-                OpenAiCompatibleConfig::new(config.api_key.clone(), config.base_url.clone());
+                OpenAiResponsesConfig::new(config.api_key.clone(), config.base_url.clone());
             provider_config.timeout = config.timeout;
             provider_config.max_retries = config.max_retries;
-            Ok(Box::new(OpenAiCompatibleProvider::new(provider_config)))
+            Ok(Box::new(OpenAiResponsesProvider::new(provider_config)))
+        }
+        // Chat Completions（含旧 openai_compatible 别名）。
+        ProviderProtocol::OpenAiChatCompletions => {
+            let mut provider_config =
+                OpenAiChatConfig::new(config.api_key.clone(), config.base_url.clone());
+            provider_config.timeout = config.timeout;
+            provider_config.max_retries = config.max_retries;
+            Ok(Box::new(OpenAiChatCompletionsProvider::new(
+                provider_config,
+            )))
         }
         ProviderProtocol::Anthropic => {
             let mut provider_config = AnthropicConfig::new(config.api_key.clone());

--- a/crates/tiangong-memory/examples/memory_llm_smoke.rs
+++ b/crates/tiangong-memory/examples/memory_llm_smoke.rs
@@ -165,7 +165,7 @@ fn print_sample_config() -> Result<()> {
             base_url: "https://api.example.com/v1".to_string(),
             api_key: "${MEMORY_LLM_API_KEY}".to_string(),
             model: "memory-model-name".to_string(),
-            protocol: ProviderProtocol::OpenAiCompatible,
+            protocol: ProviderProtocol::OpenAiChatCompletions,
             timeout_ms: 60_000,
         }),
         ..Default::default()

--- a/crates/tiangong-memory/src/config.rs
+++ b/crates/tiangong-memory/src/config.rs
@@ -60,7 +60,8 @@ impl Default for MemoryLlmConfig {
             base_url: String::new(),
             api_key: String::new(),
             model: String::new(),
-            protocol: ProviderProtocol::default(),
+            // Memory 模型端点通常为第三方 OpenAI 兼容服务，默认走 Chat Completions。
+            protocol: ProviderProtocol::OpenAiChatCompletions,
             timeout_ms: DEFAULT_TIMEOUT_MS,
         }
     }
@@ -88,7 +89,8 @@ impl Default for MemoryEmbeddingConfig {
             base_url: String::new(),
             api_key: String::new(),
             model: String::new(),
-            protocol: ProviderProtocol::default(),
+            // Embedding 端点通常为第三方 OpenAI 兼容服务，默认走 Chat Completions。
+            protocol: ProviderProtocol::OpenAiChatCompletions,
             timeout_ms: DEFAULT_TIMEOUT_MS,
             dimension: 0,
         }
@@ -115,7 +117,8 @@ impl Default for MemoryRerankConfig {
             base_url: String::new(),
             api_key: String::new(),
             model: String::new(),
-            protocol: ProviderProtocol::default(),
+            // Rerank 端点通常为第三方 OpenAI 兼容服务，默认走 Chat Completions。
+            protocol: ProviderProtocol::OpenAiChatCompletions,
             timeout_ms: DEFAULT_TIMEOUT_MS,
         }
     }

--- a/crates/tiangong-memory/tests/hybrid_retrieval_integration.rs
+++ b/crates/tiangong-memory/tests/hybrid_retrieval_integration.rs
@@ -148,7 +148,7 @@ impl DeterministicEmbeddingServer {
             base_url: self.base_url.clone(),
             api_key: "deterministic-test-key".to_string(),
             model: "deterministic-memory-embedding".to_string(),
-            protocol: ProviderProtocol::OpenAiCompatible,
+            protocol: ProviderProtocol::OpenAiChatCompletions,
             timeout: Duration::from_secs(5),
             dimension: 4,
         }
@@ -475,7 +475,10 @@ async fn embedded_hybrid_retrieval_loads_configured_embedding_and_recalls_semant
         println!("[skip] 未在配置文件中找到 embedding 路由或 options.dimension");
         return;
     };
-    if embedding.protocol != ProviderProtocol::OpenAiCompatible {
+    if !matches!(
+        embedding.protocol,
+        ProviderProtocol::OpenAi | ProviderProtocol::OpenAiChatCompletions
+    ) {
         println!(
             "[skip] embedding 协议不是 OpenAI 兼容协议: {}",
             embedding.protocol.as_str()

--- a/crates/tiangong-memory/tests/runtime_integration.rs
+++ b/crates/tiangong-memory/tests/runtime_integration.rs
@@ -1256,7 +1256,7 @@ async fn deep_recall_fixed_scenario_traces_cross_session_artifact_entity_and_dec
         api_key: "test-memory-key".to_string(),
         base_url: mock_llm.base_url(),
         model: "memory-deep-recall-mock".to_string(),
-        protocol: ProviderProtocol::OpenAiCompatible,
+        protocol: ProviderProtocol::OpenAiChatCompletions,
         // Deep Recall 会触发 5-7 轮 LLM 调用（裁决器 + 锚点规划器 + 整理器），
         // CI 慢环境下累积延迟可能超过 5s。加大超时并允许 1 次重试，避免瞬时超时
         // 导致 LLM 返回空 → deep→Normal 降级。

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -52,6 +52,7 @@
 - 核心对话链路必须按 Provider 协议动态构建请求，不允许将所有聊天模型强制视为 OpenAI 兼容接口。
 - 当 `chat` 或 `lite` routing 指向 `anthropic` Provider 时，必须支持 Anthropic Messages 请求格式的同步、流式、工具调用与轻量模型调用，并保持 CLI/GUI/Server 行为一致。
 - 当 `chat` 或 `lite` routing 指向 `deepseek` Provider 时，必须支持 DeepSeek Chat Completions 请求格式的同步、流式、工具调用与轻量模型调用，包括思考模式（thinking）控制、reasoning_effort 映射（Low/Medium/High → high，Max → max）以及上下文缓存 token 报告，并保持 CLI/GUI/Server 行为一致。
+- OpenAI 协议层必须同时支持 Responses API（`/responses`，协议值 `openai`）与 Chat Completions API（`/chat/completions`，协议值 `openai_chatcompletions`，默认协议）；Responses 路径必须支持文本、工具调用、思考摘要（reasoning summary）与流式事件映射，并通过 `max_output_tokens` / `reasoning.effort` 等字段对齐统一请求模型。第三方 OpenAI 兼容端点（vLLM/Ollama/智谱等）应使用 `openai_chatcompletions` 或旧别名 `openai_compatible`，避免触发不支持的 `/responses`。
 - Rust 侧 LLM 协议层必须沉淀为独立库（当前为 `tiangong-llm`），由该库统一维护 Provider 抽象、领域模型与错误边界；Anthropic 适配层必须拆分为独立 crate `tiangong-anthropic`，DeepSeek 适配层必须拆分为独立 crate `tiangong-deepseek`，由该 crate 内部使用 `reqwest + serde` 原生实现 DeepSeek Chat Completions 与 SSE 解析，并通过 `tiangong-llm` 接入上层；OpenAI 兼容适配层内部可接入 `async-openai`，但第三方 SDK 类型不允许泄漏到上层业务。
 - 必须维护 `tiangong-llm` 的架构约束文档，明确其职责仅限统一抽象、Provider 封装、请求/响应映射、错误边界与流事件边界；新增协议或修复兼容问题时不得继续将 transport、业务规则和上层策略堆叠进该 crate，后续若需拆分 transport 或共享执行器，必须以该文档为准。
 

--- a/docs/tiangong-llm-architecture.md
+++ b/docs/tiangong-llm-architecture.md
@@ -26,7 +26,9 @@
   - `crates/tiangong-llm/src/provider.rs`
 - 维护 provider 适配入口：
   - `crates/tiangong-llm/src/providers/anthropic`
-  - `crates/tiangong-llm/src/providers/openai`
+  - `crates/tiangong-llm/src/providers/openai`（Responses API）
+  - `crates/tiangong-llm/src/providers/openai_chatcompletions`（Chat Completions API）
+  - `crates/tiangong-llm/src/providers/deepseek`
 - 在 provider 内完成统一模型与协议模型之间的映射
 - 在 provider 内完成统一错误模型与协议错误之间的映射
 
@@ -73,8 +75,8 @@
 - Anthropic 链路相对符合目标结构
   - `crates/tiangong-anthropic` 承担了原生 transport
   - `tiangong-llm` 中 Anthropic provider 主要负责映射和封装
-- OpenAI 兼容链路仍处于过渡态
-  - `crates/tiangong-llm/src/providers/openai/provider.rs` 目前同时承担了 client 构建、重试、timeout、list models、错误分类等职责
+- OpenAI 链路分为 Responses（`providers/openai`）与 Chat Completions（`providers/openai_chatcompletions`）两套适配，仍处于过渡态
+  - `crates/tiangong-llm/src/providers/openai_chatcompletions/provider.rs` 目前同时承担了 client 构建、重试、timeout、list models、错误分类等职责
   - 这部分后续应拆出独立 transport 或共享执行层，但当前不作为阻塞其他功能开发的前置任务
 
 结论：
@@ -99,7 +101,7 @@
 
 以下事项属于后续收敛方向，但当前不阻塞其他主功能开发：
 
-- 将 OpenAI 兼容 transport 从 `crates/tiangong-llm/src/providers/openai/provider.rs` 中拆出
+- 将 OpenAI transport 从 `crates/tiangong-llm/src/providers/openai_chatcompletions/provider.rs` 中拆出
 - 抽取 provider 共用的 retry/logging 执行器
 - 统一 `list_models` 的 transport 承载方式
 - 继续缩减 provider 文件中的 HTTP 直连细节

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -688,7 +688,7 @@ function MemoryModelSelectSection({
 
 const DEFAULT_PROVIDERS: Record<string, ProviderConfigView> = {
   'DeepSeek': { base_url: 'https://api.deepseek.com', api_key: '', timeout_ms: 300000, protocol: 'deepseek' },
-  '智谱': { base_url: 'https://open.bigmodel.cn/api/paas/v4', api_key: '', timeout_ms: 300000, protocol: 'openai' },
+  '智谱': { base_url: 'https://open.bigmodel.cn/api/paas/v4', api_key: '', timeout_ms: 300000, protocol: 'openai_chatcompletions' },
 };
 
 interface UrlPreset {
@@ -699,8 +699,8 @@ interface UrlPreset {
 
 const DEFAULT_PROVIDER_URL_PRESETS: Record<string, UrlPreset[]> = {
   '智谱': [
-    { label: 'OpenAI 兼容（通用）', url: 'https://open.bigmodel.cn/api/paas/v4', protocol: 'openai' },
-    { label: 'OpenAI 兼容（Coding 套餐）', url: 'https://open.bigmodel.cn/api/coding/paas/v4', protocol: 'openai' },
+    { label: 'OpenAI 兼容（通用）', url: 'https://open.bigmodel.cn/api/paas/v4', protocol: 'openai_chatcompletions' },
+    { label: 'OpenAI 兼容（Coding 套餐）', url: 'https://open.bigmodel.cn/api/coding/paas/v4', protocol: 'openai_chatcompletions' },
     { label: 'Anthropic 兼容（Coding 套餐）', url: 'https://open.bigmodel.cn/api/anthropic', protocol: 'anthropic' },
   ],
 };
@@ -708,6 +708,7 @@ const DEFAULT_PROVIDER_URL_PRESETS: Record<string, UrlPreset[]> = {
 // 协议对应的默认 URL
 const PROTOCOL_DEFAULTS: Record<string, string> = {
   openai: 'https://api.openai.com/v1',
+  openai_chatcompletions: 'https://api.openai.com/v1',
   anthropic: 'https://api.anthropic.com',
 };
 
@@ -791,7 +792,7 @@ function ProviderModelsView({
   const [showAddProvider, setShowAddProvider] = useState(false);
   const [newProviderKey, setNewProviderKey] = useState('');
   const [newProviderDraft, setNewProviderDraft] = useState<ProviderConfigView>({
-    base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai',
+    base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai_chatcompletions',
   });
   const [showNewApiKey, setShowNewApiKey] = useState(false);
 
@@ -860,7 +861,7 @@ function ProviderModelsView({
     setSelectedProvider(key);
     setShowAddProvider(false);
     setNewProviderKey('');
-    setNewProviderDraft({ base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai' });
+    setNewProviderDraft({ base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai_chatcompletions' });
   };
 
   // ---- Model handlers ----
@@ -1029,7 +1030,7 @@ function ProviderModelsView({
           ))}
         </div>
         <div className="border-t p-2">
-          <Button size="sm" className="w-full" onClick={() => { setShowAddProvider(true); setNewProviderKey(''); setNewProviderDraft({ base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai' }); setShowNewApiKey(false); }}>
+          <Button size="sm" className="w-full" onClick={() => { setShowAddProvider(true); setNewProviderKey(''); setNewProviderDraft({ base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai_chatcompletions' }); setShowNewApiKey(false); }}>
             <Plus className="w-3 h-3 mr-1" />自定义供应商
           </Button>
         </div>
@@ -1127,7 +1128,7 @@ function ProviderModelsView({
                   <div className="flex-1">
                     <Label className="text-xs">协议</Label>
                     <Select
-                      value={selectedConfig.protocol || 'openai'}
+                      value={selectedConfig.protocol || 'openai_chatcompletions'}
                       onValueChange={(v) => {
                         const next = { ...config };
                         next.providers = { ...next.providers, [activeProvider]: { ...selectedConfig, protocol: v } };
@@ -1136,7 +1137,8 @@ function ProviderModelsView({
                     >
                       <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="openai">OpenAI 兼容</SelectItem>
+                        <SelectItem value="openai">OpenAI（Responses）</SelectItem>
+                        <SelectItem value="openai_chatcompletions">OpenAI Chat Completions</SelectItem>
                         <SelectItem value="anthropic">Anthropic</SelectItem>
                       </SelectContent>
                     </Select>
@@ -1374,14 +1376,15 @@ function ProviderForm({
       <div>
         <Label className="text-xs">请求格式（协议类型）</Label>
         <Select
-          value={draft.protocol || 'openai'}
+          value={draft.protocol || 'openai_chatcompletions'}
           onValueChange={handleProtocolChange}
         >
           <SelectTrigger className="text-sm h-8">
             <SelectValue placeholder="选择协议" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="openai">OpenAI 兼容</SelectItem>
+            <SelectItem value="openai">OpenAI（Responses）</SelectItem>
+            <SelectItem value="openai_chatcompletions">OpenAI Chat Completions</SelectItem>
             <SelectItem value="anthropic">Anthropic</SelectItem>
           </SelectContent>
         </Select>


### PR DESCRIPTION
## 变更概览

扩展 LLM provider 层，将 OpenAI 协议拆分为 **Responses API**（`/responses`）与 **Chat Completions API**（`/chat/completions`）双轨，并修复 Responses 模式下 reasoning 流式输出被截断的 bug。

涉及 2 个 commit：
- `feat(llm): add OpenAI Responses provider and chat-completions split`（主功能）
- `fix(openai-responses): 修复 reasoning 流式输出被截断`（review 修复）

---

## 一、协议与目录重构

### 协议枚举（`tiangong-llm/src/model.rs`）

彻底删除 `OpenAiCompatible` 变体，保留两个清晰的 OpenAI 变体：

| 协议字符串 | 变体 | 实际 API |
|---|---|---|
| `openai` | `OpenAi` | `/responses` |
| `openai_chatcompletions`（**默认**） | `OpenAiChatCompletions` | `/chat/completions` |
| `openai_compatible`（旧别名） | → `OpenAiChatCompletions` | 向后兼容 vLLM/Ollama 等 |
| `anthropic` / `deepseek` | — | 不变 |

- `#[default]` 改为 `OpenAiChatCompletions`，`from_str("")` 回退到 Chat Completions，避免未配置端点误走 Responses 破坏现有部署
- 前端协议下拉、`PROTOCOL_DEFAULTS`、新建 provider 默认值全部统一为 `openai_chatcompletions`

### 目录重命名

```
providers/openai/                    ← Responses API（原 openai_responses/）
providers/openai_chatcompletions/    ← Chat Completions API（原 openai/）
```

结构体同步重命名：`OpenAiCompatibleConfig` → `OpenAiChatConfig`、`OpenAiCompatibleProvider` → `OpenAiChatCompletionsProvider`、`OpenAiCompatibleRerankProvider` → `OpenAiChatRerankProvider`。

---

## 二、Responses provider 实现（`providers/openai/`）

完整实现 `LlmProvider` 的 complete/stream/list_models：

- **client.rs** — 通过 `async-openai` 的 `responses().create_byot` / `create_stream_byot` 调用，复用重试/超时框架
- **mapping.rs** — `ProviderRequest` ↔ Responses JSON 双向映射（input items / instructions / FunctionTool / reasoning effort / usage），复用 Chat Completions 的 `normalize_api_base` / `strip_think_tags` / 错误映射
- **stream.rs** — Responses SSE 事件 → 统一 `ProviderStreamEvent`
- 共享 Chat Completions 的 `/models` 端点逻辑（抽为 `list_models_via_config` 公共函数）

---

## 三、Reasoning 流式截断修复（review 诊断）

通过 Python 脚本分析 session `03gcd1u8of0o5i5l5r46vkrlh`，发现 **assistant#256（2026-06-21 18:33）后所有 reasoning 退化为「\`**标题**\n\nI\`」截断片段**，根因有三：

1. **请求侧缺少 `reasoning.summary = \"auto\"`**：Responses API 的 reasoning summary 必须显式请求。抽取 `build_reasoning()` 在 effort 与 thinking 两条分支统一带上 `summary: \"auto\"`。

2. **dedupe 逻辑误杀流式增量 delta（关键 bug）**：原实现用 `seen_reasoning_delta` 标志，收到首个 reasoning delta 后丢弃所有后续 `ReasoningDelta`。但 OpenAI 的流式 reasoning 是多段增量拼接，第一段标题被保留并标记后，后续几十段真实增量全被当作重复丢弃。重构为：流式增量一律保留，仅当全程无 delta 时从 `response.completed` 的 `output[]` 兜底补发，通过 `received_reasoning_delta` 条件控制。

3. **流式 reasoning 事件覆盖不全**：补充 `reasoning_summary_part.added/done`（`part.text`）、`reasoning_summary_text.done` / `reasoning_text.done`（`text`）等事件，并对未识别的 reasoning 事件打 debug 日志。

> 注：Responses API 即使开启 summary 也只返回 reasoning summary（思考摘要），而非 Claude/DeepSeek 那种完整 thinking text，这是 API 设计限制。

---

## 四、顶层 wiring

- `tiangong-llm`：`text.rs`/`embedding.rs`/`rerank.rs`/`client.rs`/`lib.rs` 按协议分发，启用 `async-openai` 的 `responses` feature
- `tiangong-core`：`ProviderDispatch` 新增 `OpenAiResponses` 变体；`build_openai_variant_provider` 统一非流式 complete 路径分发；`CancelStrategy` 补齐 Responses 分支
- `tiangong-memory`：config 默认协议改为 `OpenAiChatCompletions`（避免第三方兼容端点误走 `/responses`）

---

## 测试

新增 ~20 个单元测试，覆盖：
- Responses mapping round-trip（请求/响应/工具调用/思考/usage）
- `reasoning.summary = \"auto\"` 请求构建（effort + thinking 两分支）
- reasoning 流式事件解析（summary_text.delta/part/done、completed 兜底）
- dedupe 条件去重（有 delta 跳过兜底 / 无 delta 兜底 / 无 reasoning 不误发）

```
cargo fmt -- --check                                ✅
cargo clippy --workspace --all-targets ... -D warnings  ✅
cargo nextest run --workspace                       ✅ 396 passed, 2 skipped
frontend: yarn build + yarn test                    ✅
```

## 文档

- `AGENTS.md` 环境变量表补充 `API_PROTOCOL` 可选值
- `docs/requirements.md` 补充 Responses/Chat Completions 双轨说明
- `docs/tiangong-llm-architecture.md` 同步新目录结构