### PR TITLE
fix(terminal): 修复终端面板无法输入内容（xterm 未聚焦）

### DIFF
--- a/frontend/src/components/TerminalTabContent.tsx
+++ b/frontend/src/components/TerminalTabContent.tsx
@@ -205,6 +205,15 @@ export function TerminalTabContent({ sessionId, tabId, isActive }: TerminalTabCo
           } catch {
             // ignore
           }
+          // xterm 的输入捕获依赖一个隐藏的辅助 textarea 获得焦点：
+          // 没有焦点时 onData 不触发，键盘输入被丢弃（Windows WebView2 下
+          // 尤其明显，容器不会从父元素继承焦点）。终端 open 后主动聚焦，
+          // 同时覆盖 terminal:reset 重建（全新 textarea）的路径。
+          try {
+            terminalRef.current?.focus();
+          } catch {
+            // ignore
+          }
         });
 
         const info = await api.terminalSessionStatus(terminalId).catch(() => null);
@@ -221,6 +230,20 @@ export function TerminalTabContent({ sessionId, tabId, isActive }: TerminalTabCo
 
     mountTerminal();
   }, [isActive, ptyVersion, sessionCwd, sessionId, tabId, terminalId, workspaceDir]);
+
+  // Tab 激活时重新聚焦：终端已存在会跳过创建分支，焦点不会自动重建，
+  // 需在此显式聚焦，否则切回终端 Tab 后键盘输入静默失效。
+  useEffect(() => {
+    if (!isActive) return;
+    const raf = requestAnimationFrame(() => {
+      try {
+        terminalRef.current?.focus();
+      } catch {
+        // ignore
+      }
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isActive]);
 
   useEffect(() => {
     return () => {
@@ -258,7 +281,17 @@ export function TerminalTabContent({ sessionId, tabId, isActive }: TerminalTabCo
           <RotateCw className="h-3 w-3" />
         </Button>
       </div>
-      <div ref={containerRef} className="min-h-0 flex-1" />
+      <div
+        ref={containerRef}
+        className="min-h-0 flex-1"
+        onMouseDown={() => {
+          try {
+            terminalRef.current?.focus();
+          } catch {
+            // ignore
+          }
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 问题
Windows（及通用平台）下终端面板无法输入内容，敲键盘无任何反应。

## 根因
实际渲染的终端组件 `TerminalTabContent` **从未调用 `term.focus()`**。

xterm.js 的键盘输入捕获依赖一个隐藏的辅助 `<textarea>`（由 `term.open(container)` 创建）获得焦点。当该 textarea 没有焦点时：
- `term.onData(...)` 永远不触发
- → `terminalSessionSendInput` 不被调用
- → 后端 PTY writer 收不到输入

Windows WebView2 下容器不会从父元素继承焦点（Unix/macOS 偶尔能继承，所以不一定复现），表现为「完全打不出字」。

> 注：旧分析里提到的 `TerminalPanel.tsx` 的 `currentIdRef` 问题是死代码（`<TerminalPanel` 全局无引用），与实际渲染组件无关。

## 修复（仅改 \`frontend/src/components/TerminalTabContent.tsx\`，3 处）

| # | 改动 | 覆盖场景 |
|---|------|---------|
| 1 | 终端 \`open()\` 后在 rAF 内 \`term.focus()\` | 首次创建 + \`terminal:reset\` 重建（全新 textarea） |
| 2 | 新增 \`isActive\` 依赖 effect，激活时 rAF 内聚焦 | 切走再切回终端 Tab（终端已存在，跳过创建分支，焦点不自动重建） |
| 3 | 容器加 \`onMouseDown\` 聚焦 | 点击终端区域即聚焦，覆盖 WebView2 偶发焦点丢失 |

后端 PTY writer（\`manager.rs\` 的 \`SendInput\` → \`write_all\`+\`flush\`）与 ConPTY 写入路径本身正确，未改动。

## 验证
- \`npx tsc --noEmit\` 通过
- Windows 实测四个场景全部 OK：
  - ✅ 打开终端能直接打字
  - ✅ 切走再切回终端 Tab 能打字
  - ✅ 切 workspace（触发 \`terminal:reset\` 重建）后能打字
  - ✅ 点击终端区域可聚焦