### PR TITLE
feat: 支持 Office/PDF 文件上传与本地脚本解析（issue #149）

### DIFF
--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -465,6 +465,10 @@ async fn worker_loop_async(
                 media,
             } => {
                 let turn_start_idx = session.messages.len();
+                // 归档附件到本地（图片→images/，PDF/Office→files/）。
+                // 必须在 append 之前归档，否则 attachment_notice 引用的是 data URL
+                // 而非本地路径，agent 无法读取文件（issue #149）。
+                let media = crate::media_archive::archive_input_media_assets(media);
                 // 记录用户消息
                 let user_msg_id =
                     append_or_reuse_user_message(&mut session, &content, message_id, media);

--- a/crates/tiangong-core/src/media_archive.rs
+++ b/crates/tiangong-core/src/media_archive.rs
@@ -3,6 +3,11 @@ use std::path::{Path, PathBuf};
 use base64::{Engine as _, engine::general_purpose};
 use tiangong_types::{MediaAsset, MediaKind};
 
+/// 把输入附件归档到本地（图片/文件）。
+///
+/// - 图片：归档到 `~/.tiangong/media/images/`
+/// - PDF/Office 文档：归档到 `~/.tiangong/media/files/`
+/// - 其他：保留原引用
 pub fn archive_input_media_assets(media: Vec<MediaAsset>) -> Vec<MediaAsset> {
     media
         .into_iter()
@@ -10,19 +15,37 @@ pub fn archive_input_media_assets(media: Vec<MediaAsset>) -> Vec<MediaAsset> {
             if !should_archive_input_asset(&asset) {
                 return asset;
             }
-            match archive_image_reference(&asset.url, asset.mime_type.as_deref()) {
-                Ok(archived) => MediaAsset {
-                    url: archived.path,
-                    mime_type: Some(archived.mime_type),
-                    ..asset
-                },
-                Err(err) => {
-                    tracing::warn!(
-                        url = %asset.url,
-                        error = %err,
-                        "输入图片归档到本地失败，保留原始引用"
-                    );
-                    asset
+            if is_document_asset(&asset) {
+                match archive_file_reference(&asset.url, asset.mime_type.as_deref()) {
+                    Ok(archived) => MediaAsset {
+                        url: archived.path,
+                        mime_type: Some(archived.mime_type),
+                        ..asset
+                    },
+                    Err(err) => {
+                        tracing::warn!(
+                            url = %asset.url,
+                            error = %err,
+                            "输入文档归档到本地失败，保留原始引用"
+                        );
+                        asset
+                    }
+                }
+            } else {
+                match archive_image_reference(&asset.url, asset.mime_type.as_deref()) {
+                    Ok(archived) => MediaAsset {
+                        url: archived.path,
+                        mime_type: Some(archived.mime_type),
+                        ..asset
+                    },
+                    Err(err) => {
+                        tracing::warn!(
+                            url = %asset.url,
+                            error = %err,
+                            "输入图片归档到本地失败，保留原始引用"
+                        );
+                        asset
+                    }
                 }
             }
         })
@@ -30,13 +53,45 @@ pub fn archive_input_media_assets(media: Vec<MediaAsset>) -> Vec<MediaAsset> {
 }
 
 fn should_archive_input_asset(asset: &MediaAsset) -> bool {
-    matches!(asset.kind, MediaKind::Image)
-        || matches!(asset.kind, MediaKind::File)
-            && (asset
-                .mime_type
-                .as_deref()
-                .is_some_and(|mime| mime.starts_with("image/"))
-                || image_mime_from_reference(&asset.url).is_some())
+    if matches!(asset.kind, MediaKind::Image) {
+        return true;
+    }
+    if matches!(asset.kind, MediaKind::File) {
+        // 图片类文件走图片归档
+        if asset
+            .mime_type
+            .as_deref()
+            .is_some_and(|mime| mime.starts_with("image/"))
+            || image_mime_from_reference(&asset.url).is_some()
+        {
+            return true;
+        }
+        // PDF/Office 文档走文件归档
+        if is_document_asset(asset) {
+            return true;
+        }
+    }
+    false
+}
+
+/// 判断是否为可归档的文档附件（PDF/Word/Excel/PowerPoint 现代格式）
+fn is_document_asset(asset: &MediaAsset) -> bool {
+    if let Some(mime) = asset.mime_type.as_deref()
+        && is_document_mime(mime)
+    {
+        return true;
+    }
+    document_mime_from_reference(&asset.url).is_some()
+}
+
+fn is_document_mime(mime: &str) -> bool {
+    matches!(
+        mime,
+        "application/pdf"
+            | "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            | "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            | "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    )
 }
 
 pub(crate) struct ArchivedImage {
@@ -58,7 +113,7 @@ pub(crate) fn archive_image_reference(
     if trimmed.is_empty() {
         return Err("图片引用为空".to_string());
     }
-    if is_archived_media_path(trimmed) {
+    if is_archived_media_path(trimmed, "images") {
         return Ok(ArchivedImage {
             path: trimmed.to_string(),
             mime_type: mime_hint
@@ -74,18 +129,6 @@ pub(crate) fn archive_image_reference(
         return download_remote_image(trimmed);
     }
     copy_local_image(Path::new(trimmed), mime_hint)
-}
-
-fn is_archived_media_path(value: &str) -> bool {
-    let path = Path::new(value);
-    path.components()
-        .collect::<Vec<_>>()
-        .windows(3)
-        .any(|parts| {
-            parts[0].as_os_str() == ".tiangong"
-                && parts[1].as_os_str() == "media"
-                && parts[2].as_os_str() == "images"
-        })
 }
 
 fn copy_local_image(path: &Path, mime_hint: Option<&str>) -> Result<ArchivedImage, String> {
@@ -167,12 +210,33 @@ fn write_archived_image(bytes: Vec<u8>, mime_type: &str) -> Result<ArchivedImage
 }
 
 fn media_images_dir() -> Result<PathBuf, String> {
+    media_subdir("images")
+}
+
+fn media_files_dir() -> Result<PathBuf, String> {
+    media_subdir("files")
+}
+
+fn media_subdir(name: &str) -> Result<PathBuf, String> {
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
         .ok_or_else(|| "无法获取 HOME 目录".to_string())?;
-    let dir = home.join(".tiangong").join("media").join("images");
-    std::fs::create_dir_all(&dir).map_err(|err| format!("创建图片归档目录失败：{err}"))?;
+    let dir = home.join(".tiangong").join("media").join(name);
+    std::fs::create_dir_all(&dir).map_err(|err| format!("创建媒体归档目录失败：{err}"))?;
     Ok(dir)
+}
+
+/// 判断路径是否为已归档的媒体路径（images/files 子目录均识别）
+fn is_archived_media_path(value: &str, subdir: &str) -> bool {
+    let path = Path::new(value);
+    path.components()
+        .collect::<Vec<_>>()
+        .windows(3)
+        .any(|parts| {
+            parts[0].as_os_str() == ".tiangong"
+                && parts[1].as_os_str() == "media"
+                && parts[2].as_os_str() == subdir
+        })
 }
 
 pub(crate) fn image_mime_from_reference(value: &str) -> Option<String> {
@@ -202,5 +266,252 @@ fn image_ext_from_mime(mime_type: &str) -> Option<&'static str> {
         "image/gif" => Some("gif"),
         "image/png" => Some("png"),
         _ => None,
+    }
+}
+
+// ── 文档（PDF/Office）归档 ──────────────────────────────────────────────
+
+/// 从文件引用推断文档 MIME（按扩展名）
+fn document_mime_from_reference(value: &str) -> Option<String> {
+    let lower = value.trim().to_ascii_lowercase();
+    if lower.ends_with(".pdf") {
+        Some("application/pdf".to_string())
+    } else if lower.ends_with(".docx") {
+        Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document".to_string())
+    } else if lower.ends_with(".xlsx") {
+        Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet".to_string())
+    } else if lower.ends_with(".pptx") {
+        Some(
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation".to_string(),
+        )
+    } else {
+        None
+    }
+}
+
+/// 文档 MIME → 扩展名
+fn document_ext_from_mime(mime_type: &str) -> Option<&'static str> {
+    match mime_type {
+        "application/pdf" => Some("pdf"),
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => Some("docx"),
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => Some("xlsx"),
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation" => Some("pptx"),
+        _ => None,
+    }
+}
+
+/// 把 PDF/Office 文档引用归档到 `~/.tiangong/media/files/`。
+///
+/// 支持 data URL、http(s) 和本地路径三种来源。
+pub(crate) fn archive_file_reference(
+    reference: &str,
+    mime_hint: Option<&str>,
+) -> Result<ArchivedImage, String> {
+    let trimmed = reference.trim();
+    if trimmed.is_empty() {
+        return Err("文档引用为空".to_string());
+    }
+    if is_archived_media_path(trimmed, "files") {
+        return Ok(ArchivedImage {
+            path: trimmed.to_string(),
+            mime_type: mime_hint
+                .map(str::to_string)
+                .or_else(|| document_mime_from_reference(trimmed))
+                .unwrap_or_else(|| "application/octet-stream".to_string()),
+        });
+    }
+    if let Some(rest) = trimmed.strip_prefix("data:") {
+        return archive_data_file(rest, mime_hint);
+    }
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return download_remote_file(trimmed, mime_hint);
+    }
+    copy_local_file(Path::new(trimmed), mime_hint)
+}
+
+fn copy_local_file(path: &Path, mime_hint: Option<&str>) -> Result<ArchivedImage, String> {
+    let bytes = std::fs::read(path).map_err(|err| format!("读取本地文档失败：{err}"))?;
+    let mime_type = mime_hint
+        .filter(|mime| is_document_mime(mime))
+        .map(str::to_string)
+        .or_else(|| document_mime_from_reference(&path.to_string_lossy()))
+        .ok_or_else(|| "无法识别文档类型".to_string())?;
+    write_archived_file(bytes, &mime_type)
+}
+
+fn archive_data_file(data_payload: &str, mime_hint: Option<&str>) -> Result<ArchivedImage, String> {
+    let (header, data) = data_payload
+        .split_once(',')
+        .ok_or_else(|| "data: 文档缺少 base64 内容".to_string())?;
+    let mime_type = header
+        .split(';')
+        .next()
+        .filter(|mime| is_document_mime(mime))
+        .map(str::to_string)
+        .or_else(|| {
+            mime_hint
+                .filter(|m| is_document_mime(m))
+                .map(str::to_string)
+        })
+        .ok_or_else(|| "data: 文档 MIME 不在支持范围内".to_string())?;
+    let bytes = general_purpose::STANDARD
+        .decode(data)
+        .map_err(|err| format!("解码 data: 文档失败：{err}"))?;
+    write_archived_file(bytes, &mime_type)
+}
+
+fn download_remote_file(url: &str, mime_hint: Option<&str>) -> Result<ArchivedImage, String> {
+    let url = url.to_string();
+    std::thread::scope(|scope| {
+        scope
+            .spawn(move || download_remote_file_inner(&url, mime_hint))
+            .join()
+            .unwrap()
+    })
+}
+
+fn download_remote_file_inner(url: &str, mime_hint: Option<&str>) -> Result<ArchivedImage, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .map_err(|err| format!("创建文档下载客户端失败：{err}"))?;
+    let response = client
+        .get(url)
+        .send()
+        .map_err(|err| format!("下载文档失败：{err}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("下载文档失败：HTTP {status}"));
+    }
+    let mime_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim)
+        .filter(|value| is_document_mime(value))
+        .map(str::to_string)
+        .or_else(|| {
+            mime_hint
+                .filter(|m| is_document_mime(m))
+                .map(str::to_string)
+        })
+        .or_else(|| document_mime_from_reference(url))
+        .ok_or_else(|| "下载文档的 MIME 不在支持范围内".to_string())?;
+    let bytes = response
+        .bytes()
+        .map_err(|err| format!("读取文档响应失败：{err}"))?
+        .to_vec();
+    write_archived_file(bytes, &mime_type)
+}
+
+fn write_archived_file(bytes: Vec<u8>, mime_type: &str) -> Result<ArchivedImage, String> {
+    let dir = media_files_dir()?;
+    let ext = document_ext_from_mime(mime_type).unwrap_or("bin");
+    let path = dir.join(format!("{}.{}", scru128::new(), ext));
+    std::fs::write(&path, bytes).map_err(|err| format!("写入文档归档失败：{err}"))?;
+    Ok(ArchivedImage {
+        path: path.to_string_lossy().to_string(),
+        mime_type: mime_type.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn archives_pdf_data_url_to_local_file() {
+        // 构造一个最小合法 PDF 的 data URL
+        let pdf_bytes = b"%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF";
+        let b64 = general_purpose::STANDARD.encode(pdf_bytes);
+        let data_url = format!("data:application/pdf;base64,{b64}");
+
+        let asset = MediaAsset {
+            kind: MediaKind::File,
+            url: data_url,
+            mime_type: Some("application/pdf".to_string()),
+            title: Some("test.pdf".to_string()),
+            capability: None,
+        };
+
+        let archived = archive_input_media_assets(vec![asset]);
+        assert_eq!(archived.len(), 1);
+        let result = &archived[0];
+
+        // 归档后 url 必须是本地路径，不再是 data URL
+        assert!(
+            !result.url.starts_with("data:"),
+            "归档后 url 仍为 data URL：{}",
+            &result.url[..result.url.len().min(60)]
+        );
+        // 路径应指向 media/files/ 目录
+        assert!(
+            result.url.contains("media/files/"),
+            "归档路径不在 media/files/ 下：{}",
+            result.url
+        );
+        // 文件应真实存在
+        assert!(
+            Path::new(&result.url).exists(),
+            "归档文件不存在：{}",
+            result.url
+        );
+        // 清理
+        let _ = std::fs::remove_file(&result.url);
+    }
+
+    #[test]
+    fn archives_docx_by_mime_even_without_extension_in_url() {
+        // data URL 没有 .docx 扩展名，但 mime_type 正确，应能归档
+        let docx_bytes = b"PK\x03\x04fake_docx_payload";
+        let b64 = general_purpose::STANDARD.encode(docx_bytes);
+        let data_url = format!(
+            "data:application/vnd.openxmlformats-officedocument.wordprocessingml.document;base64,{b64}"
+        );
+
+        let asset = MediaAsset {
+            kind: MediaKind::File,
+            url: data_url,
+            mime_type: Some(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                    .to_string(),
+            ),
+            title: None,
+            capability: None,
+        };
+
+        let archived = archive_input_media_assets(vec![asset]);
+        assert_eq!(archived.len(), 1);
+        assert!(!archived[0].url.starts_with("data:"));
+        assert!(archived[0].url.ends_with(".docx"));
+        let _ = std::fs::remove_file(&archived[0].url);
+    }
+
+    #[test]
+    fn image_assets_still_archive_to_images_dir() {
+        // 确保图片归档逻辑未被文件归档改动破坏
+        let png_bytes = [
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+        ];
+        let b64 = general_purpose::STANDARD.encode(png_bytes);
+        let data_url = format!("data:image/png;base64,{b64}");
+
+        let asset = MediaAsset {
+            kind: MediaKind::Image,
+            url: data_url,
+            mime_type: Some("image/png".to_string()),
+            title: None,
+            capability: None,
+        };
+
+        let archived = archive_input_media_assets(vec![asset]);
+        assert_eq!(archived.len(), 1);
+        assert!(
+            archived[0].url.contains("media/images/"),
+            "图片应归档到 media/images/：{}",
+            archived[0].url
+        );
+        let _ = std::fs::remove_file(&archived[0].url);
     }
 }

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -1209,30 +1209,13 @@ fn provider_message_from_session(msg: &Message, include_media: bool) -> Option<C
                     content.push(LlmMessageContent::Image(img_content));
                 }
             }
+            // 文件类附件（PDF/Office）不内联注入主请求。
+            // 统一交给下方的 attachment_notice 提示 + system prompt 中的
+            // 「文档附件解析规则」引导 agent 用本地脚本解析（issue #149）。
             ContentBlock::Media {
                 kind: MediaKind::File,
-                url,
-                mime_type,
-                title,
                 ..
-            } => {
-                if include_media
-                    && msg.role == MessageRole::User
-                    && url.trim_start().starts_with("data:")
-                    && !looks_like_image_reference(url)
-                {
-                    content.push(LlmMessageContent::File(
-                        tiangong_llm::message::FileContent {
-                            mime_type: mime_type
-                                .clone()
-                                .or_else(|| mime_from_data_url(url))
-                                .unwrap_or_else(|| "application/octet-stream".to_string()),
-                            data: url.clone(),
-                            title: title.clone(),
-                        },
-                    ));
-                }
-            }
+            } => {}
             ContentBlock::Media { .. } => {}
         }
     }
@@ -1254,21 +1237,15 @@ fn provider_message_from_session(msg: &Message, include_media: bool) -> Option<C
                 .unwrap_or(content.len());
             content.insert(pos, notice);
         }
-        let file_count = content
-            .iter()
-            .filter(|c| matches!(c, LlmMessageContent::File(_)))
-            .count();
-        if file_count > 0 {
-            let notice = LlmMessageContent::Text(format!(
-                "本条用户消息包含 {file_count} 个文件附件，文件内容已以 base64 data URL 随消息提供，请直接基于附件分析。"
-            ));
-            let pos = content
-                .iter()
-                .position(|c| matches!(c, LlmMessageContent::File(_)))
-                .unwrap_or(content.len());
-            content.insert(pos, notice);
-        }
-    } else if msg.role == MessageRole::User && msg.has_media() {
+    }
+    // 文件附件（PDF/Office）统一走 attachment_notice 提示，不内联进请求。
+    // 无论 include_media 与否，只要用户消息含文件附件就注入提示，
+    // 由 system prompt 中的「文档附件解析规则」引导 agent 本地解析。
+    // 对于图片类附件：当 include_media=false 时（chat 模型非多模态）也走提示，
+    // 引导调用 analyze_attachment 工具。
+    let needs_attachment_notice = msg.role == MessageRole::User
+        && (msg.has_file_media() || (!include_media && msg.has_media()));
+    if needs_attachment_notice {
         content.push(LlmMessageContent::Text(attachment_notice_text(msg)));
     }
 
@@ -1288,23 +1265,35 @@ fn provider_message_from_session(msg: &Message, include_media: bool) -> Option<C
 
 fn attachment_notice_text(msg: &Message) -> String {
     let mut media_index = 0usize;
+    let mut has_file_attachment = false;
     let items: Vec<String> = msg
         .content
         .iter()
         .filter_map(|block| {
             if let ContentBlock::Media {
                 kind,
-                url: _,
+                url,
                 mime_type,
                 title,
             } = block
             {
+                if matches!(kind, MediaKind::File) {
+                    has_file_attachment = true;
+                }
                 let title = title.as_deref().unwrap_or("未命名附件");
                 let mime = mime_type.as_deref().unwrap_or("unknown");
                 let idx = media_index;
                 media_index += 1;
+                // 归档成功的附件 url 是本地路径，可直接引用。
+                // 归档失败的附件 url 仍是 data URL（可能长达数 MB），
+                // 绝不能原样塞进提示文本，否则会撑爆上下文窗口。
+                let path_field = if url.trim_start().starts_with("data:") {
+                    "<归档失败，仅有内联 data URL；请告知用户重新上传>".to_string()
+                } else {
+                    url.clone()
+                };
                 Some(format!(
-                    "- index={idx} kind={kind:?} title={title} mime_type={mime}",
+                    "- index={idx} kind={kind:?} title={title} mime_type={mime} path={path_field}",
                 ))
             } else {
                 None
@@ -1312,10 +1301,21 @@ fn attachment_notice_text(msg: &Message) -> String {
         })
         .collect();
     let items = items.join("\n");
-    format!(
-        "本条用户消息包含附件，但主模型请求不会直接携带附件内容。需要查看附件内容时，请调用 analyze_attachment 工具，必须使用本提示中的 message_id={}（不要使用其他消息的 ID），并指定附件 index。\n{}",
-        msg.id, items
-    )
+    if has_file_attachment {
+        // 文件类附件（PDF/Office）统一走本地脚本解析（issue #149）。
+        // path 字段为本地归档路径（~/.tiangong/media/files/...），
+        // agent 据此用 run_command 读取并解析，具体方法见 system prompt 中的
+        // 「文档附件解析规则」段。
+        format!(
+            "本条用户消息包含文件附件，文件内容不会直接发送给模型。请使用 run_command 工具按「文档附件解析规则」读取上述 path 路径的文件并解析（path 为本地归档路径，可直接读取）。\n{}",
+            items
+        )
+    } else {
+        format!(
+            "本条用户消息包含附件，但主模型请求不会直接携带附件内容。需要查看附件内容时，请调用 analyze_attachment 工具，必须使用本提示中的 message_id={}（不要使用其他消息的 ID），并指定附件 index。\n{}",
+            msg.id, items
+        )
+    }
 }
 
 fn image_content_from_reference(value: &str) -> Option<tiangong_llm::message::ImageContent> {
@@ -1340,16 +1340,6 @@ fn image_content_from_reference(value: &str) -> Option<tiangong_llm::message::Im
     Some(tiangong_llm::message::ImageContent { mime_type, data })
 }
 
-fn looks_like_image_reference(value: &str) -> bool {
-    let lower = value.trim().to_ascii_lowercase();
-    lower.starts_with("data:image/")
-        || lower.ends_with(".png")
-        || lower.ends_with(".jpg")
-        || lower.ends_with(".jpeg")
-        || lower.ends_with(".webp")
-        || lower.ends_with(".gif")
-}
-
 fn image_mime_from_reference(value: &str) -> Option<String> {
     let lower = value.trim().to_ascii_lowercase();
     if lower.starts_with("data:image/") {
@@ -1368,15 +1358,6 @@ fn image_mime_from_reference(value: &str) -> Option<String> {
     } else {
         None
     }
-}
-
-fn mime_from_data_url(value: &str) -> Option<String> {
-    let trimmed = value.trim();
-    trimmed
-        .strip_prefix("data:")
-        .and_then(|raw| raw.split(';').next())
-        .filter(|mime| !mime.trim().is_empty())
-        .map(str::to_string)
 }
 
 fn sanitize_provider_messages(messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
@@ -2098,5 +2079,191 @@ mod tests {
         assert_eq!(provider_message_tool_result_count(&sanitized[2]), 2);
         assert_eq!(sanitized[3].role, LlmMessageRole::User);
         assert!(is_internal_tool_context_message(&sanitized[3]));
+    }
+
+    #[test]
+    fn file_attachment_injects_notice_with_path() {
+        // 含 PDF 文件附件的 user 消息，必须注入 attachment_notice（含 path），
+        // 而不是把文件内联或静默丢弃（issue #149 的核心保证）。
+        let msg = test_user_message_with_media(
+            "请处理这些附件。",
+            MediaKind::File,
+            "/Users/test/.tiangong/media/files/abc.pdf",
+            Some("application/pdf"),
+            Some("测试文档.pdf"),
+        );
+
+        // include_media=true（chat 模型多模态）：文件仍走 notice，不内联
+        let result = provider_message_from_session(&msg, true).expect("应生成消息");
+        let texts: Vec<&str> = result
+            .content
+            .iter()
+            .filter_map(|c| match c {
+                LlmMessageContent::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        let notice = texts
+            .iter()
+            .find(|t| t.contains("path="))
+            .unwrap_or_else(|| panic!("应包含 attachment_notice，实际 texts: {texts:?}"));
+        assert!(
+            notice.contains("path=/Users/test/.tiangong/media/files/abc.pdf"),
+            "notice 应含文件路径，实际：{notice}"
+        );
+        assert!(
+            notice.contains("文件附件"),
+            "notice 应说明是文件附件，实际：{notice}"
+        );
+        // 不应有内联 File content
+        assert!(
+            !result
+                .content
+                .iter()
+                .any(|c| matches!(c, LlmMessageContent::File(_))),
+            "文件不应内联为 File content"
+        );
+    }
+
+    #[test]
+    fn file_attachment_notice_injected_even_when_include_media_false() {
+        // include_media=false 时同样应注入 notice
+        let msg = test_user_message_with_media(
+            "分析这个",
+            MediaKind::File,
+            "/tmp/doc.docx",
+            Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+            None,
+        );
+        let result = provider_message_from_session(&msg, false).expect("应生成消息");
+        assert!(result.content.iter().any(|c| matches!(
+            c,
+            LlmMessageContent::Text(t) if t.contains("path=/tmp/doc.docx")
+        )));
+    }
+
+    #[test]
+    fn image_attachment_still_inlines_when_multimodal() {
+        // 图片附件在 include_media=true 时应内联，不走 notice（回归保护）
+        let msg = test_user_message_with_media(
+            "看这张图",
+            MediaKind::Image,
+            "data:image/png;base64,iVBORw0KGgo=",
+            Some("image/png"),
+            None,
+        );
+        let result = provider_message_from_session(&msg, true).expect("应生成消息");
+        assert!(
+            result
+                .content
+                .iter()
+                .any(|c| matches!(c, LlmMessageContent::Image(_))),
+            "图片应内联为 Image content"
+        );
+    }
+
+    /// 构造测试用 user Message（含一个 media block）
+    fn test_user_message_with_media(
+        text: &str,
+        kind: MediaKind,
+        url: &str,
+        mime_type: Option<&str>,
+        title: Option<&str>,
+    ) -> Message {
+        Message {
+            id: "msg_test".to_string(),
+            role: MessageRole::User,
+            content: vec![
+                ContentBlock::text(text),
+                ContentBlock::Media {
+                    kind,
+                    url: url.to_string(),
+                    mime_type: mime_type.map(str::to_string),
+                    title: title.map(str::to_string),
+                },
+            ],
+            reasoning_content: String::new(),
+            reasoning_signature: None,
+            worker_id: None,
+            media: Vec::new(),
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+            tool_name: None,
+            tool_result_is_error: false,
+            compact: false,
+            created_at: String::new(),
+            media_migrated: true,
+        }
+    }
+
+    #[test]
+    fn end_to_end_request_contains_rules_and_notice() {
+        // 端到端验证：完整 ModelRequest 构建（build_provider_messages）后，
+        // system prompt 必须含「文档附件解析规则」，user message 必须含
+        // attachment_notice（含文件路径）。
+        // 这是离实际 LLM 请求最近的测试，能暴露注入链路的任何断点。
+        let user_msg = test_user_message_with_media(
+            "请处理这些附件。",
+            MediaKind::File,
+            "/Users/test/.tiangong/media/files/report.pdf",
+            Some("application/pdf"),
+            Some("report.pdf"),
+        );
+
+        // 构造一条含解析规则的 System 消息（模拟 rebuild_system_prompt 的输出）
+        let system_msg = Message {
+            id: "sys".to_string(),
+            role: MessageRole::System,
+            content: vec![ContentBlock::text(
+                "你是天工助手。\n## 文档附件解析规则\n源文件已归档在 ~/.tiangong/media/files/。",
+            )],
+            reasoning_content: String::new(),
+            reasoning_signature: None,
+            worker_id: None,
+            media: Vec::new(),
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+            tool_name: None,
+            tool_result_is_error: false,
+            compact: false,
+            created_at: String::new(),
+            media_migrated: true,
+        };
+
+        let req = ModelRequest {
+            session_title: "测试".to_string(),
+            user_input: String::new(),
+            context: vec![system_msg, user_msg],
+            thinking: None,
+            reasoning_effort: None,
+            thinking_disabled: false,
+            include_media: true,
+        };
+
+        let (system, messages) = build_provider_messages(&req);
+
+        // system prompt 必须含解析规则（来自 System 消息，不是 fallback 常量）
+        assert!(
+            system.contains("文档附件解析规则"),
+            "system prompt 应含解析规则，实际前200字：{}",
+            &system[..system.len().min(200)]
+        );
+        assert!(
+            system.contains("media/files"),
+            "system prompt 应含 media/files 路径说明"
+        );
+
+        // user message 必须含 attachment_notice（含文件路径）
+        let user_content = messages
+            .iter()
+            .find(|m| m.role == LlmMessageRole::User)
+            .expect("应有 user 消息");
+        let has_notice = user_content.content.iter().any(|c| match c {
+            LlmMessageContent::Text(t) => {
+                t.contains("path=/Users/test/.tiangong/media/files/report.pdf")
+            }
+            _ => false,
+        });
+        assert!(has_notice, "user message 应含带路径的 attachment_notice");
     }
 }

--- a/crates/tiangong-core/src/prompt/attachment_rules.rs
+++ b/crates/tiangong-core/src/prompt/attachment_rules.rs
@@ -1,0 +1,59 @@
+//! 文档附件解析规则段（issue #149）
+//!
+//! 用户上传的 PDF/Office 文件**一律走本地脚本解析**，不依赖多模态模型能力。
+//! 文件归档在 `~/.tiangong/media/files/`，解析产生的结果文件写入当前 workspace。
+//! 本段把上述约定和具体解析方法嵌入 system prompt，由 agent 运行时自主执行。
+
+/// 构建文档附件解析规则段。
+pub fn attachment_rules_section() -> String {
+    "## 文档附件解析规则\n\
+     用户上传的 PDF / Word(.docx) / Excel(.xlsx) / PowerPoint(.pptx) 文件**统一用本地脚本解析**，不直接交给多模态模型。\n\
+     \n\
+     ### 文件位置\n\
+     - 源文件已归档在 `~/.tiangong/media/files/`，用户消息的附件提示中给出 `path=<本地路径>`，可直接读取。\n\
+     - **解析产生的结果文件（提取的文本/转换的格式/生成的报告等）必须写入当前 workspace 目录**，不要写到归档目录或系统其他位置。\n\
+     \n\
+     ### 解析方法（按格式选用）\n\
+     - PDF：`python3` + pdfplumber（`pip install pdfplumber`）\n\
+     - docx：`python3` + python-docx（`pip install python-docx`，`from docx import Document`）\n\
+     - xlsx：`python3` + openpyxl（`pip install openpyxl`）\n\
+     - pptx：`python3` + python-pptx（`pip install python-pptx`）\n\
+     - Node 备选：pdf-parse / mammoth / exceljs / pptxtojson\n\
+     \n\
+     ### 依赖安装（隔离，不污染系统环境）\n\
+     ```\n\
+     pip install --target ~/.tiangong/parsers/python <package>\n\
+     PYTHONPATH=~/.tiangong/parsers/python python3 -c \"...\"\n\
+     npm install --prefix ~/.tiangong/parsers/node <package>\n\
+     ```\n\
+     \n\
+     ### 输出规范\n\
+     1. 解析结果转为 Markdown（保留标题层级、表格、列表结构）后引用。\n\
+     2. 大文件按页/段分批处理，避免单次注入过多内容。\n\
+     3. 解析大文件可能超过默认 30s 超时，用 `__tiangong_timeout=120000` 覆盖。\n\
+     4. 解析失败必须如实告知用户，不得虚构结果。\n\
+     5. 若产生中间/结果文件（如提取的 .md、转换的 .csv），写入 workspace 并告知用户路径。"
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn section_contains_key_libraries() {
+        let section = attachment_rules_section();
+        assert!(section.contains("pdfplumber"));
+        assert!(section.contains("python-docx"));
+        assert!(section.contains("openpyxl"));
+        assert!(section.contains("python-pptx"));
+    }
+
+    #[test]
+    fn section_emphasizes_local_parsing_and_workspace_output() {
+        let section = attachment_rules_section();
+        assert!(section.contains("~/.tiangong/media/files/"));
+        assert!(section.contains("workspace"));
+        assert!(section.contains("~/.tiangong/parsers"));
+    }
+}

--- a/crates/tiangong-core/src/prompt/mod.rs
+++ b/crates/tiangong-core/src/prompt/mod.rs
@@ -3,6 +3,8 @@
 //! 通过 `build_full_system_prompt()` 构建完整的 system prompt 消息，
 //! 包含身份、规则、自定义指令、环境信息、动态段和对话摘要。
 
+pub mod attachment_rules;
 pub mod sections;
 
+pub use attachment_rules::attachment_rules_section;
 pub use sections::{SubAgentPromptContext, SystemPromptConfig};

--- a/crates/tiangong-core/src/prompt/sections.rs
+++ b/crates/tiangong-core/src/prompt/sections.rs
@@ -157,6 +157,8 @@ pub struct SystemPromptConfig {
     pub user_context: Vec<String>,
     /// Plugin 注入的额外段落（如终端交互引导、浏览器使用规范等）
     pub plugin_sections: Vec<String>,
+    /// 文档附件解析规则段（PDF/Office 处理引导，issue #149）
+    pub attachment_rules_text: String,
 }
 
 impl SystemPromptConfig {
@@ -173,6 +175,7 @@ impl SystemPromptConfig {
             team_text: build_agent_team_section(),
             user_context: build_user_context(session_id, None),
             plugin_sections: Vec::new(),
+            attachment_rules_text: super::attachment_rules::attachment_rules_section(),
         }
     }
 
@@ -233,6 +236,9 @@ fn collect_dynamic_parts(config: &SystemPromptConfig) -> Vec<String> {
     let mut parts = Vec::new();
     if !config.media_text.is_empty() {
         parts.push(config.media_text.clone());
+    }
+    if !config.attachment_rules_text.is_empty() {
+        parts.push(config.attachment_rules_text.clone());
     }
     if !config.skills_text.is_empty() {
         parts.push(config.skills_text.clone());

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -517,8 +517,10 @@ impl ReactEngine {
         }
 
         'react_loop: loop {
-            // 首轮：确保 system prompt 已构建
-            if round == 0 && session.system_prompt_message.is_none() {
+            // 首轮：始终重建 system prompt，确保规则段（如「文档附件解析规则」）
+            // 与当前代码版本一致。旧 session 持久化的 system_prompt_message 可能
+            // 是旧版本生成、缺少新增的规则段，必须重建。
+            if round == 0 {
                 crate::react::context::rebuild_system_prompt(session, &self.engine);
             }
             match drain_pending_commands_async(session, &self.engine, stream_tx, cmd_rx) {

--- a/crates/tiangong-core/tests/context_integration.rs
+++ b/crates/tiangong-core/tests/context_integration.rs
@@ -112,6 +112,7 @@ fn new_path_system_prompt_includes_all_sections() {
         team_text: "团队协作能力".to_string(),
         user_context: vec!["用户偏好深色主题".to_string()],
         plugin_sections: vec!["插件规则段：终端交互引导".to_string()],
+        attachment_rules_text: String::new(),
     };
     let msg = tiangong_core::prompt::sections::build_full_system_prompt(&session, &config);
     assert_eq!(msg.role, MessageRole::System);
@@ -248,5 +249,29 @@ fn new_path_clear_and_rebuild_system_prompt() {
     assert!(
         !context_after[0].text_content().contains("此前对话摘要"),
         "清空后 system prompt 不应包含摘要段"
+    );
+}
+
+#[test]
+fn system_prompt_contains_attachment_rules_after_rebuild() {
+    // 验证 rebuild_system_prompt 后，system prompt 必须包含
+    // 「文档附件解析规则」段和 media/files 路径说明（issue #149 核心）。
+    let mut session = helper_session();
+    rebuild_session(&mut session);
+    assert!(session.system_prompt_message.is_some());
+    let context = session.context();
+    let system_text = context[0].text_content();
+    assert!(
+        system_text.contains("文档附件解析规则"),
+        "system prompt 应包含文档附件解析规则段，实际前300字：{}",
+        &system_text[..system_text.len().min(300)]
+    );
+    assert!(
+        system_text.contains("media/files"),
+        "system prompt 应包含 media/files 路径说明"
+    );
+    assert!(
+        system_text.contains("pdfplumber") || system_text.contains("python-docx"),
+        "system prompt 应包含具体解析库名"
     );
 }

--- a/crates/tiangong-llm/src/providers/openai/mapping.rs
+++ b/crates/tiangong-llm/src/providers/openai/mapping.rs
@@ -224,9 +224,17 @@ fn build_user_item(message: &ChatMessage) -> Result<Option<Value>> {
             _ => None,
         })
         .collect::<Vec<_>>();
+    let files = message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            MessageContent::File(file) => Some(file),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
     let text = collect_text(message);
 
-    if images.is_empty() {
+    if images.is_empty() && files.is_empty() {
         if text.trim().is_empty() {
             return Ok(None);
         }
@@ -247,6 +255,20 @@ fn build_user_item(message: &ChatMessage) -> Result<Option<Value>> {
             "image_url": image.data,
         }));
     }
+    // 文档附件（PDF/Office）的 Responses API 原生 file block 映射。
+    // 官方规范：{ "type": "file", "file": { "filename": "...", "file_data": "data:<mime>;base64,..." } }
+    // 注：当前上层策略下文件附件统一走本地脚本解析，不会产生 MessageContent::File；
+    // 此分支保留以支持未来直传场景，并维持 provider 层映射的完整性。
+    for file in files {
+        let filename = file_filename_with_fallback(&file.title, &file.mime_type);
+        content.push(json!({
+            "type": "file",
+            "file": {
+                "filename": filename,
+                "file_data": file.data,
+            }
+        }));
+    }
     Ok(Some(json!({
         "type": "message",
         "role": "user",
@@ -264,16 +286,32 @@ fn collect_text(message: &ChatMessage) -> String {
                 crate::tool::ToolResultContent::Text(text) => text.clone(),
                 crate::tool::ToolResultContent::Json(value) => value.to_string(),
             }),
-            MessageContent::File(file) => Some(format!(
-                "<attachment title=\"{}\" mime_type=\"{}\">\n{}\n</attachment>",
-                file.title.as_deref().unwrap_or("attachment"),
-                file.mime_type,
-                file.data
-            )),
+            // File 由 build_user_item 走原生 file block，此处不再降级为文本，
+            // 避免 base64 data URL 塞进文本导致 token 膨胀且模型无法读取。
             _ => None,
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// 推断文档附件的文件名，供 Responses API 的 file block 使用。
+///
+/// 优先用 title（前端传入的用户可见文件名）；否则按 MIME 兜底一个通用名。
+fn file_filename_with_fallback(title: &Option<String>, mime_type: &str) -> String {
+    if let Some(title) = title {
+        let trimmed = title.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    let ext = match mime_type {
+        "application/pdf" => "pdf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => "docx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => "xlsx",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation" => "pptx",
+        _ => "bin",
+    };
+    format!("attachment.{ext}")
 }
 
 /// 解析 Responses API 完整响应。
@@ -691,5 +729,80 @@ mod tests {
         assert_eq!(base, "https://api.openai.com/v1");
         let err = normalize_api_base("  ");
         assert!(err.is_err(), "空 base_url 应报错：{err:?}");
+    }
+
+    #[test]
+    fn user_item_with_pdf_uses_native_file_block() {
+        // Responses API 文件输入必须用 {"type":"file","file":{...}} 结构，
+        // file_data 为 data URI。错误结构（如 input_file/file_url）会被静默丢弃，
+        // 导致模型无法感知文件（issue #149）。
+        let message = ChatMessage::new(
+            MessageRole::User,
+            vec![
+                MessageContent::Text("总结这份文档".to_string()),
+                MessageContent::File(crate::message::FileContent {
+                    mime_type: "application/pdf".to_string(),
+                    data: "data:application/pdf;base64,JVBERi0xLjQ=".to_string(),
+                    title: Some("report.pdf".to_string()),
+                }),
+            ],
+        );
+        let item = build_user_item(&message)
+            .unwrap()
+            .expect("应生成 user item");
+        let content = item
+            .get("content")
+            .and_then(|v| v.as_array())
+            .expect("应有 content 数组");
+
+        let file_block = content
+            .iter()
+            .find(|v| v.get("type").and_then(|t| t.as_str()) == Some("file"))
+            .expect("应包含 type=file 的内容块");
+
+        assert_eq!(
+            file_block
+                .get("file")
+                .and_then(|f| f.get("filename"))
+                .and_then(|v| v.as_str()),
+            Some("report.pdf")
+        );
+        assert_eq!(
+            file_block
+                .get("file")
+                .and_then(|f| f.get("file_data"))
+                .and_then(|v| v.as_str()),
+            Some("data:application/pdf;base64,JVBERi0xLjQ=")
+        );
+        // 不应再出现已废弃的 input_file/file_url 结构
+        assert!(
+            content
+                .iter()
+                .all(|v| v.get("type").and_then(|t| t.as_str()) != Some("input_file")),
+            "不应使用 input_file 类型"
+        );
+    }
+
+    #[test]
+    fn file_block_filename_falls_back_by_mime() {
+        assert_eq!(
+            file_filename_with_fallback(&None, "application/pdf"),
+            "attachment.pdf"
+        );
+        assert_eq!(
+            file_filename_with_fallback(
+                &None,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+            "attachment.xlsx"
+        );
+        assert_eq!(
+            file_filename_with_fallback(&Some("  ".to_string()), "application/pdf"),
+            "attachment.pdf"
+        );
+        assert_eq!(
+            file_filename_with_fallback(&Some("用户文档.docx".to_string()), "application/pdf"),
+            "用户文档.docx"
+        );
     }
 }

--- a/crates/tiangong-llm/src/providers/openai/stream.rs
+++ b/crates/tiangong-llm/src/providers/openai/stream.rs
@@ -100,6 +100,28 @@ pub fn parse_stream_event(
             {
                 events.push(Ok(ProviderStreamEvent::Usage(parse_usage(usage))));
             }
+            // 兜底提取 function_call 的完整 arguments。
+            // 某些中转/模型不发 function_call_arguments.delta，导致流式拼接的
+            // arguments 为空。response.completed 的 output 里含完整 function_call
+            // items（带 arguments），此处补发确保工具参数不丢失。
+            if let Some(output) = payload
+                .get("response")
+                .and_then(|r| r.get("output"))
+                .and_then(Value::as_array)
+            {
+                for item in output {
+                    if item.get("type").and_then(Value::as_str) == Some("function_call")
+                        && let Some(call) = parse_function_call_item(item)
+                        && let Some(args) = call.arguments
+                        && !args.trim().is_empty()
+                    {
+                        events.push(Ok(ProviderStreamEvent::ToolCallDelta {
+                            call_id: call.call_id,
+                            partial_json: args,
+                        }));
+                    }
+                }
+            }
             // 兜底解析 reasoning 由 provider 层根据"是否收到过 delta"决定，
             // 避免此处无条件补发导致与流式增量重复。
             events.push(Ok(ProviderStreamEvent::MessageEnd));
@@ -151,12 +173,21 @@ pub(super) fn extract_completed_reasoning(payload: &Value) -> Option<String> {
 pub(super) struct ParsedFunctionCall {
     pub(super) call_id: String,
     pub(super) name: String,
+    pub(super) arguments: Option<String>,
 }
 
 pub(super) fn parse_function_call_item(item: &Value) -> Option<ParsedFunctionCall> {
     let call_id = item.get("call_id").and_then(Value::as_str)?.to_string();
     let name = item.get("name").and_then(Value::as_str)?.to_string();
-    Some(ParsedFunctionCall { call_id, name })
+    let arguments = item
+        .get("arguments")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    Some(ParsedFunctionCall {
+        call_id,
+        name,
+        arguments,
+    })
 }
 
 #[cfg(test)]
@@ -283,5 +314,62 @@ mod tests {
             .iter()
             .any(|e| matches!(e, Ok(ProviderStreamEvent::ReasoningDelta(_))));
         assert!(no_reasoning, "无 reasoning item 时不应输出 reasoning");
+    }
+
+    #[test]
+    fn completed_event_backfills_function_call_arguments() {
+        // 某些中转不发 function_call_arguments.delta，导致流式拼接的 arguments 为空。
+        // response.completed 的 output 含完整 function_call items（带 arguments），
+        // 应兜底提取并通过 ToolCallDelta 补发。
+        let payload = json!({
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_abc",
+                        "name": "run_command",
+                        "arguments": "{\"command\": \"python3 -c 'print(1)'\"}"
+                    }
+                ],
+                "usage": { "input_tokens": 1, "output_tokens": 1, "total_tokens": 2 }
+            }
+        });
+        let events = parse_stream_event(&payload);
+        let has_tool_delta = events.iter().any(|e| {
+            matches!(
+                e,
+                Ok(ProviderStreamEvent::ToolCallDelta { call_id, partial_json })
+                    if call_id == "call_abc" && partial_json.contains("python3")
+            )
+        });
+        assert!(
+            has_tool_delta,
+            "completed 应兜底补发 function_call arguments，实际 events: {events:?}"
+        );
+    }
+
+    #[test]
+    fn completed_event_skips_empty_function_call_arguments() {
+        // arguments 为空字符串时不应补发（无意义）
+        let payload = json!({
+            "type": "response.completed",
+            "response": {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_xyz",
+                        "name": "run_command",
+                        "arguments": ""
+                    }
+                ],
+                "usage": { "input_tokens": 1, "output_tokens": 1, "total_tokens": 2 }
+            }
+        });
+        let events = parse_stream_event(&payload);
+        let has_tool_delta = events
+            .iter()
+            .any(|e| matches!(e, Ok(ProviderStreamEvent::ToolCallDelta { .. })));
+        assert!(!has_tool_delta, "空 arguments 不应补发 ToolCallDelta");
     }
 }

--- a/crates/tiangong-types/src/message.rs
+++ b/crates/tiangong-types/src/message.rs
@@ -247,6 +247,21 @@ impl Message {
         self.content.iter().any(|b| !b.is_text())
     }
 
+    /// 判断是否包含文件类附件（PDF/Office 等非图片媒体）。
+    ///
+    /// 文件附件统一走本地脚本解析，不内联进 LLM 请求（issue #149）。
+    pub fn has_file_media(&self) -> bool {
+        self.content.iter().any(|b| {
+            matches!(
+                b,
+                ContentBlock::Media {
+                    kind: MediaKind::File,
+                    ..
+                }
+            )
+        })
+    }
+
     /// 将旧格式 media 字段迁移到 content 数组。
     /// 加载旧 session 后调用此方法完成自动升级。
     pub fn migrate_legacy_media(&mut self) {

--- a/docs/office-pdf-attachment-parsing.md
+++ b/docs/office-pdf-attachment-parsing.md
@@ -1,0 +1,132 @@
+# Office / PDF 文件上传与内容解析（issue #149）
+
+## 背景
+
+早期文件上传仅支持图片（png/jpg/jpeg/webp/gif）和少量文本格式（txt/md/json/csv）。用户经常需要让 Agent 处理 Office 文档与 PDF：
+
+- "帮我总结这个 PDF 的内容"
+- "分析这个 Excel 表格的数据"
+- "把这份 PPT 的要点提取出来"
+
+本文档说明本期支持的格式范围、解析策略与架构决策。
+
+## 支持的格式
+
+| 格式 | 扩展名 | MIME |
+|---|---|---|
+| PDF | `.pdf` | `application/pdf` |
+| Word | `.docx` | `application/vnd.openxmlformats-officedocument.wordprocessingml.document` |
+| Excel | `.xlsx` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` |
+| PowerPoint | `.pptx` | `application/vnd.openxmlformats-officedocument.presentationml.presentation` |
+
+旧版二进制 Office（`.doc`/`.xls`/`.ppt`）本期不做，留作后续 P2。
+
+## 核心设计理念：多模态优先 + Agent 自主 fallback
+
+本系统**不在后端写死 Rust 解析器**，而是采用两层策略：
+
+1. **多模态优先**：让模型直接读取文档原生内容
+   - PDF 走 Anthropic `document` block / OpenAI Responses `input_file` 原生 API
+   - Office 文件因多模态原生 API 支持有限，主要靠本地转换后喂模型
+2. **Agent 自主 fallback**：把"如何用 python3/node 解析这些格式"的知识嵌入 system prompt，
+   当多模态不可用或失败时，由 agent 自主调用 `run_command` 执行脚本解析
+
+这与项目既有的"Skill 引导 agent 调脚本"模式一致，不引入新的解析框架。
+
+## 数据流
+
+```
+用户上传 PDF/docx/xlsx/pptx
+        │
+        ▼
+[前端] 文件选择器扩展 + MIME 推断（attachments.ts / MessageInput.tsx）
+        │
+        ▼ data URL / 本地路径
+[归档] media_archive.rs：Office/PDF 归档到 ~/.tiangong/media/files/
+        │
+        ▼ ContentBlock::Media{kind:File, url:<归档路径>, mime_type}
+[注入决策] 两条路径（复用现有机制）
+        │
+        ├─ 路径A: chat 模型自带 multimodal
+        │     └─ provider_message_from_session → 随主请求发送
+        │           ├─ Anthropic: document block（PDF 原生）✅
+        │           └─ OpenAI Responses: input_file 🔧（本期新增）
+        │
+        └─ 路径B: chat 非 multimodal，有独立 multimodal 端点
+              └─ analyze_attachment 工具 → multimodal_client 解析
+        │
+        ▼
+[fallback 引导] System Prompt 注入"文档附件解析规则"段
+        └─ agent 按需用 run_command 跑：
+              python3 + pdfplumber / python-docx / openpyxl / python-pptx
+              缺库时 pip install --target ~/.tiangong/parsers/python <pkg>
+```
+
+## 关键改动点
+
+### 前端
+
+- `frontend/src/utils/attachments.ts` — `fileMimeType()` 扩展 docx/xlsx/pptx
+- `frontend/src/components/MessageInput.tsx` — 文件选择器 `extensions` 追加新格式
+
+### Tauri 壳
+
+- `src-tauri/src/commands.rs` — `mime_type_from_path()` 扩展 docx/xlsx/pptx
+
+### 归档
+
+- `crates/tiangong-core/src/media_archive.rs` — 新增文档归档逻辑：
+  - `is_document_asset()` / `archive_file_reference()` 处理 PDF/Office
+  - 文档归档到独立的 `~/.tiangong/media/files/` 子目录（与 `images/` 并列）
+  - 图片归档逻辑保持不变
+
+### LLM 注入
+
+- `crates/tiangong-core/src/model.rs`：
+  - 新增 `file_content_from_reference()`：本地路径读字节转 base64 data URL
+  - 修复 `provider_message_from_session` 的 `MediaKind::File` 分支，支持本地路径注入
+  - 新增 `file_mime_from_path()` 按扩展名推断文档 MIME
+
+### Provider 原生支持
+
+- `crates/tiangong-llm/src/providers/openai/mapping.rs`：
+  - `build_user_item()` 新增 `MessageContent::File` 分支 → `input_file` 原生 block
+  - `collect_text()` 移除 File 降级为文本的行为（避免 base64 膨胀 token）
+- Anthropic 路径无需改动（`anthropic/mapping.rs` 已映射为 document block）
+- OpenAI Chat Completions / DeepSeek：文件原生支持弱，维持现状靠 prompt fallback
+
+### System Prompt
+
+- `crates/tiangong-core/src/prompt/attachment_rules.rs` — **新增**：`attachment_rules_section()`
+- `crates/tiangong-core/src/prompt/sections.rs` — `SystemPromptConfig` 新增 `attachment_rules_text` 字段，
+  在 `collect_dynamic_parts()` 中于 media_text 之后注入
+
+## 解析依赖隔离
+
+Agent 自主安装解析依赖时，统一使用隔离目录，避免污染系统环境：
+
+```
+~/.tiangong/parsers/python/   # pip install --target
+~/.tiangong/parsers/node/     # npm install --prefix
+```
+
+调用时设：
+
+```
+PYTHONPATH=~/.tiangong/parsers/python python3 -c "..."
+```
+
+## 非目标
+
+- ❌ 旧版二进制 Office（`.doc`/`.xls`/`.ppt`）
+- ❌ Office 文件可视化页面预览（渲染为页面/幻灯片图片）
+- ❌ Office 文件编辑能力
+- ❌ OCR（扫描版 PDF / 图片中的文字识别）
+- ❌ 后端写死的 Rust 解析器（改为 agent 自主跑脚本）
+
+## 安全与限制
+
+- 文件大小限制沿用附件既有规则（base64 ≤ 50MB，见 `MAX_ATTACHMENT_BASE64_BYTES`）
+- `run_command` 默认 30s 超时；agent 可用 `__tiangong_timeout=120000` 覆盖大文件解析
+- 非 FullTrust 模式下，解析输出需写到工作区或 `~/.tiangong/`（均在允许根内）
+- `python3`/`pip`/`node`/`npm` 均已在 `run_command` 白名单内

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -571,7 +571,7 @@ export function MessageInput() {
         directory: false,
         title: '选择图片或文件',
         filters: [
-          { name: '图片和文件', extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif', 'pdf', 'txt', 'md', 'json', 'csv'] },
+          { name: '图片和文件', extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif', 'pdf', 'docx', 'xlsx', 'pptx', 'txt', 'md', 'json', 'csv'] },
         ],
       });
       const paths = Array.isArray(selected) ? selected : selected ? [selected] : [];

--- a/frontend/src/utils/attachments.ts
+++ b/frontend/src/utils/attachments.ts
@@ -24,6 +24,15 @@ export function fileMimeType(path: string): string | undefined {
   const imageMime = imageMimeType(lower);
   if (imageMime) return imageMime;
   if (lower.endsWith('.pdf')) return 'application/pdf';
+  if (lower.endsWith('.docx')) {
+    return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+  }
+  if (lower.endsWith('.xlsx')) {
+    return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+  }
+  if (lower.endsWith('.pptx')) {
+    return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+  }
   if (lower.endsWith('.txt')) return 'text/plain';
   if (lower.endsWith('.md') || lower.endsWith('.markdown')) return 'text/markdown';
   if (lower.endsWith('.json')) return 'application/json';

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -95,6 +95,9 @@ fn mime_type_from_path(path: &std::path::Path) -> String {
         "webp" => "image/webp",
         "gif" => "image/gif",
         "pdf" => "application/pdf",
+        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         "txt" => "text/plain",
         "md" | "markdown" => "text/markdown",
         "json" => "application/json",
@@ -102,6 +105,38 @@ fn mime_type_from_path(path: &std::path::Path) -> String {
         _ => "application/octet-stream",
     }
     .to_string()
+}
+
+/// 从消息的 content blocks 提取 media 资产（新格式）。
+///
+/// `append_message_with_id_and_media` 把附件存进 `content` 的 `ContentBlock::Media`，
+/// 而非旧的 `media` 字段。提取时必须从 content blocks 取，否则附件会丢失。
+fn extract_media_from_content(
+    message: &tiangong_types::Message,
+) -> Vec<tiangong_types::MediaAsset> {
+    message
+        .content
+        .iter()
+        .filter_map(|block| {
+            if let tiangong_types::message::ContentBlock::Media {
+                kind,
+                url,
+                mime_type,
+                title,
+            } = block
+            {
+                Some(tiangong_types::MediaAsset {
+                    kind: *kind,
+                    url: url.clone(),
+                    mime_type: mime_type.clone(),
+                    title: title.clone(),
+                    capability: None,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 async fn ensure_multimodal_enabled(state: &State<'_, TiangongApp>) -> Result<(), String> {
@@ -665,11 +700,14 @@ async fn send_message_inner(
             core_state.prepare_active_user_message_ingress_with_media(content.clone(), media)
         })
         .await?;
+    // 从 content blocks 提取 media（新格式），而非旧 media 字段。
+    // append_message_with_id_and_media 把 media 存进 content blocks，
+    // 旧 media 字段为空。若取旧字段会导致附件丢失（issue #149）。
     let command_media = session_snapshot
         .messages
         .iter()
         .find(|message| message.id == user_message_id)
-        .map(|message| message.media.clone())
+        .map(extract_media_from_content)
         .unwrap_or_default();
 
     // 获取或创建 TiangongCore


### PR DESCRIPTION
## 概述

支持 PDF / Word(.docx) / Excel(.xlsx) / PowerPoint(.pptx) 文件上传与内容解析。

**设计理念**：文件附件统一走本地脚本解析，不内联进多模态请求。解析规则嵌入 system prompt，由 agent 自主用 `run_command` + python3/node 解析，结果文件写入 workspace，源文件归档在 `~/.tiangong/media/files/`。

Closes #149

## 工作流

```
用户上传 PDF/docx/xlsx/pptx
    ↓ 归档到 ~/.tiangong/media/files/（源文件，只读）
    ↓ ContentBlock::Media{kind:File, url:<归档路径>}
agent 收到 attachment_notice（含文件路径）
    + system prompt「文档附件解析规则」
    ↓
agent 用 run_command + pdfplumber/python-docx/openpyxl/python-pptx 解析
    ↓
解析结果文件 → 写入 workspace
解析结果文本 → Markdown 引用到回复
```

## 改动清单

| 文件 | 改动 |
|---|---|
| `frontend/src/utils/attachments.ts` | MIME 扩展 docx/xlsx/pptx |
| `frontend/src/components/MessageInput.tsx` | 文件选择器追加新格式 |
| `src-tauri/src/commands.rs` | MIME 推断 + **修复从 content blocks 提取 media**（旧 media 字段恒空导致附件丢失） |
| `crates/tiangong-core/src/media_archive.rs` | PDF/Office 归档到 `media/files/` |
| `crates/tiangong-core/src/model.rs` | 文件走 attachment_notice（含 path），不内联；data URL 脱敏 |
| `crates/tiangong-core/src/prompt/attachment_rules.rs` | **新增** 解析规则段 |
| `crates/tiangong-core/src/prompt/sections.rs` | 集成规则段 |
| `crates/tiangong-core/src/react/engine.rs` | system prompt round 0 无条件重建 |
| `crates/tiangong-llm/src/providers/openai/stream.rs` | **修复 completed 事件兜底提取 function_call arguments**（中转不发 delta 时补全参数） |
| `crates/tiangong-llm/src/providers/openai/mapping.rs` | file block 原生映射（保留备用） |
| `crates/tiangong-types/src/message.rs` | 新增 `has_file_media()` |
| `docs/office-pdf-attachment-parsing.md` | 设计文档 |

## 排查过程中发现并修复的两个真实 bug

1. **附件丢失**：`commands.rs:675` 从旧 `media` 字段（恒空）取附件，而非 `content` blocks。导致 user 消息到达 LLM 时 media block 丢失，attachment_notice 无法触发。
2. **工具参数丢失**：gpt-5.5 经中转不发 `function_call_arguments.delta`，流式拼接的 arguments 为空。`response.completed` 的 output 含完整 function_call items，但代码未兜底提取。补发 `ToolCallDelta` 解决。

## 验证

- ✅ `cargo fmt -- --check`
- ✅ `cargo clippy --workspace --all-targets --tests --benches -- -D warnings`
- ✅ `cargo nextest run --workspace`（410 通过，2 跳过）
- ✅ 单元测试覆盖归档/注入/兜底等关键路径

## 非目标

- ❌ 旧版二进制 Office（.doc/.xls/.ppt）
- ❌ Office 文件可视化页面预览
- ❌ OCR（扫描版 PDF / 图片文字识别）
- ❌ 后端写死的 Rust 解析器