### PR TITLE
fix(frontend): 侧边栏分组点击不再展开，仅通过"显示全部"按钮展开

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -9,7 +9,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from './ui/context-menu';
-import { Plus, Trash2, ChevronRight, ChevronDown, Folder, FilePlus2, FolderX } from 'lucide-react';
+import { Plus, Trash2, Folder, FilePlus2, FolderX } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { SettingsDialog } from './SettingsDialog';
 import type { Session } from '@/api/tauri';
@@ -205,21 +205,15 @@ export function AppSidebar() {
         <ContextMenuTrigger asChild>
           <div className="space-y-1 select-none">
             <div className="flex items-center gap-1 group">
-              <button
-                className="flex-1 flex items-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-sidebar-accent/50 transition-colors min-w-0"
-                onClick={() => canCollapse && toggleGroup(group.key)}
+              {/* 分组头为纯展示：点击不展开，展开仅通过下方"显示全部"按钮 */}
+              <div
+                className="flex-1 flex items-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium text-muted-foreground min-w-0"
                 title={group.fullPath}
-                disabled={!canCollapse}
               >
-                {isExpanded ? (
-                  <ChevronDown className="w-3 h-3 shrink-0" />
-                ) : (
-                  <ChevronRight className="w-3 h-3 shrink-0" />
-                )}
                 <Folder className="w-3.5 h-3.5 shrink-0" />
                 <span className="truncate">{group.label}</span>
                 <span className="text-muted-foreground/70 shrink-0">{group.sessions.length}</span>
-              </button>
+              </div>
               <button
                 className="p-1 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-sidebar-accent/50 transition-opacity shrink-0"
                 onClick={() => !isSending && createSession(group.fullPath)}


### PR DESCRIPTION
## 变更说明

调整侧边栏分组的交互行为：

### 改动点

1. **分组头点击不再展开/收缩**
   - 非默认分组的分组头由可点击的 `<button onClick={toggleGroup}>` 改为纯展示型 `<div>`
   - 点击分组头不再有任何展开行为

2. **展开仅通过「显示全部」按钮**
   - 保留每组底部的「显示全部 (N) / 收起」按钮，作为唯一的展开入口

3. **移除目录图标左侧的箭头**
   - 删除分组头中的 `ChevronDown` / `ChevronRight` 图标，目录直接以 `Folder` 图标开头
   - 同步清理未使用的图标导入

### 影响范围
- 仅 `frontend/src/components/AppSidebar.tsx`
- 默认分组、右键菜单、hover「+」新建按钮等行为保持不变

### 验证
- ✅ TypeScript 检查（`tsc -b`）通过
- ✅ pre-push hooks：`yarn build` / `yarn test` 通过