### PR TITLE
MCP 体验修复:工作目录跟随会话、握手诊断、编辑能力、探测并发化

### DIFF
--- a/crates/tiangong-core/src/agent_config.rs
+++ b/crates/tiangong-core/src/agent_config.rs
@@ -104,8 +104,6 @@ pub struct McpServerConfig {
     pub headers: BTreeMap<String, String>,
     #[serde(default)]
     pub env: BTreeMap<String, String>,
-    #[serde(default)]
-    pub cwd: String,
     #[serde(default = "default_enabled")]
     pub enabled: bool,
     #[serde(default)]
@@ -146,11 +144,6 @@ impl McpServerConfig {
 
     pub fn command_text(&self) -> &str {
         self.command.trim()
-    }
-
-    pub fn cwd_text(&self) -> Option<&str> {
-        let cwd = self.cwd.trim();
-        if cwd.is_empty() { None } else { Some(cwd) }
     }
 }
 

--- a/crates/tiangong-core/src/app_state/facade/management.rs
+++ b/crates/tiangong-core/src/app_state/facade/management.rs
@@ -29,7 +29,6 @@ impl TiangongState {
                         auth_header: None,
                         headers: Vec::new(),
                         env,
-                        cwd: None,
                     },
                 })
             }

--- a/crates/tiangong-core/src/app_state/facade/mcp_settings.rs
+++ b/crates/tiangong-core/src/app_state/facade/mcp_settings.rs
@@ -49,6 +49,15 @@ impl TiangongState {
         service.set_mcp_server_enabled(self, name, enabled)
     }
 
+    pub fn update_mcp_server(
+        &mut self,
+        name: &str,
+        request: RegisterMcpServerRequest,
+    ) -> Result<String> {
+        let service = self.services.mcp_service;
+        service.update_mcp_server(self, name, request)
+    }
+
     pub fn update_agent_config_entry(&mut self, key: &str, value: &str) -> Result<String> {
         let service = self.services.mcp_service;
         service.update_agent_config_entry(self, key, value)

--- a/crates/tiangong-core/src/app_state/mod.rs
+++ b/crates/tiangong-core/src/app_state/mod.rs
@@ -69,7 +69,6 @@ pub struct RegisterMcpServerOptions {
     pub auth_header: Option<String>,
     pub headers: Vec<(String, String)>,
     pub env: Vec<(String, String)>,
-    pub cwd: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/tiangong-core/src/app_state/services/mcp.rs
+++ b/crates/tiangong-core/src/app_state/services/mcp.rs
@@ -10,8 +10,7 @@ impl AppMcpService {
         state: &mut TiangongState,
         request: RegisterMcpServerRequest,
     ) -> Result<String> {
-        let name = request.name.trim();
-        let command = request.command.trim();
+        let name = request.name.trim().to_string();
         if name.is_empty() {
             return Err(anyhow!("MCP server 名称不能为空"));
         }
@@ -27,68 +26,8 @@ impl AppMcpService {
             return Err(anyhow!("MCP server 已存在：{name}"));
         }
 
-        let tags = request
-            .tags
-            .into_iter()
-            .map(|tag| tag.trim().to_string())
-            .filter(|tag| !tag.is_empty())
-            .collect::<Vec<_>>();
-        let args = request
-            .args
-            .into_iter()
-            .map(|arg| arg.trim().to_string())
-            .filter(|arg| !arg.is_empty())
-            .collect::<Vec<_>>();
-        let transport = request.options.transport.unwrap_or_default();
-        let endpoint = request
-            .options
-            .endpoint
-            .unwrap_or_default()
-            .trim()
-            .to_string();
-        let auth_header = request
-            .options
-            .auth_header
-            .unwrap_or_default()
-            .trim()
-            .to_string();
-
-        let headers = request
-            .options
-            .headers
-            .into_iter()
-            .filter_map(|(key, value)| {
-                let key = key.trim().to_string();
-                let value = value.trim().to_string();
-                if key.is_empty() || value.is_empty() {
-                    None
-                } else {
-                    Some((key, value))
-                }
-            })
-            .fold(BTreeMap::new(), |mut map, (key, value)| {
-                map.insert(key, value);
-                map
-            });
-        let env = request
-            .options
-            .env
-            .into_iter()
-            .filter_map(|(key, value)| {
-                let key = key.trim().to_string();
-                let value = value.trim().to_string();
-                if key.is_empty() || value.is_empty() {
-                    None
-                } else {
-                    Some((key, value))
-                }
-            })
-            .fold(BTreeMap::new(), |mut map, (key, value)| {
-                map.insert(key, value);
-                map
-            });
-
-        if command.is_empty() && endpoint.is_empty() && tags.is_empty() {
+        let fields = normalize_request_fields(request)?;
+        if fields.command.is_empty() && fields.endpoint.is_empty() && fields.tags.is_empty() {
             return Err(anyhow!("MCP server 需至少配置 command、endpoint 或 tags"));
         }
 
@@ -99,16 +38,16 @@ impl AppMcpService {
             .mcp
             .servers
             .push(McpServerConfig {
-                name: name.to_string(),
-                transport,
-                command: command.to_string(),
-                args,
-                endpoint,
-                auth_header,
-                headers,
-                env,
-                enabled: request.enabled,
-                tags,
+                name: name.clone(),
+                transport: fields.transport,
+                command: fields.command,
+                args: fields.args,
+                endpoint: fields.endpoint,
+                auth_header: fields.auth_header,
+                headers: fields.headers,
+                env: fields.env,
+                enabled: fields.enabled,
+                tags: fields.tags,
             });
         validate_agent_config(&state.store.agent.agent_config)?;
         state.rebuild_runtime_for_agent_config();
@@ -116,11 +55,63 @@ impl AppMcpService {
         state.persist_agent_configs_only()?;
         audit::append_audit_log(&audit::AuditEntry::new(
             "mcp.register",
-            name,
+            &name,
             &format!("MCP server 已注册：{name}"),
             true,
         ));
         Ok(format!("MCP server 已注册：{name}"))
+    }
+
+    pub(in crate::app_state) fn update_mcp_server(
+        self,
+        state: &mut TiangongState,
+        name: &str,
+        request: RegisterMcpServerRequest,
+    ) -> Result<String> {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(anyhow!("MCP server 名称不能为空"));
+        }
+
+        let Some(server) = state
+            .store
+            .agent
+            .agent_config
+            .mcp
+            .servers
+            .iter_mut()
+            .find(|server| server.name == name)
+        else {
+            return Err(anyhow!("未找到 MCP server：{name}"));
+        };
+
+        let fields = normalize_request_fields(request)?;
+        if fields.command.is_empty() && fields.endpoint.is_empty() && fields.tags.is_empty() {
+            return Err(anyhow!("MCP server 需至少配置 command、endpoint 或 tags"));
+        }
+
+        // name 作为主键保持不变，就地更新其余字段
+        server.transport = fields.transport;
+        server.command = fields.command;
+        server.args = fields.args;
+        server.endpoint = fields.endpoint;
+        server.auth_header = fields.auth_header;
+        server.headers = fields.headers;
+        server.env = fields.env;
+        server.enabled = fields.enabled;
+        server.tags = fields.tags;
+
+        validate_agent_config(&state.store.agent.agent_config)?;
+        state.rebuild_runtime_for_agent_config();
+        state.persist_app_only()?;
+        state.persist_agent_configs_only()?;
+        audit::append_audit_log(&audit::AuditEntry::new(
+            "mcp.update",
+            name,
+            &format!("MCP server 已更新：{name}"),
+            true,
+        ));
+        Ok(format!("MCP server 已更新：{name}"))
     }
 
     pub(in crate::app_state) fn remove_mcp_server(
@@ -264,4 +255,88 @@ impl AppMcpService {
 
         Ok(format!("配置已更新：{key}={updated_value}"))
     }
+}
+
+/// 规范化后的 MCP server 字段（不含 name，name 作为主键由调用方处理）。
+struct NormalizedMcpFields {
+    transport: McpTransportMode,
+    command: String,
+    args: Vec<String>,
+    endpoint: String,
+    auth_header: String,
+    headers: BTreeMap<String, String>,
+    env: BTreeMap<String, String>,
+    enabled: bool,
+    tags: Vec<String>,
+}
+
+/// 把注册/编辑请求规范化为可直接写入 McpServerConfig 的字段。
+/// register_mcp_server 与 update_mcp_server 共用，避免 trim/filter 逻辑重复。
+fn normalize_request_fields(request: RegisterMcpServerRequest) -> Result<NormalizedMcpFields> {
+    let tags = request
+        .tags
+        .into_iter()
+        .map(|tag| tag.trim().to_string())
+        .filter(|tag| !tag.is_empty())
+        .collect::<Vec<_>>();
+    let args = request
+        .args
+        .into_iter()
+        .map(|arg| arg.trim().to_string())
+        .filter(|arg| !arg.is_empty())
+        .collect::<Vec<_>>();
+    let transport = request.options.transport.unwrap_or_default();
+    let endpoint = request
+        .options
+        .endpoint
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let auth_header = request
+        .options
+        .auth_header
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    let headers = request
+        .options
+        .headers
+        .into_iter()
+        .filter_map(|(key, value)| {
+            let key = key.trim().to_string();
+            let value = value.trim().to_string();
+            if key.is_empty() || value.is_empty() {
+                None
+            } else {
+                Some((key, value))
+            }
+        })
+        .collect::<BTreeMap<_, _>>();
+    let env = request
+        .options
+        .env
+        .into_iter()
+        .filter_map(|(key, value)| {
+            let key = key.trim().to_string();
+            let value = value.trim().to_string();
+            if key.is_empty() || value.is_empty() {
+                None
+            } else {
+                Some((key, value))
+            }
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    Ok(NormalizedMcpFields {
+        transport,
+        command: request.command.trim().to_string(),
+        args,
+        endpoint,
+        auth_header,
+        headers,
+        env,
+        enabled: request.enabled,
+        tags,
+    })
 }

--- a/crates/tiangong-core/src/app_state/services/mcp.rs
+++ b/crates/tiangong-core/src/app_state/services/mcp.rs
@@ -52,7 +52,6 @@ impl AppMcpService {
             .unwrap_or_default()
             .trim()
             .to_string();
-        let cwd = request.options.cwd.unwrap_or_default().trim().to_string();
 
         let headers = request
             .options
@@ -108,7 +107,6 @@ impl AppMcpService {
                 auth_header,
                 headers,
                 env,
-                cwd,
                 enabled: request.enabled,
                 tags,
             });

--- a/crates/tiangong-core/src/app_state/services/mcp.rs
+++ b/crates/tiangong-core/src/app_state/services/mcp.rs
@@ -90,7 +90,8 @@ impl AppMcpService {
             return Err(anyhow!("MCP server 需至少配置 command、endpoint 或 tags"));
         }
 
-        // name 作为主键保持不变，就地更新其余字段
+        // name 作为主键保持不变，就地更新其余字段。
+        // enabled 由列表里的开关单独控制，编辑表单不覆盖它。
         server.transport = fields.transport;
         server.command = fields.command;
         server.args = fields.args;
@@ -98,7 +99,6 @@ impl AppMcpService {
         server.auth_header = fields.auth_header;
         server.headers = fields.headers;
         server.env = fields.env;
-        server.enabled = fields.enabled;
         server.tags = fields.tags;
 
         validate_agent_config(&state.store.agent.agent_config)?;

--- a/crates/tiangong-core/src/app_state/tests/repository.rs
+++ b/crates/tiangong-core/src/app_state/tests/repository.rs
@@ -28,7 +28,6 @@ fn repository_persist_to_disk_round_trips_split_configs_and_sessions() -> Result
                 auth_header: String::new(),
                 headers: Default::default(),
                 env: Default::default(),
-                cwd: String::new(),
                 enabled: true,
                 tags: vec!["demo".to_string()],
             });

--- a/crates/tiangong-core/src/app_state/tests/skill.rs
+++ b/crates/tiangong-core/src/app_state/tests/skill.rs
@@ -693,7 +693,6 @@ fn test_mcp_server(name: &str) -> McpServerConfig {
         auth_header: String::new(),
         headers: Default::default(),
         env: Default::default(),
-        cwd: String::new(),
         enabled: true,
         tags: Vec::new(),
     }

--- a/crates/tiangong-core/src/mcp/capability.rs
+++ b/crates/tiangong-core/src/mcp/capability.rs
@@ -141,25 +141,47 @@ pub fn refresh_mcp_capabilities_async(config: McpConfig) {
 }
 
 pub fn refresh_mcp_capabilities(config: &McpConfig) {
+    // 第一段：并发探测所有启用的 server，全程不持锁，避免阻塞 getMcpHealth 读锁。
+    let targets: Vec<&McpServerConfig> = config
+        .servers
+        .iter()
+        .filter(|server| server.enabled)
+        .collect();
+    let results: Vec<(String, McpServerCapability)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = targets
+            .iter()
+            .map(|server| {
+                let server = (**server).clone();
+                scope.spawn(move || {
+                    (
+                        server.name.clone(),
+                        probe_server_capability(&server, config.timeout_ms),
+                    )
+                })
+            })
+            .collect();
+        handles.into_iter().filter_map(|h| h.join().ok()).collect()
+    });
+
+    // 第二段：短暂持写锁，只做合并 + 清理。
     if let Ok(mut guard) = capability_index().write() {
-        for server in config.servers.iter().filter(|server| server.enabled) {
-            let capability = probe_server_capability(server, config.timeout_ms);
+        for (name, capability) in results {
             if !capability.healthy {
                 // 探测失败：更新健康状态和错误信息，但保留已有工具缓存
-                if let Some(existing) = guard.get_mut(&server.name) {
+                if let Some(existing) = guard.get_mut(&name) {
                     existing.healthy = false;
                     existing.last_error = capability.last_error;
                     tracing::warn!(
                         "MCP 探测失败，标记为不健康并保留工具缓存：server={}（缓存 {} 个工具）",
-                        server.name,
+                        name,
                         existing.tools.len()
                     );
                 } else {
-                    guard.insert(server.name.clone(), capability);
+                    guard.insert(name, capability);
                 }
                 continue;
             }
-            guard.insert(server.name.clone(), capability);
+            guard.insert(name, capability);
         }
         // 清理已移除或禁用的服务器
         let active_names: std::collections::HashSet<_> = config
@@ -170,6 +192,54 @@ pub fn refresh_mcp_capabilities(config: &McpConfig) {
             .collect();
         guard.retain(|name, _| active_names.contains(name));
     }
+}
+
+/// 按 name 探测单个 MCP server 并写回缓存。
+/// 供前端"添加/编辑后只探测该 server"和"行内重试"使用，避免触发全量探测。
+pub fn probe_single_mcp_server_by_name(name: &str) -> Result<()> {
+    // 从 scheduler 缓存的 config 取 server 配置 + timeout_ms
+    let (server, timeout_ms) = {
+        let guard = capability_scheduler()
+            .read()
+            .map_err(|_| anyhow!("MCP 能力调度器锁中毒"))?;
+        let server = guard
+            .mcp_config
+            .servers
+            .iter()
+            .find(|s| s.name == name && s.enabled)
+            .ok_or_else(|| anyhow!("未找到启用中的 MCP server：{name}"))?
+            .clone();
+        (server, guard.mcp_config.timeout_ms)
+    };
+
+    // 探测期间不持锁，探测完只短暂持写锁写回单个结果
+    let capability = probe_server_capability(&server, timeout_ms);
+    if let Ok(mut guard) = capability_index().write() {
+        if !capability.healthy {
+            if let Some(existing) = guard.get_mut(name) {
+                existing.healthy = false;
+                existing.last_error = capability.last_error;
+                tracing::warn!(
+                    "MCP 单 server 探测失败，保留工具缓存：server={}（缓存 {} 个工具）",
+                    name,
+                    existing.tools.len()
+                );
+            } else {
+                guard.insert(name.to_string(), capability);
+            }
+        } else {
+            guard.insert(name.to_string(), capability);
+        }
+    }
+    // 探测完持久化一次，避免重启丢失
+    if let Some(path) = capability_scheduler()
+        .read()
+        .ok()
+        .and_then(|guard| guard.cache_path.clone())
+    {
+        let _ = persist_mcp_capabilities_cache(&path);
+    }
+    Ok(())
 }
 
 pub fn cached_server_tools(server_name: &str) -> Option<Vec<McpToolMeta>> {

--- a/crates/tiangong-core/src/mcp/client.rs
+++ b/crates/tiangong-core/src/mcp/client.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::process::Stdio;
-use std::sync::{OnceLock, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
@@ -12,13 +12,17 @@ use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig
 use rmcp::transport::{ConfigureCommandExt, StreamableHttpClientTransport, TokioChildProcess};
 use rmcp::{Peer, RoleClient, ServiceExt};
 use serde_json::{Value, json};
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
+use tokio::sync::Mutex;
 use tokio::time::timeout;
 
 use crate::agent_config::{McpServerConfig, ResolvedMcpTransport};
 use crate::process::configure_tokio_no_window;
 
 const MAX_LIST_PAGES: usize = 8;
+/// 最多保留的 stderr 末尾字节数，用于在握手失败时诊断子进程报错。
+const STDERR_CAPTURE_BYTES: usize = 8 * 1024;
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -412,46 +416,110 @@ async fn run_stdio_mcp_request_async(
     params: Option<Value>,
 ) -> Result<Value> {
     let command = server.command_text();
-    let (transport, _stderr) = TokioChildProcess::builder(Command::new(command).configure(|cmd| {
-        configure_tokio_no_window(cmd);
-        cmd.args(&server.args);
-        // stdio MCP 跟随当前会话工作目录（与 run_command 一致）；能力探测等无会话上下文
-        // 的路径下此值为 None，子进程自然继承宿主进程 cwd。
-        if let Some(cwd) = crate::tool::session_workspace_root() {
-            cmd.current_dir(cwd);
-        }
-        for (key, value) in &server.env {
-            cmd.env(key, value);
-        }
-    }))
-    .stderr(Stdio::null())
-    .spawn()
-    .with_context(|| {
-        format!(
-            "MCP进程启动失败：server={} command={} args={}",
-            server.name,
-            command,
-            if server.args.is_empty() {
-                "(none)".to_string()
-            } else {
-                server.args.join(" ")
+    let args_desc = if server.args.is_empty() {
+        "(none)".to_string()
+    } else {
+        server.args.join(" ")
+    };
+    let (transport, stderr_handle) =
+        TokioChildProcess::builder(Command::new(command).configure(|cmd| {
+            configure_tokio_no_window(cmd);
+            cmd.args(&server.args);
+            // stdio MCP 跟随当前会话工作目录（与 run_command 一致）；能力探测等无会话上下文
+            // 的路径下此值为 None，子进程自然继承宿主进程 cwd。
+            if let Some(cwd) = crate::tool::session_workspace_root() {
+                cmd.current_dir(cwd);
             }
-        )
-    })?;
+            for (key, value) in &server.env {
+                cmd.env(key, value);
+            }
+        }))
+        // 捕获 stderr 用于握手失败时诊断子进程报错（如 npx 下载失败、缺少 API key 等）。
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| {
+            format!(
+                "MCP进程启动失败：server={} command={} args={}",
+                server.name, command, args_desc
+            )
+        })?;
 
-    let service = ()
-        .serve(transport)
-        .await
-        .with_context(|| format!("MCP握手失败：server={} command={}", server.name, command))?;
+    // 后台持续读取 stderr，仅保留末尾窗口，避免缓冲区写满阻塞子进程。
+    let stderr_tail = Arc::new(Mutex::new(String::new()));
+    if let Some(mut child_stderr) = stderr_handle {
+        let tail = stderr_tail.clone();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            loop {
+                match child_stderr.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        let chunk = String::from_utf8_lossy(&buf[..n]).into_owned();
+                        let mut guard = tail.lock().await;
+                        guard.push_str(&chunk);
+                        if guard.len() > STDERR_CAPTURE_BYTES {
+                            let start = guard.len() - STDERR_CAPTURE_BYTES;
+                            let trimmed = guard.split_off(start);
+                            *guard = trimmed;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    let stderr_snapshot = || -> String {
+        stderr_tail
+            .try_lock()
+            .ok()
+            .map(|guard| guard.trim().to_string())
+            .unwrap_or_default()
+    };
+
+    let service = ().serve(transport).await.with_context(|| {
+        let mut msg = format!("MCP握手失败：server={} command={}", server.name, command);
+        if let Some(snippet) = nonempty_snippet(&stderr_snapshot()) {
+            msg.push_str(" stderr=");
+            msg.push_str(&snippet);
+        }
+        msg
+    })?;
 
     // 缓存 server 版本信息
     if let Some(info) = service.peer_info() {
         cache_server_version(&server.name, &info.server_info.version);
     }
 
-    let response = dispatch_mcp_request(service.peer(), method, params).await;
+    let response = dispatch_mcp_request(service.peer(), method, params)
+        .await
+        .with_context(|| {
+            let mut msg = format!(
+                "MCP调用失败：server={} method={} command={}",
+                server.name, method, command
+            );
+            if let Some(snippet) = nonempty_snippet(&stderr_snapshot()) {
+                msg.push_str(" stderr=");
+                msg.push_str(&snippet);
+            }
+            msg
+        });
     let _ = service.cancel().await;
     response
+}
+
+/// 截取 stderr 末尾用于错误诊断；超长时只保留最后若干行。
+fn nonempty_snippet(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    const MAX_LINES: usize = 12;
+    let lines: Vec<&str> = trimmed.lines().collect();
+    if lines.len() <= MAX_LINES {
+        Some(trimmed.to_string())
+    } else {
+        Some(lines[lines.len() - MAX_LINES..].join("\n"))
+    }
 }
 
 async fn run_http_mcp_request_async(

--- a/crates/tiangong-core/src/mcp/client.rs
+++ b/crates/tiangong-core/src/mcp/client.rs
@@ -415,7 +415,9 @@ async fn run_stdio_mcp_request_async(
     let (transport, _stderr) = TokioChildProcess::builder(Command::new(command).configure(|cmd| {
         configure_tokio_no_window(cmd);
         cmd.args(&server.args);
-        if let Some(cwd) = server.cwd_text() {
+        // stdio MCP 跟随当前会话工作目录（与 run_command 一致）；能力探测等无会话上下文
+        // 的路径下此值为 None，子进程自然继承宿主进程 cwd。
+        if let Some(cwd) = crate::tool::session_workspace_root() {
             cmd.current_dir(cwd);
         }
         for (key, value) in &server.env {

--- a/crates/tiangong-core/src/mcp/config.rs
+++ b/crates/tiangong-core/src/mcp/config.rs
@@ -94,11 +94,10 @@ fn format_server_detail(server: &McpServerConfig) -> String {
     };
 
     format!(
-        "mcp name: {name}\n  status: {status}\n  transport: {transport}\n  command: {command}\n  args: {args}\n  endpoint: {endpoint}\n  auth: {auth}\n  headers: {headers}\n  env: {env}\n  cwd: {cwd}\n  tags: {tags}",
+        "mcp name: {name}\n  status: {status}\n  transport: {transport}\n  command: {command}\n  args: {args}\n  endpoint: {endpoint}\n  auth: {auth}\n  headers: {headers}\n  env: {env}\n  tags: {tags}",
         name = server.name,
         headers = server.headers.len(),
-        env = server.env.len(),
-        cwd = server.cwd_text().unwrap_or("(none)")
+        env = server.env.len()
     )
 }
 
@@ -194,11 +193,8 @@ pub fn validate_mcp_config(config: &McpConfig) -> Result<()> {
                 if !server.args.is_empty() {
                     return Err(anyhow!("mcp.servers http 模式不支持 args：{}", server.name));
                 }
-                if !server.env.is_empty() || server.cwd_text().is_some() {
-                    return Err(anyhow!(
-                        "mcp.servers http 模式不支持 env/cwd：{}",
-                        server.name
-                    ));
+                if !server.env.is_empty() {
+                    return Err(anyhow!("mcp.servers http 模式不支持 env：{}", server.name));
                 }
             }
         }

--- a/crates/tiangong-core/src/mcp/mod.rs
+++ b/crates/tiangong-core/src/mcp/mod.rs
@@ -7,7 +7,7 @@ mod util;
 pub use capability::{
     McpServerHealthStatus, build_mcp_tools_system_prompt, cached_active_tools, cached_server_tools,
     configure_mcp_capability_scheduler, load_mcp_capabilities_cache, mcp_server_health_statuses,
-    refresh_mcp_capabilities_async,
+    probe_single_mcp_server_by_name, refresh_mcp_capabilities_async,
 };
 pub use client::{LocalMcpClient, McpClient, McpToolMeta};
 pub use config::{describe_mcp_servers, summarize_mcp_servers, validate_mcp_config};

--- a/crates/tiangong-core/src/mcp/tests/mod.rs
+++ b/crates/tiangong-core/src/mcp/tests/mod.rs
@@ -17,7 +17,6 @@ fn server(name: &str, command: &str, tags: &[&str]) -> McpServerConfig {
         auth_header: String::new(),
         headers: Default::default(),
         env: Default::default(),
-        cwd: String::new(),
         enabled: true,
         tags: tags.iter().map(|item| item.to_string()).collect(),
     }
@@ -126,7 +125,6 @@ fn validate_mcp_config_rejects_invalid_server() {
             auth_header: String::new(),
             headers: Default::default(),
             env: Default::default(),
-            cwd: String::new(),
             enabled: true,
             tags: Vec::new(),
         }],
@@ -149,7 +147,6 @@ fn validate_mcp_config_accepts_http_server_with_endpoint() {
             auth_header: "token".to_string(),
             headers: Default::default(),
             env: Default::default(),
-            cwd: String::new(),
             enabled: true,
             tags: vec!["remote".to_string()],
         }],
@@ -172,7 +169,6 @@ fn validate_mcp_config_rejects_http_server_with_args() {
             auth_header: String::new(),
             headers: Default::default(),
             env: Default::default(),
-            cwd: String::new(),
             enabled: true,
             tags: vec!["remote".to_string()],
         }],
@@ -275,7 +271,6 @@ done
         auth_header: String::new(),
         headers: Default::default(),
         env: Default::default(),
-        cwd: String::new(),
         enabled: true,
         tags: vec!["demo".to_string()],
     };
@@ -361,7 +356,6 @@ done
         auth_header: String::new(),
         headers: Default::default(),
         env: Default::default(),
-        cwd: String::new(),
         enabled: true,
         tags: vec!["slow".to_string()],
     };
@@ -439,7 +433,6 @@ done
             auth_header: String::new(),
             headers: Default::default(),
             env: Default::default(),
-            cwd: String::new(),
             enabled: true,
             tags: vec!["filesystem".to_string()],
         }],
@@ -461,7 +454,6 @@ async fn test_http_mcp_rmcp_connect() {
         auth_header: String::new(),
         headers: Default::default(),
         env: Default::default(),
-        cwd: String::new(),
         enabled: true,
         tags: Vec::new(),
     };

--- a/crates/tiangong-core/src/runtime.rs
+++ b/crates/tiangong-core/src/runtime.rs
@@ -1767,7 +1767,6 @@ mod tests {
             auth_header: String::new(),
             headers: Default::default(),
             env: Default::default(),
-            cwd: String::new(),
             enabled: true,
             tags: Vec::new(),
         });

--- a/crates/tiangong-core/src/tool.rs
+++ b/crates/tiangong-core/src/tool.rs
@@ -9,7 +9,7 @@ use crate::agent_config::AgentConfig;
 pub mod background_task;
 mod common;
 mod current_time;
-pub use common::set_session_cwd;
+pub use common::{session_workspace_root, set_session_cwd};
 mod list_dir;
 mod read_file;
 mod replace_in_file;

--- a/crates/tiangong-core/src/tool/common.rs
+++ b/crates/tiangong-core/src/tool/common.rs
@@ -30,6 +30,14 @@ pub(super) fn workspace_root() -> Result<PathBuf> {
     })
 }
 
+/// 读取当前线程的会话工作目录，供需要跟随会话 workspace 的子系统（如 stdio MCP 子进程）使用。
+///
+/// 仅当线程已通过 [`set_session_cwd`] 设置过有效目录时返回 `Some`；否则返回 `None`，
+/// 由调用方自行决定回退策略（典型做法是不设置 `current_dir`，让子进程继承宿主 cwd）。
+pub fn session_workspace_root() -> Option<PathBuf> {
+    SESSION_CWD.with(|cell| cell.borrow().as_ref().filter(|cwd| cwd.is_dir()).cloned())
+}
+
 fn write_allowed_roots() -> Result<Vec<PathBuf>> {
     let workspace = workspace_root()?;
     let workspace_canonical = workspace

--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -176,8 +176,6 @@ pub(crate) enum McpSubcommand {
             help = "stdio env，格式 key=value，可重复"
         )]
         env: Vec<(String, String)>,
-        #[arg(long, help = "stdio 工作目录")]
-        cwd: Option<String>,
         #[arg(
             trailing_var_arg = true,
             allow_hyphen_values = true,

--- a/crates/tiangong-entry/src/mcp.rs
+++ b/crates/tiangong-entry/src/mcp.rs
@@ -37,7 +37,6 @@ pub(crate) fn run_mcp_command(args: McpArgs) -> anyhow::Result<()> {
             auth_header,
             headers,
             env,
-            cwd,
             cmdline,
             enabled,
         } => {
@@ -52,7 +51,6 @@ pub(crate) fn run_mcp_command(args: McpArgs) -> anyhow::Result<()> {
                     &auth_header,
                     &headers,
                     &env,
-                    &cwd,
                     &cmdline,
                 )?;
                 let raw_json = load_add_json_payload(json, json_file)?;
@@ -84,7 +82,6 @@ pub(crate) fn run_mcp_command(args: McpArgs) -> anyhow::Result<()> {
                         auth_header,
                         headers,
                         env,
-                        cwd,
                     },
                 })?;
                 println!("{msg}");
@@ -151,7 +148,6 @@ fn ensure_no_mixed_json_add_args(
     auth_header: &Option<String>,
     headers: &[(String, String)],
     env: &[(String, String)],
-    cwd: &Option<String>,
     cmdline: &[String],
 ) -> anyhow::Result<()> {
     if name.as_ref().is_some_and(|value| !value.trim().is_empty())
@@ -169,11 +165,10 @@ fn ensure_no_mixed_json_add_args(
             .is_some_and(|value| !value.trim().is_empty())
         || !headers.is_empty()
         || !env.is_empty()
-        || cwd.as_ref().is_some_and(|value| !value.trim().is_empty())
         || !cmdline.is_empty()
     {
         return Err(anyhow!(
-            "JSON 导入模式下不允许同时传 name/command/arg/tags/transport/endpoint/auth/header/env/cwd/CMDLINE 参数"
+            "JSON 导入模式下不允许同时传 name/command/arg/tags/transport/endpoint/auth/header/env/CMDLINE 参数"
         ));
     }
     Ok(())
@@ -233,7 +228,9 @@ struct JsonMcpServerInput {
     headers: BTreeMap<String, String>,
     #[serde(default)]
     env: BTreeMap<String, String>,
+    /// 旧配置可能含 cwd 字段，已废弃：stdio MCP 现跟随会话工作目录。保留反序列化以容忍旧 JSON。
     #[serde(default)]
+    #[allow(dead_code)]
     cwd: String,
     #[serde(default = "default_enabled")]
     enabled: bool,
@@ -321,7 +318,6 @@ fn normalize_json_server(
     let headers = normalize_map_pairs(input.headers);
     let env = normalize_map_pairs(input.env);
     let auth_header = input.auth_header.trim().to_string();
-    let cwd = input.cwd.trim().to_string();
 
     Ok(ImportedMcpServer {
         name,
@@ -335,7 +331,6 @@ fn normalize_json_server(
             auth_header: Some(auth_header),
             headers,
             env,
-            cwd: Some(cwd),
         },
     })
 }
@@ -469,7 +464,6 @@ fn ensure_import_conflicts(
 fn imported_server_to_config(server: &ImportedMcpServer) -> McpServerConfig {
     let endpoint = server.options.endpoint.clone().unwrap_or_default();
     let auth_header = server.options.auth_header.clone().unwrap_or_default();
-    let cwd = server.options.cwd.clone().unwrap_or_default();
     let headers = server
         .options
         .headers
@@ -492,7 +486,6 @@ fn imported_server_to_config(server: &ImportedMcpServer) -> McpServerConfig {
         auth_header,
         headers,
         env,
-        cwd,
         enabled: server.enabled,
         tags: server.tags.clone(),
     }

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -579,6 +579,9 @@ export const api = {
   getMcpHealth: (): Promise<McpHealthStatus[]> =>
     invoke('get_mcp_health'),
 
+  probeMcpServer: (name: string): Promise<void> =>
+    invoke('probe_mcp_server', { name }),
+
   registerMcpServer: (input: RegisterMcpServerInput): Promise<string> =>
     invoke('register_mcp_server', {
       name: input.name,

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -231,6 +231,18 @@ export interface RegisterMcpServerInput {
   env?: Record<string, string>;
 }
 
+export interface UpdateMcpServerInput {
+  name: string;
+  transport?: 'auto' | 'stdio' | 'http' | 'sse';
+  command?: string;
+  args?: string[];
+  endpoint?: string;
+  authHeader?: string;
+  headers?: Record<string, string>;
+  env?: Record<string, string>;
+  enabled: boolean;
+}
+
 export interface Skill {
   id: string;
   name: string;
@@ -577,6 +589,19 @@ export const api = {
       authHeader: input.authHeader,
       headers: input.headers,
       env: input.env,
+    }),
+
+  updateMcpServer: (name: string, input: UpdateMcpServerInput): Promise<string> =>
+    invoke('update_mcp_server', {
+      name,
+      command: input.command ?? '',
+      args: input.args ?? [],
+      transport: input.transport,
+      endpoint: input.endpoint,
+      authHeader: input.authHeader,
+      headers: input.headers,
+      env: input.env,
+      enabled: input.enabled,
     }),
 
   removeMcpServer: (name: string): Promise<string> =>

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -217,7 +217,6 @@ export interface McpServer {
   auth_header: string;
   headers?: Record<string, string>;
   env?: Record<string, string>;
-  cwd: string;
   enabled: boolean;
 }
 
@@ -230,7 +229,6 @@ export interface RegisterMcpServerInput {
   authHeader?: string;
   headers?: Record<string, string>;
   env?: Record<string, string>;
-  cwd?: string;
 }
 
 export interface Skill {
@@ -579,7 +577,6 @@ export const api = {
       authHeader: input.authHeader,
       headers: input.headers,
       env: input.env,
-      cwd: input.cwd,
     }),
 
   removeMcpServer: (name: string): Promise<string> =>

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -240,7 +240,6 @@ export interface UpdateMcpServerInput {
   authHeader?: string;
   headers?: Record<string, string>;
   env?: Record<string, string>;
-  enabled: boolean;
 }
 
 export interface Skill {
@@ -604,7 +603,6 @@ export const api = {
       authHeader: input.authHeader,
       headers: input.headers,
       env: input.env,
-      enabled: input.enabled,
     }),
 
   removeMcpServer: (name: string): Promise<string> =>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -55,6 +55,14 @@ function parseKeyValueText(value: string, label: string): Record<string, string>
   return Object.keys(entries).length > 0 ? entries : undefined;
 }
 
+/// parseKeyValueText 的逆函数：把 Record 格式化为 KEY=VALUE 文本，每行一条。
+function formatKeyValue(record?: Record<string, string>): string {
+  if (!record) return '';
+  return Object.entries(record)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -1572,7 +1580,8 @@ function McpSettings() {
   const [servers, setServers] = useState<McpServer[]>([]);
   const [healthMap, setHealthMap] = useState<Record<string, { healthy: boolean; tool_count: number; last_error?: string; server_version?: string }>>({});
   const [isLoading, setIsLoading] = useState(false);
-  const [showAddDialog, setShowAddDialog] = useState(false);
+  const [serverModalMode, setServerModalMode] = useState<'add' | 'edit' | null>(null);
+  const [editingServerName, setEditingServerName] = useState<string | null>(null);
   const [newServer, setNewServer] = useState({
     name: '',
     transport: 'stdio' as McpTransportDraft,
@@ -1582,9 +1591,8 @@ function McpSettings() {
     authHeader: '',
     headers: '',
     env: '',
+    enabled: true,
   });
-  const [editEnvTarget, setEditEnvTarget] = useState<string | null>(null);
-  const [editEnvValues, setEditEnvValues] = useState<Record<string, string>>({});
   const { showSuccess, showError } = useToast();
 
   const loadServers = async () => {
@@ -1612,6 +1620,42 @@ function McpSettings() {
     loadServers();
   }, []);
 
+  const resetDraft = () => {
+    setNewServer({
+      name: '',
+      transport: 'stdio',
+      command: '',
+      args: '',
+      endpoint: '',
+      authHeader: '',
+      headers: '',
+      env: '',
+      enabled: true,
+    });
+  };
+
+  const closeServerModal = () => {
+    setServerModalMode(null);
+    setEditingServerName(null);
+    resetDraft();
+  };
+
+  const openEditServer = (server: McpServer) => {
+    setEditingServerName(server.name);
+    setNewServer({
+      name: server.name,
+      transport: (server.transport === 'http' ? 'http' : 'stdio') as McpTransportDraft,
+      command: server.command,
+      args: server.args.join(' '),
+      endpoint: server.endpoint,
+      authHeader: server.auth_header,
+      headers: formatKeyValue(server.headers),
+      env: formatKeyValue(server.env),
+      enabled: server.enabled,
+    });
+    setServerModalMode('edit');
+  };
+
   const handleAddServer = async () => {
     try {
       const isStdio = newServer.transport === 'stdio';
@@ -1634,22 +1678,46 @@ function McpSettings() {
           };
 
       await api.registerMcpServer(request);
-      setNewServer({
-        name: '',
-        transport: 'stdio',
-        command: '',
-        args: '',
-        endpoint: '',
-        authHeader: '',
-        headers: '',
-        env: '',
-      });
-      setShowAddDialog(false);
       showSuccess('添加成功', `MCP 服务器 "${newServer.name}" 已添加`);
+      closeServerModal();
       loadServers();
     } catch (error) {
       console.error('添加 MCP 服务器失败:', error);
       showError('添加失败', errorMessage(error));
+    }
+  };
+
+  const handleUpdateServer = async () => {
+    if (!editingServerName) return;
+    try {
+      const isStdio = newServer.transport === 'stdio';
+      const request = isStdio
+        ? {
+            name: editingServerName,
+            transport: newServer.transport,
+            command: newServer.command.trim(),
+            args: parseListArgs(newServer.args),
+            env: parseKeyValueText(newServer.env, '环境变量'),
+            enabled: newServer.enabled,
+          }
+        : {
+            name: editingServerName,
+            transport: newServer.transport,
+            command: '',
+            args: [],
+            endpoint: newServer.endpoint.trim(),
+            authHeader: newServer.authHeader.trim() || undefined,
+            headers: parseKeyValueText(newServer.headers, 'Header'),
+            enabled: newServer.enabled,
+          };
+
+      await api.updateMcpServer(editingServerName, request);
+      showSuccess('保存成功', `MCP 服务器 "${editingServerName}" 已更新`);
+      closeServerModal();
+      loadServers();
+    } catch (error) {
+      console.error('更新 MCP 服务器失败:', error);
+      showError('保存失败', errorMessage(error));
     }
   };
 
@@ -1684,7 +1752,7 @@ function McpSettings() {
             <RefreshCw className="w-4 h-4 mr-2" />
             刷新
           </Button>
-          <Button size="sm" onClick={() => setShowAddDialog(true)}>
+          <Button size="sm" onClick={() => { resetDraft(); setServerModalMode('add'); }}>
             <Plus className="w-4 h-4 mr-2" />
             添加服务器
           </Button>
@@ -1743,20 +1811,15 @@ function McpSettings() {
                   )}
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
-                  {!isRemote && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8"
-                      onClick={() => {
-                        setEditEnvTarget(server.name);
-                        setEditEnvValues(server.env || {});
-                      }}
-                      title="编辑环境变量"
-                    >
-                      <KeyRound className="w-4 h-4" />
-                    </Button>
-                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => openEditServer(server)}
+                    title="编辑配置"
+                  >
+                    <Edit2 className="w-4 h-4" />
+                  </Button>
                   <Switch
                     checked={server.enabled}
                     onCheckedChange={(checked) => handleToggleEnabled(server.name, checked)}
@@ -1778,34 +1841,16 @@ function McpSettings() {
         </div>
       )}
 
-      {/* MCP 环境变量编辑 */}
-      <EnvEditDialog
-        open={editEnvTarget !== null}
-        title={`编辑环境变量: ${editEnvTarget}`}
-        values={editEnvValues}
-        onChange={setEditEnvValues}
-        onSave={async () => {
-          if (!editEnvTarget) return;
-          try {
-            // MCP env 通过注册接口更新（重新注册同名服务器）
-            // 简单方案：先删后加会丢配置，这里直接修改 mcp.json
-            // TODO: 添加专门的 update_mcp_env 命令
-            showSuccess('环境变量已保存', `MCP "${editEnvTarget}" 的环境变量已更新`);
-            setEditEnvTarget(null);
-            loadServers();
-          } catch (error) {
-            showError('保存失败', `${error}`);
-          }
-        }}
-        onCancel={() => setEditEnvTarget(null)}
-      />
-
-      {/* 添加服务器对话框 */}
-      {showAddDialog && (
+      {/* 添加/编辑服务器对话框 */}
+      {serverModalMode !== null && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <Card className="max-w-md w-full mx-4">
             <CardContent className="p-6">
-              <h3 className="text-lg font-medium mb-4">添加 MCP 服务器</h3>
+              <h3 className="text-lg font-medium mb-4">
+                {serverModalMode === 'add'
+                  ? '添加 MCP 服务器'
+                  : `编辑 MCP 服务器: ${editingServerName}`}
+              </h3>
               <div className="space-y-4">
                 <div>
                   <Label htmlFor="serverName">名称</Label>
@@ -1814,6 +1859,7 @@ function McpSettings() {
                     value={newServer.name}
                     onChange={(e) => setNewServer({ ...newServer, name: e.target.value })}
                     placeholder="my-mcp-server"
+                    disabled={serverModalMode === 'edit'}
                   />
                 </div>
                 <div>
@@ -1894,21 +1940,29 @@ function McpSettings() {
                     </div>
                   </>
                 )}
+                <div className="flex items-center gap-2">
+                  <Switch
+                    id="serverEnabled"
+                    checked={newServer.enabled}
+                    onCheckedChange={(checked) => setNewServer({ ...newServer, enabled: checked })}
+                  />
+                  <Label htmlFor="serverEnabled">启用</Label>
+                </div>
               </div>
               <div className="flex justify-end gap-2 mt-6">
-                <Button variant="ghost" onClick={() => setShowAddDialog(false)}>
+                <Button variant="ghost" onClick={closeServerModal}>
                   取消
                 </Button>
                 <Button
-                  onClick={handleAddServer}
+                  onClick={serverModalMode === 'add' ? handleAddServer : handleUpdateServer}
                   disabled={
-                    !newServer.name.trim()
+                    (serverModalMode === 'add' && !newServer.name.trim())
                     || (newServer.transport === 'stdio'
                       ? !newServer.command.trim()
                       : !newServer.endpoint.trim())
                   }
                 >
-                  添加
+                  {serverModalMode === 'add' ? '添加' : '保存'}
                 </Button>
               </div>
             </CardContent>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1595,24 +1595,43 @@ function McpSettings() {
   });
   const { showSuccess, showError } = useToast();
 
+  // 立即拉取 server 列表（config 读，瞬时），不等待探测。健康状态单独异步更新。
   const loadServers = async () => {
     setIsLoading(true);
     try {
-      const [data, health] = await Promise.all([
-        api.getMcpServers(),
-        api.getMcpHealth(),
-      ]);
+      const data = await api.getMcpServers();
       setServers(data);
+    } catch (error) {
+      console.error('加载 MCP 服务器失败:', error);
+      showError('加载失败', '无法加载 MCP 服务器列表');
+    } finally {
+      setIsLoading(false);
+    }
+    // 健康状态异步刷新，不阻塞列表渲染
+    refreshHealth();
+  };
+
+  const refreshHealth = async () => {
+    try {
+      const health = await api.getMcpHealth();
       const map: typeof healthMap = {};
       for (const s of health) {
         map[s.name] = { healthy: s.healthy, tool_count: s.tool_count, last_error: s.last_error, server_version: s.server_version };
       }
       setHealthMap(map);
     } catch (error) {
-      console.error('加载 MCP 服务器失败:', error);
-      showError('加载失败', '无法加载 MCP 服务器列表');
+      console.error('加载 MCP 健康状态失败:', error);
+    }
+  };
+
+  // 探测单个 server 后刷新健康状态（用于添加/编辑/行内重试）
+  const probeServer = async (name: string) => {
+    try {
+      await api.probeMcpServer(name);
+    } catch (error) {
+      console.error('探测 MCP 服务器失败:', error);
     } finally {
-      setIsLoading(false);
+      refreshHealth();
     }
   };
 
@@ -1679,8 +1698,11 @@ function McpSettings() {
 
       await api.registerMcpServer(request);
       showSuccess('添加成功', `MCP 服务器 "${newServer.name}" 已添加`);
+      const addedName = newServer.name.trim();
       closeServerModal();
-      loadServers();
+      await loadServers();
+      // 异步探测新 server，完成后刷新该行健康状态（不阻塞列表渲染）
+      probeServer(addedName);
     } catch (error) {
       console.error('添加 MCP 服务器失败:', error);
       showError('添加失败', errorMessage(error));
@@ -1713,8 +1735,11 @@ function McpSettings() {
 
       await api.updateMcpServer(editingServerName, request);
       showSuccess('保存成功', `MCP 服务器 "${editingServerName}" 已更新`);
+      const updatedName = editingServerName;
       closeServerModal();
-      loadServers();
+      await loadServers();
+      // 编辑后重新探测该 server（配置可能影响握手）
+      probeServer(updatedName);
     } catch (error) {
       console.error('更新 MCP 服务器失败:', error);
       showError('保存失败', errorMessage(error));
@@ -1743,12 +1768,29 @@ function McpSettings() {
     }
   };
 
+  // 刷新：对全部 server 并发重探，全部完成后统一读一次健康状态。真正重置探测状态。
+  const handleRefresh = async () => {
+    setIsLoading(true);
+    try {
+      const data = await api.getMcpServers();
+      setServers(data);
+      // 并发探测所有 server（后端单 server 探测互不阻塞）
+      await Promise.allSettled(data.map((s) => api.probeMcpServer(s.name)));
+      await refreshHealth();
+    } catch (error) {
+      console.error('刷新 MCP 服务器失败:', error);
+      showError('刷新失败', '无法刷新 MCP 服务器状态');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <div className="p-4">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-medium">MCP 服务器</h3>
         <div className="flex items-center gap-2">
-          <Button size="sm" variant="outline" onClick={loadServers}>
+          <Button size="sm" variant="outline" onClick={handleRefresh}>
             <RefreshCw className="w-4 h-4 mr-2" />
             刷新
           </Button>
@@ -1811,6 +1853,17 @@ function McpSettings() {
                   )}
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
+                  {server.enabled && hasHealth && !isHealthy && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      onClick={() => probeServer(server.name)}
+                      title="重新探测"
+                    >
+                      <RefreshCw className="w-4 h-4" />
+                    </Button>
+                  )}
                   <Button
                     variant="ghost"
                     size="icon"

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1582,7 +1582,6 @@ function McpSettings() {
     authHeader: '',
     headers: '',
     env: '',
-    cwd: '',
   });
   const [editEnvTarget, setEditEnvTarget] = useState<string | null>(null);
   const [editEnvValues, setEditEnvValues] = useState<Record<string, string>>({});
@@ -1623,7 +1622,6 @@ function McpSettings() {
             command: newServer.command.trim(),
             args: parseListArgs(newServer.args),
             env: parseKeyValueText(newServer.env, '环境变量'),
-            cwd: newServer.cwd.trim() || undefined,
           }
         : {
             name: newServer.name.trim(),
@@ -1645,7 +1643,6 @@ function McpSettings() {
         authHeader: '',
         headers: '',
         env: '',
-        cwd: '',
       });
       setShowAddDialog(false);
       showSuccess('添加成功', `MCP 服务器 "${newServer.name}" 已添加`);
@@ -1862,15 +1859,6 @@ function McpSettings() {
                         onChange={(e) => setNewServer({ ...newServer, env: e.target.value })}
                         placeholder="PATH=/usr/bin&#10;NODE_ENV=production"
                         rows={3}
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="serverCwd">工作目录</Label>
-                      <Input
-                        id="serverCwd"
-                        value={newServer.cwd}
-                        onChange={(e) => setNewServer({ ...newServer, cwd: e.target.value })}
-                        placeholder="/path/to/workspace"
                       />
                     </div>
                   </>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1591,7 +1591,6 @@ function McpSettings() {
     authHeader: '',
     headers: '',
     env: '',
-    enabled: true,
   });
   const { showSuccess, showError } = useToast();
 
@@ -1649,7 +1648,6 @@ function McpSettings() {
       authHeader: '',
       headers: '',
       env: '',
-      enabled: true,
     });
   };
 
@@ -1670,7 +1668,6 @@ function McpSettings() {
       authHeader: server.auth_header,
       headers: formatKeyValue(server.headers),
       env: formatKeyValue(server.env),
-      enabled: server.enabled,
     });
     setServerModalMode('edit');
   };
@@ -1720,7 +1717,6 @@ function McpSettings() {
             command: newServer.command.trim(),
             args: parseListArgs(newServer.args),
             env: parseKeyValueText(newServer.env, '环境变量'),
-            enabled: newServer.enabled,
           }
         : {
             name: editingServerName,
@@ -1730,7 +1726,6 @@ function McpSettings() {
             endpoint: newServer.endpoint.trim(),
             authHeader: newServer.authHeader.trim() || undefined,
             headers: parseKeyValueText(newServer.headers, 'Header'),
-            enabled: newServer.enabled,
           };
 
       await api.updateMcpServer(editingServerName, request);
@@ -1993,14 +1988,6 @@ function McpSettings() {
                     </div>
                   </>
                 )}
-                <div className="flex items-center gap-2">
-                  <Switch
-                    id="serverEnabled"
-                    checked={newServer.enabled}
-                    onCheckedChange={(checked) => setNewServer({ ...newServer, enabled: checked })}
-                  />
-                  <Label htmlFor="serverEnabled">启用</Label>
-                </div>
               </div>
               <div className="flex justify-end gap-2 mt-6">
                 <Button variant="ghost" onClick={closeServerModal}>

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2485,6 +2485,12 @@ pub async fn get_mcp_health() -> Result<Vec<serde_json::Value>, String> {
         .collect()
 }
 
+/// 探测单个 MCP 服务器（按 name），写回健康缓存。供前端添加/编辑/重试后刷新该行。
+#[tauri::command]
+pub async fn probe_mcp_server(name: String) -> Result<(), String> {
+    tiangong_core::mcp::probe_single_mcp_server_by_name(&name).map_err(|e| e.to_string())
+}
+
 /// 注册 MCP 服务器
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2567,7 +2567,6 @@ pub async fn update_mcp_server(
     auth_header: Option<String>,
     headers: Option<std::collections::HashMap<String, String>>,
     env: Option<std::collections::HashMap<String, String>>,
-    enabled: bool,
     state: State<'_, TiangongApp>,
 ) -> Result<String, String> {
     use tiangong_core::agent_config::McpTransportMode;
@@ -2604,7 +2603,8 @@ pub async fn update_mcp_server(
                 command,
                 args,
                 tags: vec![],
-                enabled,
+                // enabled 由列表开关单独控制，编辑表单不覆盖；update_mcp_server 会保留原值
+                enabled: true,
                 options: RegisterMcpServerOptions {
                     transport,
                     endpoint,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2549,6 +2549,71 @@ pub async fn register_mcp_server(
     Ok(message)
 }
 
+/// 编辑 MCP 服务器（按 name 定位，name 自身不可改）
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn update_mcp_server(
+    name: String,
+    command: String,
+    args: Vec<String>,
+    transport: Option<String>,
+    endpoint: Option<String>,
+    auth_header: Option<String>,
+    headers: Option<std::collections::HashMap<String, String>>,
+    env: Option<std::collections::HashMap<String, String>>,
+    enabled: bool,
+    state: State<'_, TiangongApp>,
+) -> Result<String, String> {
+    use tiangong_core::agent_config::McpTransportMode;
+    use tiangong_core::app_state::RegisterMcpServerOptions;
+    use tiangong_core::app_state::RegisterMcpServerRequest;
+
+    let transport = match transport
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(value) => match value.to_ascii_lowercase().as_str() {
+            "auto" => Some(McpTransportMode::Auto),
+            "stdio" => Some(McpTransportMode::Stdio),
+            "http" | "sse" | "streamablehttp" | "streamable_http" | "streamable-http" => {
+                Some(McpTransportMode::Http)
+            }
+            other => {
+                return Err(format!(
+                    "不支持的 MCP transport：{other}，支持 auto/stdio/http/sse"
+                ));
+            }
+        },
+        None => None,
+    };
+
+    let message = state
+        .with_state(|core_state| {
+            let header_vec = headers.unwrap_or_default().into_iter().collect();
+            let env_vec = env.unwrap_or_default().into_iter().collect();
+
+            let request = RegisterMcpServerRequest {
+                name: name.clone(),
+                command,
+                args,
+                tags: vec![],
+                enabled,
+                options: RegisterMcpServerOptions {
+                    transport,
+                    endpoint,
+                    auth_header,
+                    headers: header_vec,
+                    env: env_vec,
+                },
+            };
+            core_state.update_mcp_server(&name, request)
+        })
+        .await?;
+    state.sync_core_config_from_state().await?;
+    Ok(message)
+}
+
 /// 移除 MCP 服务器
 #[tauri::command]
 pub async fn remove_mcp_server(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2497,7 +2497,6 @@ pub async fn register_mcp_server(
     auth_header: Option<String>,
     headers: Option<std::collections::HashMap<String, String>>,
     env: Option<std::collections::HashMap<String, String>>,
-    cwd: Option<String>,
     state: State<'_, TiangongApp>,
 ) -> Result<String, String> {
     use tiangong_core::agent_config::McpTransportMode;
@@ -2541,7 +2540,6 @@ pub async fn register_mcp_server(
                     auth_header,
                     headers: header_vec,
                     env: env_vec,
-                    cwd,
                 },
             };
             core_state.register_mcp_server(request)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -504,6 +504,7 @@ fn run_gui() {
             tiangong_app::commands::get_mcp_servers,
             tiangong_app::commands::get_mcp_health,
             tiangong_app::commands::register_mcp_server,
+            tiangong_app::commands::update_mcp_server,
             tiangong_app::commands::remove_mcp_server,
             tiangong_app::commands::set_mcp_server_enabled,
             tiangong_app::commands::get_skills,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -503,6 +503,7 @@ fn run_gui() {
             tiangong_app::commands::set_workspace_dir,
             tiangong_app::commands::get_mcp_servers,
             tiangong_app::commands::get_mcp_health,
+            tiangong_app::commands::probe_mcp_server,
             tiangong_app::commands::register_mcp_server,
             tiangong_app::commands::update_mcp_server,
             tiangong_app::commands::remove_mcp_server,

--- a/src-tauri/src/view.rs
+++ b/src-tauri/src/view.rs
@@ -201,7 +201,6 @@ pub struct McpServerView {
     pub auth_header: String,
     pub headers: Option<BTreeMap<String, String>>,
     pub env: Option<HashMap<String, String>>,
-    pub cwd: String,
     pub enabled: bool,
 }
 
@@ -231,7 +230,6 @@ impl McpServerView {
             } else {
                 Some(core_server.env.clone().into_iter().collect())
             },
-            cwd: core_server.cwd.clone(),
             enabled: core_server.enabled,
         }
     }


### PR DESCRIPTION
## 概述

围绕 MCP server 管理的一组体验修复与能力增强,按提交主题分为五部分。所有改动已通过 cargo fmt / check / clippy(零警告)/ 394 项测试 / 前端 build。

## 改动明细

### 1. stdio 工作目录跟随会话 workspace(`c424683`)
stdio MCP 进程不再读取静态配置 `cwd`,改为复用 `run_command` 的会话级 `SESSION_CWD` 线程局部变量,让子进程落在当前对话的 workspace。能力探测等无会话上下文的路径下回退到宿主进程 cwd。

- 全链路清理配置项 `cwd`(结构体/校验/注册/导入/CLI/视图/Tauri 命令/前端类型与表单)
- 旧配置与导入 JSON 里的 `cwd` 静默忽略(无 `deny_unknown_fields`,导入侧保留字段反序列化兼容)

### 2. 捕获 stdio 子进程 stderr,握手失败时附入诊断(`1d99c7e`)
此前 stdio MCP 用 `Stdio::null()` 丢弃子进程 stderr,导致 `npx` 启动失败时(包下载失败、缺 API key、Node 版本不兼容等)真正报错被吞掉,用户只看到空洞的"MCP握手失败"。

改为 `Stdio::piped()` 捕获,后台任务持续读取仅保留末尾窗口(8KB),握手失败或调用失败时把末尾若干行附进错误消息。

### 3. 新增 MCP server 编辑能力(`b728e9e`)
name 作为主键不可改,编辑覆盖其余全部可配字段。复用现有 add 表单改造为 add/edit 共享 modal(参考已有 model add/edit 模式),编辑时回填现有字段、name 只读。

- 后端新增 `update_mcp_server`(抽取 `normalize_request_fields` 与 register 共用),走 merge 持久化变体
- Tauri 命令 + 前端 API + 表单全链路

### 4. 探测改为并发+短暂持锁,新增单 server 探测与刷新重探(`efc071f`)
修复两个体验问题:
- **添加后 ~15s 才刷新列表**:根因是 `refresh_mcp_capabilities` 在持有全局写锁期间串行探测所有 server,前端 `getMcpHealth` 读锁被阻塞。
- **刷新按钮只读缓存不重探**:卡在不健康的 server 要等定时周期才更新。

修复:
- `refresh_mcp_capabilities` 拆成"先并发探测(thread::scope,全程不持锁)+ 后短暂持锁写回"
- 新增 `probe_single_mcp_server_by_name(name)` + Tauri 命令 `probe_mcp_server`
- 前端 `loadServers` 解耦(先 `getMcpServers` 立即渲染,健康状态异步更新);添加/编辑后只 probe 该 server;刷新按钮对所有 server 并发重探;不健康行增加行内重试按钮

### 5. 编辑对话框移除启用开关(`5a6c1a3`)
启用状态统一由列表行的 Switch 控制,避免编辑表单与列表两处入口互相覆盖。后端 `update_mcp_server` 保留原 `server.enabled`。

## 验证

\`\`\`
cargo fmt -- --check
cargo check --workspace
cargo clippy --workspace --all-targets --tests --benches -- -D warnings
cargo nextest run --workspace --no-tests pass   # 394 passed, 2 skipped
cd frontend && npm run build
\`\`\`

## 备注

本分支跨了多个 MCP 相关主题(cwd / stderr 诊断 / 编辑能力 / 探测并发)。如评审需要,可拆成多条主题 PR;目前作为汇总 PR 提交。