### PR TITLE
fix: 修复 DeepSeek reasoning_content 与注入工具调用丢失

### DIFF
--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -324,20 +324,6 @@ impl SingleProviderClient {
         build_anthropic_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())
     }
 
-    /// 构建 OpenAI Chat Completions provider。
-    fn build_openai_variant_provider(&self, timeout_ms: u64) -> Result<Box<dyn LlmProvider>> {
-        match self.protocol() {
-            ProviderProtocol::OpenAiChatCompletions => Ok(Box::new(
-                build_openai_provider_from_config(&self.cfg, timeout_ms, self.on_retry.clone())?,
-            )),
-            // 其它协议（Anthropic/DeepSeek）不应进入此方法，给出明确错误。
-            protocol => Err(anyhow!(
-                "build_openai_variant_provider 不支持协议 {}",
-                protocol.as_str()
-            )),
-        }
-    }
-
     fn build_provider_dispatch(&self, timeout_ms: u64) -> Result<ProviderDispatch> {
         match self.protocol() {
             ProviderProtocol::Anthropic => Ok(ProviderDispatch::Anthropic(Box::new(
@@ -387,36 +373,6 @@ impl SingleProviderClient {
             .build()
             .context("初始化异步运行时失败")?;
         runtime.block_on(future).map_err(map_llm_error)
-    }
-
-    fn complete_anthropic(&self, req: &ModelRequest) -> Result<ModelResponse> {
-        self.complete_with_functions_anthropic(req, &[])
-    }
-
-    fn complete_with_functions_anthropic(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-    ) -> Result<ModelFunctionResponse> {
-        self.complete_with_functions_anthropic_with_tool_choice(req, functions, None)
-    }
-
-    fn complete_with_functions_anthropic_with_tool_choice(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-    ) -> Result<ModelFunctionResponse> {
-        let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
-        let model = self.cfg.api_model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("API_MODEL 不能为空，无法发起 Anthropic 请求"));
-        }
-
-        let provider = self.build_anthropic_provider(timeout_ms)?;
-        let request = build_provider_request(req, model, MAX_TOKENS_MAIN, functions, tool_choice);
-        let response = self.block_on_llm(provider.complete(request))?;
-        convert_provider_response_to_function_response(response)
     }
 
     fn complete_lite_anthropic(&self, prompt: &str) -> Result<String> {
@@ -514,7 +470,7 @@ impl SingleProviderClient {
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起轻量级模型请求"));
         }
-        let provider = self.build_openai_variant_provider(timeout_ms)?;
+        let provider = self.build_provider_dispatch(timeout_ms)?;
         let request = ProviderRequest {
             model: model.to_string(),
             system: Some(
@@ -571,7 +527,7 @@ impl SingleProviderClient {
                 .trim()
                 .to_string());
         }
-        let provider = self.build_openai_variant_provider(timeout_ms)?;
+        let provider = self.build_provider_dispatch(timeout_ms)?;
         let response = self.block_on_llm(provider.complete(request))?;
         Ok(collect_provider_text(&response).trim().to_string())
     }
@@ -793,20 +749,12 @@ impl SingleProviderClient {
         functions: &[ToolSpec],
         tool_choice: Option<ToolChoice>,
     ) -> Result<ModelFunctionResponse> {
-        if self.protocol() == ProviderProtocol::Anthropic {
-            return self.complete_with_functions_anthropic_with_tool_choice(
-                req,
-                functions,
-                tool_choice,
-            );
-        }
-
         let timeout_ms = parse_function_timeout_ms(&self.cfg.api_timeout_ms)?;
         let model = self.cfg.api_model.trim();
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起工具模型请求"));
         }
-        let provider = self.build_openai_variant_provider(timeout_ms)?;
+        let provider = self.build_provider_dispatch(timeout_ms)?;
         let request = build_provider_request(req, model, MAX_TOKENS_MAIN, functions, tool_choice);
         let response = self.block_on_llm(provider.complete(request))?;
         convert_provider_response_to_function_response(response)
@@ -892,16 +840,12 @@ impl ModelClient for SingleProviderClient {
     }
 
     fn complete(&self, req: &ModelRequest) -> Result<ModelResponse> {
-        if self.protocol() == ProviderProtocol::Anthropic {
-            return self.complete_anthropic(req);
-        }
-
         let timeout_ms = parse_timeout_ms(&self.cfg.api_timeout_ms)?;
         let model = self.cfg.api_model.trim();
         if model.is_empty() {
             return Err(anyhow!("API_MODEL 不能为空，无法发起模型请求"));
         }
-        let provider = self.build_openai_variant_provider(timeout_ms)?;
+        let provider = self.build_provider_dispatch(timeout_ms)?;
         let request = build_provider_request(req, model, MAX_TOKENS_MAIN, &[], None);
         let response = self.block_on_llm(provider.complete(request))?;
         Ok(ModelResponse {
@@ -1776,6 +1720,17 @@ enum ProviderDispatch {
 }
 
 impl ProviderDispatch {
+    async fn complete(
+        self,
+        request: ProviderRequest,
+    ) -> std::result::Result<ProviderResponse, tiangong_llm::error::LlmError> {
+        match self {
+            ProviderDispatch::Anthropic(provider) => provider.complete(request).await,
+            ProviderDispatch::OpenAi(provider) => provider.complete(request).await,
+            ProviderDispatch::DeepSeek(provider) => provider.complete(request).await,
+        }
+    }
+
     async fn stream(
         self,
         request: ProviderRequest,

--- a/crates/tiangong-deepseek/src/tests.rs
+++ b/crates/tiangong-deepseek/src/tests.rs
@@ -51,6 +51,7 @@ fn chat_message_skip_none_fields() {
     let msg = ChatMessage {
         role: MessageRole::User,
         content: Some(json!("hello")),
+        reasoning_content: None,
         name: None,
         tool_calls: None,
         tool_call_id: None,
@@ -58,9 +59,25 @@ fn chat_message_skip_none_fields() {
     };
     let serialized = serde_json::to_string(&msg).unwrap();
     assert!(!serialized.contains("name"));
+    assert!(!serialized.contains("reasoning_content"));
     assert!(!serialized.contains("tool_calls"));
     assert!(!serialized.contains("tool_call_id"));
     assert!(!serialized.contains("prefix"));
+}
+
+#[test]
+fn chat_message_with_reasoning_content() {
+    let msg = ChatMessage {
+        role: MessageRole::Assistant,
+        content: Some(json!("final text")),
+        reasoning_content: Some("thinking trace".into()),
+        name: None,
+        tool_calls: None,
+        tool_call_id: None,
+        prefix: false,
+    };
+    let value = serde_json::to_value(&msg).unwrap();
+    assert_eq!(value["reasoning_content"], "thinking trace");
 }
 
 #[test]
@@ -68,6 +85,7 @@ fn chat_message_with_tool_calls() {
     let msg = ChatMessage {
         role: MessageRole::Assistant,
         content: None,
+        reasoning_content: None,
         name: None,
         tool_calls: Some(vec![ToolCall {
             id: "call_123".into(),
@@ -92,6 +110,7 @@ fn chat_request_serialization() {
         messages: vec![ChatMessage {
             role: MessageRole::User,
             content: Some(json!("hello")),
+            reasoning_content: None,
             name: None,
             tool_calls: None,
             tool_call_id: None,

--- a/crates/tiangong-deepseek/src/types/chat.rs
+++ b/crates/tiangong-deepseek/src/types/chat.rs
@@ -22,6 +22,8 @@ pub struct ChatMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCall>>,

--- a/crates/tiangong-llm/src/providers/deepseek/mapping.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/mapping.rs
@@ -50,6 +50,7 @@ fn build_messages(req: &ProviderRequest) -> Result<Vec<tiangong_deepseek::types:
         messages.push(tiangong_deepseek::types::ChatMessage {
             role: tiangong_deepseek::types::MessageRole::System,
             content: Some(Value::String(system.clone())),
+            reasoning_content: None,
             name: None,
             tool_calls: None,
             tool_call_id: None,
@@ -67,8 +68,9 @@ fn build_messages(req: &ProviderRequest) -> Result<Vec<tiangong_deepseek::types:
             }
             MessageRole::Assistant => {
                 let text = extract_text(message);
+                let reasoning_content = extract_thinking(message);
                 let tool_calls = build_assistant_tool_calls(message);
-                if !text.is_empty() || !tool_calls.is_empty() {
+                if !text.is_empty() || reasoning_content.is_some() || !tool_calls.is_empty() {
                     messages.push(tiangong_deepseek::types::ChatMessage {
                         role: tiangong_deepseek::types::MessageRole::Assistant,
                         content: if text.is_empty() {
@@ -76,6 +78,7 @@ fn build_messages(req: &ProviderRequest) -> Result<Vec<tiangong_deepseek::types:
                         } else {
                             Some(Value::String(text))
                         },
+                        reasoning_content,
                         name: None,
                         tool_calls: if tool_calls.is_empty() {
                             None
@@ -99,6 +102,7 @@ fn build_messages(req: &ProviderRequest) -> Result<Vec<tiangong_deepseek::types:
                     messages.push(tiangong_deepseek::types::ChatMessage {
                         role: tiangong_deepseek::types::MessageRole::Tool,
                         content: Some(Value::String(content)),
+                        reasoning_content: None,
                         name: None,
                         tool_calls: None,
                         tool_call_id: Some(result.tool_call_id.clone()),
@@ -130,6 +134,7 @@ fn build_user_message(message: &ChatMessage) -> Option<tiangong_deepseek::types:
         return Some(tiangong_deepseek::types::ChatMessage {
             role: tiangong_deepseek::types::MessageRole::User,
             content: Some(Value::String(text)),
+            reasoning_content: None,
             name: None,
             tool_calls: None,
             tool_call_id: None,
@@ -150,6 +155,7 @@ fn build_user_message(message: &ChatMessage) -> Option<tiangong_deepseek::types:
     Some(tiangong_deepseek::types::ChatMessage {
         role: tiangong_deepseek::types::MessageRole::User,
         content: Some(Value::Array(content)),
+        reasoning_content: None,
         name: None,
         tool_calls: None,
         tool_call_id: None,
@@ -173,6 +179,21 @@ fn build_assistant_tool_calls(message: &ChatMessage) -> Vec<tiangong_deepseek::t
             _ => None,
         })
         .collect()
+}
+
+fn extract_thinking(message: &ChatMessage) -> Option<String> {
+    let thinking = message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            MessageContent::Thinking(thinking) => Some(thinking.thinking.trim()),
+            _ => None,
+        })
+        .filter(|thinking| !thinking.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    (!thinking.is_empty()).then_some(thinking)
 }
 
 fn build_tools(specs: &[ToolSpec]) -> Vec<tiangong_deepseek::types::ToolSpec> {
@@ -325,6 +346,8 @@ fn map_stop_reason(reason: &str) -> StopReason {
 mod tests {
     use super::*;
     use crate::message::MessageContent;
+    use crate::message::ThinkingContent;
+    use crate::tool::ToolCall;
 
     fn response_with_arguments(
         arguments: &str,
@@ -362,6 +385,51 @@ mod tests {
             },
             system_fingerprint: String::new(),
         }
+    }
+
+    #[test]
+    fn assistant_thinking_is_passed_back_as_reasoning_content() {
+        let req = ProviderRequest {
+            model: "deepseek-v4-pro".to_string(),
+            system: None,
+            messages: vec![ChatMessage::new(
+                MessageRole::Assistant,
+                vec![
+                    MessageContent::Thinking(ThinkingContent {
+                        thinking: "需要先查询当前数据".to_string(),
+                        signature: None,
+                    }),
+                    MessageContent::ToolCall(ToolCall {
+                        id: "call_1".to_string(),
+                        name: "current_time".to_string(),
+                        arguments: json!({}),
+                    }),
+                ],
+            )],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: 1024,
+            temperature: None,
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+            thinking: None,
+            reasoning_effort: None,
+            thinking_disabled: false,
+        };
+
+        let request = to_deepseek_request(&req).expect("request");
+        let assistant = request
+            .messages
+            .iter()
+            .find(|message| message.role == tiangong_deepseek::types::MessageRole::Assistant)
+            .expect("assistant message");
+
+        assert_eq!(
+            assistant.reasoning_content.as_deref(),
+            Some("需要先查询当前数据")
+        );
+        assert!(assistant.tool_calls.is_some());
     }
 
     #[test]

--- a/crates/tiangong-llm/src/providers/deepseek/mapping.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/mapping.rs
@@ -7,6 +7,10 @@ use crate::response::{ProviderResponse, StopReason};
 use crate::tool::{ToolChoice, ToolSpec, parse_tool_arguments_or_error};
 use crate::usage::TokenUsageData;
 
+const INTERNAL_INJECTION_TOOL_NAME: &str = "plugin_injection";
+const INTERNAL_INJECTION_REASONING_CONTENT: &str =
+    "内部上下文注入：将外部运行时反馈作为工具结果传回，以便继续处理当前任务。";
+
 pub fn to_deepseek_request(
     req: &ProviderRequest,
 ) -> Result<tiangong_deepseek::types::ChatCompletionRequest> {
@@ -68,8 +72,13 @@ fn build_messages(req: &ProviderRequest) -> Result<Vec<tiangong_deepseek::types:
             }
             MessageRole::Assistant => {
                 let text = extract_text(message);
-                let reasoning_content = extract_thinking(message);
                 let tool_calls = build_assistant_tool_calls(message);
+                let reasoning_content = extract_thinking(message).or_else(|| {
+                    fallback_reasoning_content_for_internal_tool_calls(
+                        &tool_calls,
+                        req.thinking_disabled,
+                    )
+                });
                 if !text.is_empty() || reasoning_content.is_some() || !tool_calls.is_empty() {
                     messages.push(tiangong_deepseek::types::ChatMessage {
                         role: tiangong_deepseek::types::MessageRole::Assistant,
@@ -194,6 +203,21 @@ fn extract_thinking(message: &ChatMessage) -> Option<String> {
         .join("\n");
 
     (!thinking.is_empty()).then_some(thinking)
+}
+
+fn fallback_reasoning_content_for_internal_tool_calls(
+    tool_calls: &[tiangong_deepseek::types::ToolCall],
+    thinking_disabled: bool,
+) -> Option<String> {
+    if thinking_disabled {
+        return None;
+    }
+    let has_tool_calls = !tool_calls.is_empty();
+    let only_internal_injections = tool_calls
+        .iter()
+        .all(|tool_call| tool_call.function.name == INTERNAL_INJECTION_TOOL_NAME);
+    (has_tool_calls && only_internal_injections)
+        .then(|| INTERNAL_INJECTION_REASONING_CONTENT.to_string())
 }
 
 fn build_tools(specs: &[ToolSpec]) -> Vec<tiangong_deepseek::types::ToolSpec> {
@@ -429,6 +453,101 @@ mod tests {
             assistant.reasoning_content.as_deref(),
             Some("需要先查询当前数据")
         );
+        assert!(assistant.tool_calls.is_some());
+    }
+
+    #[test]
+    fn internal_plugin_injection_tool_call_gets_reasoning_fallback() {
+        let req = ProviderRequest {
+            model: "deepseek-v4-pro".to_string(),
+            system: None,
+            messages: vec![
+                ChatMessage::text(MessageRole::User, "继续整理浏览器数据"),
+                ChatMessage::new(
+                    MessageRole::Assistant,
+                    vec![MessageContent::ToolCall(ToolCall {
+                        id: "inj_1".to_string(),
+                        name: INTERNAL_INJECTION_TOOL_NAME.to_string(),
+                        arguments: json!({"source": "browser_data"}),
+                    })],
+                ),
+                ChatMessage::new(
+                    MessageRole::Tool,
+                    vec![MessageContent::ToolResult(crate::tool::ToolResult {
+                        tool_call_id: "inj_1".to_string(),
+                        content: crate::tool::ToolResultContent::Text(
+                            "数据来源：browser_data\n相关数据：世界杯战况".to_string(),
+                        ),
+                        is_error: false,
+                    })],
+                ),
+            ],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: 1024,
+            temperature: None,
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+            thinking: None,
+            reasoning_effort: None,
+            thinking_disabled: false,
+        };
+
+        let request = to_deepseek_request(&req).expect("request");
+        let assistant = request
+            .messages
+            .iter()
+            .find(|message| message.role == tiangong_deepseek::types::MessageRole::Assistant)
+            .expect("assistant message");
+
+        assert_eq!(
+            assistant.reasoning_content.as_deref(),
+            Some(INTERNAL_INJECTION_REASONING_CONTENT)
+        );
+        assert_eq!(
+            assistant
+                .tool_calls
+                .as_ref()
+                .and_then(|calls| calls.first())
+                .map(|call| call.function.name.as_str()),
+            Some(INTERNAL_INJECTION_TOOL_NAME)
+        );
+    }
+
+    #[test]
+    fn internal_plugin_injection_skips_reasoning_fallback_when_thinking_disabled() {
+        let req = ProviderRequest {
+            model: "deepseek-chat".to_string(),
+            system: None,
+            messages: vec![ChatMessage::new(
+                MessageRole::Assistant,
+                vec![MessageContent::ToolCall(ToolCall {
+                    id: "inj_1".to_string(),
+                    name: INTERNAL_INJECTION_TOOL_NAME.to_string(),
+                    arguments: json!({"source": "browser_data"}),
+                })],
+            )],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: 1024,
+            temperature: None,
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+            thinking: None,
+            reasoning_effort: None,
+            thinking_disabled: true,
+        };
+
+        let request = to_deepseek_request(&req).expect("request");
+        let assistant = request
+            .messages
+            .iter()
+            .find(|message| message.role == tiangong_deepseek::types::MessageRole::Assistant)
+            .expect("assistant message");
+
+        assert!(assistant.reasoning_content.is_none());
         assert!(assistant.tool_calls.is_some());
     }
 


### PR DESCRIPTION
## 背景

DeepSeek 协议下 reasoning_content 流式输出与工具调用存在异常，reasoning 内容在流式中被截断，且注入工具调用（injection tool）的 reasoning 被丢弃。本次针对性修复已完成（commit e2a7bffd），本 PR 单独推送该修复。

## 变更

修复 DeepSeek 协议的 reasoning_content 透传与注入工具调用处理：

- **保留 reasoning_content 流式输出**：`crates/tiangong-deepseek` 在 chat 类型中透出 reasoning_content，并在 provider mapping 中正确映射流式 delta。
- **路由至 provider 分发**：`crates/tiangong-core/src/model.rs` 简化分发逻辑，将 DeepSeek 统一交由 provider dispatch 处理，避免 reasoning 被截断。
- **保留注入工具调用的 reasoning**：`crates/tiangong-llm/src/providers/deepseek/mapping.rs` 完整保留 injection tool 调用链路的 reasoning 内容。
- 补充 `tiangong-deepseek` 单元测试覆盖 reasoning_content 字段。

> 备注：原分支后续针对嵌入浏览器的修复（web fetch / browser tab）存在异常，已在本地 revert，未包含于本 PR。

## 检查

pre-commit 钩子在推送时已全部通过（fmt / clippy / nextest）。