### PR TITLE
fix(terminal): 修复终端未就绪、workspace 路径与窗口无法创建

### DIFF
--- a/crates/tiangong-plugin-terminal/src/lib.rs
+++ b/crates/tiangong-plugin-terminal/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tauri::{
     plugin::{Builder, TauriPlugin},
-    Manager, Wry,
+    Emitter, Manager, Wry,
 };
 
 use crate::session_pty::SessionPtyRegistry;
@@ -74,6 +74,21 @@ pub fn init(session_id: String, cwd: String) -> TauriPlugin<Wry> {
 pub async fn set_cwd(app: &tauri::AppHandle<Wry>, cwd: String) {
     let state = app.state::<TerminalPluginState>();
     state.registry.set_default_cwd(cwd);
+}
+
+/// workspace 切换时同步终端：更新默认 cwd 并销毁所有存活 PTY。
+///
+/// workspace 切换发生在尚未产生对话的阶段，直接销毁重建 PTY 比发送 `cd`
+/// 更干净（不留历史命令、不误发到交互式程序）。用户下次打开终端时 `ensure`
+/// 用新 `default_cwd` 创建全新 PTY（见 [`SessionPtyRegistry::reset_all_for_workspace`]）。
+///
+/// 销毁后通过 `terminal:reset` 事件通知前端丢弃 xterm 缓存并重新 `ensure`，
+/// 使当前已打开的终端面板也能感知到后端 PTY 重建。
+pub fn sync_workspace_cwd(app: &tauri::AppHandle<Wry>, cwd: &str) {
+    let state = app.state::<TerminalPluginState>();
+    state.registry.reset_all_for_workspace(cwd);
+    // 通知前端：所有 PTY 已重置，丢弃 xterm 缓存后由 ensure 重建
+    let _ = app.emit("terminal:reset", ());
 }
 
 /// 销毁指定对话的 PTY（删除对话时调用）

--- a/crates/tiangong-plugin-terminal/src/session_pty.rs
+++ b/crates/tiangong-plugin-terminal/src/session_pty.rs
@@ -41,22 +41,63 @@ impl SessionPtyRegistry {
     }
 
     /// 更新默认 cwd（workspace 切换或初始化同步时调用）。
-    /// 仅影响后续懒创建的 PTY；已存在的对话 PTY 的 cwd 由其自身管理。
+    ///
+    /// 仅影响后续懒创建的 PTY；已存在对话 PTY 的 cwd 由其自身管理。
     pub fn set_default_cwd(&self, cwd: String) {
         if let Ok(mut guard) = self.default_cwd.lock() {
             *guard = cwd;
         }
     }
 
+    /// workspace 切换时同步：更新默认 cwd，并销毁所有存活 PTY。
+    ///
+    /// workspace 切换发生在尚未产生对话的阶段（活跃 session 处于草稿/无消息状态），
+    /// 此时终端 PTY 不承载有价值的 shell 状态，直接销毁重建比发送 `cd` 更干净：
+    /// - 不在终端历史里留下自动 `cd` 痕迹
+    /// - 不误把 `cd` 当作按键发给交互式前台程序（vi/nano/REPL）
+    /// - 用户下次打开终端时 `ensure` 用新 `default_cwd` 创建全新 PTY
+    ///
+    /// 已销毁的 PTY（如固定 id `__draft_terminal__`）会在前端 TerminalPanel 的
+    /// `ensure` effect 中被重新创建，xterm 渲染层会感知到后端 PTY 重建。
+    pub fn reset_all_for_workspace(&self, cwd: &str) {
+        // 1. 更新默认 cwd，使后续懒创建的 PTY 落入新 workspace
+        self.set_default_cwd(cwd.to_string());
+
+        // 2. 销毁所有存活 PTY（drop cmd_tx → 命令循环退出 → 子进程终止）
+        let ids: Vec<String> = {
+            let sessions = self.sessions.lock().unwrap();
+            sessions.keys().cloned().collect()
+        };
+        for id in ids {
+            self.destroy(&id);
+        }
+    }
+
     /// 懒创建：获取或创建指定 session 的 PTY。返回 true 表示 PTY 存活。
+    ///
+    /// 若注册表里已存在该 session 的条目但底层 PTY 已死亡（子进程退出、
+    /// `cmd_tx` 失效），会先销毁陈旧条目再重建，避免复用死掉的 PTY 导致
+    /// 「终端未就绪」（草稿态固定 id 复用场景的根因，见 issue #156 后续修复）。
     pub fn ensure(&self, session_id: &str, cwd: &str) -> bool {
         {
             let sessions = self.sessions.lock().unwrap();
-            if sessions.contains_key(session_id) {
-                return true;
+            if let Some(pty) = sessions.get(session_id) {
+                if pty.manager.is_alive() {
+                    return true;
+                }
+                // PTY 已死亡：释放锁后销毁重建
+            } else {
+                // 不存在，走下面的创建分支
+                return self.create_pty(session_id, cwd);
             }
         }
+        // 走到这里说明存在陈旧 PTY，先销毁再创建
+        self.destroy(session_id);
+        self.create_pty(session_id, cwd)
+    }
 
+    /// 创建指定 session 的 PTY（调用方负责保证注册表里无该 session 的存活条目）。
+    fn create_pty(&self, session_id: &str, cwd: &str) -> bool {
         let default_cwd = self
             .default_cwd
             .lock()

--- a/crates/tiangong-plugin-terminal/src/session_pty.rs
+++ b/crates/tiangong-plugin-terminal/src/session_pty.rs
@@ -79,20 +79,20 @@ impl SessionPtyRegistry {
     /// `cmd_tx` 失效），会先销毁陈旧条目再重建，避免复用死掉的 PTY 导致
     /// 「终端未就绪」（草稿态固定 id 复用场景的根因，见 issue #156 后续修复）。
     pub fn ensure(&self, session_id: &str, cwd: &str) -> bool {
-        {
+        // 检查是否已有存活 PTY（注意：必须在此块作用域内释放 sessions 锁，
+        // 不得在持锁时调用 create_pty——create_pty 末尾会再次获取 sessions 锁，
+        // std::sync::Mutex 不支持递归获取，会导致死锁。）
+        let existing_is_dead = {
             let sessions = self.sessions.lock().unwrap();
-            if let Some(pty) = sessions.get(session_id) {
-                if pty.manager.is_alive() {
-                    return true;
-                }
-                // PTY 已死亡：释放锁后销毁重建
-            } else {
-                // 不存在，走下面的创建分支
-                return self.create_pty(session_id, cwd);
+            match sessions.get(session_id) {
+                Some(pty) if pty.manager.is_alive() => return true,
+                Some(_) => true, // 存在但已死亡，需销毁重建
+                None => false,   // 不存在，直接创建
             }
+        };
+        if existing_is_dead {
+            self.destroy(session_id);
         }
-        // 走到这里说明存在陈旧 PTY，先销毁再创建
-        self.destroy(session_id);
         self.create_pty(session_id, cwd)
     }
 

--- a/frontend/src/components/TerminalPanel.tsx
+++ b/frontend/src/components/TerminalPanel.tsx
@@ -77,7 +77,7 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const poolRef = useRef<Map<string, TerminalEntry>>(new Map());
   const currentIdRef = useRef<string>('');
-  const globalUnlistenRef = useRef<(() => void) | null>(null);
+  const globalUnlistenRef = useRef<Array<() => void>>([]);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const pendingCreateRef = useRef<Set<string>>(new Set());
   const createdTimeRef = useRef<number>(0);
@@ -94,6 +94,10 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
     cwd: '',
     alive: false,
   });
+  // PTY 重建版本：terminal:reset 事件递增，作为 mount effect 依赖强制重新 ensure。
+  // workspace 切换时后端销毁所有 PTY 后发出 reset，前端 pool 已清空，需重跑 ensure
+  // 重建当前会话的 xterm（effectiveId 不变，仅靠它无法触发重挂载）。
+  const [ptyVersion, setPtyVersion] = useState(0);
 
   // 按对话 PTY 模型：effectiveId 为当前对话 id。
   // 草稿态（activeSessionId=null）用 draftTerminalId 作为临时 id 创建草稿 PTY，
@@ -130,13 +134,49 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
         unlisten();
         return;
       }
-      globalUnlistenRef.current = unlisten;
+      globalUnlistenRef.current.push(unlisten);
     };
     setup();
     return () => {
       cancelled = true;
-      globalUnlistenRef.current?.();
-      globalUnlistenRef.current = null;
+      for (const fn of globalUnlistenRef.current) fn();
+      globalUnlistenRef.current = [];
+    };
+  }, []);
+
+  // 监听后端 terminal:reset 事件（workspace 切换等场景，后端销毁所有 PTY 后发出）。
+  // 前端需丢弃所有 xterm 缓存，使切换对话的 ensure effect 重新用新 workspace 创建 PTY。
+  useEffect(() => {
+    let cancelled = false;
+    const setup = async () => {
+      const unlisten = await listen('terminal:reset', () => {
+        if (cancelled) return;
+        // 销毁所有缓存的 xterm entry（DOM 容器由 React 卸载/重挂）
+        for (const entry of poolRef.current.values()) {
+          try {
+            entry.term.dispose();
+          } catch {
+            // ignore
+          }
+        }
+        poolRef.current.clear();
+        // 清空 currentIdRef，强制下方「切换对话挂载」effect 重建当前会话的 xterm
+        currentIdRef.current = '';
+        // 递增版本号触发 mount effect 重跑（effectiveId 不变时唯一可靠的重建入口）
+        setPtyVersion((v) => v + 1);
+        setDisplayInfo({ cwd: '', alive: false });
+      });
+      if (cancelled) {
+        unlisten();
+        return;
+      }
+      globalUnlistenRef.current.push(unlisten);
+    };
+    setup();
+    return () => {
+      cancelled = true;
+      for (const fn of globalUnlistenRef.current) fn();
+      globalUnlistenRef.current = [];
     };
   }, []);
 
@@ -339,7 +379,7 @@ export function TerminalPanel({ onClose }: { onClose: () => void }) {
       }
     };
     switchTo();
-  }, [effectiveId]);
+  }, [effectiveId, ptyVersion]);
 
   // 会话独立终端模型：PTY 创建时已用 workspace cwd，之后 cwd 由用户/命令
   // 自然管理。切换会话时不强制 cd，避免覆盖用户在终端内的 cd 操作。

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -328,6 +328,12 @@ export const useStore = create<AppState>((set, get) => ({
     // 为草稿态终端生成稳定临时 id：同一时刻只有一个草稿，用固定常量即可。
     // TerminalPanel 草稿态会以此 id 创建 PTY；转正时迁移归属到真实 session_id。
     const draftTerminalId = '__draft_terminal__';
+    // 销毁上一轮草稿残留的 PTY（草稿用固定 id，若上次草稿没转正也没销毁，
+    // 后端会残留死掉的 PTY，导致下次 ensure 复用陈旧条目、终端显示「未就绪」）。
+    // 销毁是幂等的：后端无此 id 时 no-op。后端 ensure 也会兜底检测陈旧 PTY 重建。
+    api.terminalDestroySession(draftTerminalId).catch((e) =>
+      console.error('销毁陈旧草稿 PTY 失败:', e),
+    );
     set({
       isDraft: true,
       activeSessionId: null,

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -8,7 +8,7 @@ use tiangong_core::agent_input::{AgentInput, AgentInputKind};
 use tiangong_core::core::TiangongCore;
 use tiangong_core::core_config::CoreConfigProvider;
 use tokio::sync::Mutex as AsyncMutex;
-use tracing::warn;
+use tracing::{error, warn};
 
 /// 天工应用状态
 ///
@@ -77,8 +77,13 @@ impl TiangongApp {
     /// 全部能力（页面获取、终端能力、工具覆盖、Prompt 段落等），替代旧的
     /// `set_page_fetcher` / `register_tool_override` 等逐字段注册。
     pub fn register_plugin(&self, plugin: std::sync::Arc<dyn tiangong_core::core::Plugin>) {
-        if let Ok(mut guard) = self.plugins.lock() {
-            guard.push(plugin);
+        match self.plugins.lock() {
+            Ok(mut guard) => guard.push(plugin),
+            Err(err) => error!(
+                plugin_id = plugin.id(),
+                error = %err,
+                "plugins 锁已污染，插件注册失败，其能力将静默缺失",
+            ),
         }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2263,6 +2263,7 @@ pub async fn get_workspace_dir(state: State<'_, TiangongApp>) -> Result<String, 
 /// 设置 Desktop 工作空间目录
 #[tauri::command]
 pub async fn set_workspace_dir(
+    app: tauri::AppHandle,
     workspace_dir: String,
     state: State<'_, TiangongApp>,
 ) -> Result<(), String> {
@@ -2273,6 +2274,10 @@ pub async fn set_workspace_dir(
     state
         .with_state(|core_state| core_state.update_workspace_dir(workspace_dir.clone()))
         .await?;
+
+    // 同步终端：更新终端默认 cwd（后续懒创建的 PTY），并对所有存活 PTY
+    // 发送 cd 使已打开的终端进入新 workspace。
+    tiangong_plugin_terminal::sync_workspace_cwd(&app, &workspace_dir);
 
     // 同步活跃 core 的 cwd（仅限无对话的 Inherit 会话）
     let active_session_id = state

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -284,24 +284,30 @@ fn run_gui() {
 
             // 注册进程内插件（issue #156）：每个插件封装自己的全部能力，
             // 在 engine 创建/重建时自行注册，替代旧的逐字段手工注册。
-            if let Some(plugin) = tiangong_plugin_browser::build_plugin(app.handle()) {
-                state.register_plugin(plugin);
+            // 注意：build_plugin 必须在对应 Tauri plugin（.plugin(init())）注册之后调用，
+            // 否则 app.state::<X>() 拿不到插件 state，from_app_handle 返回 None。
+            match tiangong_plugin_browser::build_plugin(app.handle()) {
+                Some(plugin) => state.register_plugin(plugin),
+                None => warn!("浏览器插件构造失败（Tauri state 未就绪），浏览器能力将缺失"),
             }
-            if let Some(plugin) = tiangong_plugin_terminal::build_plugin(app.handle()) {
-                state.register_plugin(plugin);
+            match tiangong_plugin_terminal::build_plugin(app.handle()) {
+                Some(plugin) => {
+                    state.register_plugin(plugin);
 
-                // 将 workspace 目录设为系统 PTY 默认 cwd。
-                // 系统 PTY 启动时 cwd 取自环境变量（HOME/tmp），若不在此 cd，
-                // agent 命令会在用户主目录而非 workspace 执行。
-                let app_handle = app.handle().clone();
-                let core_state = state.state.clone();
-                tauri::async_runtime::spawn(async move {
-                    let workspace = {
-                        let guard = core_state.lock().await;
-                        guard.workspace_dir().to_string()
-                    };
-                    tiangong_plugin_terminal::set_cwd(&app_handle, workspace).await;
-                });
+                    // 将 workspace 目录设为系统 PTY 默认 cwd。
+                    // 系统 PTY 启动时 cwd 取自环境变量（HOME/tmp），若不在此 cd，
+                    // agent 命令会在用户主目录而非 workspace 执行。
+                    let app_handle = app.handle().clone();
+                    let core_state = state.state.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let workspace = {
+                            let guard = core_state.lock().await;
+                            guard.workspace_dir().to_string()
+                        };
+                        tiangong_plugin_terminal::set_cwd(&app_handle, workspace).await;
+                    });
+                }
+                None => warn!("终端插件构造失败（Tauri state 未就绪），终端能力将缺失"),
             }
 
             // 启动工具消息注入消费者任务（插件 push → 消费者统一处理）


### PR DESCRIPTION
## 概述

本 PR 在 #156（插件自注册架构，已合并）之后，修复终端插件的三个回归问题并补充可观测性日志。

> 注：前 3 个 commit（Plugin trait 引入、插件实现、应用层切换）已在 #156 合入 main。本 PR 仅包含其后新增的 3 个 commit。

## 改动内容

### 1. 修复新建对话终端未就绪（`ff4d9ff`）

**根因**：草稿态终端用固定 id `__draft_terminal__` 复用 PTY，但 `terminalDestroySession` 在前端从未被调用。上轮草稿残留的死掉的 PTY 被 `ensure()` 命中——原 `ensure` 只按 key 存在就返回 `true`，不检查存活，前端拿到死 PTY 显示「未就绪」。

**修复**：
- `ensure()` 检测 `pty.manager.is_alive()`，死亡则销毁重建（兜底）。
- `createSession()` 主动 `terminalDestroySession('__draft_terminal__')` 清掉陈旧草稿 PTY（根治）。

### 2. 修复切换 workspace 后终端路径不更新（`ff4d9ff`）

**根因**：`set_workspace_dir` 只更新 core 的 `workspace_dir` 和 agent cwd，完全不通知终端插件；终端 PTY 的 `default_cwd` 只在启动时同步一次。

**修复**（切换发生在无对话阶段，销毁重建比 `cd` 更干净）：
- `SessionPtyRegistry::reset_all_for_workspace`：更新 `default_cwd` + 销毁所有存活 PTY。
- `sync_workspace_cwd` 接入 `set_workspace_dir`，并 `emit('terminal:reset')` 通知前端。
- `TerminalPanel` 监听 `terminal:reset`：清空 xterm pool、递增 `ptyVersion` 强制 mount effect 重跑 `ensure`。

### 3. 修复 `ensure` 死锁导致 GUI 窗口无法创建（`d5ebf51`）

**根因**：上一 commit 把 `ensure` 拆成 `ensure` + `create_pty` 时，`else { return self.create_pty(...) }` 写在 `sessions` 锁的块作用域内，而 `create_pty` 末尾再次 `sessions.lock()` —— `std::sync::Mutex` 不支持递归获取 → 死锁。

死锁发生在终端插件 init 的 setup 阶段，卡在 Tauri `plugin initialize_all` → 主线程永久阻塞 → webview/窗口永远不创建（进程存活、后台日志照常输出，造成「后端正常但窗口不出」的假象）。

**修复**：先在持锁块内完成判断得到 `bool`，释放锁后再调用 `destroy`/`create_pty`。

### 4. 补充静默失败路径日志（`84a241a`）

按 code review 补充两处可观测性：
- `register_plugin`：plugins 锁被污染时 `error!` 记录，明确「能力将静默缺失」。
- `build_plugin`：返回 `None` 时 `warn!` 记录「Tauri state 未就绪」，并注释调用时序要求。

## 验证

- `cargo fmt --check` / `cargo clippy --workspace -D warnings` / `cargo nextest run --workspace`（396 passed）
- 前端 `tsc --noEmit` / `yarn build` / `yarn test`
- 实跑 `target/debug/tiangong-app` 确认：死锁消除（`对话 PTY 已创建` 日志出现、webview 子进程产生、CPU 非零）

## 测试建议

GUI 运行时行为，建议实跑 `cargo tauri dev` 验证：
1. 新建对话 → 打开终端 → 应立即可用（不卡「未就绪」）
2. 切换 workspace → 新开终端 & 已开终端均进入新路径
3. 启动后窗口正常出现、Dock 图标显示

Closes #156 