### PR TITLE
ci(rust): 按 crate 独立校验，避免一处变更触发全量 workspace 校验

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,31 +20,184 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      # 按改动范围拆分：纯前端只跑 frontend，纯后端只跑 rust/tauri，都改时全跑
-      frontend: ${{ steps.filter.outputs.frontend }}
-      rust: ${{ steps.filter.outputs.rust }}
+      # 是否触发了任何后端 Rust 改动（含 workflow 自身），用于编排 fmt / tauri / frontend
+      rust: ${{ steps.resolve.outputs.rust }}
+      frontend: ${{ steps.resolve.outputs.frontend }}
+      # 需要校验的 crate 列表（JSON 数组），已根据依赖闭包展开。
+      # 仅包含「自身或其传递依赖发生改动」的 crate，matrix 作业据此按需启动 runner。
+      matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+
+      - name: Filter changed paths
         id: filter
+        uses: dorny/paths-filter@v3
         with:
           filters: |
             frontend:
               - 'frontend/**'
               - '.github/workflows/**'
-            rust:
+            rust_any:
               - 'crates/**'
               - 'src-tauri/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.github/workflows/**'
 
-  rust:
-    name: Rust Workspace
+      - name: Resolve affected crates
+        id: resolve
+        env:
+          FRONTEND_ANY: ${{ steps.filter.outputs.frontend }}
+          RUST_ANY: ${{ steps.filter.outputs.rust_any }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # 1) 顶层 Rust / frontend 开关
+          if [[ "$RUST_ANY" == "true" ]]; then rust_flag="true"; else rust_flag="false"; fi
+          if [[ "$FRONTEND_ANY" == "true" ]]; then frontend_flag="true"; else frontend_flag="false"; fi
+
+          # 2) 若无任何 Rust 改动，直接输出空矩阵，跳过全部逐 crate 作业
+          if [[ "$rust_flag" != "true" ]]; then
+            echo "rust=false" >> "$GITHUB_OUTPUT"
+            echo "frontend=${frontend_flag}" >> "$GITHUB_OUTPUT"
+            echo 'matrix=[]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 3) 解析 diff。PR 用 base..HEAD，push 事件用 before..HEAD，兜底取全部文件。
+          if [[ -n "$PR_BASE" ]]; then
+            range="${PR_BASE}...HEAD"
+          elif [[ -n "$BEFORE" && "$BEFORE" != "0000000000000000000000000000000000000000" ]]; then
+            range="${BEFORE}..HEAD"
+          else
+            range=""
+          fi
+
+          if [[ -n "$range" ]]; then
+            mapfile -t files < <(git diff --name-only "$range")
+          else
+            mapfile -t files < <(git diff --name-only HEAD)
+          fi
+
+          # 把改动文件列表经环境变量传给 Python（换行分隔）
+          export CHANGED_FILES="$(printf '%s\n' "${files[@]}")"
+
+          # 4) 用 Python 计算受影响的 crate 闭包：把改动文件映射到 crate，
+          #    再沿正向依赖图把闭包扩展到所有直接/间接依赖它们的上游 crate。
+          matrix_json="$(python3 <<'PY'
+          import json, os
+
+          # workspace 中所有 crate -> 其源码目录前缀（相对仓库根）
+          # 包名与 cargo -p 用的标识一致；src-tauri 的二进制包名为 tiangong-app
+          crate_to_prefix = {
+              "tiangong-types":           "crates/tiangong-types/",
+              "tiangong-anthropic":       "crates/tiangong-anthropic/",
+              "tiangong-deepseek":        "crates/tiangong-deepseek/",
+              "tiangong-media":           "crates/tiangong-media/",
+              "tiangong-scheduler":       "crates/tiangong-scheduler/",
+              "tiangong-llm":             "crates/tiangong-llm/",
+              "tiangong-config":          "crates/tiangong-config/",
+              "tiangong-memory":          "crates/tiangong-memory/",
+              "tiangong-core":            "crates/tiangong-core/",
+              "tiangong-cli":             "crates/tiangong-cli/",
+              "tiangong-server":          "crates/tiangong-server/",
+              "tiangong-entry":           "crates/tiangong-entry/",
+              "tiangong-plugin-browser":  "crates/tiangong-plugin-browser/",
+              "tiangong-plugin-terminal": "crates/tiangong-plugin-terminal/",
+              "tiangong-app":             "src-tauri/",
+          }
+
+          # 正向依赖图：key 直接依赖 value 列表中的 crate（取自各 Cargo.toml 的 workspace 依赖）
+          forward_deps = {
+              "tiangong-types":           [],
+              "tiangong-anthropic":       [],
+              "tiangong-deepseek":        [],
+              "tiangong-media":           [],
+              "tiangong-scheduler":       [],
+              "tiangong-llm":             ["tiangong-types", "tiangong-anthropic", "tiangong-deepseek"],
+              "tiangong-config":          ["tiangong-core"],
+              "tiangong-memory":          ["tiangong-llm", "tiangong-config"],
+              "tiangong-core":            ["tiangong-types", "tiangong-llm", "tiangong-memory", "tiangong-scheduler", "tiangong-media"],
+              "tiangong-cli":             ["tiangong-core", "tiangong-config", "tiangong-types"],
+              "tiangong-server":          ["tiangong-core", "tiangong-config", "tiangong-media", "tiangong-scheduler", "tiangong-types"],
+              "tiangong-entry":           ["tiangong-cli", "tiangong-core", "tiangong-server"],
+              "tiangong-plugin-browser":  ["tiangong-core", "tiangong-types"],
+              "tiangong-plugin-terminal": ["tiangong-core", "tiangong-types"],
+              "tiangong-app":             [
+                  "tiangong-cli", "tiangong-config", "tiangong-core", "tiangong-entry",
+                  "tiangong-media", "tiangong-memory", "tiangong-plugin-browser",
+                  "tiangong-plugin-terminal", "tiangong-scheduler", "tiangong-server", "tiangong-types",
+              ],
+          }
+
+          # 反向依赖图：dep -> 直接依赖它的 crate 列表
+          reverse_deps = {c: [] for c in forward_deps}
+          for crate, deps in forward_deps.items():
+              for dep in deps:
+                  reverse_deps[dep].append(crate)
+
+          files = os.environ.get("CHANGED_FILES", "")
+          file_list = [f for f in files.splitlines() if f]
+
+          # 4a) 找出被直接改动的 crate
+          directly_changed = set()
+          for crate, prefix in crate_to_prefix.items():
+              if any(f.startswith(prefix) for f in file_list):
+                  directly_changed.add(crate)
+
+          # 4b) 沿反向依赖图扩展传递闭包：改动 types -> 所有依赖 types 的 crate 都要重校验
+          affected = set()
+          stack = list(directly_changed)
+          while stack:
+              cur = stack.pop()
+              if cur in affected:
+                  continue
+              affected.add(cur)
+              for parent in reverse_deps.get(cur, []):
+                  if parent not in affected:
+                      stack.append(parent)
+
+          # 4c) 保持稳定输出顺序（与 workspace members 顺序一致）
+          order = list(crate_to_prefix.keys())
+          ordered = [c for c in order if c in affected]
+
+          print(json.dumps(ordered))
+          PY
+          )"
+
+          echo "Affected crates: $matrix_json"
+          echo "rust=true" >> "$GITHUB_OUTPUT"
+          echo "frontend=${frontend_flag}" >> "$GITHUB_OUTPUT"
+          echo "matrix=${matrix_json}" >> "$GITHUB_OUTPUT"
+
+  rust-fmt:
+    name: Rust fmt (workspace)
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        # 格式校验必须保证整个 workspace 一致，因此仅做一次、不按 crate 拆分
+        run: cargo fmt --all -- --check
 
+  # 逐 crate 校验：changes 作业已按依赖闭包筛选出真正受影响的 crate，
+  # 这里只对它们运行 check / clippy / test。
+  # cargo -p <crate> 仅编译该 crate 的依赖闭包，避免触发全量 workspace 编译。
+  rust-crate:
+    name: Rust ${{ matrix.crate }}
+    needs: changes
+    if: needs.changes.outputs.matrix != '[]' && needs.changes.outputs.matrix != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
@@ -57,16 +210,20 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Install Linux system dependencies
+        # tiangong-core / tiangong-memory 间接引入 tantivy/lancedb/rusqlite/scraper，
+        # tiangong-plugin-* 与 tiangong-app 引入 tauri，均需下列系统库。
+        # 为避免逐 crate 维护系统依赖矩阵，统一安装一次。
         run: |
+          # GitHub runner 预装的 Microsoft apt 源偶发 403，提前移除避免污染 apt-get update
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install -y \
             protobuf-compiler \
@@ -86,33 +243,67 @@ jobs:
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-      - name: Check workspace
-        run: cargo check --workspace
+      - name: Check crate
+        run: cargo check -p ${{ matrix.crate }}
 
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets --tests --benches -- -D warnings
+        run: cargo clippy -p ${{ matrix.crate }} --all-targets --tests --benches -- -D warnings
 
       - name: Run nextest
         env:
           CARGO_BUILD_JOBS: "1"
           RUSTFLAGS: "-C linker-features=-lld"
-        run: cargo nextest run --workspace --no-tests pass
+        run: cargo nextest run -p ${{ matrix.crate }} --no-tests pass
+
+  tauri:
+    name: Tauri Shell Check
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - uses: actions/checkout@v4
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y \
+            protobuf-compiler \
+            pkg-config \
+            libglib2.0-dev \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check Tauri shell
+        run: cargo check --manifest-path src-tauri/Cargo.toml
 
   frontend:
     name: Frontend Build
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: yarn
@@ -129,49 +320,3 @@ jobs:
 
       - name: Build frontend
         run: yarn --cwd frontend build
-
-  tauri:
-    name: Tauri Shell Check
-    needs: changes
-    if: needs.changes.outputs.rust == 'true'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Tauri system dependencies
-        run: |
-          # GitHub runner 预装的 Microsoft apt 源（azure-cli / ubuntu prod）偶发 403，
-          # 与本仓库无关，提前移除避免污染 apt-get update
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
-          sudo apt-get install -y \
-            protobuf-compiler \
-            pkg-config \
-            libglib2.0-dev \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            patchelf
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Check Tauri shell
-        run: cargo check --manifest-path src-tauri/Cargo.toml


### PR DESCRIPTION
## 背景

当前 CI 中任意一处 Rust 变更（哪怕只改 `tiangong-server`）都会触发 `cargo check/clippy/nextest --workspace` 全量校验，包括与改动无关的 crate，浪费 runner 资源、拖慢反馈。

## 改动

将 `.github/workflows/ci.yml` 的后端 Rust 校验重构为**按 crate 独立校验**：

| 作业 | 触发条件 | 行为 |
|------|---------|------|
| `changes` | 总是 | 解析 diff，按**依赖闭包**算出受影响 crate 列表（JSON 数组） |
| `rust-fmt` | 有 Rust 改动 | 单次 `cargo fmt --all --check`（格式必须 workspace 一致） |
| `rust-crate` | 列表非空 | **矩阵**，每个 crate 一个 job，跑 `cargo check/clippy/nextest -p <crate>` |
| `tauri` / `frontend` | 同前 | 保持原逻辑 |

## 关键设计

1. **反向依赖闭包**：`changes` 作业用 Python 沿依赖图计算受影响 crate 的传递闭包。
   - 改 `types` → 连带校验所有上游 crate
   - 改 `server` → 只校验 `server + entry + tiangong-app`
   - 改 `src-tauri` → 只校验 `tiangong-app`

2. **动态矩阵**：`rust-crate` 用 `fromJSON(needs.changes.outputs.matrix)` 消费闭包结果。未受影响的 crate **不会启动 runner**（而非启动后自我 skip）。

3. **`cargo -p` 隔离编译**：每个 crate 的 check/clippy/nextest 只编译其依赖闭包，绝不触碰无关 crate。

4. **系统依赖统一安装**：因 `core`/`memory` 引入 tantivy/lancedb/rusqlite、`plugin-*`/`app` 引入 tauri，仍统一安装一次系统库，但编译范围严格隔离。

## 验证

- ✅ YAML 语法校验通过
- ✅ 闭包算法本地跑通（types-only / server-only / 非 rust 改动 三种场景输出正确）
- ✅ 全部 15 个 `cargo -p` 包名（`src-tauri` 对应 `tiangong-app`）在 workspace 中可解析

## 备注

依赖图当前硬编码在工作流脚本中（取自各 `Cargo.toml` 的 workspace 依赖）。后续若 crate 依赖关系调整，需同步更新该图。