### PR TITLE
fix: ReAct 循环失败时持久化错误痕迹

### DIFF
--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -18,6 +18,11 @@ use crate::runtime::{RuntimeEngine, inject_enhanced_tools};
 use crate::session::{Message, MessageRole, Session};
 use tiangong_types::{SessionStreamEvent, StreamEvent};
 
+/// 单次工具执行阶段（ReAct Loop 内层）的最大轮次。
+///
+/// 30 轮：review 类多步骤任务（连续读取多个文件做审查）在 15 轮时容易触顶，
+/// 过早进入总结阶段。30 轮给复杂任务更多空间；触顶后仍走与正常完成相同的总结
+/// 路径（由模型自行判断完成度），无需特殊触顶逻辑。
 const MAX_TOOL_ROUNDS: usize = 30;
 /// 总结阶段后重新进入工具执行阶段的最大次数。
 const MAX_OUTER_ITERATIONS: u32 = 3;

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -18,7 +18,7 @@ use crate::runtime::{RuntimeEngine, inject_enhanced_tools};
 use crate::session::{Message, MessageRole, Session};
 use tiangong_types::{SessionStreamEvent, StreamEvent};
 
-const MAX_TOOL_ROUNDS: usize = 15;
+const MAX_TOOL_ROUNDS: usize = 30;
 /// 总结阶段后重新进入工具执行阶段的最大次数。
 const MAX_OUTER_ITERATIONS: u32 = 3;
 

--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -228,13 +228,21 @@ impl ForceFinalReason {
 
 /// 将错误持久化到 session，作为 LLM 请求失败时的诊断痕迹。
 ///
-/// 前端 `StreamEvent::Error` 会在 commands.rs 写入 `[错误]` 系统消息，但存在
-/// 时序丢失风险（execute_turn return 后转发线程可能未及时处理）。本函数在
-/// engine 侧直接写入 session 并持久化，确保事后重载会话仍可看到失败原因。
+/// 复用 `inject_tool_to_messages` 统一注入通道（合法的 assistant tool_call + tool result
+/// 消息对），而非手工追加消息：
+/// - 避免使用 `MessageRole::System`——它会被 `build_provider_messages` 的
+///   `system_texts.clear()` 覆盖整个 system prompt，污染 prompt 并破坏 KV cache 前缀；
+/// - 走标准注入通道保证 append-only、去重、provider 序列化为合法 tool pair，cache 友好。
+///
+/// 前端 `StreamEvent::Error` 也会落盘 `[错误]` 消息，`inject_tool_to_messages` 内置
+/// 去重（与上一条 plugin_injection 渲染文本相同则跳过），避免重复。
 pub(crate) fn persist_error(session: &mut Session, message: impl Into<String>) {
-    let mut msg = Message::new(MessageRole::System, format!("[错误] {}", message.into()));
-    msg.tool_name = Some("react_loop_error".to_string());
-    session.messages.push(msg);
+    let message = message.into();
+    let payload = serde_json::json!({
+        "error": message,
+        "instruction": "上一步执行失败，请基于已有结果继续或向用户说明原因。",
+    });
+    crate::react::message::inject_tool_to_messages(session, "react_loop_error", &payload);
     session.persist_to_disk();
 }
 

--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -226,6 +226,18 @@ impl ForceFinalReason {
     }
 }
 
+/// 将错误持久化到 session，作为 LLM 请求失败时的诊断痕迹。
+///
+/// 前端 `StreamEvent::Error` 会在 commands.rs 写入 `[错误]` 系统消息，但存在
+/// 时序丢失风险（execute_turn return 后转发线程可能未及时处理）。本函数在
+/// engine 侧直接写入 session 并持久化，确保事后重载会话仍可看到失败原因。
+pub(crate) fn persist_error(session: &mut Session, message: impl Into<String>) {
+    let mut msg = Message::new(MessageRole::System, format!("[错误] {}", message.into()));
+    msg.tool_name = Some("react_loop_error".to_string());
+    session.messages.push(msg);
+    session.persist_to_disk();
+}
+
 /// 超限时强制最终回复
 pub(crate) fn force_final_response(
     session: &mut Session,

--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -302,6 +302,7 @@ pub(crate) fn force_final_response(
                 let _ = stream_tx.send(StreamEvent::Error {
                     message: err.to_string(),
                 });
+                persist_error(session, format!("force_final_response（流式）失败：{err}"));
                 return;
             }
         }
@@ -327,6 +328,10 @@ pub(crate) fn force_final_response(
                 let _ = stream_tx.send(StreamEvent::Error {
                     message: err.to_string(),
                 });
+                persist_error(
+                    session,
+                    format!("force_final_response（非流式）失败：{err}"),
+                );
                 return;
             }
         }

--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -232,10 +232,12 @@ impl ForceFinalReason {
 /// 消息对），而非手工追加消息：
 /// - 避免使用 `MessageRole::System`——它会被 `build_provider_messages` 的
 ///   `system_texts.clear()` 覆盖整个 system prompt，污染 prompt 并破坏 KV cache 前缀；
-/// - 走标准注入通道保证 append-only、去重、provider 序列化为合法 tool pair，cache 友好。
+/// - 走标准注入通道保证 append-only、provider 序列化为合法 tool pair，cache 友好。
 ///
-/// 前端 `StreamEvent::Error` 也会落盘 `[错误]` 消息，`inject_tool_to_messages` 内置
-/// 去重（与上一条 plugin_injection 渲染文本相同则跳过），避免重复。
+/// 去重边界：`inject_tool_to_messages` 仅对连续相同的 plugin_injection 结果去重，
+/// 不会与前端 `StreamEvent::Error` 落盘的 `[错误]` System 消息跨格式去重——因此
+/// 前端若也落盘，UI 上仍可能出现重复错误消息。engine 侧落盘作为前端时序丢失的
+/// 兜底，确保会话重载后至少能看到失败原因。
 pub(crate) fn persist_error(session: &mut Session, message: impl Into<String>) {
     let message = message.into();
     let payload = serde_json::json!({

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -2471,19 +2471,22 @@ impl ReactEngine {
         // 处理结果
         for (agent_id, agent_label, _agent_role, child_session, _output_messages, usage) in results
         {
-            // 检查 Sub Agent 是否有错误输出
-            let has_error = child_session
-                .messages
-                .iter()
-                .any(|m| m.role == MessageRole::System && m.text_content().starts_with("[错误]"));
+            // 检查 Sub Agent 是否有错误输出。
+            // 错误由 persist_error 经 inject_tool_to_messages 注入（plugin_injection 消息对，
+            // 渲染文本含 "数据来源：react_loop_error"）；兼容历史 System 角色 [错误] 消息。
+            let is_error_message = |m: &Message| {
+                let text = m.text_content();
+                (m.tool_name.as_deref() == Some(crate::react::message::INJECTION_TOOL_NAME)
+                    && text.contains("数据来源：react_loop_error"))
+                    || (m.role == MessageRole::System && text.starts_with("[错误]"))
+            };
+            let has_error = child_session.messages.iter().any(is_error_message);
 
             let completion_content = if has_error {
                 let error_content = child_session
                     .messages
                     .iter()
-                    .filter(|m| {
-                        m.role == MessageRole::System && m.text_content().starts_with("[错误]")
-                    })
+                    .filter(|m: &&Message| is_error_message(m))
                     .map(|m| m.text_content().replace("[错误] ", ""))
                     .collect::<Vec<_>>()
                     .join("; ");

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -2027,6 +2027,27 @@ fn strip_summary_marker<'a>(text: &'a str, marker: &str) -> Option<&'a str> {
     )
 }
 
+/// 从错误消息文本中提取简洁的错误描述。
+///
+/// 支持两种格式：
+/// - `plugin_injection` 渲染格式（`数据来源：react_loop_error\n相关数据：\n    error: ...`）：
+///   只提取 `error:` 字段值，剔除 instruction 等噪声；
+/// - 历史 `[错误] xxx` System 消息：去掉前缀后返回。
+fn extract_error_brief(text: &str) -> String {
+    // plugin_injection 渲染格式：逐行查找 "    error: " 开头的字段值。
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("error:") {
+            return rest.trim().to_string();
+        }
+    }
+    // 历史 System 格式：去掉 "[错误] " 前缀。
+    text.strip_prefix("[错误] ")
+        .unwrap_or(text)
+        .trim()
+        .to_string()
+}
+
 fn format_team_roster(team_arc: &Arc<Mutex<TeamContext>>) -> String {
     let Ok(team) = team_arc.lock() else {
         return String::new();
@@ -2483,11 +2504,13 @@ impl ReactEngine {
             let has_error = child_session.messages.iter().any(is_error_message);
 
             let completion_content = if has_error {
+                // 从错误消息中提取简洁的错误描述，避免把完整渲染文本（含 instruction
+                // 等字段）当作汇报内容传给主 Agent。
                 let error_content = child_session
                     .messages
                     .iter()
                     .filter(|m: &&Message| is_error_message(m))
-                    .map(|m| m.text_content().replace("[错误] ", ""))
+                    .map(|m| extract_error_brief(&m.text_content()))
                     .collect::<Vec<_>>()
                     .join("; ");
                 format!("[{agent_label}] 执行出错：{error_content}")

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -23,7 +23,7 @@ use crate::permission::{
 };
 use crate::react::context::{
     ForceFinalReason, emit_token_usage, force_final_response, maybe_update_context_summary,
-    request_for_summary_phase, select_client_for_request,
+    persist_error, request_for_summary_phase, select_client_for_request,
 };
 use crate::react::message::*;
 use crate::runtime::LlmOutputRecord;
@@ -1066,7 +1066,11 @@ impl ReactEngine {
                                 continue 'react_loop;
                             }
                         }
-                        let _ = stream_tx.send(StreamEvent::Error { message: err_msg });
+                        let _ = stream_tx.send(StreamEvent::Error {
+                            message: err_msg.clone(),
+                        });
+                        // 持久化错误到 session，避免前端 Error 事件时序丢失导致中断无痕迹。
+                        persist_error(session, format!("ReAct 循环请求失败：{err_msg}"));
                         return accumulated_usage;
                     }
                 };
@@ -1146,9 +1150,11 @@ impl ReactEngine {
                 // 工具调用
                 let executable_calls = response.tool_calls.iter().collect::<Vec<_>>();
                 if executable_calls.is_empty() {
+                    let msg = "模型没有返回可执行工具调用，任务已停止".to_string();
                     let _ = stream_tx.send(StreamEvent::Error {
-                        message: "模型没有返回可执行工具调用，任务已停止".to_string(),
+                        message: msg.clone(),
                     });
+                    persist_error(session, msg);
                     return accumulated_usage;
                 }
                 let tool_names: Vec<String> =
@@ -1967,6 +1973,7 @@ impl ReactEngine {
                     let _ = stream_tx.send(StreamEvent::Error {
                         message: format!("总结阶段失败：{message}"),
                     });
+                    persist_error(session, format!("总结阶段失败：{message}"));
                     force_final_response(
                         session,
                         &self.engine,

--- a/crates/tiangong-core/src/react/engine.rs
+++ b/crates/tiangong-core/src/react/engine.rs
@@ -2027,27 +2027,6 @@ fn strip_summary_marker<'a>(text: &'a str, marker: &str) -> Option<&'a str> {
     )
 }
 
-/// 从错误消息文本中提取简洁的错误描述。
-///
-/// 支持两种格式：
-/// - `plugin_injection` 渲染格式（`数据来源：react_loop_error\n相关数据：\n    error: ...`）：
-///   只提取 `error:` 字段值，剔除 instruction 等噪声；
-/// - 历史 `[错误] xxx` System 消息：去掉前缀后返回。
-fn extract_error_brief(text: &str) -> String {
-    // plugin_injection 渲染格式：逐行查找 "    error: " 开头的字段值。
-    for line in text.lines() {
-        let trimmed = line.trim_start();
-        if let Some(rest) = trimmed.strip_prefix("error:") {
-            return rest.trim().to_string();
-        }
-    }
-    // 历史 System 格式：去掉 "[错误] " 前缀。
-    text.strip_prefix("[错误] ")
-        .unwrap_or(text)
-        .trim()
-        .to_string()
-}
-
 fn format_team_roster(team_arc: &Arc<Mutex<TeamContext>>) -> String {
     let Ok(team) = team_arc.lock() else {
         return String::new();
@@ -2493,24 +2472,20 @@ impl ReactEngine {
         for (agent_id, agent_label, _agent_role, child_session, _output_messages, usage) in results
         {
             // 检查 Sub Agent 是否有错误输出。
-            // 错误由 persist_error 经 inject_tool_to_messages 注入（plugin_injection 消息对，
-            // 渲染文本含 "数据来源：react_loop_error"）；兼容历史 System 角色 [错误] 消息。
+            // 错误由 persist_error 经 inject_tool_to_messages 注入（plugin_injection
+            // 消息对，渲染文本含 "数据来源：react_loop_error"）。
             let is_error_message = |m: &Message| {
-                let text = m.text_content();
-                (m.tool_name.as_deref() == Some(crate::react::message::INJECTION_TOOL_NAME)
-                    && text.contains("数据来源：react_loop_error"))
-                    || (m.role == MessageRole::System && text.starts_with("[错误]"))
+                m.tool_name.as_deref() == Some(crate::react::message::INJECTION_TOOL_NAME)
+                    && m.text_content().contains("数据来源：react_loop_error")
             };
             let has_error = child_session.messages.iter().any(is_error_message);
 
             let completion_content = if has_error {
-                // 从错误消息中提取简洁的错误描述，避免把完整渲染文本（含 instruction
-                // 等字段）当作汇报内容传给主 Agent。
                 let error_content = child_session
                     .messages
                     .iter()
                     .filter(|m: &&Message| is_error_message(m))
-                    .map(|m| extract_error_brief(&m.text_content()))
+                    .map(|m| m.text_content())
                     .collect::<Vec<_>>()
                     .join("; ");
                 format!("[{agent_label}] 执行出错：{error_content}")


### PR DESCRIPTION
## 问题

会话在 ReAct 循环工具结果后异常中断，session 中无任何错误痕迹，事后无法定位根因。

根因经分析确认：**轮次上限（原 15）触发后进入总结阶段，总结阶段 LLM 请求失败**。原代码的错误退出分支只发 \`StreamEvent::Error\`（前端 commands.rs 写 \`[错误]\` 消息），存在时序丢失风险——execute_turn return 后转发线程可能未及时处理，导致 session 不留任何诊断信息。

## 改动

### 1. 新增 \`persist_error\` 统一错误持久化（核心）

复用 \`inject_tool_to_messages\` 固定且安全的注入通道（合法的 assistant tool_call + tool result 消息对），而非手工追加消息：
- **不使用 \`MessageRole::System\`**——它会被 \`build_provider_messages\` 的 \`system_texts.clear()\` 覆盖整个 system prompt，污染 prompt 并破坏 KV cache 前缀
- 走标准注入通道保证 append-only、provider 序列化为合法 tool pair，cache 友好
- engine 侧落盘作为前端时序丢失的兜底，确保会话重载后至少能看到失败原因

### 2. 覆盖所有错误退出点

| 退出点 | 位置 |
|--------|------|
| ReAct 循环 LLM 请求失败 | \`engine.rs\` |
| 模型未返回可执行工具调用 | \`engine.rs\` |
| 总结阶段 LLM 请求失败（Failed） | \`engine.rs\` |
| force_final_response 内部失败（流式/非流式） | \`context.rs\` |

### 3. Sub Agent 错误检测

识别 \`plugin_injection\` 注入的 \`react_loop_error\` 来源（tool result 文本含 \`数据来源：react_loop_error\`）。

### 4. \`MAX_TOOL_ROUNDS\` 15 → 30

review 类多步骤任务（连续读取多个文件做审查）在 15 轮时容易触顶，过早进入总结阶段。30 轮给复杂任务更多空间；触顶后仍走与正常完成相同的总结路径（由模型自行判断完成度），无需特殊触顶逻辑。

## 验证

- \`cargo check -p tiangong-core --all-targets\` ✓（零 warning）
- \`cargo clippy -p tiangong-core --all-targets --tests -- -D warnings\` ✓（零 warning）
- \`cargo nextest run -p tiangong-core\` ✓（213 通过，1 跳过）
- pre-commit / pre-push hooks 全过