### PR TITLE
feat(cli): 0.12.0 CLI 模块化配置增强（参数式 + 交互式向导）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
       # 仅包含「自身或其传递依赖发生改动」的 crate，matrix 作业据此按需启动 runner。
       matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
+      # 完整克隆：crate 闭包计算需用 git diff base.sha...HEAD 解析改动文件，
+      # 默认 fetch-depth: 1 是浅克隆，base commit 不可达会导致 diff 为空、matrix=[]。
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Filter changed paths
         id: filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
       # 是否触发了任何后端 Rust 改动（含 workflow 自身），用于编排 fmt / tauri / frontend
       rust: ${{ steps.resolve.outputs.rust }}
       frontend: ${{ steps.resolve.outputs.frontend }}
-      # 需要校验的 crate 列表（JSON 数组），已根据依赖闭包展开。
-      # 仅包含「自身或其传递依赖发生改动」的 crate，matrix 作业据此按需启动 runner。
+      # 需要校验的 crate 列表（JSON 数组），仅含被直接改动的 crate。
+      # 不做反向依赖闭包扩散，避免底层改动触发几乎全部上游作业。
       matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
-      # 完整克隆：crate 闭包计算需用 git diff base.sha...HEAD 解析改动文件，
+      # 完整克隆：改动文件解析需用 git diff base.sha...HEAD，
       # 默认 fetch-depth: 1 是浅克隆，base commit 不可达会导致 diff 为空、matrix=[]。
       - uses: actions/checkout@v4
         with:
@@ -115,63 +115,18 @@ jobs:
               "tiangong":                 "src/",
           }
 
-          # 正向依赖图：key 直接依赖 value 列表中的 crate（取自各 Cargo.toml 的 workspace 依赖）
-          forward_deps = {
-              "tiangong-types":           [],
-              "tiangong-anthropic":       [],
-              "tiangong-deepseek":        [],
-              "tiangong-media":           [],
-              "tiangong-scheduler":       [],
-              "tiangong-llm":             ["tiangong-types", "tiangong-anthropic", "tiangong-deepseek"],
-              "tiangong-config":          ["tiangong-core"],
-              "tiangong-memory":          ["tiangong-llm", "tiangong-config"],
-              "tiangong-core":            ["tiangong-types", "tiangong-llm", "tiangong-memory", "tiangong-scheduler", "tiangong-media"],
-              "tiangong-cli":             ["tiangong-core", "tiangong-config", "tiangong-types"],
-              "tiangong-server":          ["tiangong-core", "tiangong-config", "tiangong-media", "tiangong-scheduler", "tiangong-types"],
-              "tiangong-entry":           ["tiangong-cli", "tiangong-core", "tiangong-server"],
-              "tiangong-plugin-browser":  ["tiangong-core", "tiangong-types"],
-              "tiangong-plugin-terminal": ["tiangong-core", "tiangong-types"],
-              "tiangong-app":             [
-                  "tiangong-cli", "tiangong-config", "tiangong-core", "tiangong-entry",
-                  "tiangong-media", "tiangong-memory", "tiangong-plugin-browser",
-                  "tiangong-plugin-terminal", "tiangong-scheduler", "tiangong-server", "tiangong-types",
-              ],
-              # 根二进制（src/main.rs），依赖 entry 与 config（取自根 Cargo.toml [dependencies]）
-              "tiangong":                 ["tiangong-entry", "tiangong-config"],
-          }
-
-          # 反向依赖图：dep -> 直接依赖它的 crate 列表
-          reverse_deps = {c: [] for c in forward_deps}
-          for crate, deps in forward_deps.items():
-              for dep in deps:
-                  reverse_deps[dep].append(crate)
-
           files = os.environ.get("CHANGED_FILES", "")
           file_list = [f for f in files.splitlines() if f]
 
-          # 4a) 找出被直接改动的 crate
-          directly_changed = set()
-          for crate, prefix in crate_to_prefix.items():
-              if any(f.startswith(prefix) for f in file_list):
-                  directly_changed.add(crate)
-
-          # 4b) 沿反向依赖图扩展传递闭包：改动 types -> 所有依赖 types 的 crate 都要重校验
-          affected = set()
-          stack = list(directly_changed)
-          while stack:
-              cur = stack.pop()
-              if cur in affected:
-                  continue
-              affected.add(cur)
-              for parent in reverse_deps.get(cur, []):
-                  if parent not in affected:
-                      stack.append(parent)
-
-          # 4c) 保持稳定输出顺序（与 workspace members 顺序一致）
+          # 只校验被直接改动的 crate（不做反向依赖闭包扩散）。
+          # 闭包扩散会让底层 crate 改动触发几乎全部上游作业，而每个作业又各自
+          # 全量编译依赖闭包，总编译量远超单次 workspace 校验，反而更慢更费资源。
+          # 直接改动校验已能覆盖大多数破坏；上游编译问题由 Rust fmt（workspace 级）
+          # 与单次 workspace check 兜底。
           order = list(crate_to_prefix.keys())
-          ordered = [c for c in order if c in affected]
+          affected = [c for c in order if any(f.startswith(crate_to_prefix[c]) for f in file_list)]
 
-          print(json.dumps(ordered))
+          print(json.dumps(affected))
           PY
           )"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,8 @@ jobs:
           import json, os
 
           # workspace 中所有 crate -> 其源码目录前缀（相对仓库根）
-          # 包名与 cargo -p 用的标识一致；src-tauri 的二进制包名为 tiangong-app
+          # 包名与 cargo -p 用的标识一致；src-tauri 的二进制包名为 tiangong-app，
+          # 根二进制（src/main.rs）包名为 tiangong
           crate_to_prefix = {
               "tiangong-types":           "crates/tiangong-types/",
               "tiangong-anthropic":       "crates/tiangong-anthropic/",
@@ -107,6 +108,7 @@ jobs:
               "tiangong-plugin-browser":  "crates/tiangong-plugin-browser/",
               "tiangong-plugin-terminal": "crates/tiangong-plugin-terminal/",
               "tiangong-app":             "src-tauri/",
+              "tiangong":                 "src/",
           }
 
           # 正向依赖图：key 直接依赖 value 列表中的 crate（取自各 Cargo.toml 的 workspace 依赖）
@@ -130,6 +132,8 @@ jobs:
                   "tiangong-media", "tiangong-memory", "tiangong-plugin-browser",
                   "tiangong-plugin-terminal", "tiangong-scheduler", "tiangong-server", "tiangong-types",
               ],
+              # 根二进制（src/main.rs），依赖 entry 与 config（取自根 Cargo.toml [dependencies]）
+              "tiangong":                 ["tiangong-entry", "tiangong-config"],
           }
 
           # 反向依赖图：dep -> 直接依赖它的 crate 列表

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9496,6 +9496,7 @@ dependencies = [
  "scru128",
  "serde",
  "serde_json",
+ "tempfile",
  "tiangong-core",
  "tracing",
  "tracing-appender",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9493,6 +9493,7 @@ name = "tiangong-config"
 version = "0.11.0"
 dependencies = [
  "anyhow",
+ "scru128",
  "serde",
  "serde_json",
  "tiangong-core",
@@ -9559,6 +9560,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tiangong-cli",
+ "tiangong-config",
  "tiangong-core",
  "tiangong-server",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9562,6 +9562,7 @@ dependencies = [
  "tiangong-cli",
  "tiangong-config",
  "tiangong-core",
+ "tiangong-memory",
  "tiangong-server",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,6 +1228,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,6 +2423,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "700357d9fb22b5232a85e34a413c1a76ae649f532c31107e402dc84e9c03bfb2"
 
 [[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "diffy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +2654,12 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding"
@@ -9556,6 +9586,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dialoguer",
  "reqwest 0.13.4",
  "semver",
  "serde",

--- a/PLAN.md
+++ b/PLAN.md
@@ -21,11 +21,13 @@
 | 0.10.1 | 发布后异常修复：Agent 协作与运行时稳定性 | ✅ |
 | 0.10.2 | Hotfix：DeepSeek reasoning_content、浏览器标签与 MCP 体验修复 | ✅ |
 | 0.11.0 | ReAct Loop 与总结阶段分离、会话列表分组、工具输出截取与执行时间持久化 | ✅ |
+| 0.12.0 | CLI 模块化配置增强：Prompt/Server/Model/Memory/doctor + Linux 服务器支持 | 🚧 进行中 |
 
-## 当前执行策略（2026-06-26）
+## 当前执行策略（2026-06-29）
 
 - Phase 1~21 已完成。
 - 0.11.0 已从 `main` 发布，版本标签为 `v0.11.0`。
+- 当前主线为 **0.12.0：CLI 模块化配置增强**（Phase 22），目标是让纯服务端（Linux 服务器、Docker、无桌面环境）具备与桌面设置页等价的分模块配置能力。设计方向见 `docs/rfc/0015-cli-modular-config.md`。
 - 0.11.0 聚焦 ReAct Loop 与总结阶段分离架构重构、左侧会话列表按 workspace 分组、工具输出截取与执行时间持久化、双总结修复与智能提升最终回复、终端面板聚焦修复、ReAct 循环失败错误痕迹持久化，以及扁平 Message 语义构造器与前端 reasoning 空值保护。
 - Phase 21-M 统一工作区 Tabs 与会话绑定已完成，不再作为当前开发主线。
 - 0.10.0 已交付内容包括工作区标签页与会话绑定、Office/PDF 文件上传与本地脚本解析、OpenAI Responses provider 与 Chat Completions 拆分、插件能力 Plugin::register 自注册、统一 Agent 交互通道（AgentInput trait）及若干终端与 OpenAI 流式修复。
@@ -104,9 +106,40 @@
 | 21-J | 用户批注模式 — canvas 覆盖层绘制、Agent 读取批注 | ✅ |
 | 21-G | 浏览器能力插件化 — Core trait 抽象、Tauri Plugin 封装、应用层切换 | ✅ |
 
+## Phase 22：CLI 模块化配置体系（进行中）
+
+> RFC：`docs/rfc/0015-cli-modular-config.md`
+
+让纯服务端环境具备与桌面设置页等价的分模块配置能力。Desktop 优先不变，CLI 与 Desktop 共享同一份 `~/.tiangong/` 配置。不做 `tiangong init` 一站式向导，每类配置由独立命令管理。
+
+**设计原则**：
+
+- 不做 `init`，不把模型/Server/Memory/MCP/Prompt 混在一个流程。
+- 每类配置独立命令，用户按需配置。
+- CLI 与 Desktop 共享同一份配置目录。
+- `doctor` 提供诊断，不强制初始化。
+
+| 子阶段 | 内容 | 状态 |
+|--------|------|------|
+| 22-A | 文档与 Roadmap — RFC 0015、PLAN.md、TODO.md、Linux 服务器部署指南 | 🚧 |
+| 22-B | Prompt 独立配置 — `custom-prompt.md` 独立存储 + 加载优先级兼容 + `prompt show/set/edit/clear/path` | ⬜ |
+| 22-C | Server 配置 CLI — `server config/token/status` + ServerConfig 统一 + Token 生成 | ⬜ |
+| 22-D | 模型配置 CLI — Provider/Model/Routing 增删改查 + `model validate/test` 连通性测试 | ⬜ |
+| 22-E | Memory 配置 CLI — `memory config/enable/disable/status/test` + 标记文件开关 | ⬜ |
+| 22-F | config + doctor — `config path/show/validate` + `doctor` 聚合诊断 | ⬜ |
+
+**关键决策**：
+
+- 自定义 Prompt 写入 `custom-prompt.md` 时清空 app.json 旧字段，使 .md 成为唯一事实来源。
+- Memory enable/disable 用轻量标记文件 `~/.tiangong/memory/.disabled`，不破坏 MemoryConfig 结构。
+- ServerConfig 统一到 `tiangong-config` 版本，消除两套同名结构的技术债。
+- API Key 复用现有 `${VAR}` 模板机制处理 `--api-key-env` / `--api-key`。
+
 ## 参考文档
 
 - 架构基准：`docs/desktop-agent-technical-architecture.md`
 - 需求基线：`docs/requirements.md`
 - Server API：`docs/server-api.md`
 - RFC 0011：`docs/rfc/0011-multi-agent-collaboration.md`
+- RFC 0015（CLI 模块化配置）：`docs/rfc/0015-cli-modular-config.md`
+- Linux 服务器部署：`docs/linux-server-deployment.md`

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ sudo install -m 0755 target/release/tiangong /usr/local/bin/tiangong
 ```bash
 tiangong model add-provider deepseek --protocol deepseek --base-url https://api.deepseek.com --api-key-env DEEPSEEK_API_KEY
 tiangong model add-model deepseek-chat --provider deepseek --model-id deepseek-chat --capability chat
-tiangong model route chat deepseek-chat
+tiangong model route set chat deepseek-chat
 tiangong server config set --host 127.0.0.1 --port 8080
 tiangong server token generate
 tiangong doctor
@@ -189,7 +189,7 @@ tiangong update
 
 ```bash
 tiangong model list                      # 查看模型配置
-tiangong model route chat deepseek-chat  # 切换 chat 模型
+tiangong model route set chat deepseek-chat  # 切换 chat 模型
 tiangong server token show               # 查看 Server Token
 tiangong memory enable                   # 启用 Memory
 tiangong prompt edit                     # 编辑自定义 Prompt

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ yarn --cwd frontend dev
 
 ## 文档
 
+- [CLI 配置指南](docs/cli-configuration-guide.md)
 - [Server API](docs/server-api.md)
 - [Linux 服务器部署指南](docs/linux-server-deployment.md)
 - [RFC 0015：CLI 模块化配置](docs/rfc/0015-cli-modular-config.md)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,35 @@ macOS 当前构建暂未接入 Apple 签名和公证，首次打开如提示应�
 xattr -cr /Applications/天工.app
 ```
 
+### Linux 服务器安装
+
+在无桌面环境的服务器上（VPS、云主机、Docker 容器），推荐通过源码编译获得纯 CLI/Server 二进制（不依赖 WebKit/GTK 等桌面运行时）：
+
+```bash
+# 安装编译依赖（Debian/Ubuntu）
+sudo apt-get install -y build-essential pkg-config protobuf-compiler libssl-dev ca-certificates curl
+
+# 安装 Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && source "$HOME/.cargo/env"
+
+# 编译
+git clone https://github.com/silent-rs/silent-Tiangong.git && cd silent-Tiangong
+cargo build --release
+sudo install -m 0755 target/release/tiangong /usr/local/bin/tiangong
+```
+
+服务端通过模块化 CLI 完成无界面配置（详见 [`docs/linux-server-deployment.md`](docs/linux-server-deployment.md)）：
+
+```bash
+tiangong model add-provider deepseek --protocol deepseek --base-url https://api.deepseek.com --api-key-env DEEPSEEK_API_KEY
+tiangong model add-model deepseek-chat --provider deepseek --model-id deepseek-chat --capability chat
+tiangong model route chat deepseek-chat
+tiangong server config set --host 127.0.0.1 --port 8080
+tiangong server token generate
+tiangong doctor
+tiangong server -d
+```
+
 ### 命令行入口
 
 桌面安装包内包含同一个 `tiangong` 入口，可用于 CLI、Server 和更新命令。macOS 可创建软链接：
@@ -152,6 +181,22 @@ tiangong update --check
 tiangong update
 ```
 
+**更新机制**：桌面应用通过设置页或 `tiangong update` 自动下载安装更新；CLI/Server 二进制（Linux 服务器）当前需重新编译或下载新版本二进制替换（`tiangong update --check` 仅检查版本不自动安装）。配置独立存储在 `~/.tiangong/`，更新二进制不丢失配置。
+
+### 模块化配置（0.12.0+）
+
+纯服务端环境可通过 CLI 完成与桌面设置页等价的分模块配置，无需 GUI（设计详见 [RFC 0015](docs/rfc/0015-cli-modular-config.md)）：
+
+```bash
+tiangong model list                      # 查看模型配置
+tiangong model route chat deepseek-chat  # 切换 chat 模型
+tiangong server token show               # 查看 Server Token
+tiangong memory enable                   # 启用 Memory
+tiangong prompt edit                     # 编辑自定义 Prompt
+tiangong config show                     # 配置概览
+tiangong doctor                          # 环境诊断
+```
+
 ## 配置
 
 默认数据目录：
@@ -160,15 +205,19 @@ tiangong update
 ~/.tiangong/
   app.json              应用主配置
   models.json           模型配置：Provider + Model + Routing
+  server.json           Server 监听配置（host/port/auth_token）
+  custom-prompt.md      自定义 Prompt（独立文件，CLI 可直接编辑）
   skills.json           Skill 配置
   mcp.json              MCP 配置
   sessions/             会话持久化
   logs/                 运行日志
   media/                生成或归档的媒体文件
-  memory/               长期记忆数据
+  memory/               长期记忆数据（含独立 config.json）
 ```
 
-模型配置采用 Provider、Model、Routing 三层结构。`api_key` 支持 `${ENV_VAR}` 环境变量引用，便于避免明文保存密钥。
+模型配置采用 Provider、Model、Routing 三层结构。`api_key` 支持 `${ENV_VAR}` 环境变量引用，便于避免明文保存密钥。自定义 Prompt 独立存储为 `custom-prompt.md`，可通过 `tiangong prompt` 命令管理，兼容旧的 `app.json` 内 `custom_system_prompt` 字段。
+
+详细的 Linux 服务器部署、systemd 托管、反向代理与更新策略见 [部署指南](docs/linux-server-deployment.md)。
 
 ## 开发
 
@@ -199,6 +248,8 @@ yarn --cwd frontend dev
 ## 文档
 
 - [Server API](docs/server-api.md)
+- [Linux 服务器部署指南](docs/linux-server-deployment.md)
+- [RFC 0015：CLI 模块化配置](docs/rfc/0015-cli-modular-config.md)
 
 ## 许可证
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,17 +1,32 @@
 # TODO - 天工当前开发任务
 
-> 最后更新：2026-06-26
-> 当前主线：0.11.0 已发布
-> 参考：`PLAN.md`、Issue #95
+> 最后更新：2026-06-29
+> 当前主线：0.12.0 CLI 模块化配置增强（进行中）
+> 参考：`PLAN.md`、`docs/rfc/0015-cli-modular-config.md`
 
 ---
 
-## 当前入口（0.10.1）
+## 当前入口（0.12.0）
 
-- 0.10.0 已从 `main` 发布，版本标签为 `v0.10.0`。
-- 当前阶段不扩展新功能，优先修复发布后暴露的 Agent 协作与运行时异常。
-- 后续开发以 `docs/exception-fixes-0.10.1/README.md` 为任务清单，以 `docs/exception-fixes-0.10.1/PROGRESS.md` 为进度记录。
-- Phase 21-M 统一工作区 Tabs 与会话绑定已完成，不再作为当前开发主线。
+- 0.11.0 已从 `main` 发布，版本标签为 `v0.11.0`。
+- 当前主线为 **0.12.0：CLI 模块化配置增强**，从最新 `main` 创建 `feature/cli-modular-config` 分支。
+- 目标：让纯服务端环境具备与桌面设置页等价的分模块配置能力。设计方向见 `docs/rfc/0015-cli-modular-config.md`，进度记录见本文件。
+- 开发顺序：文档先行（Roadmap）→ Prompt → Server → Model → Memory → config + doctor。
+
+## 0.12.0 CLI 模块化配置任务
+
+| 序号 | 子阶段 | 优先级 | 任务 | 状态 | Spec |
+|---|---|---:|---|---|---|
+| 01 | 22-A | P0 | Roadmap 文档（RFC 0015 + PLAN.md + TODO.md） | 🚧 | `docs/rfc/0015-cli-modular-config.md` |
+| 02 | 22-A | P0 | Linux 服务器部署与更新机制文档 | ⬜ | `docs/linux-server-deployment.md` |
+| 03 | 22-B | P0 | Prompt 独立配置（custom-prompt.md + prompt 命令） | ⬜ | `docs/rfc/0015-cli-modular-config.md` §6.4 |
+| 04 | 22-C | P0 | Server 配置 CLI + ServerConfig 统一 + Token 生成 | ⬜ | `docs/rfc/0015-cli-modular-config.md` §6.2 |
+| 05 | 22-D | P0 | 模型配置 CLI（model 命令组） | ⬜ | `docs/rfc/0015-cli-modular-config.md` §6.1 |
+| 06 | 22-E | P1 | Memory 配置 CLI（memory 命令组） | ⬜ | `docs/rfc/0015-cli-modular-config.md` §6.3 |
+| 07 | 22-F | P1 | config + doctor 命令 | ⬜ | `docs/rfc/0015-cli-modular-config.md` §6.5/§6.6 |
+| 08 | — | P0 | 版本号 0.11.0 → 0.12.0 + 完整检查链 | ⬜ | — |
+
+---
 
 ## 当前调整
 

--- a/crates/tiangong-config/Cargo.toml
+++ b/crates/tiangong-config/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 [dependencies]
 tiangong-core = { workspace = true }
 anyhow = { workspace = true }
+scru128 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/tiangong-config/Cargo.toml
+++ b/crates/tiangong-config/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/tiangong-config/src/config.rs
+++ b/crates/tiangong-config/src/config.rs
@@ -72,9 +72,9 @@ pub fn server_config_path() -> PathBuf {
         .join("server.json")
 }
 
-/// 从 ~/.tiangong/server.json 加载配置，文件不存在时返回默认值
-pub fn load_server_config() -> ServerConfig {
-    let path = server_config_path();
+/// 从指定目录加载 Server 配置，文件不存在时返回默认值。
+pub fn load_server_config_from_dir(dir: &std::path::Path) -> ServerConfig {
+    let path = dir.join("server.json");
     if !path.exists() {
         return ServerConfig::default();
     }
@@ -84,15 +84,28 @@ pub fn load_server_config() -> ServerConfig {
     }
 }
 
-/// 保存 Server 配置到 ~/.tiangong/server.json
-pub fn save_server_config(config: &ServerConfig) -> anyhow::Result<()> {
-    let path = server_config_path();
+/// 从 ~/.tiangong/server.json 加载配置，文件不存在时返回默认值
+pub fn load_server_config() -> ServerConfig {
+    load_server_config_from_dir(&crate::loader::default_tiangong_dir())
+}
+
+/// 保存 Server 配置到指定目录的 server.json
+pub fn save_server_config_to_dir(
+    dir: &std::path::Path,
+    config: &ServerConfig,
+) -> anyhow::Result<()> {
+    let path = dir.join("server.json");
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     let content = serde_json::to_string_pretty(config)?;
     std::fs::write(&path, content)?;
     Ok(())
+}
+
+/// 保存 Server 配置到 ~/.tiangong/server.json
+pub fn save_server_config(config: &ServerConfig) -> anyhow::Result<()> {
+    save_server_config_to_dir(&crate::loader::default_tiangong_dir(), config)
 }
 
 impl ServerConfig {

--- a/crates/tiangong-config/src/config.rs
+++ b/crates/tiangong-config/src/config.rs
@@ -1,5 +1,7 @@
 //! TiangongConfig：完整应用配置
 
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 use tiangong_core::agent_config::{McpConfig, SkillsConfig};
 use tiangong_core::core_config::CoreConfig;
@@ -19,6 +21,9 @@ pub struct ServerConfig {
     /// API 认证 Token
     #[serde(default)]
     pub auth_token: Option<String>,
+    /// 上次退出时 Server 是否在运行，用于重启后自动拉起
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 fn default_host() -> String {
@@ -34,8 +39,90 @@ impl Default for ServerConfig {
             host: default_host(),
             port: default_port(),
             auth_token: None,
+            enabled: false,
         }
     }
+}
+
+/// 获取用户 home 目录（与 app_state::repository::utils 保持一致）。
+fn user_home_dir() -> Option<PathBuf> {
+    if let Some(home) = std::env::var_os("HOME").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(home));
+    }
+    if let Some(profile) = std::env::var_os("USERPROFILE").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(profile));
+    }
+    let drive = std::env::var_os("HOMEDRIVE").filter(|v| !v.is_empty());
+    let path = std::env::var_os("HOMEPATH").filter(|v| !v.is_empty());
+    match (drive, path) {
+        (Some(drive), Some(path)) => {
+            let mut buf = PathBuf::from(drive);
+            buf.push(path);
+            Some(buf)
+        }
+        _ => None,
+    }
+}
+
+/// Server 配置文件路径：~/.tiangong/server.json
+pub fn server_config_path() -> PathBuf {
+    user_home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".tiangong")
+        .join("server.json")
+}
+
+/// 从 ~/.tiangong/server.json 加载配置，文件不存在时返回默认值
+pub fn load_server_config() -> ServerConfig {
+    let path = server_config_path();
+    if !path.exists() {
+        return ServerConfig::default();
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => ServerConfig::default(),
+    }
+}
+
+/// 保存 Server 配置到 ~/.tiangong/server.json
+pub fn save_server_config(config: &ServerConfig) -> anyhow::Result<()> {
+    let path = server_config_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let content = serde_json::to_string_pretty(config)?;
+    std::fs::write(&path, content)?;
+    Ok(())
+}
+
+impl ServerConfig {
+    /// 返回脱敏后的 auth_token（显示前 4 位 + ****）
+    pub fn masked_auth_token(&self) -> String {
+        match &self.auth_token {
+            None => "(未设置)".to_string(),
+            Some(token) if token.trim().is_empty() => "(空)".to_string(),
+            Some(token) if token.len() <= 4 => "****".to_string(),
+            Some(token) => format!("{}****", &token[..4]),
+        }
+    }
+}
+
+/// 生成随机 Server Token。
+///
+/// 使用 scru128 生成具备时间序与随机性的标识，加 `tg_` 前缀。
+/// 长度 `length` 指定 token 主体（不含前缀）的近似字节数；
+/// 实际长度按 scru128 段落数向上取整。
+pub fn generate_token(length: usize) -> String {
+    let normalized = length.clamp(16, 256);
+    let mut out = String::from("tg_");
+    while out.len() - 3 < normalized {
+        out.push_str(&scru128::new().to_string());
+    }
+    // 截断到目标长度（含前缀）
+    if out.len() > 3 + normalized {
+        out.truncate(3 + normalized);
+    }
+    out
 }
 
 /// Connector 类型
@@ -103,5 +190,101 @@ impl TiangongConfig {
     /// 创建 CoreConfigProvider（用于注入 TiangongCore）
     pub fn into_core_config_provider(self) -> tiangong_core::core_config::CoreConfigProvider {
         tiangong_core::core_config::CoreConfigProvider::new(self.to_core_config())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_config_default() {
+        let config = ServerConfig::default();
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.port, 8080);
+        assert_eq!(config.auth_token, None);
+        assert!(!config.enabled);
+    }
+
+    #[test]
+    fn server_config_serde_roundtrip_with_enabled() {
+        let config = ServerConfig {
+            host: "0.0.0.0".to_string(),
+            port: 9000,
+            auth_token: Some("tg_secret".to_string()),
+            enabled: true,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        // enabled 应被序列化
+        assert!(json.contains("\"enabled\":true"));
+        let parsed: ServerConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.host, config.host);
+        assert_eq!(parsed.port, config.port);
+        assert_eq!(parsed.auth_token, config.auth_token);
+        assert!(parsed.enabled);
+    }
+
+    #[test]
+    fn server_config_back_compat_without_enabled() {
+        // 旧的 server.json（无 enabled 字段）应能反序列化，enabled 默认 false
+        let legacy_json = r#"{"host":"127.0.0.1","port":8080,"auth_token":null}"#;
+        let parsed: ServerConfig = serde_json::from_str(legacy_json).unwrap();
+        assert_eq!(parsed.host, "127.0.0.1");
+        assert_eq!(parsed.port, 8080);
+        assert!(!parsed.enabled);
+    }
+
+    #[test]
+    fn masked_auth_token_variants() {
+        let none = ServerConfig {
+            auth_token: None,
+            ..Default::default()
+        };
+        assert_eq!(none.masked_auth_token(), "(未设置)");
+
+        let empty = ServerConfig {
+            auth_token: Some("".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(empty.masked_auth_token(), "(空)");
+
+        let short = ServerConfig {
+            auth_token: Some("ab".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(short.masked_auth_token(), "****");
+
+        let long = ServerConfig {
+            auth_token: Some("tg_abcd1234567890".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(long.masked_auth_token(), "tg_a****");
+    }
+
+    #[test]
+    fn generate_token_has_prefix_and_length() {
+        let token = generate_token(32);
+        assert!(token.starts_with("tg_"));
+        // 主体长度应接近 32（向上取整到 scru128 段落边界）
+        let body = &token[3..];
+        assert!(body.len() >= 32, "body len = {}", body.len());
+        assert!(token.len() < 3 + 32 + 40); // 不应远超目标
+    }
+
+    #[test]
+    fn generate_token_clamps_extremes() {
+        let too_short = generate_token(4);
+        let too_long = generate_token(1000);
+        // 过短被钳制到最小 16
+        assert!(too_short.len() >= 3 + 16);
+        // 过长被钳制到最大 256
+        assert!(too_long.len() <= 3 + 256 + 40);
+    }
+
+    #[test]
+    fn generate_token_unique() {
+        let a = generate_token(32);
+        let b = generate_token(32);
+        assert_ne!(a, b, "连续生成的 token 不应相同");
     }
 }

--- a/crates/tiangong-config/src/config.rs
+++ b/crates/tiangong-config/src/config.rs
@@ -161,6 +161,8 @@ pub struct TiangongConfig {
     pub skills: SkillsConfig,
     /// 权限信任模式
     pub trust_mode: TrustMode,
+    /// 自定义系统 Prompt（从 custom-prompt.md 加载，注入 system prompt）
+    pub custom_system_prompt: String,
 
     // ===== 应用层配置 =====
     /// Server 配置
@@ -172,7 +174,8 @@ pub struct TiangongConfig {
 impl TiangongConfig {
     /// 转换为 CoreConfig（提取 Core 所需的最小子集）
     ///
-    /// 将 ModelsConfig（3 层）解析为 LlmConfig（扁平端点）
+    /// 将 ModelsConfig（3 层）解析为 LlmConfig（扁平端点）。
+    /// 自定义 Prompt 来自加载时读取的 custom-prompt.md（见 load_tiangong_config_from_dir）。
     pub fn to_core_config(&self) -> CoreConfig {
         CoreConfig {
             llm: tiangong_core::core_config::LlmConfig::from_models_config(&self.models),
@@ -181,7 +184,7 @@ impl TiangongConfig {
             skills: self.skills.clone(),
             trust_mode: self.trust_mode,
             default_trust_mode: self.trust_mode,
-            custom_system_prompt: String::new(),
+            custom_system_prompt: self.custom_system_prompt.clone(),
             reasoning_effort: "medium".to_string(),
             context_limit: 0, // 0 表示自动根据模型名称解析
         }
@@ -286,5 +289,40 @@ mod tests {
         let a = generate_token(32);
         let b = generate_token(32);
         assert_ne!(a, b, "连续生成的 token 不应相同");
+    }
+
+    #[test]
+    fn to_core_config_carries_custom_system_prompt() {
+        // P0 回归：to_core_config 必须携带 custom_system_prompt，
+        // 否则 CLI/Server 启动的 Core 拿不到自定义 Prompt。
+        let config = TiangongConfig {
+            custom_system_prompt: "总是用简体中文".to_string(),
+            ..Default::default()
+        };
+        let core = config.to_core_config();
+        assert_eq!(core.custom_system_prompt, "总是用简体中文");
+    }
+
+    #[test]
+    fn to_core_config_default_prompt_empty() {
+        let config = TiangongConfig::default();
+        let core = config.to_core_config();
+        assert!(core.custom_system_prompt.is_empty());
+    }
+
+    #[test]
+    fn load_custom_prompt_from_dir_reads_md_file() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        // 写入 custom-prompt.md
+        fs::write(dir.path().join("custom-prompt.md"), "测试 Prompt 内容").unwrap();
+
+        // 直接验证 load_custom_prompt_at 行为（与 load_tiangong_config_from_dir 一致）
+        let prompt = tiangong_core::custom_prompt::load_custom_prompt_at(
+            &dir.path().join("custom-prompt.md"),
+            "",
+        )
+        .unwrap();
+        assert_eq!(prompt, "测试 Prompt 内容");
     }
 }

--- a/crates/tiangong-config/src/lib.rs
+++ b/crates/tiangong-config/src/lib.rs
@@ -22,8 +22,11 @@ mod config;
 mod loader;
 pub mod logging;
 
-pub use config::{ConnectorConfig, ConnectorType, ServerConfig, TiangongConfig};
-pub use loader::{load_tiangong_config, load_tiangong_config_from_dir};
+pub use config::{
+    ConnectorConfig, ConnectorType, ServerConfig, TiangongConfig, generate_token,
+    load_server_config, save_server_config, server_config_path,
+};
+pub use loader::{default_tiangong_dir, load_tiangong_config, load_tiangong_config_from_dir};
 
 // re-export core config types for convenience
 pub use tiangong_core::core_config::{CoreConfig, CoreConfigBuilder, CoreConfigProvider};

--- a/crates/tiangong-config/src/lib.rs
+++ b/crates/tiangong-config/src/lib.rs
@@ -24,7 +24,8 @@ pub mod logging;
 
 pub use config::{
     ConnectorConfig, ConnectorType, ServerConfig, TiangongConfig, generate_token,
-    load_server_config, save_server_config, server_config_path,
+    load_server_config, load_server_config_from_dir, save_server_config, save_server_config_to_dir,
+    server_config_path,
 };
 pub use loader::{default_tiangong_dir, load_tiangong_config, load_tiangong_config_from_dir};
 

--- a/crates/tiangong-config/src/loader.rs
+++ b/crates/tiangong-config/src/loader.rs
@@ -15,7 +15,7 @@ use tiangong_core::agent_config::{McpConfig, SkillsConfig};
 use tiangong_core::model::ModelProviderConfig;
 use tiangong_core::models_config::ModelsConfig;
 
-use crate::config::{ConnectorConfig, ServerConfig, TiangongConfig};
+use crate::config::{ConnectorConfig, TiangongConfig};
 
 /// Connector 配置文件结构
 #[derive(serde::Deserialize)]
@@ -42,7 +42,7 @@ pub fn load_tiangong_config_from_dir(dir: &Path) -> TiangongConfig {
     let models = load_models_config();
     let mcp = load_json_config::<McpConfig>(dir, "mcp.json").unwrap_or_default();
     let skills = load_json_config::<SkillsConfig>(dir, "skills.json").unwrap_or_default();
-    let server = load_json_config::<ServerConfig>(dir, "server.json").unwrap_or_default();
+    let server = crate::config::load_server_config_from_dir(dir);
     let connectors = load_json_config::<ConnectorsFile>(dir, "connectors.json")
         .map(|f| f.connectors)
         .unwrap_or_default();

--- a/crates/tiangong-config/src/loader.rs
+++ b/crates/tiangong-config/src/loader.rs
@@ -47,6 +47,11 @@ pub fn load_tiangong_config_from_dir(dir: &Path) -> TiangongConfig {
         .map(|f| f.connectors)
         .unwrap_or_default();
 
+    // 自定义 Prompt：从 custom-prompt.md 加载（兼容 app.json 旧字段为空回退）
+    let custom_system_prompt =
+        tiangong_core::custom_prompt::load_custom_prompt_at(&dir.join("custom-prompt.md"), "")
+            .unwrap_or_default();
+
     // 首次安装：释放默认 context_windows.json
     ensure_context_windows(dir);
 
@@ -61,6 +66,7 @@ pub fn load_tiangong_config_from_dir(dir: &Path) -> TiangongConfig {
         mcp,
         mcp_capabilities,
         skills,
+        custom_system_prompt,
         server,
         connectors,
         ..Default::default()

--- a/crates/tiangong-core/src/app_state/mod.rs
+++ b/crates/tiangong-core/src/app_state/mod.rs
@@ -143,9 +143,28 @@ impl TiangongState {
     }
 
     pub fn set_custom_system_prompt(&mut self, prompt: String) -> Result<()> {
-        self.store.agent.agent_config.custom_system_prompt = prompt;
+        let trimmed = prompt.trim();
+        if trimmed.is_empty() {
+            // 清空：删除 custom-prompt.md 并清空旧字段
+            crate::custom_prompt::clear_custom_prompt()?;
+            self.store.agent.agent_config.custom_system_prompt = String::new();
+        } else {
+            // 写入 custom-prompt.md 作为唯一事实来源，并清空 app.json 旧字段
+            crate::custom_prompt::save_custom_prompt(&prompt)?;
+            self.store.agent.agent_config.custom_system_prompt = String::new();
+        }
         self.rebuild_runtime_from_current_config();
         self.persist_app_only()
+    }
+
+    /// 获取自定义 Prompt 内容（已按 custom-prompt.md > 旧字段 > 空 优先级加载）。
+    pub fn custom_system_prompt(&self) -> &str {
+        &self.store.agent.agent_config.custom_system_prompt
+    }
+
+    /// 获取自定义 Prompt 独立存储路径（~/.tiangong/custom-prompt.md）。
+    pub fn custom_prompt_path(&self) -> std::path::PathBuf {
+        crate::custom_prompt::custom_prompt_path()
     }
 
     pub fn set_reasoning_effort(&mut self, effort: String) -> Result<()> {

--- a/crates/tiangong-core/src/app_state/repository/load.rs
+++ b/crates/tiangong-core/src/app_state/repository/load.rs
@@ -114,7 +114,17 @@ impl AppRepository {
         let skills = self.load_skills_config_from_disk()?;
         let mcp = self.load_mcp_config_from_disk()?;
         if skills.is_none() && mcp.is_none() {
-            return Ok(legacy_agent_config);
+            // 无 skills/mcp 独立配置，直接用 legacy agent_config，
+            // 但仍需用 custom-prompt.md 加载优先级回填 custom_system_prompt
+            // （custom-prompt.md 优先，回退 legacy 旧字段）。
+            let mut agent_config = legacy_agent_config;
+            if let Some(config) = &mut agent_config {
+                let legacy_prompt = config.custom_system_prompt.clone();
+                let prompt = crate::custom_prompt::load_custom_prompt(&legacy_prompt)
+                    .unwrap_or(legacy_prompt);
+                config.custom_system_prompt = prompt;
+            }
+            return Ok(agent_config);
         }
         let mut agent_config = legacy_agent_config.unwrap_or_default();
         if let Some(skills) = skills {
@@ -123,6 +133,12 @@ impl AppRepository {
         if let Some(mcp) = mcp {
             agent_config.mcp = mcp;
         }
+        // 用 custom-prompt.md 加载优先级回填 custom_system_prompt
+        // （custom-prompt.md 优先，回退 app.json 旧字段）。
+        let legacy_prompt = agent_config.custom_system_prompt.clone();
+        let prompt =
+            crate::custom_prompt::load_custom_prompt(&legacy_prompt).unwrap_or(legacy_prompt);
+        agent_config.custom_system_prompt = prompt;
         Ok(Some(agent_config))
     }
 

--- a/crates/tiangong-core/src/custom_prompt.rs
+++ b/crates/tiangong-core/src/custom_prompt.rs
@@ -1,0 +1,187 @@
+//! 自定义 Prompt 独立存储（0.12.0+）。
+//!
+//! 将用户自定义 Prompt 从 `app.json` 的 `agent_config.custom_system_prompt`
+//! 字段迁移到独立文件 `~/.tiangong/custom-prompt.md`，便于 CLI 编辑、
+//! 用户备份与版本管理（避免 JSON 字符串转义问题）。
+//!
+//! # 加载优先级
+//!
+//! 1. `custom-prompt.md` 存在且非空 → 读取它（唯一事实来源）。
+//! 2. 否则读取 `app.json` 中 `agent_config.custom_system_prompt`（兼容旧配置）。
+//! 3. 再否则为空。
+//!
+//! # 写入行为
+//!
+//! `save` 写入 `custom-prompt.md` 后，调用方应清空 `app.json` 的旧字段，
+//! 使 `custom-prompt.md` 成为唯一事实来源，消除歧义（见 RFC 0015）。
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// 获取用户 home 目录（与 app_state::repository::utils 保持一致）。
+fn user_home_dir() -> Option<PathBuf> {
+    if let Some(home) = std::env::var_os("HOME").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(home));
+    }
+    if let Some(profile) = std::env::var_os("USERPROFILE").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(profile));
+    }
+    let drive = std::env::var_os("HOMEDRIVE").filter(|v| !v.is_empty());
+    let path = std::env::var_os("HOMEPATH").filter(|v| !v.is_empty());
+    match (drive, path) {
+        (Some(drive), Some(path)) => {
+            let mut buf = PathBuf::from(drive);
+            buf.push(path);
+            Some(buf)
+        }
+        _ => None,
+    }
+}
+
+/// 天工存储根目录：~/.tiangong/
+fn storage_root() -> PathBuf {
+    user_home_dir()
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+        .join(".tiangong")
+}
+
+/// 自定义 Prompt 独立文件路径：~/.tiangong/custom-prompt.md
+pub fn custom_prompt_path() -> PathBuf {
+    storage_root().join("custom-prompt.md")
+}
+
+/// 读取自定义 Prompt，优先 `custom-prompt.md`，回退 `legacy`（旧字段值）。
+///
+/// - `custom-prompt.md` 存在 → 读取其内容（去除首尾空白后非空才采用）。
+/// - 否则返回 `legacy`（调用方传入的 app.json 旧字段值）。
+pub fn load_custom_prompt(legacy: &str) -> Result<String> {
+    load_custom_prompt_at(&custom_prompt_path(), legacy)
+}
+
+/// 从指定路径加载自定义 Prompt（供测试与自定义目录使用）。
+pub fn load_custom_prompt_at(path: &Path, legacy: &str) -> Result<String> {
+    if !path.exists() {
+        return Ok(legacy.to_string());
+    }
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("读取自定义 Prompt 失败：{}", path.display()))?;
+    if content.trim().is_empty() {
+        // 空文件视为未配置，回退旧字段
+        Ok(legacy.to_string())
+    } else {
+        Ok(content)
+    }
+}
+
+/// 保存自定义 Prompt 到 `custom-prompt.md`。
+///
+/// 调用方应在保存后清空 `app.json` 的 `custom_system_prompt` 旧字段。
+pub fn save_custom_prompt(content: &str) -> Result<()> {
+    save_custom_prompt_at(&custom_prompt_path(), content)
+}
+
+/// 保存自定义 Prompt 到指定路径（供测试使用）。
+pub fn save_custom_prompt_at(path: &Path, content: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("创建配置目录失败：{}", parent.display()))?;
+    }
+    fs::write(path, content).with_context(|| format!("写入自定义 Prompt 失败：{}", path.display()))
+}
+
+/// 删除 `custom-prompt.md`（清空 Prompt）。
+///
+/// 文件不存在视为成功。调用方应同时清空 `app.json` 的旧字段。
+pub fn clear_custom_prompt() -> Result<()> {
+    clear_custom_prompt_at(&custom_prompt_path())
+}
+
+/// 删除指定路径的自定义 Prompt 文件（供测试使用）。
+pub fn clear_custom_prompt_at(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    fs::remove_file(path).with_context(|| format!("删除自定义 Prompt 失败：{}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// 为测试创建唯一的临时文件路径。
+    fn temp_prompt_path(label: &str) -> PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!("tiangong-cp-test-{nanos}-{label}"));
+        dir.join("custom-prompt.md")
+    }
+
+    fn cleanup(path: &Path) {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
+    }
+
+    #[test]
+    fn load_falls_back_to_legacy_when_no_file() {
+        let path = temp_prompt_path("fallback");
+        let result = load_custom_prompt_at(&path, "旧值").unwrap();
+        assert_eq!(result, "旧值");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn load_prefers_md_file_over_legacy() {
+        let path = temp_prompt_path("prefer");
+        save_custom_prompt_at(&path, "新的 Prompt").unwrap();
+        let result = load_custom_prompt_at(&path, "旧值").unwrap();
+        assert_eq!(result, "新的 Prompt");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn empty_md_file_falls_back_to_legacy() {
+        let path = temp_prompt_path("empty");
+        save_custom_prompt_at(&path, "   \n  ").unwrap();
+        let result = load_custom_prompt_at(&path, "旧值").unwrap();
+        assert_eq!(result, "旧值");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn clear_removes_file() {
+        let path = temp_prompt_path("clear");
+        save_custom_prompt_at(&path, "临时 Prompt").unwrap();
+        assert!(path.exists());
+        clear_custom_prompt_at(&path).unwrap();
+        assert!(!path.exists());
+        // 再次清空不报错
+        clear_custom_prompt_at(&path).unwrap();
+        cleanup(&path);
+    }
+
+    #[test]
+    fn save_creates_parent_dir() {
+        let path = temp_prompt_path("mkdir");
+        assert!(!path.parent().unwrap().exists());
+        save_custom_prompt_at(&path, "内容").unwrap();
+        assert!(path.exists());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn multiline_content_preserved() {
+        let path = temp_prompt_path("multiline");
+        let content = "第一行\n第二行\n\n第四行";
+        save_custom_prompt_at(&path, content).unwrap();
+        let result = load_custom_prompt_at(&path, "").unwrap();
+        assert_eq!(result, content);
+        cleanup(&path);
+    }
+}

--- a/crates/tiangong-core/src/lib.rs
+++ b/crates/tiangong-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config_watch;
 pub mod context;
 pub mod core;
 pub mod core_config;
+pub mod custom_prompt;
 pub mod event;
 pub mod index;
 pub mod mcp;

--- a/crates/tiangong-core/src/memory/registry.rs
+++ b/crates/tiangong-core/src/memory/registry.rs
@@ -61,6 +61,13 @@ pub(crate) async fn get_or_init_memory_async(
     config_generation: u64,
     process_type: tiangong_memory::ProcessType,
 ) -> Option<tiangong_memory::MemoryHandle> {
+    // 运行时禁用检查：`tiangong memory disable` 会创建标记文件。
+    // 标记存在时跳过 Memory 启动，全局生效（CLI/Server/Desktop）。
+    if tiangong_memory::is_memory_disabled() {
+        tracing::info!("Memory 已被禁用标记关闭（memory/.disabled），跳过启动");
+        return None;
+    }
+
     let options = config.to_memory_options();
     let config_summary = memory_config_summary_from_options(&options);
     let slot = MEMORY_HANDLE.get_or_init(|| Mutex::new(None));

--- a/crates/tiangong-core/src/models_config.rs
+++ b/crates/tiangong-core/src/models_config.rs
@@ -873,7 +873,12 @@ impl ModelsConfig {
 
     /// 设置路由槽位指向某个已注册的模型。
     ///
-    /// `name` 必须是 models 注册表中的 key。返回 Ok(()) 或错误（模型不存在）。
+    /// `name` 必须是 models 注册表中的 key。
+    /// 同时校验模型具备该槽位所需能力：
+    /// - 有明确能力映射的槽位（chat/multimodal/embedding 等）要求模型声明该能力。
+    /// - Lite 槽位无对应能力枚举，宽松接受 chat 能力（轻量文本任务用 chat 模型降级）。
+    ///
+    /// 返回 Ok(()) 或错误（模型不存在 / 能力不匹配）。
     pub fn set_route_by_name(
         &mut self,
         slot: RoutingSlot,
@@ -884,6 +889,47 @@ impl ModelsConfig {
             .get(name)
             .ok_or_else(|| format!("模型 {name} 不存在于 models 注册表"))?
             .clone();
+
+        // capability 校验：确保路由指向的模型确实具备该槽位所需能力
+        match slot.capability() {
+            Some(expected) if !entry.capabilities.contains(&expected) => {
+                let current = if entry.capabilities.is_empty() {
+                    "无".to_string()
+                } else {
+                    entry
+                        .capabilities
+                        .iter()
+                        .map(|c| c.key())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                };
+                return Err(format!(
+                    "模型 {name} 不具备 {} 能力（当前能力：{current}），不能设置到 {} 路由",
+                    expected.key(),
+                    slot.key()
+                ));
+            }
+            None if slot == RoutingSlot::Lite
+                && !entry.capabilities.contains(&ModelCapability::Chat) =>
+            {
+                // Lite 槽位要求 chat 能力（轻量文本任务降级）
+                let current = if entry.capabilities.is_empty() {
+                    "无".to_string()
+                } else {
+                    entry
+                        .capabilities
+                        .iter()
+                        .map(|c| c.key())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                };
+                return Err(format!(
+                    "模型 {name} 不具备 chat 能力（当前能力：{current}），不能设置到 lite 路由"
+                ));
+            }
+            _ => {}
+        }
+
         self.routing.insert(slot, entry);
         Ok(())
     }
@@ -1194,6 +1240,50 @@ mod tests {
             config.routing.get(&RoutingSlot::Chat).unwrap().model,
             "deepseek-chat"
         );
+    }
+
+    #[test]
+    fn set_route_by_name_rejects_capability_mismatch() {
+        // P1 回归：route 设置必须校验模型 capability
+        let mut config = ModelsConfig::default();
+        // chat 模型不应能设置到 embedding 路由
+        config.upsert_model("chat-only", "p", "gpt", vec![ModelCapability::Chat]);
+        let err = config.set_route_by_name(RoutingSlot::Embedding, "chat-only");
+        assert!(err.is_err());
+        assert!(
+            err.unwrap_err().contains("embedding"),
+            "应报告缺少 embedding 能力"
+        );
+        // embedding 模型不应能设置到 chat 路由
+        config.upsert_model(
+            "embed-only",
+            "p",
+            "text-embed",
+            vec![ModelCapability::Embedding],
+        );
+        let err = config.set_route_by_name(RoutingSlot::Chat, "embed-only");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn set_route_lite_accepts_chat_capability() {
+        // Lite 槽位无对应能力枚举，接受 chat 能力（轻量文本降级）
+        let mut config = ModelsConfig::default();
+        config.upsert_model("lite", "p", "deepseek-lite", vec![ModelCapability::Chat]);
+        config.set_route_by_name(RoutingSlot::Lite, "lite").unwrap();
+        assert_eq!(
+            config.routing.get(&RoutingSlot::Lite).unwrap().model,
+            "deepseek-lite"
+        );
+    }
+
+    #[test]
+    fn set_route_lite_rejects_non_chat() {
+        // Lite 槽位要求 chat 能力，embedding 模型不能设为 lite
+        let mut config = ModelsConfig::default();
+        config.upsert_model("embed", "p", "text-embed", vec![ModelCapability::Embedding]);
+        let err = config.set_route_by_name(RoutingSlot::Lite, "embed");
+        assert!(err.is_err());
     }
 
     #[test]

--- a/crates/tiangong-core/src/models_config.rs
+++ b/crates/tiangong-core/src/models_config.rs
@@ -763,6 +763,163 @@ impl ModelsConfig {
             self.to_chat_provider_config()
         }
     }
+
+    // ── CLI 友好方法（RFC 0015 §6.1，供 tiangong model 命令使用） ──────
+
+    /// 新增或覆盖 Provider。
+    ///
+    /// `api_key` 可为明文或 `${ENV_VAR}` 模板（由调用方决定）。
+    pub fn upsert_provider(
+        &mut self,
+        name: &str,
+        base_url: &str,
+        api_key: &str,
+        protocol: ProviderProtocol,
+        timeout_ms: u64,
+    ) {
+        self.providers.insert(
+            name.to_string(),
+            ProviderConfig {
+                base_url: base_url.to_string(),
+                api_key: api_key.to_string(),
+                timeout_ms,
+                protocol,
+            },
+        );
+    }
+
+    /// 删除 Provider。
+    ///
+    /// 若有模型或路由引用该 Provider，返回引用列表，调用方据此决定是否强制删除。
+    pub fn provider_referenced_by(&self, name: &str) -> ProviderReferences {
+        let mut models = Vec::new();
+        for (key, entry) in &self.models {
+            if entry.provider == name {
+                models.push(key.clone());
+            }
+        }
+        let mut routes = Vec::new();
+        for (slot, entry) in &self.routing {
+            if entry.provider == name {
+                routes.push(slot.key().to_string());
+            }
+        }
+        ProviderReferences { models, routes }
+    }
+
+    /// 强制删除 Provider（连同引用它的 model 注册项与路由）。
+    pub fn remove_provider_force(&mut self, name: &str) -> usize {
+        let mut removed = self.providers.remove(name).is_some() as usize;
+        let model_keys: Vec<String> = self
+            .models
+            .iter()
+            .filter(|(_, e)| e.provider == name)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for key in &model_keys {
+            self.models.remove(key);
+            removed += 1;
+        }
+        let slots: Vec<RoutingSlot> = self
+            .routing
+            .iter()
+            .filter(|(_, e)| e.provider == name)
+            .map(|(s, _)| *s)
+            .collect();
+        for slot in slots {
+            self.routing.remove(&slot);
+            removed += 1;
+        }
+        removed
+    }
+
+    /// 新增或覆盖模型注册项。
+    pub fn upsert_model(
+        &mut self,
+        name: &str,
+        provider: &str,
+        model_id: &str,
+        capabilities: Vec<ModelCapability>,
+    ) {
+        self.models.insert(
+            name.to_string(),
+            ModelEntry {
+                provider: provider.to_string(),
+                model: model_id.to_string(),
+                capabilities,
+                options: default_options(),
+            },
+        );
+    }
+
+    /// 删除模型注册项。
+    ///
+    /// 返回 (是否删除成功, 删除后变为悬空的路由槽位 key 列表)。
+    /// 悬空路由指其 provider+model 在删除后无法在 models 注册表找到匹配的条目。
+    pub fn remove_model(&mut self, name: &str) -> (bool, Vec<String>) {
+        let removed = self.models.remove(name).is_some();
+        let mut dangling_routes = Vec::new();
+        for (slot, entry) in &self.routing {
+            let still_referenced = self
+                .models
+                .iter()
+                .any(|(_, m)| m.provider == entry.provider && m.model == entry.model);
+            if !still_referenced {
+                dangling_routes.push(slot.key().to_string());
+            }
+        }
+        (removed, dangling_routes)
+    }
+
+    /// 设置路由槽位指向某个已注册的模型。
+    ///
+    /// `name` 必须是 models 注册表中的 key。返回 Ok(()) 或错误（模型不存在）。
+    pub fn set_route_by_name(
+        &mut self,
+        slot: RoutingSlot,
+        name: &str,
+    ) -> std::result::Result<(), String> {
+        let entry = self
+            .models
+            .get(name)
+            .ok_or_else(|| format!("模型 {name} 不存在于 models 注册表"))?
+            .clone();
+        self.routing.insert(slot, entry);
+        Ok(())
+    }
+
+    /// 设置路由槽位（直接传入 provider + model_id）。
+    ///
+    /// 若 models 注册表有匹配条目则复用，否则内联创建路由条目。
+    pub fn set_route_inline(&mut self, slot: RoutingSlot, provider: &str, model_id: &str) {
+        if let Some(entry) = self
+            .models
+            .iter()
+            .find(|(_, m)| m.provider == provider && m.model == model_id)
+            .map(|(_, e)| e.clone())
+        {
+            self.routing.insert(slot, entry);
+        } else {
+            self.routing.insert(
+                slot,
+                ModelEntry {
+                    provider: provider.to_string(),
+                    model: model_id.to_string(),
+                    capabilities: vec![],
+                    options: default_options(),
+                },
+            );
+        }
+    }
+}
+
+/// Provider 引用情况（供 remove_provider 检查）。
+#[derive(Debug, Clone, Default)]
+pub struct ProviderReferences {
+    /// 引用该 provider 的模型注册项 key 列表
+    pub models: Vec<String>,
+    /// 引用该 provider 的路由槽位 key 列表
+    pub routes: Vec<String>,
 }
 
 #[cfg(test)]
@@ -970,5 +1127,124 @@ mod tests {
         let mut cfg = config.clone();
         cfg.ensure_routing_models_registered();
         assert!(cfg.models.values().any(|m| m.model == "gpt-4"));
+    }
+
+    // ── CLI 友好方法测试（RFC 0015 §6.1） ──
+
+    fn sample_provider() -> ProviderConfig {
+        ProviderConfig {
+            base_url: "https://api.deepseek.com".to_string(),
+            api_key: "${DEEPSEEK_API_KEY}".to_string(),
+            timeout_ms: 60_000,
+            protocol: ProviderProtocol::DeepSeek,
+        }
+    }
+
+    #[test]
+    fn upsert_and_reference_provider() {
+        let mut config = ModelsConfig::default();
+        config.upsert_provider(
+            "deepseek",
+            "https://api.deepseek.com",
+            "${DEEPSEEK_API_KEY}",
+            ProviderProtocol::DeepSeek,
+            60_000,
+        );
+        assert!(config.providers.contains_key("deepseek"));
+
+        // 添加引用该 provider 的模型
+        config.upsert_model(
+            "ds-chat",
+            "deepseek",
+            "deepseek-chat",
+            vec![ModelCapability::Chat],
+        );
+        let refs = config.provider_referenced_by("deepseek");
+        assert_eq!(refs.models, vec!["ds-chat".to_string()]);
+        assert!(refs.routes.is_empty());
+    }
+
+    #[test]
+    fn remove_provider_force_cascades() {
+        let mut config = ModelsConfig::default();
+        config.providers.insert("p".to_string(), sample_provider());
+        config.upsert_model("m1", "p", "model-1", vec![ModelCapability::Chat]);
+        config.set_route_by_name(RoutingSlot::Chat, "m1").unwrap();
+
+        let refs = config.provider_referenced_by("p");
+        assert_eq!(refs.models.len(), 1);
+        assert_eq!(refs.routes.len(), 1);
+
+        let removed = config.remove_provider_force("p");
+        assert!(removed >= 3); // provider + model + route
+        assert!(!config.providers.contains_key("p"));
+        assert!(config.models.is_empty());
+        assert!(config.routing.is_empty());
+    }
+
+    #[test]
+    fn set_route_by_name_requires_registered_model() {
+        let mut config = ModelsConfig::default();
+        let result = config.set_route_by_name(RoutingSlot::Chat, "nonexistent");
+        assert!(result.is_err());
+
+        config.upsert_model("ds", "p", "deepseek-chat", vec![ModelCapability::Chat]);
+        config.set_route_by_name(RoutingSlot::Chat, "ds").unwrap();
+        assert_eq!(
+            config.routing.get(&RoutingSlot::Chat).unwrap().model,
+            "deepseek-chat"
+        );
+    }
+
+    #[test]
+    fn set_route_inline_reuses_registered_entry() {
+        let mut config = ModelsConfig::default();
+        config.providers.insert("p".to_string(), sample_provider());
+        config.upsert_model(
+            "ds",
+            "p",
+            "deepseek-chat",
+            vec![ModelCapability::Chat, ModelCapability::Multimodal],
+        );
+        config.set_route_inline(RoutingSlot::Chat, "p", "deepseek-chat");
+        // 复用注册项时应携带 capabilities
+        assert_eq!(
+            config
+                .routing
+                .get(&RoutingSlot::Chat)
+                .unwrap()
+                .capabilities
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn set_route_inline_creates_bare_entry_when_no_match() {
+        let mut config = ModelsConfig::default();
+        config.providers.insert("p".to_string(), sample_provider());
+        config.set_route_inline(RoutingSlot::Lite, "p", "deepseek-lite");
+        let entry = config.routing.get(&RoutingSlot::Lite).unwrap();
+        assert_eq!(entry.model, "deepseek-lite");
+        assert!(entry.capabilities.is_empty());
+    }
+
+    #[test]
+    fn remove_model_reports_dangling_routes() {
+        let mut config = ModelsConfig::default();
+        config.providers.insert("p".to_string(), sample_provider());
+        config.upsert_model("ds", "p", "deepseek-chat", vec![ModelCapability::Chat]);
+        config.set_route_by_name(RoutingSlot::Chat, "ds").unwrap();
+
+        let (removed, dangling) = config.remove_model("ds");
+        assert!(removed);
+        assert_eq!(dangling, vec!["chat".to_string()]);
+    }
+
+    #[test]
+    fn remove_model_not_found() {
+        let mut config = ModelsConfig::default();
+        let (removed, _) = config.remove_model("nope");
+        assert!(!removed);
     }
 }

--- a/crates/tiangong-entry/Cargo.toml
+++ b/crates/tiangong-entry/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 tiangong-core = { workspace = true }
+tiangong-config = { workspace = true }
 tiangong-cli = { workspace = true }
 tiangong-server = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/tiangong-entry/Cargo.toml
+++ b/crates/tiangong-entry/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 [dependencies]
 tiangong-core = { workspace = true }
 tiangong-config = { workspace = true }
+tiangong-memory = { workspace = true }
 tiangong-cli = { workspace = true }
 tiangong-server = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/tiangong-entry/Cargo.toml
+++ b/crates/tiangong-entry/Cargo.toml
@@ -16,3 +16,4 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["blocking", "json", "rustls"] }
 semver = { workspace = true }
+dialoguer = "0.12.0"

--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -60,14 +60,14 @@ pub(crate) struct UpdateArgs {
 pub(crate) struct ServerArgs {
     #[command(subcommand)]
     pub(crate) command: Option<ServerSubcommand>,
-    /// 监听地址
-    #[arg(long, default_value = "127.0.0.1")]
-    pub(crate) host: String,
-    /// 监听端口
-    #[arg(long, default_value_t = 8080)]
-    pub(crate) port: u16,
-    /// API 认证 Token
-    #[arg(long, help = "API 认证 Token")]
+    /// 监听地址（不传时使用 server.json 保存值，再回退 127.0.0.1）
+    #[arg(long, help = "监听地址，覆盖 server.json 保存值")]
+    pub(crate) host: Option<String>,
+    /// 监听端口（不传时使用 server.json 保存值，再回退 8080）
+    #[arg(long, help = "监听端口，覆盖 server.json 保存值")]
+    pub(crate) port: Option<u16>,
+    /// API 认证 Token（不传时使用 server.json 保存值）
+    #[arg(long, help = "API 认证 Token，覆盖 server.json 保存值")]
     pub(crate) token: Option<String>,
     /// 后台运行
     #[arg(short, long, help = "后台运行")]

--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -83,6 +83,8 @@ pub(crate) enum ServerSubcommand {
     Stop,
     #[command(about = "查看 Server 运行状态")]
     Status,
+    #[command(about = "交互式配置向导（引导完成监听地址与 Token）")]
+    Configure,
     #[command(about = "管理 Server 监听配置")]
     Config {
         #[command(subcommand)]
@@ -196,6 +198,8 @@ pub(crate) enum ModelSubcommand {
         #[arg(help = "模型名称（本地别名）")]
         name: String,
     },
+    #[command(about = "交互式配置向导（引导完成 provider → model → route）")]
+    Configure,
     #[command(about = "设置路由槽位指向的模型")]
     Route {
         #[command(subcommand)]
@@ -238,6 +242,8 @@ pub(crate) enum MemorySubcommand {
         #[command(subcommand)]
         command: MemoryConfigSubcommand,
     },
+    #[command(about = "交互式配置向导（引导选择 Memory 端点模型）")]
+    Configure,
     #[command(about = "启用 Memory")]
     Enable,
     #[command(about = "禁用 Memory")]

--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -31,6 +31,8 @@ pub(crate) enum MainCommand {
     Mcp(McpArgs),
     #[command(about = "Skill 配置管理")]
     Skill(SkillArgs),
+    #[command(about = "自定义 Prompt 管理")]
+    Prompt(PromptArgs),
     #[command(about = "检查并安装天工更新")]
     Update(UpdateArgs),
 }
@@ -82,6 +84,33 @@ pub(crate) struct McpArgs {
 pub(crate) struct SkillArgs {
     #[command(subcommand)]
     pub(crate) command: SkillSubcommand,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PromptArgs {
+    #[command(subcommand)]
+    pub(crate) command: PromptSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum PromptSubcommand {
+    #[command(about = "查看当前自定义 Prompt")]
+    Show,
+    #[command(about = "设置自定义 Prompt（直接传文本或用 --file 从文件读取）")]
+    Set {
+        /// Prompt 文本（与 --file 互斥）
+        #[arg(help = "Prompt 文本")]
+        text: Option<String>,
+        /// 从文件读取 Prompt 内容
+        #[arg(long = "file", value_name = "PATH", conflicts_with = "text")]
+        file: Option<String>,
+    },
+    #[command(about = "通过 $EDITOR 编辑自定义 Prompt")]
+    Edit,
+    #[command(about = "清空自定义 Prompt")]
+    Clear,
+    #[command(about = "显示自定义 Prompt 存储路径")]
+    Path,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -32,6 +32,8 @@ pub(crate) enum MainCommand {
     Mcp(McpArgs),
     #[command(about = "模型配置管理（Provider / Model / Routing）")]
     Model(ModelArgs),
+    #[command(about = "Memory 系统配置管理")]
+    Memory(MemoryArgs),
     #[command(about = "Skill 配置管理")]
     Skill(SkillArgs),
     #[command(about = "自定义 Prompt 管理")]
@@ -216,6 +218,44 @@ pub(crate) enum RouteSubcommand {
         capability: String,
         #[arg(help = "模型名称（本地别名）")]
         model: String,
+    },
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct MemoryArgs {
+    #[command(subcommand)]
+    pub(crate) command: MemorySubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum MemorySubcommand {
+    #[command(about = "管理 Memory 配置")]
+    Config {
+        #[command(subcommand)]
+        command: MemoryConfigSubcommand,
+    },
+    #[command(about = "启用 Memory")]
+    Enable,
+    #[command(about = "禁用 Memory")]
+    Disable,
+    #[command(about = "查看 Memory 状态")]
+    Status,
+    #[command(about = "测试 Memory 模型连通性")]
+    Test,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum MemoryConfigSubcommand {
+    #[command(about = "查看 Memory 配置")]
+    Show,
+    #[command(about = "从 models.json 引用模型填充 Memory 端点")]
+    Set {
+        #[arg(long, help = "Memory LLM 模型名（models.json 中的别名）")]
+        llm: Option<String>,
+        #[arg(long, help = "Embedding 模型名")]
+        embedding: Option<String>,
+        #[arg(long, help = "Rerank 模型名")]
+        rerank: Option<String>,
     },
 }
 

--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use tiangong_core::agent_config::McpTransportMode;
+use tiangong_core::model::ProviderProtocol;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -29,6 +30,8 @@ pub(crate) enum MainCommand {
     Server(ServerArgs),
     #[command(about = "MCP 配置管理")]
     Mcp(McpArgs),
+    #[command(about = "模型配置管理（Provider / Model / Routing）")]
+    Model(ModelArgs),
     #[command(about = "Skill 配置管理")]
     Skill(SkillArgs),
     #[command(about = "自定义 Prompt 管理")]
@@ -119,6 +122,107 @@ pub(crate) enum ServerTokenSubcommand {
 pub(crate) struct McpArgs {
     #[command(subcommand)]
     pub(crate) command: McpSubcommand,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ModelArgs {
+    #[command(subcommand)]
+    pub(crate) command: ModelSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ModelSubcommand {
+    #[command(about = "查看模型配置（providers / models / routes，默认全部）")]
+    List {
+        #[arg(help = "过滤范围：providers | models | routes")]
+        scope: Option<String>,
+    },
+    #[command(about = "新增或覆盖模型供应商")]
+    AddProvider {
+        #[arg(help = "供应商名称")]
+        name: String,
+        #[arg(long, value_parser = parse_protocol, help = "协议（openai_chatcompletions / anthropic / deepseek）")]
+        protocol: ProviderProtocol,
+        #[arg(long = "base-url", help = "API base URL")]
+        base_url: String,
+        #[arg(
+            long = "api-key",
+            conflicts_with = "api_key_env",
+            help = "明文 API Key（不推荐，建议用 --api-key-env）"
+        )]
+        api_key: Option<String>,
+        #[arg(
+            long = "api-key-env",
+            conflicts_with = "api_key",
+            help = "API Key 环境变量名（写入为 ${VAR} 模板）"
+        )]
+        api_key_env: Option<String>,
+        #[arg(
+            long = "timeout-ms",
+            default_value_t = 60_000,
+            help = "请求超时（毫秒）"
+        )]
+        timeout_ms: u64,
+    },
+    #[command(about = "删除模型供应商（--force 连同引用它的模型和路由一并删除）")]
+    RemoveProvider {
+        #[arg(help = "供应商名称")]
+        name: String,
+        #[arg(long, help = "强制删除，连同引用该供应商的模型与路由")]
+        force: bool,
+    },
+    #[command(about = "新增或覆盖模型")]
+    AddModel {
+        #[arg(help = "模型名称（本地别名）")]
+        name: String,
+        #[arg(long, help = "所属供应商名称")]
+        provider: String,
+        #[arg(long = "model-id", help = "供应商侧的模型 ID")]
+        model_id: String,
+        #[arg(
+            long = "capability",
+            help = "模型能力（可重复）：chat/multimodal/image_generation/video_generation/stt/tts/embedding/rerank"
+        )]
+        capability: Vec<String>,
+    },
+    #[command(about = "删除模型")]
+    RemoveModel {
+        #[arg(help = "模型名称（本地别名）")]
+        name: String,
+    },
+    #[command(about = "设置路由槽位指向的模型")]
+    Route {
+        #[command(subcommand)]
+        command: RouteSubcommand,
+    },
+    #[command(about = "校验模型配置结构（路由引用、provider 存在性等）")]
+    Validate,
+    #[command(about = "测试模型连通性（真实请求 /models）")]
+    Test {
+        #[arg(help = "测试目标：capability（chat/lite/...）或模型名；默认 chat")]
+        target: Option<String>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum RouteSubcommand {
+    #[command(about = "查看当前路由表")]
+    List,
+    #[command(about = "设置 capability 路由指向某个已注册模型")]
+    Set {
+        #[arg(
+            help = "能力槽位：chat/lite/multimodal/image_generation/video_generation/stt/tts/embedding/rerank"
+        )]
+        capability: String,
+        #[arg(help = "模型名称（本地别名）")]
+        model: String,
+    },
+}
+
+/// 解析 ProviderProtocol 字符串
+fn parse_protocol(raw: &str) -> Result<ProviderProtocol, String> {
+    raw.parse::<ProviderProtocol>()
+        .map_err(|e| format!("无效的协议 {raw}：{e}"))
 }
 
 #[derive(Debug, Args)]

--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -38,6 +38,10 @@ pub(crate) enum MainCommand {
     Skill(SkillArgs),
     #[command(about = "自定义 Prompt 管理")]
     Prompt(PromptArgs),
+    #[command(about = "通用配置查看与校验")]
+    Config(ConfigArgs),
+    #[command(about = "环境诊断")]
+    Doctor(DoctorArgs),
     #[command(about = "检查并安装天工更新")]
     Update(UpdateArgs),
 }
@@ -296,6 +300,29 @@ pub(crate) enum PromptSubcommand {
     Clear,
     #[command(about = "显示自定义 Prompt 存储路径")]
     Path,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ConfigArgs {
+    #[command(subcommand)]
+    pub(crate) command: ConfigSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ConfigSubcommand {
+    #[command(about = "列出全部配置文件路径")]
+    Path,
+    #[command(about = "配置概览（不展开 JSON）")]
+    Show,
+    #[command(about = "校验本地配置结构（不做外部连通性测试）")]
+    Validate,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct DoctorArgs {
+    /// 深度诊断：执行模型连通性与端口探活（可能较慢）
+    #[arg(long, help = "深度诊断（含模型连通性与端口探活）")]
+    pub(crate) deep: bool,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -72,6 +72,47 @@ pub(crate) struct ServerArgs {
 pub(crate) enum ServerSubcommand {
     #[command(about = "停止后台 Server")]
     Stop,
+    #[command(about = "查看 Server 运行状态")]
+    Status,
+    #[command(about = "管理 Server 监听配置")]
+    Config {
+        #[command(subcommand)]
+        command: ServerConfigSubcommand,
+    },
+    #[command(about = "管理 Server 鉴权 Token")]
+    Token {
+        #[command(subcommand)]
+        command: ServerTokenSubcommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ServerConfigSubcommand {
+    #[command(about = "查看 Server 监听配置")]
+    Show,
+    #[command(about = "修改 Server 监听配置（host/port 可选）")]
+    Set {
+        #[arg(long, help = "监听地址")]
+        host: Option<String>,
+        #[arg(long, help = "监听端口")]
+        port: Option<u16>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ServerTokenSubcommand {
+    #[command(about = "查看当前 Token（脱敏）")]
+    Show,
+    #[command(about = "直接设置 Token")]
+    Set {
+        #[arg(help = "Token 值")]
+        token: String,
+    },
+    #[command(about = "生成随机 Token 并写入配置")]
+    Generate {
+        #[arg(long, default_value_t = 32, help = "Token 长度（16-256）")]
+        length: usize,
+    },
 }
 
 #[derive(Debug, Args)]

--- a/crates/tiangong-entry/src/config.rs
+++ b/crates/tiangong-entry/src/config.rs
@@ -1,0 +1,149 @@
+use anyhow::{Result, anyhow};
+
+use tiangong_config::{default_tiangong_dir, load_server_config};
+use tiangong_core::app_state::TiangongState;
+use tiangong_core::custom_prompt::custom_prompt_path;
+use tiangong_core::models_config::ModelsConfig;
+use tiangong_memory::{MemoryConfig, is_memory_disabled};
+
+use crate::args::{ConfigArgs, ConfigSubcommand};
+
+pub(crate) fn run_config_command(args: ConfigArgs) -> Result<()> {
+    match args.command {
+        ConfigSubcommand::Path => {
+            print_paths();
+            Ok(())
+        }
+        ConfigSubcommand::Show => {
+            print_overview();
+            Ok(())
+        }
+        ConfigSubcommand::Validate => validate(),
+    }
+}
+
+fn print_paths() {
+    let root = default_tiangong_dir();
+    println!("配置目录：    {}", root.display());
+    println!("主配置：      {}", root.join("app.json").display());
+    println!("模型配置：    {}", root.join("models.json").display());
+    println!("MCP 配置：    {}", root.join("mcp.json").display());
+    println!("Server 配置： {}", root.join("server.json").display());
+    println!(
+        "Memory 配置： {}",
+        root.join("memory").join("config.json").display()
+    );
+    println!("自定义 Prompt：{}", custom_prompt_path().display());
+    println!("Skill 目录：  {}", root.join("skills").display());
+    println!("Skill 配置：  {}", root.join("skills.json").display());
+}
+
+fn print_overview() {
+    let models = ModelsConfig::load();
+    let server = load_server_config();
+    let memory = MemoryConfig::load_or_default();
+    let state = TiangongState::load_or_default();
+
+    // 模型
+    let chat_model = models
+        .resolve_slot(tiangong_core::models_config::RoutingSlot::Chat)
+        .map(|r| r.model);
+    match &chat_model {
+        Some(m) => println!("模型配置：✅ 已配置 chat={m}"),
+        None => println!("模型配置：❌ 未配置 chat 路由"),
+    }
+
+    // Server
+    let token_status = match &server.auth_token {
+        Some(t) if !t.trim().is_empty() => "Token 已配置",
+        _ => "Token 未配置",
+    };
+    println!(
+        "Server：   {}:{}，{}",
+        server.host, server.port, token_status
+    );
+
+    // Memory
+    let memory_model = memory
+        .model
+        .as_ref()
+        .map(|m| m.model.clone())
+        .unwrap_or_else(|| "未配置".to_string());
+    let memory_state = if is_memory_disabled() {
+        "已禁用"
+    } else {
+        "已启用"
+    };
+    println!("Memory：   {memory_state}，LLM={memory_model}");
+
+    // MCP（从 state 读取已启用的 server 数）
+    let mcp_count = state.agent_config().mcp.servers.len();
+    println!("MCP：      {mcp_count} 个服务");
+
+    // Skill
+    let skills = state.installed_skills();
+    println!("Skill：    {} 个可用", skills.len());
+
+    // 自定义 Prompt
+    let prompt = state.custom_system_prompt();
+    if prompt.trim().is_empty() {
+        println!("自定义 Prompt：未配置");
+    } else {
+        let chars = prompt.chars().count();
+        println!("自定义 Prompt：已配置，{chars} 字");
+    }
+}
+
+fn validate() -> Result<()> {
+    let mut issues = Vec::new();
+
+    // 模型配置
+    let models = ModelsConfig::load();
+    if models.is_empty() {
+        issues.push("models.json 为空（未配置任何 provider 或路由）".to_string());
+    } else {
+        for (slot, entry) in &models.routing {
+            if !models.providers.contains_key(&entry.provider) {
+                issues.push(format!(
+                    "路由 {} 引用了不存在的 provider {}",
+                    slot.key(),
+                    entry.provider
+                ));
+            }
+        }
+        for (name, entry) in &models.models {
+            if !models.providers.contains_key(&entry.provider) {
+                issues.push(format!(
+                    "模型 {name} 引用了不存在的 provider {}",
+                    entry.provider
+                ));
+            }
+        }
+    }
+
+    // Server 配置
+    let server = load_server_config();
+    if server.port == 0 {
+        issues.push("server.json 端口为 0".to_string());
+    }
+
+    // Memory 配置
+    let memory = MemoryConfig::load_or_default();
+    if let Some(m) = &memory.model
+        && (m.base_url.trim().is_empty()
+            || m.api_key.trim().is_empty()
+            || m.model.trim().is_empty())
+    {
+        issues.push("memory LLM 端点配置不完整".to_string());
+    }
+
+    if issues.is_empty() {
+        println!("✅ 配置校验通过");
+        Ok(())
+    } else {
+        for issue in &issues {
+            eprintln!("❌ {issue}");
+        }
+        Err(anyhow!("配置校验未通过（{} 个问题）", issues.len()))
+    }
+}

--- a/crates/tiangong-entry/src/config.rs
+++ b/crates/tiangong-entry/src/config.rs
@@ -1,8 +1,7 @@
 use anyhow::{Result, anyhow};
 
 use tiangong_config::{default_tiangong_dir, load_server_config};
-use tiangong_core::app_state::TiangongState;
-use tiangong_core::custom_prompt::custom_prompt_path;
+use tiangong_core::custom_prompt::{custom_prompt_path, load_custom_prompt};
 use tiangong_core::models_config::ModelsConfig;
 use tiangong_memory::{MemoryConfig, is_memory_disabled};
 
@@ -38,11 +37,18 @@ fn print_paths() {
     println!("Skill 配置：  {}", root.join("skills.json").display());
 }
 
+/// 直接读取 JSON 文件并按数组/对象计数的轻量工具，避免依赖完整 TiangongState。
+fn count_json_entries(path: &std::path::Path, key: &str) -> Option<usize> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&content).ok()?;
+    value.get(key).and_then(|v| v.as_array()).map(|a| a.len())
+}
+
 fn print_overview() {
+    let root = default_tiangong_dir();
     let models = ModelsConfig::load();
     let server = load_server_config();
     let memory = MemoryConfig::load_or_default();
-    let state = TiangongState::load_or_default();
 
     // 模型
     let chat_model = models
@@ -76,16 +82,16 @@ fn print_overview() {
     };
     println!("Memory：   {memory_state}，LLM={memory_model}");
 
-    // MCP（从 state 读取已启用的 server 数）
-    let mcp_count = state.agent_config().mcp.servers.len();
+    // MCP（直接读 mcp.json 的 servers 数组长度）
+    let mcp_count = count_json_entries(&root.join("mcp.json"), "servers").unwrap_or(0);
     println!("MCP：      {mcp_count} 个服务");
 
-    // Skill
-    let skills = state.installed_skills();
-    println!("Skill：    {} 个可用", skills.len());
+    // Skill（直接读 skills.json 的 installed 数组长度）
+    let skill_count = count_json_entries(&root.join("skills.json"), "installed").unwrap_or(0);
+    println!("Skill：    {skill_count} 个可用");
 
-    // 自定义 Prompt
-    let prompt = state.custom_system_prompt();
+    // 自定义 Prompt（直接读 custom-prompt.md）
+    let prompt = load_custom_prompt("").unwrap_or_default();
     if prompt.trim().is_empty() {
         println!("自定义 Prompt：未配置");
     } else {

--- a/crates/tiangong-entry/src/config.rs
+++ b/crates/tiangong-entry/src/config.rs
@@ -44,6 +44,24 @@ fn count_json_entries(path: &std::path::Path, key: &str) -> Option<usize> {
     value.get(key).and_then(|v| v.as_array()).map(|a| a.len())
 }
 
+/// 统计 ~/.tiangong/skills/ 下含 skill.toml 的目录数量（文件系统注册表事实源）。
+///
+/// Skill 注册表已从 skills.json.installed 迁移到文件系统目录存在性，
+/// 因此扫描目录比读 JSON 更准确。目录不存在时返回 0。
+fn count_skill_dirs(root: &std::path::Path) -> usize {
+    let skills_dir = root.join("skills");
+    let Ok(entries) = std::fs::read_dir(&skills_dir) else {
+        return 0;
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|entry| {
+            let path = entry.path();
+            path.is_dir() && path.join("skill.toml").exists()
+        })
+        .count()
+}
+
 fn print_overview() {
     let root = default_tiangong_dir();
     let models = ModelsConfig::load();
@@ -86,8 +104,8 @@ fn print_overview() {
     let mcp_count = count_json_entries(&root.join("mcp.json"), "servers").unwrap_or(0);
     println!("MCP：      {mcp_count} 个服务");
 
-    // Skill（直接读 skills.json 的 installed 数组长度）
-    let skill_count = count_json_entries(&root.join("skills.json"), "installed").unwrap_or(0);
+    // Skill（扫描 ~/.tiangong/skills/<id>/ 下含 skill.toml 的目录，文件系统注册表事实源）
+    let skill_count = count_skill_dirs(&root);
     println!("Skill：    {skill_count} 个可用");
 
     // 自定义 Prompt（直接读 custom-prompt.md）

--- a/crates/tiangong-entry/src/configure.rs
+++ b/crates/tiangong-entry/src/configure.rs
@@ -134,7 +134,9 @@ fn prompt_model(
         ("rerank", ModelCapability::Rerank),
     ];
     let cap_labels: Vec<&str> = caps.iter().map(|(k, _)| *k).collect();
-    let selected = ui::multiselect("选择模型能力（空格切换，回车确认）", &cap_labels)?;
+    // 默认勾选 chat（caps[0]），降低误操作概率
+    let selected =
+        ui::multiselect_with_defaults("选择模型能力（空格切换，回车确认）", &cap_labels, &[0])?;
     let capabilities: Vec<ModelCapability> = selected.iter().map(|&i| caps[i].1).collect();
 
     // 至少要有 chat（最常见的对话场景）
@@ -208,9 +210,14 @@ pub fn run_server_configure() -> Result<()> {
     };
 
     let port_input = ui::input("监听端口", &config.port.to_string())?;
-    if let Ok(port) = port_input.trim().parse::<u16>() {
-        config.port = port;
+    let port = port_input
+        .trim()
+        .parse::<u16>()
+        .map_err(|_| anyhow!("端口必须是 1-65535 的整数，实际输入：{port_input}"))?;
+    if port == 0 {
+        return Err(anyhow!("端口不能为 0"));
     }
+    config.port = port;
 
     // Token
     let token_options = [
@@ -230,9 +237,10 @@ pub fn run_server_configure() -> Result<()> {
         }
         1 => {
             let token = ui::password("请输入 Token")?;
-            if !token.trim().is_empty() {
-                config.auth_token = Some(token.trim().to_string());
+            if token.trim().is_empty() {
+                return Err(anyhow!("Token 不能为空；如不想设置鉴权请选择「跳过」"));
             }
+            config.auth_token = Some(token.trim().to_string());
         }
         _ => {
             config.auth_token = None;
@@ -306,12 +314,13 @@ pub fn run_memory_configure() -> Result<()> {
 
 /// 让用户从已注册模型中选择一个作为 Memory LLM（校验 chat 能力）。
 fn pick_memory_llm(models: &ModelsConfig) -> Result<tiangong_memory::MemoryLlmConfig> {
-    let chat_models: Vec<(&String, &str)> = models
+    let mut chat_models: Vec<(&String, &str)> = models
         .models
         .iter()
         .filter(|(_, m)| m.capabilities.contains(&ModelCapability::Chat))
         .map(|(k, m)| (k, m.model.as_str()))
         .collect();
+    chat_models.sort_by_key(|(k, _)| k.as_str());
     if chat_models.is_empty() {
         return Err(anyhow!(
             "没有具备 chat 能力的已注册模型，请先 `tiangong model add-model ... --capability chat`"
@@ -333,12 +342,13 @@ fn pick_memory_endpoint(
     expected: ModelCapability,
     label: &str,
 ) -> Result<Option<tiangong_memory::MemoryEmbeddingConfig>> {
-    let candidates: Vec<(&String, &str)> = models
+    let mut candidates: Vec<(&String, &str)> = models
         .models
         .iter()
         .filter(|(_, m)| m.capabilities.contains(&expected))
         .map(|(k, m)| (k, m.model.as_str()))
         .collect();
+    candidates.sort_by_key(|(k, _)| k.as_str());
     if candidates.is_empty() {
         println!("⚠️  没有具备 {label} 能力的已注册模型，已跳过");
         return Ok(None);
@@ -351,7 +361,10 @@ fn pick_memory_endpoint(
     let idx = ui::select(&format!("选择 {label} 模型"), &label_refs)?;
     let (name, _) = candidates[idx];
     let provider_name = &models.models[name].provider;
-    let provider = &models.providers[provider_name];
+    let provider = models
+        .providers
+        .get(provider_name)
+        .ok_or_else(|| anyhow!("模型 {name} 引用了不存在的 provider {provider_name}"))?;
     use tiangong_memory::MemoryEmbeddingConfig;
     Ok(Some(MemoryEmbeddingConfig {
         provider_key: Some(provider_name.clone()),
@@ -369,12 +382,13 @@ fn pick_memory_rerank(
     models: &ModelsConfig,
     label: &str,
 ) -> Result<Option<tiangong_memory::MemoryRerankConfig>> {
-    let candidates: Vec<(&String, &str)> = models
+    let mut candidates: Vec<(&String, &str)> = models
         .models
         .iter()
         .filter(|(_, m)| m.capabilities.contains(&ModelCapability::Rerank))
         .map(|(k, m)| (k, m.model.as_str()))
         .collect();
+    candidates.sort_by_key(|(k, _)| k.as_str());
     if candidates.is_empty() {
         println!("⚠️  没有具备 {label} 能力的已注册模型，已跳过");
         return Ok(None);
@@ -387,7 +401,10 @@ fn pick_memory_rerank(
     let idx = ui::select(&format!("选择 {label} 模型"), &label_refs)?;
     let (name, _) = candidates[idx];
     let provider_name = &models.models[name].provider;
-    let provider = &models.providers[provider_name];
+    let provider = models
+        .providers
+        .get(provider_name)
+        .ok_or_else(|| anyhow!("模型 {name} 引用了不存在的 provider {provider_name}"))?;
     use tiangong_memory::MemoryRerankConfig;
     Ok(Some(MemoryRerankConfig {
         provider_key: Some(provider_name.clone()),
@@ -402,7 +419,10 @@ fn pick_memory_rerank(
 /// 构建 Memory LLM 配置（复用 provider 端点）。
 fn build_llm_config(models: &ModelsConfig, name: &str) -> Result<tiangong_memory::MemoryLlmConfig> {
     let entry = &models.models[name];
-    let provider = &models.providers[&entry.provider];
+    let provider = models
+        .providers
+        .get(&entry.provider)
+        .ok_or_else(|| anyhow!("模型 {name} 引用了不存在的 provider {}", entry.provider))?;
     Ok(tiangong_memory::MemoryLlmConfig {
         provider_key: Some(entry.provider.clone()),
         base_url: provider.base_url.clone(),

--- a/crates/tiangong-entry/src/configure.rs
+++ b/crates/tiangong-entry/src/configure.rs
@@ -1,0 +1,414 @@
+//! 交互式配置向导实现。
+//!
+//! 为 model / server / memory 三个模块提供可选的交互式引导，
+//! 收集用户输入后调用现有配置方法落盘。非 TTY 环境由调用前的
+//! `ensure_terminal()` 拦截，不会卡住脚本/CI。
+
+use anyhow::{Result, anyhow};
+
+use tiangong_config::{generate_token, load_server_config, save_server_config};
+use tiangong_core::model::ProviderProtocol;
+use tiangong_core::models_config::{ModelCapability, ModelsConfig, RoutingSlot};
+use tiangong_memory::{MemoryConfig, enable_memory};
+
+use crate::interactive as ui;
+
+/// 模型配置向导：引导完成 provider → model → route 三步。
+pub fn run_model_configure(config: &mut ModelsConfig) -> Result<()> {
+    ui::ensure_terminal()?;
+    println!("=== 模型配置向导 ===\n");
+
+    // ── 步骤 1：Provider ──
+    let (protocol, provider_name, base_url, api_key) = prompt_provider(config)?;
+    config.upsert_provider(&provider_name, &base_url, &api_key, protocol, 60_000);
+    println!();
+
+    // ── 步骤 2：Model ──
+    let (model_name, model_id, capabilities) = prompt_model(&provider_name, protocol)?;
+    config.upsert_model(&model_name, &provider_name, &model_id, capabilities.clone());
+    println!();
+
+    // ── 步骤 3：Route ──
+    prompt_route(config, &model_name, &capabilities)?;
+    println!();
+
+    // ── 落盘 ──
+    config.save()?;
+    println!("✅ 模型配置已保存");
+    println!("提示：可用 `tiangong model test chat` 验证连通性，或 `tiangong doctor` 检查整体环境");
+    Ok(())
+}
+
+/// 收集 Provider 信息：协议、名称、base_url、api_key。
+fn prompt_provider(_config: &ModelsConfig) -> Result<(ProviderProtocol, String, String, String)> {
+    let protocols = ["DeepSeek", "OpenAI 兼容", "Anthropic"];
+    let idx = ui::select("选择模型协议", &protocols)?;
+    let (protocol, default_name, default_url) = match idx {
+        0 => (
+            "deepseek".parse::<ProviderProtocol>().unwrap(),
+            "deepseek",
+            "https://api.deepseek.com",
+        ),
+        1 => (
+            ProviderProtocol::OpenAiChatCompletions,
+            "openai",
+            "https://api.openai.com/v1",
+        ),
+        2 => (
+            "anthropic".parse::<ProviderProtocol>().unwrap(),
+            "anthropic",
+            "https://api.anthropic.com",
+        ),
+        _ => unreachable!(),
+    };
+
+    let provider_name = ui::input("供应商名称（本地标识）", default_name)?;
+    let provider_name = if provider_name.trim().is_empty() {
+        default_name.to_string()
+    } else {
+        provider_name.trim().to_string()
+    };
+
+    let base_url = ui::input("API base URL", default_url)?;
+    let base_url = if base_url.trim().is_empty() {
+        default_url.to_string()
+    } else {
+        base_url.trim().to_string()
+    };
+
+    // api_key 方式
+    let key_modes = [
+        "环境变量名（推荐，写入为 ${VAR} 模板）",
+        "明文输入（不推荐）",
+    ];
+    let mode = ui::select("API Key 输入方式", &key_modes)?;
+    let api_key = if mode == 0 {
+        let env_name = ui::input_required("请输入环境变量名（如 DEEPSEEK_API_KEY）")?;
+        format!("${{{}}}", env_name.trim())
+    } else {
+        let plain = ui::password("请输入 API Key")?;
+        if plain.trim().is_empty() {
+            return Err(anyhow!("API Key 不能为空"));
+        }
+        plain.trim().to_string()
+    };
+
+    Ok((protocol, provider_name, base_url, api_key))
+}
+
+/// 收集 Model 信息：别名、model_id、capability。
+fn prompt_model(
+    provider_name: &str,
+    protocol: ProviderProtocol,
+) -> Result<(String, String, Vec<ModelCapability>)> {
+    let default_id = match protocol {
+        ProviderProtocol::DeepSeek => "deepseek-chat",
+        ProviderProtocol::OpenAiChatCompletions => "gpt-4o-mini",
+        ProviderProtocol::Anthropic => "claude-sonnet-4-20250514",
+    };
+
+    let default_alias = format!("{provider_name}-chat");
+    let model_name = ui::input("模型别名（本地标识）", &default_alias)?;
+    let model_name = if model_name.trim().is_empty() {
+        default_alias
+    } else {
+        model_name.trim().to_string()
+    };
+
+    let model_id = ui::input("模型 ID（供应商侧标识）", default_id)?;
+    let model_id = if model_id.trim().is_empty() {
+        default_id.to_string()
+    } else {
+        model_id.trim().to_string()
+    };
+
+    // capability 多选
+    let caps = [
+        ("chat", ModelCapability::Chat),
+        ("multimodal", ModelCapability::Multimodal),
+        ("image_generation", ModelCapability::ImageGeneration),
+        ("video_generation", ModelCapability::VideoGeneration),
+        ("stt", ModelCapability::Stt),
+        ("tts", ModelCapability::Tts),
+        ("embedding", ModelCapability::Embedding),
+        ("rerank", ModelCapability::Rerank),
+    ];
+    let cap_labels: Vec<&str> = caps.iter().map(|(k, _)| *k).collect();
+    let selected = ui::multiselect("选择模型能力（空格切换，回车确认）", &cap_labels)?;
+    let capabilities: Vec<ModelCapability> = selected.iter().map(|&i| caps[i].1).collect();
+
+    // 至少要有 chat（最常见的对话场景）
+    let capabilities = if capabilities.is_empty() {
+        vec![ModelCapability::Chat]
+    } else {
+        capabilities
+    };
+
+    Ok((model_name, model_id, capabilities))
+}
+
+/// 收集路由槽位并设置（利用已有 capability 校验）。
+fn prompt_route(
+    config: &mut ModelsConfig,
+    model_name: &str,
+    capabilities: &[ModelCapability],
+) -> Result<()> {
+    if !ui::confirm("是否设置该模型为默认路由？", true)? {
+        println!("已跳过路由设置（可稍后用 `tiangong model route set` 配置）");
+        return Ok(());
+    }
+
+    // 根据模型能力推荐槽位
+    let slots: Vec<(&str, RoutingSlot)> = vec![
+        ("chat", RoutingSlot::Chat),
+        ("lite", RoutingSlot::Lite),
+        ("multimodal", RoutingSlot::Multimodal),
+        ("image_generation", RoutingSlot::ImageGeneration),
+        ("video_generation", RoutingSlot::VideoGeneration),
+        ("stt", RoutingSlot::Stt),
+        ("tts", RoutingSlot::Tts),
+        ("embedding", RoutingSlot::Embedding),
+        ("rerank", RoutingSlot::Rerank),
+    ];
+    // 默认推荐 chat
+    let default_slot = if capabilities.contains(&ModelCapability::Chat) {
+        0
+    } else {
+        capabilities
+            .first()
+            .and_then(|c| slots.iter().position(|(_, s)| s.capability() == Some(*c)))
+            .unwrap_or(0)
+    };
+
+    let slot_labels: Vec<&str> = slots.iter().map(|(k, _)| *k).collect();
+    let idx = ui::select_with_default("选择路由槽位", &slot_labels, default_slot)?;
+    let slot = slots[idx].1;
+
+    config
+        .set_route_by_name(slot, model_name)
+        .map_err(|e| anyhow!(e))?;
+    println!("已设置路由 {} -> {model_name}", slot.key());
+    Ok(())
+}
+
+// ── Server 配置向导 ──
+
+/// Server 配置向导：引导设置监听地址与 Token。
+pub fn run_server_configure() -> Result<()> {
+    ui::ensure_terminal()?;
+    println!("=== Server 配置向导 ===\n");
+
+    let mut config = load_server_config();
+
+    let host = ui::input("监听地址", &config.host)?;
+    config.host = if host.trim().is_empty() {
+        config.host
+    } else {
+        host.trim().to_string()
+    };
+
+    let port_input = ui::input("监听端口", &config.port.to_string())?;
+    if let Ok(port) = port_input.trim().parse::<u16>() {
+        config.port = port;
+    }
+
+    // Token
+    let token_options = [
+        "生成随机 Token（推荐）",
+        "手动输入 Token",
+        "跳过（不设鉴权）",
+    ];
+    let token_mode = ui::select("鉴权 Token", &token_options)?;
+    match token_mode {
+        0 => {
+            let len_input = ui::input("Token 长度", "32")?;
+            let len: usize = len_input.trim().parse().unwrap_or(32);
+            let token = generate_token(len);
+            config.auth_token = Some(token);
+            println!("已生成 Token：{}", config.masked_auth_token());
+            println!("（完整 Token 已写入 server.json）");
+        }
+        1 => {
+            let token = ui::password("请输入 Token")?;
+            if !token.trim().is_empty() {
+                config.auth_token = Some(token.trim().to_string());
+            }
+        }
+        _ => {
+            config.auth_token = None;
+            println!("已跳过 Token 设置（接口将无鉴权）");
+        }
+    }
+
+    save_server_config(&config)?;
+    println!();
+    println!("✅ Server 配置已保存：{}:{}", config.host, config.port);
+    println!("提示：可用 `tiangong server status` 检查运行状态");
+    Ok(())
+}
+
+// ── Memory 配置向导 ──
+
+/// Memory 配置向导：引导选择 Memory 端点模型。
+pub fn run_memory_configure() -> Result<()> {
+    ui::ensure_terminal()?;
+    println!("=== Memory 配置向导 ===\n");
+
+    // 是否启用
+    let currently_disabled = tiangong_memory::is_memory_disabled();
+    if currently_disabled {
+        if ui::confirm("Memory 当前已禁用，是否启用？", true)? {
+            enable_memory()?;
+            println!("Memory 已启用");
+        } else {
+            println!("已保持禁用状态，向导结束");
+            return Ok(());
+        }
+    } else if !ui::confirm("Memory 当前已启用，继续配置端点？", true)? {
+        println!("已跳过，向导结束");
+        return Ok(());
+    }
+
+    let models = ModelsConfig::load();
+    if models.models.is_empty() {
+        println!("⚠️  models.json 中没有已注册模型，请先运行 `tiangong model configure`");
+        println!("（Memory 端点引用 models.json 中的模型）");
+        return Ok(());
+    }
+
+    let mut config = MemoryConfig::load_or_default();
+
+    // LLM 模型（要求 chat 能力）
+    config.model = Some(pick_memory_llm(&models)?);
+    println!();
+
+    // Embedding 模型（可选）
+    if ui::confirm("是否配置 Embedding 端点？", false)?
+        && let Some(m) = pick_memory_endpoint(&models, ModelCapability::Embedding, "Embedding")?
+    {
+        config.embedding = Some(m);
+    }
+    println!();
+
+    // Rerank 模型（可选）
+    if ui::confirm("是否配置 Rerank 端点？", false)?
+        && let Some(m) = pick_memory_rerank(&models, "Rerank")?
+    {
+        config.rerank = Some(m);
+    }
+
+    config.save()?;
+    println!();
+    println!("✅ Memory 配置已保存");
+    println!("提示：可用 `tiangong memory test` 检查端点有效性");
+    Ok(())
+}
+
+/// 让用户从已注册模型中选择一个作为 Memory LLM（校验 chat 能力）。
+fn pick_memory_llm(models: &ModelsConfig) -> Result<tiangong_memory::MemoryLlmConfig> {
+    let chat_models: Vec<(&String, &str)> = models
+        .models
+        .iter()
+        .filter(|(_, m)| m.capabilities.contains(&ModelCapability::Chat))
+        .map(|(k, m)| (k, m.model.as_str()))
+        .collect();
+    if chat_models.is_empty() {
+        return Err(anyhow!(
+            "没有具备 chat 能力的已注册模型，请先 `tiangong model add-model ... --capability chat`"
+        ));
+    }
+    let labels: Vec<String> = chat_models
+        .iter()
+        .map(|(k, id)| format!("{k} ({id})"))
+        .collect();
+    let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+    let idx = ui::select("选择 Memory LLM 模型", &label_refs)?;
+    let (name, _) = chat_models[idx];
+    build_llm_config(models, name)
+}
+
+/// 让用户从已注册模型中选择一个 Embedding 模型（校验对应能力），可跳过。
+fn pick_memory_endpoint(
+    models: &ModelsConfig,
+    expected: ModelCapability,
+    label: &str,
+) -> Result<Option<tiangong_memory::MemoryEmbeddingConfig>> {
+    let candidates: Vec<(&String, &str)> = models
+        .models
+        .iter()
+        .filter(|(_, m)| m.capabilities.contains(&expected))
+        .map(|(k, m)| (k, m.model.as_str()))
+        .collect();
+    if candidates.is_empty() {
+        println!("⚠️  没有具备 {label} 能力的已注册模型，已跳过");
+        return Ok(None);
+    }
+    let labels: Vec<String> = candidates
+        .iter()
+        .map(|(k, id)| format!("{k} ({id})"))
+        .collect();
+    let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+    let idx = ui::select(&format!("选择 {label} 模型"), &label_refs)?;
+    let (name, _) = candidates[idx];
+    let provider_name = &models.models[name].provider;
+    let provider = &models.providers[provider_name];
+    use tiangong_memory::MemoryEmbeddingConfig;
+    Ok(Some(MemoryEmbeddingConfig {
+        provider_key: Some(provider_name.clone()),
+        base_url: provider.base_url.clone(),
+        api_key: provider.api_key.clone(),
+        model: models.models[name].model.clone(),
+        protocol: provider.protocol,
+        timeout_ms: provider.timeout_ms,
+        dimension: 0,
+    }))
+}
+
+/// 让用户从已注册模型中选择一个 Rerank 模型（校验 rerank 能力），可跳过。
+fn pick_memory_rerank(
+    models: &ModelsConfig,
+    label: &str,
+) -> Result<Option<tiangong_memory::MemoryRerankConfig>> {
+    let candidates: Vec<(&String, &str)> = models
+        .models
+        .iter()
+        .filter(|(_, m)| m.capabilities.contains(&ModelCapability::Rerank))
+        .map(|(k, m)| (k, m.model.as_str()))
+        .collect();
+    if candidates.is_empty() {
+        println!("⚠️  没有具备 {label} 能力的已注册模型，已跳过");
+        return Ok(None);
+    }
+    let labels: Vec<String> = candidates
+        .iter()
+        .map(|(k, id)| format!("{k} ({id})"))
+        .collect();
+    let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+    let idx = ui::select(&format!("选择 {label} 模型"), &label_refs)?;
+    let (name, _) = candidates[idx];
+    let provider_name = &models.models[name].provider;
+    let provider = &models.providers[provider_name];
+    use tiangong_memory::MemoryRerankConfig;
+    Ok(Some(MemoryRerankConfig {
+        provider_key: Some(provider_name.clone()),
+        base_url: provider.base_url.clone(),
+        api_key: provider.api_key.clone(),
+        model: models.models[name].model.clone(),
+        protocol: provider.protocol,
+        timeout_ms: provider.timeout_ms,
+    }))
+}
+
+/// 构建 Memory LLM 配置（复用 provider 端点）。
+fn build_llm_config(models: &ModelsConfig, name: &str) -> Result<tiangong_memory::MemoryLlmConfig> {
+    let entry = &models.models[name];
+    let provider = &models.providers[&entry.provider];
+    Ok(tiangong_memory::MemoryLlmConfig {
+        provider_key: Some(entry.provider.clone()),
+        base_url: provider.base_url.clone(),
+        api_key: provider.api_key.clone(),
+        model: entry.model.clone(),
+        protocol: provider.protocol,
+        timeout_ms: provider.timeout_ms,
+    })
+}

--- a/crates/tiangong-entry/src/doctor.rs
+++ b/crates/tiangong-entry/src/doctor.rs
@@ -7,12 +7,14 @@ use tiangong_core::models_config::{ModelsConfig, RoutingSlot};
 use tiangong_memory::{MemoryConfig, is_memory_disabled};
 
 use crate::args::DoctorArgs;
+use crate::secrets::env_secret_resolvable;
 
 pub(crate) fn run_doctor_command(args: DoctorArgs) -> Result<()> {
     let mut report = DoctorReport::default();
 
     check_config_dir(&mut report);
     check_models(&mut report, args.deep);
+    check_model_secrets(&mut report);
     check_server(&mut report);
     check_server_token(&mut report);
     check_memory(&mut report);
@@ -127,6 +129,57 @@ fn check_models(report: &mut DoctorReport, deep: bool) {
 fn check_server(report: &mut DoctorReport) {
     let server = load_server_config();
     report.ok("Server 配置", format!("{}:{}", server.host, server.port));
+}
+
+/// 检查模型与 Memory 配置中 `${ENV}` 形式的密钥是否可解析。
+fn check_model_secrets(report: &mut DoctorReport) {
+    let models = ModelsConfig::load();
+    let mut checked = 0usize;
+    let mut missing: Vec<String> = Vec::new();
+
+    // chat 路由 provider 的 api_key
+    if let Some(entry) = models.routing.get(&RoutingSlot::Chat)
+        && let Some(provider) = models.providers.get(&entry.provider)
+    {
+        checked += 1;
+        let (ok, var) = env_secret_resolvable(&provider.api_key);
+        if !ok {
+            missing.push(format!("chat 模型（{}）", var.unwrap_or_default()));
+        }
+    }
+
+    // Memory 端点的 api_key
+    let memory = MemoryConfig::load_or_default();
+    for (label, cfg) in [
+        ("Memory LLM", memory.model.as_ref().map(|m| &m.api_key)),
+        (
+            "Memory Embedding",
+            memory.embedding.as_ref().map(|e| &e.api_key),
+        ),
+        ("Memory Rerank", memory.rerank.as_ref().map(|r| &r.api_key)),
+    ] {
+        if let Some(key) = cfg {
+            checked += 1;
+            let (ok, var) = env_secret_resolvable(key);
+            if !ok {
+                missing.push(format!("{label}（{}）", var.unwrap_or_default()));
+            }
+        }
+    }
+
+    if missing.is_empty() {
+        if checked > 0 {
+            report.ok("密钥环境变量", format!("{checked} 项密钥均可解析"));
+        } else {
+            report.skip("密钥环境变量", "未配置需解析的密钥");
+        }
+    } else {
+        report.err(
+            "密钥环境变量",
+            format!("{} 项环境变量未设置：{}", missing.len(), missing.join("、")),
+        );
+        report.hint("请在启动 tiangong 前设置对应环境变量");
+    }
 }
 
 fn check_server_token(report: &mut DoctorReport) {

--- a/crates/tiangong-entry/src/doctor.rs
+++ b/crates/tiangong-entry/src/doctor.rs
@@ -23,7 +23,11 @@ pub(crate) fn run_doctor_command(args: DoctorArgs) -> Result<()> {
     check_custom_prompt(&mut report);
 
     report.print();
-    Ok(())
+    if report.has_error {
+        Err(anyhow::anyhow!("环境诊断发现错误项，详见上方 ❌ 标记"))
+    } else {
+        Ok(())
+    }
 }
 
 #[derive(Default)]

--- a/crates/tiangong-entry/src/doctor.rs
+++ b/crates/tiangong-entry/src/doctor.rs
@@ -102,7 +102,7 @@ fn check_models(report: &mut DoctorReport, deep: bool) {
             report.hint("  tiangong model add-model deepseek-chat \\");
             report.hint("    --provider deepseek --model-id deepseek-chat --capability chat");
             report.hint("");
-            report.hint("  tiangong model route chat deepseek-chat");
+            report.hint("  tiangong model route set chat deepseek-chat");
             report.blank();
         }
     }

--- a/crates/tiangong-entry/src/doctor.rs
+++ b/crates/tiangong-entry/src/doctor.rs
@@ -1,0 +1,209 @@
+use anyhow::Result;
+
+use tiangong_config::default_tiangong_dir;
+use tiangong_config::load_server_config;
+use tiangong_core::custom_prompt::custom_prompt_path;
+use tiangong_core::models_config::{ModelsConfig, RoutingSlot};
+use tiangong_memory::{MemoryConfig, is_memory_disabled};
+
+use crate::args::DoctorArgs;
+
+pub(crate) fn run_doctor_command(args: DoctorArgs) -> Result<()> {
+    let mut report = DoctorReport::default();
+
+    check_config_dir(&mut report);
+    check_models(&mut report, args.deep);
+    check_server(&mut report);
+    check_server_token(&mut report);
+    check_memory(&mut report);
+    check_mcp(&mut report);
+    check_skills(&mut report);
+    check_custom_prompt(&mut report);
+
+    report.print();
+    Ok(())
+}
+
+#[derive(Default)]
+struct DoctorReport {
+    lines: Vec<String>,
+    has_error: bool,
+}
+
+impl DoctorReport {
+    fn ok(&mut self, label: &str, detail: impl Into<String>) {
+        self.lines
+            .push(format!("\x1b[32m✅\x1b[0m {label:<16} {}", detail.into()));
+    }
+
+    fn warn(&mut self, label: &str, detail: impl Into<String>) {
+        self.lines
+            .push(format!("\x1b[33m⚠️\x1b[0m  {label:<16} {}", detail.into()));
+    }
+
+    fn err(&mut self, label: &str, detail: impl Into<String>) {
+        self.has_error = true;
+        self.lines
+            .push(format!("\x1b[31m❌\x1b[0m {label:<16} {}", detail.into()));
+    }
+
+    fn skip(&mut self, label: &str, detail: impl Into<String>) {
+        self.lines
+            .push(format!("\x1b[90m⏭️\x1b[0m {label:<16} {}", detail.into()));
+    }
+
+    fn blank(&mut self) {
+        self.lines.push(String::new());
+    }
+
+    fn hint(&mut self, text: &str) {
+        self.lines.push(format!("    {text}"));
+    }
+
+    fn print(&self) {
+        for line in &self.lines {
+            println!("{line}");
+        }
+    }
+}
+
+fn check_config_dir(report: &mut DoctorReport) {
+    let dir = default_tiangong_dir();
+    if dir.exists() {
+        report.ok("配置目录", dir.display().to_string());
+    } else {
+        report.err("配置目录", format!("{} 不存在", dir.display()));
+    }
+}
+
+fn check_models(report: &mut DoctorReport, deep: bool) {
+    let models = ModelsConfig::load();
+    let chat = models.resolve_slot(RoutingSlot::Chat);
+
+    match &chat {
+        Some(resolved) => {
+            report.ok("模型配置", format!("chat -> {}", resolved.model));
+        }
+        None => {
+            report.err("模型配置", "未配置 chat 路由");
+            report.blank();
+            report.hint("可执行：");
+            report.hint("  tiangong model add-provider deepseek \\");
+            report.hint("    --protocol deepseek \\");
+            report.hint("    --base-url https://api.deepseek.com \\");
+            report.hint("    --api-key-env DEEPSEEK_API_KEY");
+            report.hint("");
+            report.hint("  tiangong model add-model deepseek-chat \\");
+            report.hint("    --provider deepseek --model-id deepseek-chat --capability chat");
+            report.hint("");
+            report.hint("  tiangong model route chat deepseek-chat");
+            report.blank();
+        }
+    }
+
+    // 模型连通性（深度诊断）
+    if deep {
+        if let Some(resolved) = chat {
+            let cfg = tiangong_core::model::ModelProviderConfig {
+                api_auth_token: resolved.api_key,
+                api_base_url: resolved.base_url,
+                api_timeout_ms: resolved.timeout_ms.to_string(),
+                api_protocol: resolved.protocol,
+                api_model: resolved.model.clone(),
+                api_lite_model: String::new(),
+            };
+            match tiangong_core::model::SingleProviderClient::list_models(&cfg) {
+                Ok(_) => report.ok("模型连通性", format!("{} 请求成功", resolved.model)),
+                Err(e) => report.err("模型连通性", format!("{e:#}")),
+            }
+        } else {
+            report.skip("模型连通性", "chat 路由未配置，跳过");
+        }
+    } else {
+        report.skip("模型连通性", "使用 --deep 启用");
+    }
+}
+
+fn check_server(report: &mut DoctorReport) {
+    let server = load_server_config();
+    report.ok("Server 配置", format!("{}:{}", server.host, server.port));
+}
+
+fn check_server_token(report: &mut DoctorReport) {
+    let server = load_server_config();
+    match &server.auth_token {
+        Some(t) if !t.trim().is_empty() => {
+            report.ok("Server Token", "已配置");
+        }
+        _ => {
+            report.warn("Server Token", "未配置（接口将无鉴权）");
+            report.hint("可执行：tiangong server token generate");
+        }
+    }
+}
+
+fn check_memory(report: &mut DoctorReport) {
+    let memory = MemoryConfig::load_or_default();
+    let disabled = is_memory_disabled();
+    let has_model = memory
+        .model
+        .as_ref()
+        .map(|m| {
+            !m.base_url.trim().is_empty()
+                && !m.api_key.trim().is_empty()
+                && !m.model.trim().is_empty()
+        })
+        .unwrap_or(false);
+
+    if disabled {
+        report.warn("Memory 配置", "已禁用");
+    } else if has_model {
+        let model_name = memory
+            .model
+            .as_ref()
+            .map(|m| m.model.clone())
+            .unwrap_or_default();
+        report.ok("Memory 配置", format!("已启用，LLM={model_name}"));
+    } else {
+        report.warn("Memory 配置", "已启用但 LLM 端点未配置");
+        report.hint("可执行：tiangong memory config set --llm <模型名>");
+    }
+}
+
+fn check_mcp(report: &mut DoctorReport) {
+    let state = tiangong_core::app_state::TiangongState::load_or_default();
+    let count = state.agent_config().mcp.servers.len();
+    if count == 0 {
+        report.warn("MCP 配置", "0 个服务");
+    } else {
+        report.ok("MCP 配置", format!("{count} 个服务可解析"));
+    }
+}
+
+fn check_skills(report: &mut DoctorReport) {
+    let state = tiangong_core::app_state::TiangongState::load_or_default();
+    let skills = state.installed_skills();
+    if skills.is_empty() {
+        report.warn("Skill 目录", "0 个 Skill");
+    } else {
+        report.ok("Skill 目录", format!("{} 个 Skill 可用", skills.len()));
+    }
+}
+
+fn check_custom_prompt(report: &mut DoctorReport) {
+    let path = custom_prompt_path();
+    if path.exists() {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            let chars = content.trim().chars().count();
+            if chars == 0 {
+                report.warn("自定义 Prompt", "文件存在但为空");
+            } else {
+                report.ok("自定义 Prompt", format!("已配置，{chars} 字"));
+            }
+        } else {
+            report.err("自定义 Prompt", format!("读取失败：{}", path.display()));
+        }
+    } else {
+        report.skip("自定义 Prompt", "未配置（可选）");
+    }
+}

--- a/crates/tiangong-entry/src/doctor.rs
+++ b/crates/tiangong-entry/src/doctor.rs
@@ -110,17 +110,25 @@ fn check_models(report: &mut DoctorReport, deep: bool) {
     // 模型连通性（深度诊断）
     if deep {
         if let Some(resolved) = chat {
-            let cfg = tiangong_core::model::ModelProviderConfig {
-                api_auth_token: resolved.api_key,
-                api_base_url: resolved.base_url,
-                api_timeout_ms: resolved.timeout_ms.to_string(),
-                api_protocol: resolved.protocol,
-                api_model: resolved.model.clone(),
-                api_lite_model: String::new(),
-            };
-            match tiangong_core::model::SingleProviderClient::list_models(&cfg) {
-                Ok(_) => report.ok("模型连通性", format!("{} 请求成功", resolved.model)),
-                Err(e) => report.err("模型连通性", format!("{e:#}")),
+            // 请求前检查 API Key：resolve_slot 已解析 ${ENV}，未设置则返回空串
+            if resolved.api_key.trim().is_empty() {
+                report.err(
+                    "模型连通性",
+                    "API Key 为空（${ENV} 环境变量可能未设置），跳过请求",
+                );
+            } else {
+                let cfg = tiangong_core::model::ModelProviderConfig {
+                    api_auth_token: resolved.api_key,
+                    api_base_url: resolved.base_url,
+                    api_timeout_ms: resolved.timeout_ms.to_string(),
+                    api_protocol: resolved.protocol,
+                    api_model: resolved.model.clone(),
+                    api_lite_model: String::new(),
+                };
+                match tiangong_core::model::SingleProviderClient::list_models(&cfg) {
+                    Ok(_) => report.ok("模型连通性", format!("{} 请求成功", resolved.model)),
+                    Err(e) => report.err("模型连通性", format!("{e:#}")),
+                }
             }
         } else {
             report.skip("模型连通性", "chat 路由未配置，跳过");

--- a/crates/tiangong-entry/src/interactive.rs
+++ b/crates/tiangong-entry/src/interactive.rs
@@ -87,15 +87,13 @@ pub fn multiselect_with_defaults(
     items: &[&str],
     defaults: &[usize],
 ) -> Result<Vec<usize>> {
+    // defaults() 需要长度与 items 相同的 bool 数组，每个 bool 表示对应项是否默认勾选。
+    let default_flags: Vec<bool> = (0..items.len()).map(|i| defaults.contains(&i)).collect();
+
     let selections = dialoguer::MultiSelect::new()
         .with_prompt(prompt)
         .items(items)
-        .defaults(
-            &defaults
-                .iter()
-                .map(|&i| i < items.len())
-                .collect::<Vec<_>>(),
-        )
+        .defaults(&default_flags)
         .interact()?;
     Ok(selections)
 }

--- a/crates/tiangong-entry/src/interactive.rs
+++ b/crates/tiangong-entry/src/interactive.rs
@@ -56,19 +56,46 @@ pub fn input(prompt: &str, default: &str) -> Result<String> {
     Ok(result)
 }
 
-/// 文本输入提示，无默认值，可校验非空。
+/// 文本输入提示，无默认值，强制非空（trim 后）。
 pub fn input_required(prompt: &str) -> Result<String> {
     let result = dialoguer::Input::<String>::new()
         .with_prompt(prompt)
+        .validate_with(|input: &String| -> std::result::Result<(), String> {
+            if input.trim().is_empty() {
+                Err("不能为空".to_string())
+            } else {
+                Ok(())
+            }
+        })
         .interact_text()?;
-    Ok(result)
+    Ok(result.trim().to_string())
 }
 
 /// 多选提示，返回选中项的索引列表。
+#[allow(dead_code)]
 pub fn multiselect(prompt: &str, items: &[&str]) -> Result<Vec<usize>> {
     let selections = dialoguer::MultiSelect::new()
         .with_prompt(prompt)
         .items(items)
+        .interact()?;
+    Ok(selections)
+}
+
+/// 多选提示，可指定默认勾选项的索引列表。
+pub fn multiselect_with_defaults(
+    prompt: &str,
+    items: &[&str],
+    defaults: &[usize],
+) -> Result<Vec<usize>> {
+    let selections = dialoguer::MultiSelect::new()
+        .with_prompt(prompt)
+        .items(items)
+        .defaults(
+            &defaults
+                .iter()
+                .map(|&i| i < items.len())
+                .collect::<Vec<_>>(),
+        )
         .interact()?;
     Ok(selections)
 }

--- a/crates/tiangong-entry/src/interactive.rs
+++ b/crates/tiangong-entry/src/interactive.rs
@@ -1,0 +1,89 @@
+//! 交互式配置向导的基础原语。
+//!
+//! 基于 `dialoguer` 封装 select/input/confirm/password 等提示，
+//! 供 `tiangong model/server/memory configure` 使用。
+//!
+//! 设计原则：
+//! - 非 TTY 环境（脚本/CI/Docker）调用 `ensure_terminal()` 会报错退出，
+//!   不卡住自动化流程。
+//! - 所有原语返回 `anyhow::Result`，用户按 Ctrl+C/Esc 时 dialoguer 会返回
+//!   `io::Error`（被 anyhow 转换），调用方可据此中断向导。
+
+use std::io::IsTerminal;
+
+use anyhow::{Result, anyhow};
+
+/// 确认当前处于交互式终端，否则报错退出。
+///
+/// 向导命令开头调用，保证非 TTY（管道/重定向/CI）环境不会卡住。
+pub fn ensure_terminal() -> Result<()> {
+    if std::io::stdin().is_terminal() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "当前非交互终端，无法启动配置向导。请使用参数式命令（如 `tiangong model add-provider --help`），或在 TTY 中运行。"
+        ))
+    }
+}
+
+/// 单选提示，返回选中项的索引。
+pub fn select(prompt: &str, items: &[&str]) -> Result<usize> {
+    let selection = dialoguer::Select::new()
+        .with_prompt(prompt)
+        .items(items)
+        .default(0)
+        .interact()?;
+    Ok(selection)
+}
+
+/// 单选提示，指定默认选中索引。
+pub fn select_with_default(prompt: &str, items: &[&str], default: usize) -> Result<usize> {
+    let selection = dialoguer::Select::new()
+        .with_prompt(prompt)
+        .items(items)
+        .default(default)
+        .interact()?;
+    Ok(selection)
+}
+
+/// 文本输入提示，带默认值（回车采用默认）。
+pub fn input(prompt: &str, default: &str) -> Result<String> {
+    let result = dialoguer::Input::<String>::new()
+        .with_prompt(prompt)
+        .default(default.to_string())
+        .allow_empty(true)
+        .interact_text()?;
+    Ok(result)
+}
+
+/// 文本输入提示，无默认值，可校验非空。
+pub fn input_required(prompt: &str) -> Result<String> {
+    let result = dialoguer::Input::<String>::new()
+        .with_prompt(prompt)
+        .interact_text()?;
+    Ok(result)
+}
+
+/// 多选提示，返回选中项的索引列表。
+pub fn multiselect(prompt: &str, items: &[&str]) -> Result<Vec<usize>> {
+    let selections = dialoguer::MultiSelect::new()
+        .with_prompt(prompt)
+        .items(items)
+        .interact()?;
+    Ok(selections)
+}
+
+/// 确认提示（Y/n），带默认值。
+pub fn confirm(prompt: &str, default: bool) -> Result<bool> {
+    let result = dialoguer::Confirm::new()
+        .with_prompt(prompt)
+        .default(default)
+        .interact()?;
+    Ok(result)
+}
+
+/// 密钥输入提示（不回显）。
+pub fn password(prompt: &str) -> Result<String> {
+    let result = dialoguer::Password::new().with_prompt(prompt).interact()?;
+    Ok(result)
+}

--- a/crates/tiangong-entry/src/lib.rs
+++ b/crates/tiangong-entry/src/lib.rs
@@ -1,5 +1,6 @@
 mod args;
 mod mcp;
+mod memory;
 mod model;
 mod prompt;
 mod server;
@@ -30,6 +31,7 @@ pub fn run() -> anyhow::Result<()> {
         Some(MainCommand::Server(args)) => server::run_server_command(args),
         Some(MainCommand::Mcp(args)) => mcp::run_mcp_command(args),
         Some(MainCommand::Model(args)) => model::run_model_command(args),
+        Some(MainCommand::Memory(args)) => memory::run_memory_command(args),
         Some(MainCommand::Skill(args)) => skill::run_skill_command(args),
         Some(MainCommand::Prompt(args)) => prompt::run_prompt_command(args),
         Some(MainCommand::Update(args)) => update::run_update_command(args),

--- a/crates/tiangong-entry/src/lib.rs
+++ b/crates/tiangong-entry/src/lib.rs
@@ -5,6 +5,7 @@ mod mcp;
 mod memory;
 mod model;
 mod prompt;
+mod secrets;
 mod server;
 mod skill;
 mod update;

--- a/crates/tiangong-entry/src/lib.rs
+++ b/crates/tiangong-entry/src/lib.rs
@@ -1,4 +1,6 @@
 mod args;
+mod config;
+mod doctor;
 mod mcp;
 mod memory;
 mod model;
@@ -34,6 +36,8 @@ pub fn run() -> anyhow::Result<()> {
         Some(MainCommand::Memory(args)) => memory::run_memory_command(args),
         Some(MainCommand::Skill(args)) => skill::run_skill_command(args),
         Some(MainCommand::Prompt(args)) => prompt::run_prompt_command(args),
+        Some(MainCommand::Config(args)) => config::run_config_command(args),
+        Some(MainCommand::Doctor(args)) => doctor::run_doctor_command(args),
         Some(MainCommand::Update(args)) => update::run_update_command(args),
         Some(MainCommand::Cli { trust_mode }) => {
             tiangong_cli::run_cli_with_trust_mode(trust_mode.map(|m| m.to_trust_mode()))

--- a/crates/tiangong-entry/src/lib.rs
+++ b/crates/tiangong-entry/src/lib.rs
@@ -1,6 +1,8 @@
 mod args;
 mod config;
+mod configure;
 mod doctor;
+mod interactive;
 mod mcp;
 mod memory;
 mod model;

--- a/crates/tiangong-entry/src/lib.rs
+++ b/crates/tiangong-entry/src/lib.rs
@@ -1,5 +1,6 @@
 mod args;
 mod mcp;
+mod model;
 mod prompt;
 mod server;
 mod skill;
@@ -28,6 +29,7 @@ pub fn run() -> anyhow::Result<()> {
     match args.command {
         Some(MainCommand::Server(args)) => server::run_server_command(args),
         Some(MainCommand::Mcp(args)) => mcp::run_mcp_command(args),
+        Some(MainCommand::Model(args)) => model::run_model_command(args),
         Some(MainCommand::Skill(args)) => skill::run_skill_command(args),
         Some(MainCommand::Prompt(args)) => prompt::run_prompt_command(args),
         Some(MainCommand::Update(args)) => update::run_update_command(args),

--- a/crates/tiangong-entry/src/lib.rs
+++ b/crates/tiangong-entry/src/lib.rs
@@ -1,5 +1,6 @@
 mod args;
 mod mcp;
+mod prompt;
 mod server;
 mod skill;
 mod update;
@@ -28,6 +29,7 @@ pub fn run() -> anyhow::Result<()> {
         Some(MainCommand::Server(args)) => server::run_server_command(args),
         Some(MainCommand::Mcp(args)) => mcp::run_mcp_command(args),
         Some(MainCommand::Skill(args)) => skill::run_skill_command(args),
+        Some(MainCommand::Prompt(args)) => prompt::run_prompt_command(args),
         Some(MainCommand::Update(args)) => update::run_update_command(args),
         Some(MainCommand::Cli { trust_mode }) => {
             tiangong_cli::run_cli_with_trust_mode(trust_mode.map(|m| m.to_trust_mode()))

--- a/crates/tiangong-entry/src/memory.rs
+++ b/crates/tiangong-entry/src/memory.rs
@@ -64,8 +64,8 @@ fn run_config(command: MemoryConfigSubcommand) -> Result<()> {
 
 /// 从 models.json 引用模型，构建 Memory LLM 端点配置。
 ///
-/// Memory LLM 用于记忆反刍/总结，允许 chat 或 embedding 能力的模型
-/// （实际更宽松，因为很多 OpenAI 兼容端点同时支持 chat 与轻量总结）。
+/// Memory LLM 用于记忆反刍/总结，要求 chat 能力（embedding/rerank 模型
+/// 不适合做文本总结，会被 lookup_model_for_llm 拒绝）。
 fn resolve_to_llm_endpoint(model_name: &str, models: &ModelsConfig) -> Result<MemoryLlmConfig> {
     let (provider_name, provider, model_id) = lookup_model_for_llm(models, model_name)?;
     Ok(MemoryLlmConfig {

--- a/crates/tiangong-entry/src/memory.rs
+++ b/crates/tiangong-entry/src/memory.rs
@@ -11,6 +11,7 @@ use crate::args::{MemoryArgs, MemoryConfigSubcommand, MemorySubcommand};
 pub(crate) fn run_memory_command(args: MemoryArgs) -> Result<()> {
     match args.command {
         MemorySubcommand::Config { command } => run_config(command),
+        MemorySubcommand::Configure => super::configure::run_memory_configure(),
         MemorySubcommand::Enable => {
             enable_memory()?;
             println!("Memory 已启用");

--- a/crates/tiangong-entry/src/memory.rs
+++ b/crates/tiangong-entry/src/memory.rs
@@ -1,0 +1,291 @@
+use anyhow::{Result, anyhow};
+
+use tiangong_core::models_config::{ModelsConfig, ProviderConfig};
+use tiangong_memory::{
+    MemoryConfig, MemoryEmbeddingConfig, MemoryLlmConfig, MemoryRerankConfig, disable_memory,
+    enable_memory, is_memory_disabled,
+};
+
+use crate::args::{MemoryArgs, MemoryConfigSubcommand, MemorySubcommand};
+
+pub(crate) fn run_memory_command(args: MemoryArgs) -> Result<()> {
+    match args.command {
+        MemorySubcommand::Config { command } => run_config(command),
+        MemorySubcommand::Enable => {
+            enable_memory()?;
+            println!("Memory 已启用");
+            Ok(())
+        }
+        MemorySubcommand::Disable => {
+            disable_memory()?;
+            println!("Memory 已禁用");
+            Ok(())
+        }
+        MemorySubcommand::Status => {
+            print_status();
+            Ok(())
+        }
+        MemorySubcommand::Test => {
+            test_memory();
+            Ok(())
+        }
+    }
+}
+
+fn run_config(command: MemoryConfigSubcommand) -> Result<()> {
+    let config = MemoryConfig::load_or_default();
+    match command {
+        MemoryConfigSubcommand::Show => {
+            print_config(&config);
+        }
+        MemoryConfigSubcommand::Set {
+            llm,
+            embedding,
+            rerank,
+        } => {
+            if llm.is_none() && embedding.is_none() && rerank.is_none() {
+                return Err(anyhow!("请至少指定 --llm / --embedding / --rerank 之一"));
+            }
+            let mut config = config;
+            let models = ModelsConfig::load();
+
+            if let Some(name) = llm {
+                config.model = Some(resolve_to_llm_endpoint(&name, &models)?);
+            }
+            if let Some(name) = embedding {
+                config.embedding = Some(resolve_to_embedding_endpoint(&name, &models)?);
+            }
+            if let Some(name) = rerank {
+                config.rerank = Some(resolve_to_rerank_endpoint(&name, &models)?);
+            }
+            config.save()?;
+            println!("Memory 配置已更新");
+        }
+    }
+    Ok(())
+}
+
+/// 从 models.json 引用模型，构建 Memory LLM 端点配置。
+fn resolve_to_llm_endpoint(model_name: &str, models: &ModelsConfig) -> Result<MemoryLlmConfig> {
+    let (provider_name, provider, model_id) = lookup_model(models, model_name)?;
+    Ok(MemoryLlmConfig {
+        provider_key: Some(provider_name),
+        base_url: provider.base_url.clone(),
+        api_key: provider.api_key.clone(),
+        model: model_id,
+        protocol: provider.protocol,
+        timeout_ms: provider.timeout_ms,
+    })
+}
+
+/// 从 models.json 引用模型，构建 Memory Embedding 端点配置。
+fn resolve_to_embedding_endpoint(
+    model_name: &str,
+    models: &ModelsConfig,
+) -> Result<MemoryEmbeddingConfig> {
+    let (provider_name, provider, model_id) = lookup_model(models, model_name)?;
+    Ok(MemoryEmbeddingConfig {
+        provider_key: Some(provider_name),
+        base_url: provider.base_url.clone(),
+        api_key: provider.api_key.clone(),
+        model: model_id,
+        protocol: provider.protocol,
+        timeout_ms: provider.timeout_ms,
+        dimension: 0,
+    })
+}
+
+/// 从 models.json 引用模型，构建 Memory Rerank 端点配置。
+fn resolve_to_rerank_endpoint(
+    model_name: &str,
+    models: &ModelsConfig,
+) -> Result<MemoryRerankConfig> {
+    let (provider_name, provider, model_id) = lookup_model(models, model_name)?;
+    Ok(MemoryRerankConfig {
+        provider_key: Some(provider_name),
+        base_url: provider.base_url.clone(),
+        api_key: provider.api_key.clone(),
+        model: model_id,
+        protocol: provider.protocol,
+        timeout_ms: provider.timeout_ms,
+    })
+}
+
+/// 在 models.json 注册表中查找模型，返回 (provider_name, provider_config, model_id)。
+fn lookup_model(models: &ModelsConfig, name: &str) -> Result<(String, ProviderConfig, String)> {
+    let entry = models.models.get(name).ok_or_else(|| {
+        anyhow!("模型 {name} 不存在于 models.json，请先 `tiangong model add-model {name} ...`")
+    })?;
+    let provider = models
+        .providers
+        .get(&entry.provider)
+        .ok_or_else(|| anyhow!("模型 {name} 的 provider {} 不存在", entry.provider))?;
+    Ok((
+        entry.provider.clone(),
+        provider.clone(),
+        entry.model.clone(),
+    ))
+}
+
+fn print_config(config: &MemoryConfig) {
+    println!("== Memory 配置 ==");
+    println!(
+        "启用状态：{}",
+        if is_memory_disabled() {
+            "\x1b[31m禁用\x1b[0m"
+        } else {
+            "\x1b[32m启用\x1b[0m"
+        }
+    );
+    println!("vector_mode: {:?}", config.vector_mode);
+
+    println!("\n-- LLM 端点 --");
+    match &config.model {
+        Some(m) => {
+            println!("  base_url: {}", m.base_url);
+            println!("  model: {}", m.model);
+            println!("  protocol: {}", m.protocol.as_str());
+            println!("  timeout_ms: {}", m.timeout_ms);
+        }
+        None => println!("  （未配置）"),
+    }
+
+    println!("\n-- Embedding 端点 --");
+    match &config.embedding {
+        Some(e) => {
+            println!("  base_url: {}", e.base_url);
+            println!("  model: {}", e.model);
+            println!("  dimension: {}", e.dimension);
+        }
+        None => println!("  （未配置）"),
+    }
+
+    println!("\n-- Rerank 端点 --");
+    match &config.rerank {
+        Some(r) => {
+            println!("  base_url: {}", r.base_url);
+            println!("  model: {}", r.model);
+        }
+        None => println!("  （未配置）"),
+    }
+}
+
+fn print_status() {
+    let config = MemoryConfig::load_or_default();
+    let disabled = is_memory_disabled();
+    let llm_valid = config
+        .model
+        .as_ref()
+        .map(|m| endpoint_valid(&m.base_url, &m.api_key, &m.model))
+        .unwrap_or(false);
+
+    println!("禁用标记：{}", if disabled { "存在" } else { "无" });
+    println!(
+        "启用状态：{}",
+        if !disabled && llm_valid {
+            "\x1b[32m已启用且配置有效\x1b[0m"
+        } else if disabled {
+            "\x1b[31m已禁用\x1b[0m"
+        } else {
+            "\x1b[33m启用但 LLM 端点未配置或无效\x1b[0m"
+        }
+    );
+    println!("vector_mode: {:?}", config.vector_mode);
+    println!(
+        "LLM 端点：{}",
+        config
+            .model
+            .as_ref()
+            .map(|m| format!("{} @ {}", m.model, m.base_url))
+            .unwrap_or_else(|| "（未配置）".to_string())
+    );
+    println!(
+        "Embedding 端点：{}",
+        config
+            .embedding
+            .as_ref()
+            .map(|e| format!("{} (dim={})", e.model, e.dimension))
+            .unwrap_or_else(|| "（未配置）".to_string())
+    );
+    println!(
+        "Rerank 端点：{}",
+        config
+            .rerank
+            .as_ref()
+            .map(|r| r.model.clone())
+            .unwrap_or_else(|| "（未配置）".to_string())
+    );
+}
+
+fn endpoint_valid(base_url: &str, api_key: &str, model: &str) -> bool {
+    !base_url.trim().is_empty() && !api_key.trim().is_empty() && !model.trim().is_empty()
+}
+
+/// 测试 Memory 配置完整性。
+///
+/// 校验 Memory 端点配置是否完整（base_url/api_key/model 非空），
+/// 并验证引用的模型在 models.json 中存在。真实连通性测试由
+/// `tiangong model test` 覆盖（端点最终来自 models.json）。
+fn test_memory() {
+    let config = MemoryConfig::load_or_default();
+    if is_memory_disabled() {
+        println!("⚠️  Memory 当前已被禁用（`tiangong memory enable` 可重新启用）");
+    }
+
+    println!("== Memory 配置测试 ==");
+
+    let mut issues = Vec::new();
+
+    // LLM 端点
+    match &config.model {
+        Some(m) if endpoint_valid(&m.base_url, &m.api_key, &m.model) => {
+            println!("✅ LLM 端点有效：{} @ {}", m.model, m.base_url);
+        }
+        Some(_) => {
+            issues.push("LLM 端点配置不完整（base_url/api_key/model 不能为空）".to_string());
+        }
+        None => {
+            issues.push("未配置 LLM 端点".to_string());
+        }
+    }
+
+    // Embedding 端点（可选）
+    match &config.embedding {
+        Some(e) if endpoint_valid(&e.base_url, &e.api_key, &e.model) => {
+            if e.dimension == 0 {
+                println!("⚠️  Embedding 端点有效但 dimension=0（向量维度未设置）");
+            } else {
+                println!("✅ Embedding 端点有效：{} (dim={})", e.model, e.dimension);
+            }
+        }
+        Some(_) => {
+            issues.push("Embedding 端点配置不完整".to_string());
+        }
+        None => {
+            println!("ℹ️  未配置 Embedding 端点（可选，缺失会降级）");
+        }
+    }
+
+    // Rerank 端点（可选）
+    match &config.rerank {
+        Some(r) if endpoint_valid(&r.base_url, &r.api_key, &r.model) => {
+            println!("✅ Rerank 端点有效：{}", r.model);
+        }
+        Some(_) => {
+            issues.push("Rerank 端点配置不完整".to_string());
+        }
+        None => {
+            println!("ℹ️  未配置 Rerank 端点（可选，缺失会降级）");
+        }
+    }
+
+    if issues.is_empty() {
+        println!("\n✅ Memory 配置测试通过");
+        println!("（如需验证真实连通性，可对引用的模型执行 `tiangong model test <模型名>`）");
+    } else {
+        println!("\n❌ Memory 配置测试未通过：");
+        for issue in &issues {
+            println!("  - {issue}");
+        }
+    }
+}

--- a/crates/tiangong-entry/src/memory.rs
+++ b/crates/tiangong-entry/src/memory.rs
@@ -245,12 +245,12 @@ fn print_status() {
     println!("禁用标记：{}", if disabled { "存在" } else { "无" });
     println!(
         "启用状态：{}",
-        if !disabled && llm_valid {
-            "\x1b[32m已启用且配置有效\x1b[0m"
-        } else if disabled {
+        if disabled {
             "\x1b[31m已禁用\x1b[0m"
+        } else if llm_valid {
+            "\x1b[32m已启用且配置有效\x1b[0m"
         } else {
-            "\x1b[33m启用但 LLM 端点未配置或无效\x1b[0m"
+            "\x1b[33m已启用（LLM 未配置，将降级为规则策略）\x1b[0m"
         }
     );
     println!("vector_mode: {:?}", config.vector_mode);

--- a/crates/tiangong-entry/src/memory.rs
+++ b/crates/tiangong-entry/src/memory.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 
-use tiangong_core::models_config::{ModelsConfig, ProviderConfig};
+use tiangong_core::models_config::{ModelCapability, ModelsConfig, ProviderConfig};
 use tiangong_memory::{
     MemoryConfig, MemoryEmbeddingConfig, MemoryLlmConfig, MemoryRerankConfig, disable_memory,
     enable_memory, is_memory_disabled,
@@ -25,10 +25,7 @@ pub(crate) fn run_memory_command(args: MemoryArgs) -> Result<()> {
             print_status();
             Ok(())
         }
-        MemorySubcommand::Test => {
-            test_memory();
-            Ok(())
-        }
+        MemorySubcommand::Test => test_memory(),
     }
 }
 
@@ -66,8 +63,11 @@ fn run_config(command: MemoryConfigSubcommand) -> Result<()> {
 }
 
 /// 从 models.json 引用模型，构建 Memory LLM 端点配置。
+///
+/// Memory LLM 用于记忆反刍/总结，允许 chat 或 embedding 能力的模型
+/// （实际更宽松，因为很多 OpenAI 兼容端点同时支持 chat 与轻量总结）。
 fn resolve_to_llm_endpoint(model_name: &str, models: &ModelsConfig) -> Result<MemoryLlmConfig> {
-    let (provider_name, provider, model_id) = lookup_model(models, model_name)?;
+    let (provider_name, provider, model_id) = lookup_model_for_llm(models, model_name)?;
     Ok(MemoryLlmConfig {
         provider_key: Some(provider_name),
         base_url: provider.base_url.clone(),
@@ -83,7 +83,8 @@ fn resolve_to_embedding_endpoint(
     model_name: &str,
     models: &ModelsConfig,
 ) -> Result<MemoryEmbeddingConfig> {
-    let (provider_name, provider, model_id) = lookup_model(models, model_name)?;
+    let (provider_name, provider, model_id) =
+        lookup_model_with_capability(models, model_name, ModelCapability::Embedding)?;
     Ok(MemoryEmbeddingConfig {
         provider_key: Some(provider_name),
         base_url: provider.base_url.clone(),
@@ -100,7 +101,8 @@ fn resolve_to_rerank_endpoint(
     model_name: &str,
     models: &ModelsConfig,
 ) -> Result<MemoryRerankConfig> {
-    let (provider_name, provider, model_id) = lookup_model(models, model_name)?;
+    let (provider_name, provider, model_id) =
+        lookup_model_with_capability(models, model_name, ModelCapability::Rerank)?;
     Ok(MemoryRerankConfig {
         provider_key: Some(provider_name),
         base_url: provider.base_url.clone(),
@@ -112,7 +114,11 @@ fn resolve_to_rerank_endpoint(
 }
 
 /// 在 models.json 注册表中查找模型，返回 (provider_name, provider_config, model_id)。
-fn lookup_model(models: &ModelsConfig, name: &str) -> Result<(String, ProviderConfig, String)> {
+/// 在 models.json 注册表中查找模型，返回 (provider_name, provider_config, model_id)。
+fn lookup_model_entry<'a>(
+    models: &'a ModelsConfig,
+    name: &str,
+) -> Result<(&'a str, &'a ProviderConfig, &'a str)> {
     let entry = models.models.get(name).ok_or_else(|| {
         anyhow!("模型 {name} 不存在于 models.json，请先 `tiangong model add-model {name} ...`")
     })?;
@@ -120,10 +126,67 @@ fn lookup_model(models: &ModelsConfig, name: &str) -> Result<(String, ProviderCo
         .providers
         .get(&entry.provider)
         .ok_or_else(|| anyhow!("模型 {name} 的 provider {} 不存在", entry.provider))?;
+    Ok((&entry.provider, provider, &entry.model))
+}
+
+/// 查找模型并校验其具备指定 capability。
+fn lookup_model_with_capability(
+    models: &ModelsConfig,
+    name: &str,
+    expected: ModelCapability,
+) -> Result<(String, ProviderConfig, String)> {
+    let (provider_name, provider, model_id) = lookup_model_entry(models, name)?;
+    let entry = &models.models[name];
+    if !entry.capabilities.contains(&expected) {
+        let current = if entry.capabilities.is_empty() {
+            "无".to_string()
+        } else {
+            entry
+                .capabilities
+                .iter()
+                .map(|c| c.key())
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+        return Err(anyhow!(
+            "模型 {name} 不具备 {} 能力（当前能力：{current}）",
+            expected.key()
+        ));
+    }
     Ok((
-        entry.provider.clone(),
+        provider_name.to_string(),
         provider.clone(),
-        entry.model.clone(),
+        model_id.to_string(),
+    ))
+}
+
+/// 查找模型供 Memory LLM 使用（校验 chat 能力，最常见场景）。
+fn lookup_model_for_llm(
+    models: &ModelsConfig,
+    name: &str,
+) -> Result<(String, ProviderConfig, String)> {
+    let (provider_name, provider, model_id) = lookup_model_entry(models, name)?;
+    let entry = &models.models[name];
+    // Memory LLM 宽松校验：具备 chat 能力即可（embedding/rerank 模型不适合做 LLM 总结）
+    if !entry.capabilities.contains(&ModelCapability::Chat) {
+        let current = if entry.capabilities.is_empty() {
+            "无".to_string()
+        } else {
+            entry
+                .capabilities
+                .iter()
+                .map(|c| c.key())
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+        return Err(anyhow!(
+            "模型 {name} 不具备 chat 能力，不适合作为 Memory LLM（当前能力：{current}）"
+        ));
+    }
+    Ok((
+        provider_name.to_string(),
+        provider.clone(),
+        model_id.to_string(),
     ))
 }
 
@@ -221,12 +284,26 @@ fn endpoint_valid(base_url: &str, api_key: &str, model: &str) -> bool {
     !base_url.trim().is_empty() && !api_key.trim().is_empty() && !model.trim().is_empty()
 }
 
+/// 检查端点的 `${ENV}` 密钥是否可解析，不可解析返回错误描述。
+fn endpoint_secret_issue(label: &str, api_key: &str) -> Option<String> {
+    use crate::secrets::env_secret_resolvable;
+    let (ok, var) = env_secret_resolvable(api_key);
+    if ok {
+        None
+    } else {
+        Some(format!(
+            "{label} 密钥环境变量 {} 未设置",
+            var.unwrap_or_default()
+        ))
+    }
+}
+
 /// 测试 Memory 配置完整性。
 ///
 /// 校验 Memory 端点配置是否完整（base_url/api_key/model 非空），
-/// 并验证引用的模型在 models.json 中存在。真实连通性测试由
+/// 并验证 `${ENV}` 密钥可解析到真实值。真实连通性测试由
 /// `tiangong model test` 覆盖（端点最终来自 models.json）。
-fn test_memory() {
+fn test_memory() -> Result<()> {
     let config = MemoryConfig::load_or_default();
     if is_memory_disabled() {
         println!("⚠️  Memory 当前已被禁用（`tiangong memory enable` 可重新启用）");
@@ -239,7 +316,11 @@ fn test_memory() {
     // LLM 端点
     match &config.model {
         Some(m) if endpoint_valid(&m.base_url, &m.api_key, &m.model) => {
-            println!("✅ LLM 端点有效：{} @ {}", m.model, m.base_url);
+            if let Some(issue) = endpoint_secret_issue("LLM 端点", &m.api_key) {
+                issues.push(issue);
+            } else {
+                println!("✅ LLM 端点有效：{} @ {}", m.model, m.base_url);
+            }
         }
         Some(_) => {
             issues.push("LLM 端点配置不完整（base_url/api_key/model 不能为空）".to_string());
@@ -252,7 +333,9 @@ fn test_memory() {
     // Embedding 端点（可选）
     match &config.embedding {
         Some(e) if endpoint_valid(&e.base_url, &e.api_key, &e.model) => {
-            if e.dimension == 0 {
+            if let Some(issue) = endpoint_secret_issue("Embedding 端点", &e.api_key) {
+                issues.push(issue);
+            } else if e.dimension == 0 {
                 println!("⚠️  Embedding 端点有效但 dimension=0（向量维度未设置）");
             } else {
                 println!("✅ Embedding 端点有效：{} (dim={})", e.model, e.dimension);
@@ -269,7 +352,11 @@ fn test_memory() {
     // Rerank 端点（可选）
     match &config.rerank {
         Some(r) if endpoint_valid(&r.base_url, &r.api_key, &r.model) => {
-            println!("✅ Rerank 端点有效：{}", r.model);
+            if let Some(issue) = endpoint_secret_issue("Rerank 端点", &r.api_key) {
+                issues.push(issue);
+            } else {
+                println!("✅ Rerank 端点有效：{}", r.model);
+            }
         }
         Some(_) => {
             issues.push("Rerank 端点配置不完整".to_string());
@@ -282,10 +369,12 @@ fn test_memory() {
     if issues.is_empty() {
         println!("\n✅ Memory 配置测试通过");
         println!("（如需验证真实连通性，可对引用的模型执行 `tiangong model test <模型名>`）");
+        Ok(())
     } else {
         println!("\n❌ Memory 配置测试未通过：");
         for issue in &issues {
             println!("  - {issue}");
         }
+        Err(anyhow!("Memory 配置测试未通过（{} 个问题）", issues.len()))
     }
 }

--- a/crates/tiangong-entry/src/model.rs
+++ b/crates/tiangong-entry/src/model.rs
@@ -1,0 +1,322 @@
+use anyhow::{Context, Result, anyhow};
+
+use tiangong_core::model::SingleProviderClient;
+use tiangong_core::models_config::{ModelCapability, ModelEntry, ModelsConfig, RoutingSlot};
+
+use crate::args::{ModelArgs, ModelSubcommand, RouteSubcommand};
+
+pub(crate) fn run_model_command(args: ModelArgs) -> Result<()> {
+    let mut config = ModelsConfig::load();
+    match args.command {
+        ModelSubcommand::List { scope } => {
+            print_list(&config, scope.as_deref());
+        }
+        ModelSubcommand::AddProvider {
+            name,
+            protocol,
+            base_url,
+            api_key,
+            api_key_env,
+            timeout_ms,
+        } => {
+            let api_key = match (api_key, api_key_env) {
+                (Some(key), None) => key,
+                (None, Some(env_name)) => format!("${{{env_name}}}"),
+                _ => {
+                    return Err(anyhow!(
+                        "请指定 --api-key（明文）或 --api-key-env（环境变量名），二者互斥"
+                    ));
+                }
+            };
+            config.upsert_provider(&name, &base_url, &api_key, protocol, timeout_ms);
+            config.save()?;
+            println!("已保存供应商 {name}");
+        }
+        ModelSubcommand::RemoveProvider { name, force } => {
+            if !config.providers.contains_key(&name) {
+                return Err(anyhow!("供应商 {name} 不存在"));
+            }
+            let refs = config.provider_referenced_by(&name);
+            if !refs.models.is_empty() || !refs.routes.is_empty() {
+                if !force {
+                    eprintln!("供应商 {name} 被以下配置引用：");
+                    if !refs.models.is_empty() {
+                        eprintln!("  模型：{}", refs.models.join(", "));
+                    }
+                    if !refs.routes.is_empty() {
+                        eprintln!("  路由：{}", refs.routes.join(", "));
+                    }
+                    return Err(anyhow!("请使用 --force 强制删除，或先移除引用"));
+                }
+                let removed = config.remove_provider_force(&name);
+                config.save()?;
+                println!("已强制删除供应商 {name}（连带移除 {removed} 项）");
+                return Ok(());
+            }
+            config.providers.remove(&name);
+            config.save()?;
+            println!("已删除供应商 {name}");
+        }
+        ModelSubcommand::AddModel {
+            name,
+            provider,
+            model_id,
+            capability,
+        } => {
+            if !config.providers.contains_key(&provider) {
+                return Err(anyhow!(
+                    "供应商 {provider} 不存在，请先 `tiangong model add-provider {provider} ...`"
+                ));
+            }
+            let capabilities = parse_capabilities(&capability)?;
+            config.upsert_model(&name, &provider, &model_id, capabilities.clone());
+            config.save()?;
+            let cap_str = if capabilities.is_empty() {
+                "（无显式能力）".to_string()
+            } else {
+                capabilities
+                    .iter()
+                    .map(|c| c.key())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            };
+            println!(
+                "已保存模型 {name}（provider={provider}, model_id={model_id}, capability={cap_str}）"
+            );
+        }
+        ModelSubcommand::RemoveModel { name } => {
+            let (removed, dangling) = config.remove_model(&name);
+            if !removed {
+                return Err(anyhow!("模型 {name} 不存在"));
+            }
+            config.save()?;
+            if dangling.is_empty() {
+                println!("已删除模型 {name}");
+            } else {
+                println!(
+                    "已删除模型 {name}（注意以下路由变为悬空：{}）",
+                    dangling.join(",")
+                );
+            }
+        }
+        ModelSubcommand::Route { command } => match command {
+            RouteSubcommand::List => print_routes(&config),
+            RouteSubcommand::Set { capability, model } => {
+                let slot = parse_slot(&capability)?;
+                config
+                    .set_route_by_name(slot, &model)
+                    .map_err(|e| anyhow!(e))?;
+                config.save()?;
+                println!("已设置路由 {capability} -> {model}");
+            }
+        },
+        ModelSubcommand::Validate => {
+            validate(&config)?;
+            println!("模型配置校验通过");
+        }
+        ModelSubcommand::Test { target } => {
+            test_model(&config, target.as_deref())?;
+        }
+    }
+    Ok(())
+}
+
+fn print_list(config: &ModelsConfig, scope: Option<&str>) {
+    match scope {
+        Some("providers") => print_providers(config),
+        Some("models") => print_models(config),
+        Some("routes") => print_routes(config),
+        Some(other) => {
+            eprintln!("无效的范围：{other}（可用 providers / models / routes）");
+        }
+        None => {
+            print_providers(config);
+            println!();
+            print_models(config);
+            println!();
+            print_routes(config);
+        }
+    }
+}
+
+fn print_providers(config: &ModelsConfig) {
+    println!("== Providers ({}) ==", config.providers.len());
+    if config.providers.is_empty() {
+        println!("（无）");
+        return;
+    }
+    let mut names: Vec<&String> = config.providers.keys().collect();
+    names.sort();
+    for name in names {
+        let p = &config.providers[name];
+        println!(
+            "{name}  protocol={} base_url={} timeout_ms={}",
+            p.protocol.as_str(),
+            p.base_url,
+            p.timeout_ms
+        );
+    }
+}
+
+fn print_models(config: &ModelsConfig) {
+    println!("== Models ({}) ==", config.models.len());
+    if config.models.is_empty() {
+        println!("（无）");
+        return;
+    }
+    let mut names: Vec<&String> = config.models.keys().collect();
+    names.sort();
+    for name in names {
+        let m = &config.models[name];
+        let caps = m
+            .capabilities
+            .iter()
+            .map(|c| c.key())
+            .collect::<Vec<_>>()
+            .join(",");
+        println!(
+            "{name}  provider={} model={} capability={}",
+            m.provider, m.model, caps
+        );
+    }
+}
+
+fn print_routes(config: &ModelsConfig) {
+    println!("== Routing ==");
+    if config.routing.is_empty() {
+        println!("（无）");
+        return;
+    }
+    // RoutingSlot 未实现 Ord，按 RoutingSlot::all() 的固定顺序输出
+    for slot in RoutingSlot::all() {
+        if let Some(entry) = config.routing.get(slot) {
+            println!("{}  ->  {} ({})", slot.key(), entry.model, entry.provider);
+        }
+    }
+}
+
+fn validate(config: &ModelsConfig) -> Result<()> {
+    let mut errors = Vec::new();
+
+    // 检查路由引用的 provider 是否存在
+    for (slot, entry) in &config.routing {
+        if !config.providers.contains_key(&entry.provider) {
+            errors.push(format!(
+                "路由 {} 引用了不存在的 provider {}",
+                slot.key(),
+                entry.provider
+            ));
+        }
+    }
+
+    // 检查 models 注册项引用的 provider 是否存在
+    for (name, entry) in &config.models {
+        if !config.providers.contains_key(&entry.provider) {
+            errors.push(format!(
+                "模型 {name} 引用了不存在的 provider {}",
+                entry.provider
+            ));
+        }
+    }
+
+    // chat 路由建议配置
+    if !config.has_chat() {
+        errors.push("未配置 chat 路由（建议 `tiangong model route chat <model>`）".to_string());
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        for e in &errors {
+            eprintln!("❌ {e}");
+        }
+        Err(anyhow!("模型配置校验未通过（{} 个问题）", errors.len()))
+    }
+}
+
+fn test_model(config: &ModelsConfig, target: Option<&str>) -> Result<()> {
+    // target 为 capability/槽位（如 chat）或模型名；默认 chat
+    let target = target.unwrap_or("chat");
+    let provider_config = if let Some(slot) = RoutingSlot::from_key(target) {
+        // 作为路由槽位解析
+        match slot {
+            RoutingSlot::Chat => config.to_chat_provider_config(),
+            RoutingSlot::Lite => config.to_lite_provider_config(),
+            _ => {
+                // 其他槽位（multimodal/embedding 等）尝试按槽位解析
+                let resolved = config
+                    .resolve_slot(slot)
+                    .ok_or_else(|| anyhow!("路由槽位 {target} 未配置"))?;
+                build_provider_config_from_resolved(&resolved)
+            }
+        }
+    } else {
+        // 作为模型名解析
+        let entry: &ModelEntry = config
+            .models
+            .get(target)
+            .ok_or_else(|| anyhow!("模型 {target} 不存在，也不是有效路由槽位"))?;
+        let provider = config
+            .providers
+            .get(&entry.provider)
+            .ok_or_else(|| anyhow!("模型 {target} 的 provider {} 不存在", entry.provider))?;
+        let resolved_api_key = ModelsConfig::resolve_api_key(&provider.api_key);
+        build_provider_config(provider, entry, resolved_api_key)
+    };
+
+    println!("正在测试 {target} 连通性...");
+    let models =
+        SingleProviderClient::list_models(&provider_config).context("模型连通性测试失败")?;
+    println!("✅ 连通成功，返回 {} 个模型", models.len());
+    if !models.is_empty() {
+        let preview: Vec<&str> = models.iter().take(10).map(|s| s.as_str()).collect();
+        println!("前 {} 个：{}", preview.len(), preview.join(", "));
+    }
+    Ok(())
+}
+
+/// 从 ProviderConfig + ModelEntry 构建单次测试用的 ModelProviderConfig。
+fn build_provider_config(
+    provider: &tiangong_core::models_config::ProviderConfig,
+    entry: &ModelEntry,
+    api_key: String,
+) -> tiangong_core::model::ModelProviderConfig {
+    tiangong_core::model::ModelProviderConfig {
+        api_auth_token: api_key,
+        api_base_url: provider.base_url.clone(),
+        api_timeout_ms: provider.timeout_ms.to_string(),
+        api_protocol: provider.protocol,
+        api_model: entry.model.clone(),
+        api_lite_model: String::new(),
+    }
+}
+
+/// 从 ResolvedModel 构建 ModelProviderConfig。
+fn build_provider_config_from_resolved(
+    resolved: &tiangong_core::models_config::ResolvedModel,
+) -> tiangong_core::model::ModelProviderConfig {
+    tiangong_core::model::ModelProviderConfig {
+        api_auth_token: resolved.api_key.clone(),
+        api_base_url: resolved.base_url.clone(),
+        api_timeout_ms: resolved.timeout_ms.to_string(),
+        api_protocol: resolved.protocol,
+        api_model: resolved.model.clone(),
+        api_lite_model: String::new(),
+    }
+}
+
+fn parse_capabilities(raw: &[String]) -> Result<Vec<ModelCapability>> {
+    let mut result = Vec::new();
+    for item in raw {
+        let cap = ModelCapability::from_key(item).ok_or_else(|| anyhow!("无效的能力 {item}"))?;
+        if !result.contains(&cap) {
+            result.push(cap);
+        }
+    }
+    Ok(result)
+}
+
+fn parse_slot(raw: &str) -> Result<RoutingSlot> {
+    RoutingSlot::from_key(raw)
+        .ok_or_else(|| anyhow!("无效的路由槽位 {raw}（可用 chat/lite/multimodal/image_generation/video_generation/stt/tts/embedding/rerank）"))
+}

--- a/crates/tiangong-entry/src/model.rs
+++ b/crates/tiangong-entry/src/model.rs
@@ -224,7 +224,7 @@ fn validate(config: &ModelsConfig) -> Result<()> {
 
     // chat 路由建议配置
     if !config.has_chat() {
-        errors.push("未配置 chat 路由（建议 `tiangong model route chat <model>`）".to_string());
+        errors.push("未配置 chat 路由（建议 `tiangong model route set chat <model>`）".to_string());
     }
 
     if errors.is_empty() {

--- a/crates/tiangong-entry/src/model.rs
+++ b/crates/tiangong-entry/src/model.rs
@@ -265,6 +265,12 @@ fn test_model(config: &ModelsConfig, target: Option<&str>) -> Result<()> {
     };
 
     println!("正在测试 {target} 连通性...");
+    // 请求前检查 API Key 非空（${ENV} 未设置会解析为空串，避免无效请求）
+    if provider_config.api_auth_token.trim().is_empty() {
+        return Err(anyhow!(
+            "API Key 为空，可能是环境变量未设置。请检查 models.json 中的 api_key 或设置对应环境变量"
+        ));
+    }
     let models =
         SingleProviderClient::list_models(&provider_config).context("模型连通性测试失败")?;
     println!("✅ 连通成功，返回 {} 个模型", models.len());

--- a/crates/tiangong-entry/src/model.rs
+++ b/crates/tiangong-entry/src/model.rs
@@ -99,6 +99,9 @@ pub(crate) fn run_model_command(args: ModelArgs) -> Result<()> {
                 );
             }
         }
+        ModelSubcommand::Configure => {
+            super::configure::run_model_configure(&mut config)?;
+        }
         ModelSubcommand::Route { command } => match command {
             RouteSubcommand::List => print_routes(&config),
             RouteSubcommand::Set { capability, model } => {

--- a/crates/tiangong-entry/src/prompt.rs
+++ b/crates/tiangong-entry/src/prompt.rs
@@ -1,0 +1,106 @@
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow};
+
+use tiangong_core::app_state::TiangongState;
+
+use crate::args::{PromptArgs, PromptSubcommand};
+
+pub(crate) fn run_prompt_command(args: PromptArgs) -> Result<()> {
+    let mut state = TiangongState::load_or_default();
+    match args.command {
+        PromptSubcommand::Show => {
+            let prompt = state.custom_system_prompt();
+            if prompt.trim().is_empty() {
+                println!("（未设置自定义 Prompt）");
+            } else {
+                let char_count = prompt.chars().count();
+                println!("{prompt}");
+                println!("\n— 共 {char_count} 字 —");
+            }
+        }
+        PromptSubcommand::Set { text, file } => {
+            let content = match (text, file) {
+                (Some(text), None) => text,
+                (None, Some(path)) => std::fs::read_to_string(&path)
+                    .with_context(|| format!("读取 Prompt 文件失败：{path}"))?,
+                _ => {
+                    return Err(anyhow!("请提供 Prompt 文本或使用 --file 指定文件"));
+                }
+            };
+            let char_count = content.chars().count();
+            state.set_custom_system_prompt(content)?;
+            println!("自定义 Prompt 已保存（{char_count} 字）");
+        }
+        PromptSubcommand::Edit => {
+            let content = edit_via_editor(state.custom_system_prompt().to_string())?;
+            let char_count = content.chars().count();
+            state.set_custom_system_prompt(content)?;
+            println!("自定义 Prompt 已保存（{char_count} 字）");
+        }
+        PromptSubcommand::Clear => {
+            state.set_custom_system_prompt(String::new())?;
+            println!("自定义 Prompt 已清空");
+        }
+        PromptSubcommand::Path => {
+            let path = state.custom_prompt_path();
+            println!("{}", path.display());
+        }
+    }
+    Ok(())
+}
+
+/// 通过 $EDITOR（回退 vim / nano）编辑 Prompt 内容，返回编辑后的文本。
+fn edit_via_editor(initial: String) -> Result<String> {
+    let editor = std::env::var("EDITOR")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+    let candidates: Vec<String> = match editor {
+        Some(editor) => vec![editor],
+        None => vec!["vim".to_string(), "nano".to_string()],
+    };
+
+    // 写入临时文件
+    let mut tmp_path = std::env::temp_dir();
+    tmp_path.push(format!("tiangong-prompt-{}.md", temp_name()));
+    std::fs::write(&tmp_path, &initial)
+        .with_context(|| format!("写入临时文件失败：{}", tmp_path.display()))?;
+
+    let mut launched = false;
+    for candidate in &candidates {
+        let mut cmd = Command::new(candidate);
+        cmd.arg(&tmp_path);
+        let status = match cmd.status() {
+            Ok(status) => status,
+            Err(_) => continue, // 编辑器不存在，尝试下一个
+        };
+        if !status.success() {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(anyhow!("编辑器 {candidate} 退出码异常"));
+        }
+        launched = true;
+        break;
+    }
+
+    if !launched {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(anyhow!(
+            "未找到可用编辑器（$EDITOR 未设置，且 vim/nano 不可用）。请使用 `tiangong prompt set --file <路径>` 或设置 $EDITOR 环境变量。"
+        ));
+    }
+
+    let content = std::fs::read_to_string(&tmp_path)
+        .with_context(|| format!("读取编辑后文件失败：{}", tmp_path.display()))?;
+    let _ = std::fs::remove_file(&tmp_path);
+    Ok(content)
+}
+
+/// 生成临时唯一标识（用 pid + 纳秒时间戳，避免引入额外依赖）。
+fn temp_name() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{}-{}", std::process::id(), nanos)
+}

--- a/crates/tiangong-entry/src/secrets.rs
+++ b/crates/tiangong-entry/src/secrets.rs
@@ -1,0 +1,71 @@
+//! 密钥/Token 的环境变量解析辅助。
+//!
+//! 配置中的 api_key 支持 `${VAR}` 模板引用环境变量。
+//! 结构校验（config validate）只需字段非空；而诊断/测试类命令
+//! （doctor / model test / memory test）需要确保 `${VAR}` 能解析到真实值，
+//! 否则纯服务端最常见的"环境变量未设置"问题无法被发现。
+
+/// 判断 `${VAR}` 引用的环境变量是否可解析（用于诊断报告）。
+///
+/// 返回 `(是否可解析, 解析失败时的变量名)`。
+///
+/// - 非 `${...}` 形式：`(true, None)`。
+/// - `${VAR}` 且变量存在：`(true, None)`。
+/// - `${VAR}` 且变量不存在：`(false, Some("VAR"))`。
+pub fn env_secret_resolvable(value: &str) -> (bool, Option<String>) {
+    let trimmed = value.trim();
+    if let Some(inner) = trimmed.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
+        let var_name = inner.trim();
+        if var_name.is_empty() {
+            return (true, None);
+        }
+        if std::env::var(var_name).is_ok() {
+            (true, None)
+        } else {
+            (false, Some(var_name.to_string()))
+        }
+    } else {
+        (true, None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_value_is_resolvable() {
+        assert_eq!(env_secret_resolvable("sk-plain-key"), (true, None));
+    }
+
+    #[test]
+    fn env_var_resolvable_when_present() {
+        // safety: 测试串行执行，仅设置临时变量后立即清理
+        unsafe {
+            std::env::set_var("TIANGONG_TEST_SECRET_KEY", "resolved-value");
+        }
+        let result = env_secret_resolvable("${TIANGONG_TEST_SECRET_KEY}");
+        // safety: 同上，清理测试变量
+        unsafe {
+            std::env::remove_var("TIANGONG_TEST_SECRET_KEY");
+        }
+        assert_eq!(result, (true, None));
+    }
+
+    #[test]
+    fn env_var_not_resolvable_when_missing() {
+        let result = env_secret_resolvable("${TIANGONG_DEFINITELY_MISSING_VAR_XYZ_123}");
+        assert_eq!(
+            result,
+            (
+                false,
+                Some("TIANGONG_DEFINITELY_MISSING_VAR_XYZ_123".to_string())
+            )
+        );
+    }
+
+    #[test]
+    fn empty_env_name_is_resolvable() {
+        assert_eq!(env_secret_resolvable("${}"), (true, None));
+    }
+}

--- a/crates/tiangong-entry/src/secrets.rs
+++ b/crates/tiangong-entry/src/secrets.rs
@@ -12,12 +12,13 @@
 /// - 非 `${...}` 形式：`(true, None)`。
 /// - `${VAR}` 且变量存在：`(true, None)`。
 /// - `${VAR}` 且变量不存在：`(false, Some("VAR"))`。
+/// - `${}`（空变量名）：视为配置错误 `(false, Some("<empty>"))`。
 pub fn env_secret_resolvable(value: &str) -> (bool, Option<String>) {
     let trimmed = value.trim();
     if let Some(inner) = trimmed.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
         let var_name = inner.trim();
         if var_name.is_empty() {
-            return (true, None);
+            return (false, Some("<empty>".to_string()));
         }
         if std::env::var(var_name).is_ok() {
             (true, None)
@@ -65,7 +66,11 @@ mod tests {
     }
 
     #[test]
-    fn empty_env_name_is_resolvable() {
-        assert_eq!(env_secret_resolvable("${}"), (true, None));
+    fn empty_env_name_is_invalid() {
+        // ${} 空变量名视为配置错误
+        assert_eq!(
+            env_secret_resolvable("${}"),
+            (false, Some("<empty>".to_string()))
+        );
     }
 }

--- a/crates/tiangong-entry/src/server.rs
+++ b/crates/tiangong-entry/src/server.rs
@@ -8,6 +8,7 @@ pub(crate) fn run_server_command(args: ServerArgs) -> Result<()> {
     match args.command {
         // —— 子命令：配置/状态/Token 管理 ——
         Some(ServerSubcommand::Status) => return run_status(),
+        Some(ServerSubcommand::Configure) => return super::configure::run_server_configure(),
         Some(ServerSubcommand::Config { command }) => return run_config(command),
         Some(ServerSubcommand::Token { command }) => return run_token(command),
         // —— 子命令：停止后台进程 ——

--- a/crates/tiangong-entry/src/server.rs
+++ b/crates/tiangong-entry/src/server.rs
@@ -1,11 +1,17 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 
-use crate::args::{ServerArgs, ServerSubcommand};
+use crate::args::{ServerArgs, ServerConfigSubcommand, ServerSubcommand, ServerTokenSubcommand};
 
 pub(crate) fn run_server_command(args: ServerArgs) -> Result<()> {
-    // 处理 stop 子命令
-    if let Some(ServerSubcommand::Stop) = args.command {
-        return tiangong_server::stop_daemon();
+    match args.command {
+        // —— 子命令：配置/状态/Token 管理 ——
+        Some(ServerSubcommand::Status) => return run_status(),
+        Some(ServerSubcommand::Config { command }) => return run_config(command),
+        Some(ServerSubcommand::Token { command }) => return run_token(command),
+        // —— 子命令：停止后台进程 ——
+        Some(ServerSubcommand::Stop) => return tiangong_server::stop_daemon(),
+        // 无子命令：进入启动分支（下方处理 host/port/token/daemon）
+        None => {}
     }
 
     // daemon 模式：后台启动并退出主进程
@@ -15,4 +21,93 @@ pub(crate) fn run_server_command(args: ServerArgs) -> Result<()> {
 
     // 前台运行
     tiangong_server::run_server(&args.host, args.port, args.token)
+}
+
+fn run_config(command: ServerConfigSubcommand) -> Result<()> {
+    use tiangong_config::{load_server_config, save_server_config};
+    match command {
+        ServerConfigSubcommand::Show => {
+            let config = load_server_config();
+            println!("host: {}", config.host);
+            println!("port: {}", config.port);
+            println!("auth_token: {}", config.masked_auth_token());
+        }
+        ServerConfigSubcommand::Set { host, port } => {
+            if host.is_none() && port.is_none() {
+                return Err(anyhow!("请至少指定 --host 或 --port"));
+            }
+            let mut config = load_server_config();
+            if let Some(host) = host {
+                config.host = host;
+            }
+            if let Some(port) = port {
+                config.port = port;
+            }
+            save_server_config(&config)?;
+            println!("Server 配置已更新：{}:{}", config.host, config.port);
+        }
+    }
+    Ok(())
+}
+
+fn run_token(command: ServerTokenSubcommand) -> Result<()> {
+    use tiangong_config::{generate_token, load_server_config, save_server_config};
+    match command {
+        ServerTokenSubcommand::Show => {
+            let config = load_server_config();
+            println!("{}", config.masked_auth_token());
+        }
+        ServerTokenSubcommand::Set { token } => {
+            let mut config = load_server_config();
+            config.auth_token = Some(token);
+            save_server_config(&config)?;
+            println!("Server Token 已设置：{}", config.masked_auth_token());
+        }
+        ServerTokenSubcommand::Generate { length } => {
+            let token = generate_token(length);
+            let mut config = load_server_config();
+            config.auth_token = Some(token);
+            save_server_config(&config)?;
+            println!("已生成新的 Server Token：{}", config.masked_auth_token());
+            println!("（完整 Token 已写入 server.json）");
+        }
+    }
+    Ok(())
+}
+
+fn run_status() -> Result<()> {
+    use tiangong_config::load_server_config;
+    let config = load_server_config();
+    let status = tiangong_server::daemon::server_status(&config.host, config.port);
+
+    println!("Server 配置：{}:{}", config.host, config.port);
+    println!("Token：{}", config.masked_auth_token());
+    println!(
+        "PID 文件：{}",
+        if status.pid_file_exists {
+            "存在"
+        } else {
+            "不存在"
+        }
+    );
+    if let Some(pid) = status.pid {
+        println!("记录 PID：{pid}");
+    }
+    println!(
+        "进程状态：{}",
+        if status.process_alive {
+            "\x1b[32m运行中\x1b[0m"
+        } else {
+            "\x1b[31m未运行\x1b[0m"
+        }
+    );
+    println!(
+        "端口监听：{}",
+        if status.port_listening {
+            "\x1b[32m是\x1b[0m"
+        } else {
+            "\x1b[31m否\x1b[0m"
+        }
+    );
+    Ok(())
 }

--- a/crates/tiangong-entry/src/server.rs
+++ b/crates/tiangong-entry/src/server.rs
@@ -1,5 +1,7 @@
 use anyhow::{Result, anyhow};
 
+use tiangong_config::load_server_config;
+
 use crate::args::{ServerArgs, ServerConfigSubcommand, ServerSubcommand, ServerTokenSubcommand};
 
 pub(crate) fn run_server_command(args: ServerArgs) -> Result<()> {
@@ -14,13 +16,19 @@ pub(crate) fn run_server_command(args: ServerArgs) -> Result<()> {
         None => {}
     }
 
+    // 合并启动参数：命令行 > server.json 保存值 > 默认值
+    let saved = load_server_config();
+    let host = args.host.unwrap_or(saved.host);
+    let port = args.port.unwrap_or(saved.port);
+    let token = args.token.or(saved.auth_token);
+
     // daemon 模式：后台启动并退出主进程
     if args.daemon {
-        return tiangong_server::run_daemon(&args.host, args.port, args.token);
+        return tiangong_server::run_daemon(&host, port, token);
     }
 
     // 前台运行
-    tiangong_server::run_server(&args.host, args.port, args.token)
+    tiangong_server::run_server(&host, port, token)
 }
 
 fn run_config(command: ServerConfigSubcommand) -> Result<()> {

--- a/crates/tiangong-memory/src/config.rs
+++ b/crates/tiangong-memory/src/config.rs
@@ -132,6 +132,48 @@ pub fn default_memory_config_path() -> PathBuf {
     storage_root().join("memory").join("config.json")
 }
 
+/// Memory 禁用标记文件路径：~/.tiangong/memory/.disabled
+///
+/// 用于 `tiangong memory enable/disable` 实现对称开关（RFC 0015 §6.3）。
+/// MemoryConfig 无顶层 enabled 字段，改用此标记文件存在性表示禁用，
+/// 不破坏 MemoryConfig 结构、不丢失端点配置。
+pub fn memory_disabled_marker_path() -> PathBuf {
+    storage_root().join("memory").join(".disabled")
+}
+
+/// 判断 Memory 是否被显式禁用（标记文件存在即禁用）。
+pub fn is_memory_disabled() -> bool {
+    memory_disabled_marker_path().exists()
+}
+
+/// 禁用 Memory（创建标记文件）。
+pub fn disable_memory() -> Result<()> {
+    disable_memory_at(&memory_disabled_marker_path())
+}
+
+/// 在指定路径创建禁用标记（供测试使用）。
+pub fn disable_memory_at(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("创建目录失败：{}", parent.display()))?;
+    }
+    fs::write(path, "disabled by `tiangong memory disable`\n")
+        .with_context(|| format!("写入禁用标记失败：{}", path.display()))
+}
+
+/// 启用 Memory（删除标记文件）。文件不存在视为已启用。
+pub fn enable_memory() -> Result<()> {
+    enable_memory_at(&memory_disabled_marker_path())
+}
+
+/// 在指定路径删除禁用标记（供测试使用）。
+pub fn enable_memory_at(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    fs::remove_file(path).with_context(|| format!("删除禁用标记失败：{}", path.display()))
+}
+
 fn user_home_dir() -> Option<PathBuf> {
     if let Some(home) = std::env::var_os("HOME").filter(|value| !value.is_empty()) {
         return Some(PathBuf::from(home));
@@ -319,5 +361,20 @@ mod tests {
         assert!(options.model.is_none());
         assert!(options.embedding.is_none());
         assert!(options.rerank.is_none());
+    }
+
+    #[test]
+    fn disable_enable_marker_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join(".disabled");
+
+        assert!(!marker.exists());
+        disable_memory_at(&marker).unwrap();
+        assert!(marker.exists());
+
+        enable_memory_at(&marker).unwrap();
+        assert!(!marker.exists());
+        // 再次启用不报错
+        enable_memory_at(&marker).unwrap();
     }
 }

--- a/crates/tiangong-memory/src/lib.rs
+++ b/crates/tiangong-memory/src/lib.rs
@@ -35,7 +35,8 @@ mod writer;
 pub use actor::{start_memory as start, start_memory_with_options as start_with_options};
 pub use config::{
     MemoryConfig, MemoryEmbeddingConfig, MemoryLlmConfig, MemoryRerankConfig,
-    default_memory_config_path,
+    default_memory_config_path, disable_memory, disable_memory_at, enable_memory, enable_memory_at,
+    is_memory_disabled, memory_disabled_marker_path,
 };
 pub use election::{
     LeaderInfo, LeaderState, ManagedMemory, ProcessType, leader_info_path, leader_lock_path,

--- a/crates/tiangong-server/src/config.rs
+++ b/crates/tiangong-server/src/config.rs
@@ -1,84 +1,10 @@
-use std::ffi::OsStr;
-use std::fs;
-use std::path::PathBuf;
+//! Server 模式配置。
+//!
+//! 历史上此模块自定义义了与 `tiangong_config::ServerConfig` 同名的结构体，
+//! 造成两套并存的 ServerConfig（技术债）。自 0.12.0（RFC 0015）起统一到
+//! `tiangong_config` 版本，本模块仅做 re-export 以保持 `crate::config::`
+//! 路径向后兼容。
 
-use serde::{Deserialize, Serialize};
-
-/// Server 模式配置
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ServerConfig {
-    /// 监听地址，默认 127.0.0.1
-    pub host: String,
-    /// 监听端口，默认 8080
-    pub port: u16,
-    /// API 认证 Token（为空则不鉴权）
-    pub auth_token: Option<String>,
-    /// 上次退出时 Server 是否在运行，用于重启后自动拉起
-    #[serde(default)]
-    pub enabled: bool,
-}
-
-impl Default for ServerConfig {
-    fn default() -> Self {
-        Self {
-            host: "127.0.0.1".to_string(),
-            port: 8080,
-            auth_token: None,
-            enabled: false,
-        }
-    }
-}
-
-/// 获取用户 home 目录
-fn user_home_dir() -> Option<PathBuf> {
-    if let Some(home) = std::env::var_os("HOME").filter(|v| !v.is_empty()) {
-        return Some(PathBuf::from(home));
-    }
-    if let Some(profile) = std::env::var_os("USERPROFILE").filter(|v| v != OsStr::new("")) {
-        return Some(PathBuf::from(profile));
-    }
-    None
-}
-
-/// 配置文件路径: ~/.tiangong/server.json
-fn config_file_path() -> PathBuf {
-    user_home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".tiangong")
-        .join("server.json")
-}
-
-/// 从 ~/.tiangong/server.json 加载配置，文件不存在时返回默认值
-pub fn load_server_config() -> ServerConfig {
-    let path = config_file_path();
-    if !path.exists() {
-        return ServerConfig::default();
-    }
-    match fs::read_to_string(&path) {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => ServerConfig::default(),
-    }
-}
-
-/// 保存 Server 配置到 ~/.tiangong/server.json
-pub fn save_server_config(config: &ServerConfig) -> anyhow::Result<()> {
-    let path = config_file_path();
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let content = serde_json::to_string_pretty(config)?;
-    fs::write(&path, content)?;
-    Ok(())
-}
-
-impl ServerConfig {
-    /// 返回脱敏后的 auth_token（仅显示前 4 位 + ****）
-    pub fn masked_auth_token(&self) -> String {
-        match &self.auth_token {
-            None => "(未设置)".to_string(),
-            Some(token) if token.trim().is_empty() => "(空)".to_string(),
-            Some(token) if token.len() <= 4 => "****".to_string(),
-            Some(token) => format!("{}****", &token[..4]),
-        }
-    }
-}
+pub use tiangong_config::{
+    ServerConfig, generate_token, load_server_config, save_server_config, server_config_path,
+};

--- a/crates/tiangong-server/src/daemon.rs
+++ b/crates/tiangong-server/src/daemon.rs
@@ -155,3 +155,79 @@ pub fn stop_daemon() -> Result<()> {
 
     Ok(())
 }
+
+/// Server 运行状态快照，供 `server status` 命令使用。
+#[derive(Debug, Clone)]
+pub struct ServerStatus {
+    /// PID 文件是否存在
+    pub pid_file_exists: bool,
+    /// PID 文件中记录的 PID（仅当文件存在且可解析时）
+    pub pid: Option<u32>,
+    /// 进程是否存活（仅 Unix，根据 PID 判定）
+    pub process_alive: bool,
+    /// 配置的监听端口是否正在被监听（TCP 探活）
+    pub port_listening: bool,
+}
+
+/// 检查后台 Server 的运行状态。
+///
+/// - 读取 `~/.tiangong/server.pid` 判断 PID 文件存在性。
+/// - 根据存活信号判断进程是否存活（Unix）。
+/// - 尝试 TCP 连接 `host:port` 判断端口是否监听。
+pub fn server_status(host: &str, port: u16) -> ServerStatus {
+    let pid_path = pid_file_path();
+    let (pid_file_exists, pid) = if pid_path.exists() {
+        match fs::read_to_string(&pid_path) {
+            Ok(content) => {
+                let parsed = content.trim().parse::<u32>().ok();
+                (true, parsed)
+            }
+            Err(_) => (true, None),
+        }
+    } else {
+        (false, None)
+    };
+
+    // 进程存活检查（仅 Unix）
+    let process_alive = if let Some(pid) = pid {
+        process_exists(pid)
+    } else {
+        false
+    };
+
+    // 端口监听探活
+    let port_listening = port_is_listening(host, port);
+
+    ServerStatus {
+        pid_file_exists,
+        pid,
+        process_alive,
+        port_listening,
+    }
+}
+
+/// 判断指定 PID 的进程是否存在（存活）。
+#[cfg(unix)]
+fn process_exists(pid: u32) -> bool {
+    // kill(pid, 0) 不发送信号，仅做存在性检查；返回 0 表示存在
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn process_exists(_pid: u32) -> bool {
+    // 非 Unix 平台暂不实现进程存活检查
+    false
+}
+
+/// 尝试 TCP 连接 host:port，判断端口是否正在监听。
+fn port_is_listening(host: &str, port: u16) -> bool {
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let addr = format!("{host}:{port}");
+    // 短超时探测，避免长时间阻塞
+    let Ok(socket_addr) = addr.parse() else {
+        return false;
+    };
+    TcpStream::connect_timeout(&socket_addr, Duration::from_millis(500)).is_ok()
+}

--- a/docs/cli-configuration-guide.md
+++ b/docs/cli-configuration-guide.md
@@ -1,0 +1,282 @@
+# 天工 CLI 配置指南
+
+> 适用版本：0.12.0+
+> 关联文档：`docs/rfc/0015-cli-modular-config.md`（设计）、`docs/linux-server-deployment.md`（服务器部署）
+
+天工提供完整的命令行配置能力，让纯服务端环境（Linux 服务器、Docker、无桌面环境）也能完成与桌面设置页等价的配置。
+
+支持两种配置方式：
+
+- **参数式命令**：适合脚本、CI、Docker、systemd 等自动化场景。
+- **交互式向导**：适合 SSH 登录后手动配置，引导完成每一步。
+
+两者写入同一份配置（`~/.tiangong/`），CLI 与桌面应用共享。
+
+---
+
+## 命令总览
+
+```bash
+tiangong model ...      # 模型配置（Provider / Model / Routing）
+tiangong server ...     # Server 监听与 Token 配置
+tiangong memory ...     # Memory 系统配置
+tiangong prompt ...     # 自定义 Prompt 管理
+tiangong config ...     # 通用配置查看与校验
+tiangong doctor         # 环境诊断
+```
+
+---
+
+## 1. 模型配置 `tiangong model`
+
+模型配置采用 Provider / Model / Routing 三层结构：
+
+- **Provider**：连接信息（协议、base_url、API Key）。
+- **Model**：模型注册项（别名、model_id、能力）。
+- **Routing**：路由槽位（chat / lite / embedding 等）指向某个模型。
+
+### 参数式配置
+
+```bash
+# 1. 新增供应商（推荐用环境变量名引用密钥）
+tiangong model add-provider deepseek \
+  --protocol deepseek \
+  --base-url https://api.deepseek.com \
+  --api-key-env DEEPSEEK_API_KEY
+
+# 2. 新增模型（声明能力）
+tiangong model add-model deepseek-chat \
+  --provider deepseek \
+  --model-id deepseek-chat \
+  --capability chat
+
+# 3. 设置 chat 路由
+tiangong model route set chat deepseek-chat
+```
+
+**API Key 两种方式**（互斥）：
+
+```bash
+# 方式一：环境变量名（推荐，写入为 ${VAR} 模板，运行时解析）
+--api-key-env DEEPSEEK_API_KEY
+
+# 方式二：明文（不推荐）
+--api-key sk-xxxxxxxx
+```
+
+**其他操作**：
+
+```bash
+tiangong model list                  # 查看全部（providers / models / routes）
+tiangong model list providers        # 只看供应商
+tiangong model list models           # 只看模型
+tiangong model list routes           # 只看路由
+
+tiangong model route set lite deepseek-lite        # 设置轻量路由
+tiangong model route set image_generation doubao   # 设置图片生成路由
+tiangong model route list                          # 查看路由表
+
+tiangong model remove-model deepseek-chat          # 删除模型
+tiangong model remove-provider deepseek --force    # 强制删除供应商（连带引用项）
+
+tiangong model validate               # 校验配置结构（路由引用、provider 存在性）
+tiangong model test chat              # 测试 chat 路由连通性（真实请求 /models）
+tiangong model test deepseek-chat     # 测试指定模型连通性
+```
+
+### 交互式向导
+
+```bash
+tiangong model configure
+```
+
+引导完成 provider → model → route 三步：选择协议（DeepSeek / OpenAI 兼容 / Anthropic）、输入供应商名称与 base_url、选择 API Key 方式、输入模型别名与能力（默认勾选 chat）、设置路由槽位。适合首次配置或不熟悉参数结构的用户。
+
+---
+
+## 2. Server 配置 `tiangong server`
+
+### 参数式配置
+
+```bash
+# 查看 Server 配置（Token 脱敏）
+tiangong server config show
+
+# 修改监听地址与端口（可只改一项）
+tiangong server config set --host 0.0.0.0 --port 9000
+tiangong server config set --port 8080
+
+# Token 管理
+tiangong server token show                 # 查看脱敏 Token
+tiangong server token generate             # 生成随机 Token（默认长度）
+tiangong server token generate --length 48 # 指定长度
+tiangong server token set tg_xxxxxxxxx     # 直接设置 Token
+
+# 状态检查
+tiangong server status                     # PID / 进程存活 / 端口监听 / Token
+
+# 启动
+tiangong server                            # 前台启动（使用 server.json 保存值）
+tiangong server -d                         # 后台守护进程启动
+tiangong server --host 0.0.0.0 --port 9000 # 命令行参数覆盖 server.json
+tiangong server stop                       # 停止后台进程
+```
+
+**启动参数优先级**：命令行参数 > `server.json` 保存值 > 默认值（127.0.0.1:8080）。
+
+### 交互式向导
+
+```bash
+tiangong server configure
+```
+
+引导设置监听地址、端口与 Token（生成随机 / 手动输入 / 跳过）。
+
+---
+
+## 3. Memory 配置 `tiangong memory`
+
+Memory 端点引用 `models.json` 中已注册的模型，避免重复填写连接信息。
+
+### 参数式配置
+
+```bash
+# 查看 Memory 配置
+tiangong memory config show
+
+# 从 models.json 引用模型填充端点（模型需具备对应能力）
+tiangong memory config set --llm deepseek-chat
+tiangong memory config set --llm deepseek-chat --embedding bge-embedding --rerank bge-reranker
+
+# 启用 / 禁用（标记文件，不丢失端点配置）
+tiangong memory enable
+tiangong memory disable
+
+# 状态与测试
+tiangong memory status    # 启用状态 + 端点有效性
+tiangong memory test      # 端点完整性校验 + ENV 可解析性检查
+```
+
+**能力要求**：
+
+- `--llm`：模型需具备 `chat` 能力（用于记忆反刍/总结）。
+- `--embedding`：模型需具备 `embedding` 能力。
+- `--rerank`：模型需具备 `rerank` 能力。
+
+**禁用语义**：`disable` 创建标记文件 `~/.tiangong/memory/.disabled`，运行时（CLI / Server / Desktop）会跳过 Memory 启动；`enable` 删除标记。端点配置不丢失。
+
+### 交互式向导
+
+```bash
+tiangong memory configure
+```
+
+引导确认启用状态，从已注册模型中选择 Memory LLM / Embedding / Rerank（按能力过滤，可跳过可选端点）。
+
+---
+
+## 4. 自定义 Prompt `tiangong prompt`
+
+自定义 Prompt 独立存储为 `~/.tiangong/custom-prompt.md`，便于 CLI 编辑与备份。
+
+```bash
+tiangong prompt show                    # 查看内容与字数
+tiangong prompt set "..."               # 直接设置
+tiangong prompt set --file ./prompt.md  # 从文件读取
+tiangong prompt edit                    # 通过 $EDITOR 编辑（回退 vim/nano）
+tiangong prompt clear                   # 清空
+tiangong prompt path                    # 显示存储路径
+```
+
+加载优先级：`custom-prompt.md`（非空）> `app.json` 旧字段（兼容）> 空。`prompt set` / `edit` 写入后会清空旧字段，使 `.md` 成为唯一事实来源。
+
+---
+
+## 5. 通用配置 `tiangong config`
+
+```bash
+tiangong config path       # 列出全部配置文件路径
+tiangong config show       # 配置概览（模型 / Server / Memory / MCP / Skill / Prompt）
+tiangong config validate   # 校验本地配置结构（不做外部连通性测试）
+```
+
+---
+
+## 6. 环境诊断 `tiangong doctor`
+
+```bash
+tiangong doctor        # 默认不做真实网络请求
+tiangong doctor --deep # 深度诊断（含模型连通性与端口探活）
+```
+
+聚合诊断配置目录、模型配置、密钥环境变量、Server、Token、Memory、MCP、Skill、自定义 Prompt。缺配置时给出具体修复命令。
+
+**密钥环境变量检查**：`doctor` 会检查 `${VAR}` 形式的 API Key 是否能解析到真实值，发现未设置的环境变量会标记 ❌。这是纯服务端最常见的配置问题。
+
+---
+
+## 配置文件结构
+
+```text
+~/.tiangong/
+  app.json              应用主配置
+  models.json           模型配置：Provider + Model + Routing
+  server.json           Server 监听配置（host/port/auth_token）
+  custom-prompt.md      自定义 Prompt（独立文件）
+  skills.json           Skill 配置
+  mcp.json              MCP 配置
+  sessions/             会话持久化
+  memory/
+    config.json         Memory 独立配置（LLM / Embedding / Rerank 端点）
+    .disabled           Memory 禁用标记（存在即禁用）
+  logs/                 运行日志
+  media/                生成或归档的媒体文件
+  server.pid            后台守护进程 PID 文件
+```
+
+模型配置的 `api_key` 支持 `${ENV_VAR}` 环境变量引用，避免明文保存密钥。配置与二进制完全解耦，更新二进制不丢失任何配置。
+
+---
+
+## 典型配置流程
+
+### 纯服务端首次配置（脚本化）
+
+```bash
+# 1. 配置模型
+tiangong model add-provider deepseek \
+  --protocol deepseek \
+  --base-url https://api.deepseek.com \
+  --api-key-env DEEPSEEK_API_KEY
+tiangong model add-model deepseek-chat \
+  --provider deepseek --model-id deepseek-chat --capability chat
+tiangong model route set chat deepseek-chat
+
+# 2. 配置 Server
+tiangong server config set --host 127.0.0.1 --port 8080
+tiangong server token generate
+
+# 3. 配置 Memory（可选）
+tiangong memory config set --llm deepseek-chat
+
+# 4. 配置自定义 Prompt（可选）
+tiangong prompt set "总是使用简体中文回答，回复要简洁直接。"
+
+# 5. 诊断
+tiangong doctor
+
+# 6. 启动
+tiangong server -d
+```
+
+### SSH 手动配置（交互式）
+
+```bash
+tiangong model configure    # 三步引导配模型
+tiangong server configure   # 引导配 Server
+tiangong memory configure   # 引导配 Memory
+tiangong prompt edit        # 编辑器编辑 Prompt
+tiangong doctor             # 检查环境
+```
+
+交互式向导在非 TTY 环境（管道 / 重定向 / CI / Docker）会自动检测并退出，不会卡住自动化流程。

--- a/docs/linux-server-deployment.md
+++ b/docs/linux-server-deployment.md
@@ -1,0 +1,392 @@
+# 天工 Linux 服务器部署指南
+
+> 适用版本：0.12.0+
+> 关联文档：`docs/rfc/0015-cli-modular-config.md`、`docs/server-api.md`、`README.md`
+
+本文档面向在纯 Linux 服务器（无桌面环境、Docker 容器、远程主机）上以 Server 模式部署天工的场景。天工的同一个 `tiangong` 二进制同时支持桌面、CLI 和 Server 三种模式，本文聚焦 Server 模式。
+
+---
+
+## 1. 适用场景
+
+- 无图形界面的 Linux 服务器（VPS、云主机、自建机房）。
+- Docker / Podman 容器内运行。
+- 希望通过 HTTP / WebSocket API 接入脚本、服务或外部消息通道。
+- 需要长期常驻运行，由 systemd 或容器编排托管。
+
+**关键说明**：天工的发布流水线（`.github/workflows/release.yml`）默认构建桌面安装包（macOS `.dmg`、Linux `.AppImage`、Windows NSIS）。这些安装包依赖 WebKit、GTK 等桌面运行时。**在纯服务器上，推荐通过源码编译获得无桌面依赖的纯二进制**（`target/release/tiangong`），它只包含 CLI/Server 能力，体积更小、依赖更少。
+
+---
+
+## 2. 前置依赖
+
+### 2.1 运行时依赖
+
+纯 CLI/Server 二进制不依赖 WebKit/GTK，但仍需：
+
+| 依赖 | 说明 | 安装（Debian/Ubuntu） |
+|------|------|----------------------|
+| glibc ≥ 2.31 | C 运行时（Ubuntu 20.04+ 满足） | 系统自带 |
+| OpenSSL | TLS（HTTPS 模型请求） | `sudo apt-get install -y libssl-dev` |
+| ca-certificates | HTTPS 根证书 | `sudo apt-get install -y ca-certificates` |
+
+### 2.2 编译依赖（仅源码安装需要）
+
+| 依赖 | 说明 | 安装（Debian/Ubuntu） |
+|------|------|----------------------|
+| Rust toolchain（stable） | 编译器 | 见 [rustup.rs](https://rustup.rs/) |
+| protoc ≥ 3 | Protocol Buffers 编译（Agent 协议） | `sudo apt-get install -y protobuf-compiler` |
+| pkg-config | 库探测 | `sudo apt-get install -y pkg-config` |
+| build-essential | C 编译器与 make | `sudo apt-get install -y build-essential` |
+
+一键安装编译依赖：
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  pkg-config \
+  protobuf-compiler \
+  libssl-dev \
+  ca-certificates \
+  curl
+```
+
+---
+
+## 3. 安装
+
+### 3.1 源码编译（推荐）
+
+```bash
+# 1. 安装 Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+
+# 2. 克隆源码
+git clone https://github.com/silent-rs/silent-Tiangong.git
+cd silent-Tiangong
+
+# 3. 编译 release 二进制
+cargo build --release
+
+# 4. 产物位于
+ls -lh target/release/tiangong
+```
+
+产物 `target/release/tiangong` 是独立的纯二进制（不依赖 Tauri/WebKit），可直接部署。
+
+### 3.2 部署二进制
+
+将二进制放置到标准路径并赋予执行权限：
+
+```bash
+sudo install -m 0755 target/release/tiangong /usr/local/bin/tiangong
+
+# 验证
+tiangong --version
+```
+
+建议为天工创建专用系统用户运行（避免用 root）：
+
+```bash
+sudo useradd --system --create-home --shell /usr/sbin/nologin tiangong
+```
+
+---
+
+## 4. 数据目录与权限
+
+天工的所有配置、会话、记忆、日志都存储在用户家目录下的 `~/.tiangong/`：
+
+```text
+~/.tiangong/
+  app.json              应用主配置
+  models.json           模型配置：Provider + Model + Routing
+  server.json           Server 监听配置（host/port/auth_token）
+  custom-prompt.md      自定义 Prompt（0.12.0 新增独立文件）
+  skills.json           Skill 配置
+  mcp.json              MCP 配置
+  sessions/             会话持久化
+  memory/               长期记忆数据（SQLite / Tantivy / 向量索引）
+    config.json         Memory 独立配置
+  logs/                 运行日志
+  media/                生成或归档的媒体文件
+  server.pid            后台守护进程 PID 文件
+```
+
+**关键特性**：配置与二进制完全解耦。更新二进制不会丢失任何配置、会话或记忆数据。
+
+若使用专用 `tiangong` 用户，数据目录为 `/home/tiangong/.tiangong/`，确保该用户对其有读写权限。
+
+---
+
+## 5. 无界面配置流程
+
+天工 0.12.0 提供完整的模块化 CLI 配置能力（详见 `docs/rfc/0015-cli-modular-config.md`），无需桌面即可完成全部配置。完整流程：
+
+```bash
+# 1. 配置模型供应商（推荐用环境变量名引用密钥）
+tiangong model add-provider deepseek \
+  --protocol deepseek \
+  --base-url https://api.deepseek.com \
+  --api-key-env DEEPSEEK_API_KEY
+
+# 2. 配置模型
+tiangong model add-model deepseek-chat \
+  --provider deepseek \
+  --model-id deepseek-chat \
+  --capability chat
+
+# 3. 设置 chat 路由
+tiangong model route chat deepseek-chat
+
+# 4. 验证模型连通性（真实请求一次）
+tiangong model test chat
+
+# 5. 配置 Server 监听
+tiangong server config set --host 127.0.0.1 --port 8080
+
+# 6. 生成鉴权 Token
+tiangong server token generate
+# 或指定长度：tiangong server token generate --length 48
+
+# 7. （可选）配置自定义 Prompt
+tiangong prompt set "总是使用简体中文回答，回复要简洁直接。"
+
+# 8. （可选）配置 Memory
+tiangong memory config set --llm deepseek-chat
+tiangong memory enable
+
+# 9. 完整环境诊断
+tiangong doctor
+```
+
+查看当前配置概览：
+
+```bash
+tiangong config path     # 列出所有配置文件路径
+tiangong config show     # 配置概览
+tiangong config validate # 本地结构校验
+```
+
+---
+
+## 6. 运行与托管
+
+### 6.1 前台运行（调试用）
+
+```bash
+tiangong server
+```
+
+指定监听参数（覆盖 server.json）：
+
+```bash
+tiangong server --host 0.0.0.0 --port 9000 --token tg_xxxxx
+```
+
+### 6.2 后台守护进程
+
+```bash
+tiangong server -d          # 后台启动，写入 server.pid
+tiangong server status      # 查看状态（PID、进程存活、端口监听、Token）
+tiangong server stop        # 停止后台进程
+```
+
+守护进程日志输出到 `~/.tiangong/logs/server-daemon.log`。
+
+### 6.3 systemd 托管（生产推荐）
+
+创建 `/etc/systemd/system/tiangong.service`：
+
+```ini
+[Unit]
+Description=Tiangong Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=tiangong
+Group=tiangong
+WorkingDirectory=/home/tiangong
+
+# 方式一：通过 EnvironmentFile 注入密钥等环境变量
+EnvironmentFile=/etc/tiangong/env
+
+# 方式二：直接内联（不推荐密钥明文）
+# Environment="DEEPSEEK_API_KEY=sk-xxx"
+
+ExecStart=/usr/local/bin/tiangong server --host 127.0.0.1 --port 8080
+Restart=on-failure
+RestartSec=5
+
+# 安全加固
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/tiangong/.tiangong
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+密钥通过 `/etc/tiangong/env`（权限 `0640 root:tiangong`）注入：
+
+```bash
+# /etc/tiangong/env
+DEEPSEEK_API_KEY=sk-xxxxxxxxxxxxxxxx
+ZHIPU_API_KEY=xxxxxxxxxxxxxxxx
+```
+
+启用并启动：
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now tiangong
+sudo systemctl status tiangong
+sudo journalctl -u tiangong -f    # 查看日志
+```
+
+> 注意：使用 systemd 托管时，无需通过 `tiangong server -d` 启动守护进程（systemd 自身负责进程托管与重启）。直接用 `ExecStart=/usr/local/bin/tiangong server` 前台运行即可。
+
+---
+
+## 7. 反向代理
+
+生产环境建议用 Nginx 反向代理，提供 TLS 终止与统一入口。
+
+Nginx 配置示例：
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name tiangong.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/tiangong.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/tiangong.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+
+        # WebSocket 支持
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # 流式响应
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+    }
+}
+```
+
+调用方在请求头携带 Token：
+
+```bash
+curl https://tiangong.example.com/api/v1/health \
+  -H "Authorization: Bearer $(tiangong server token show --raw)"
+```
+
+---
+
+## 8. API 速览
+
+Server 模式提供 HTTP REST + WebSocket API，详见 `docs/server-api.md`。关键端点：
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/v1/health` | 健康检查（无需鉴权） |
+| POST | `/api/v1/chat` | 对话 |
+| WS | `/api/v1/ws` | WebSocket 流式对话 |
+
+所有非 health 端点需在请求头携带 `Authorization: Bearer <token>`，Token 通过 `tiangong server token generate` 生成。
+
+---
+
+## 9. 更新策略
+
+### 9.1 CLI 二进制的更新特点
+
+天工的 `tiangong update` 命令（`crates/tiangong-entry/src/update.rs`）**仅检查版本**（`--check`），**CLI 二进制本身不能自动下载安装更新**（自动更新仅桌面应用支持，依赖 Tauri updater）。因此 Linux 服务器更新二进制需手动操作。
+
+### 9.2 检查新版本
+
+```bash
+tiangong update --check
+# 输出当前版本与最新版本，不执行更新
+```
+
+### 9.3 更新二进制
+
+```bash
+# 1. 拉取最新源码
+cd /path/to/silent-Tiangong
+git fetch --tags
+git checkout v0.12.0   # 切到目标版本标签
+
+# 2. 重新编译
+cargo build --release
+
+# 3. 停止服务
+sudo systemctl stop tiangong   # 或 tiangong server stop
+
+# 4. 替换二进制
+sudo install -m 0755 target/release/tiangong /usr/local/bin/tiangong
+
+# 5. 重启服务
+sudo systemctl start tiangong
+
+# 6. 验证
+tiangong --version
+tiangong doctor
+```
+
+**配置与数据不丢失**：所有配置、会话、记忆都存储在 `~/.tiangong/`，与二进制完全解耦。更新二进制只需替换可执行文件，数据目录保持不动。
+
+### 9.4 滚动回滚
+
+如新版本有问题，回退到上一个标签即可：
+
+```bash
+sudo systemctl stop tiangong
+git checkout v0.11.0
+cargo build --release
+sudo install -m 0755 target/release/tiangong /usr/local/bin/tiangong
+sudo systemctl start tiangong
+```
+
+---
+
+## 10. 故障排查
+
+| 现象 | 排查命令 |
+|------|---------|
+| Server 启动后无法访问 | `tiangong server status` 检查端口监听；`ss -tlnp \| grep 8080` |
+| 模型请求失败 | `tiangong model test chat` 验证连通性；检查 `--api-key-env` 对应环境变量是否注入 |
+| 鉴权失败 | `tiangong server token show` 确认 Token；请求头格式 `Authorization: Bearer <token>` |
+| Memory 未生效 | `tiangong memory status`；确认无 `~/.tiangong/memory/.disabled` 标记文件 |
+| 不确定哪里配置有问题 | `tiangong doctor`（加 `--deep` 做深度诊断） |
+
+日志位置：
+
+- 前台运行：标准输出
+- 守护进程：`~/.tiangong/logs/server-daemon.log`
+- systemd：`journalctl -u tiangong`
+
+---
+
+## 11. 后续候选能力
+
+以下能力在 RFC 0015 中列为后续候选（不在 0.12.0 范围）：
+
+- **独立 CLI 二进制发布产物**：在 CI 新增 build job，产出 `tiangong-<version>-linux-<arch>.tar.gz`，免去服务器编译步骤。
+- **CLI 二进制自更新**：扩展 `latest.json` 增加 CLI 通道，使 `tiangong update --apply` 可下载替换二进制。
+- **官方 Docker 镜像**：基于 Alpine/Debian 预装天工二进制，开箱即用。

--- a/docs/linux-server-deployment.md
+++ b/docs/linux-server-deployment.md
@@ -139,7 +139,7 @@ tiangong model add-model deepseek-chat \
   --capability chat
 
 # 3. 设置 chat 路由
-tiangong model route chat deepseek-chat
+tiangong model route set chat deepseek-chat
 
 # 4. 验证模型连通性（真实请求一次）
 tiangong model test chat

--- a/docs/rfc/0015-cli-modular-config.md
+++ b/docs/rfc/0015-cli-modular-config.md
@@ -147,8 +147,8 @@ tiangong model add-model deepseek-chat \
 
 ```bash
 tiangong model route set chat deepseek-chat
-tiangong model route lite deepseek-lite
-tiangong model route image_generation doubao-image
+tiangong model route set lite deepseek-lite
+tiangong model route set image_generation doubao-image
 tiangong model route list
 ```
 

--- a/docs/rfc/0015-cli-modular-config.md
+++ b/docs/rfc/0015-cli-modular-config.md
@@ -1,0 +1,444 @@
+# RFC 0015：CLI 模块化配置增强
+
+- 状态：In Progress（进行中）
+- 日期：2026-06-29
+- 作者：Tiangong 工程组
+- 关联文档：
+  - `docs/requirements.md`
+  - `PLAN.md`
+  - `TODO.md`
+  - `docs/rfc/0002-cli-agent-roadmap.md`（CLI Agent 主线）
+  - `docs/server-api.md`
+
+## 1. 背景
+
+天工的桌面应用是主入口，模型、Server、Memory、MCP、Skill 等配置都通过桌面设置页完成。但在纯服务端（Linux 服务器、Docker 容器、无桌面环境）场景下，用户无法启动 GUI，只能依赖 CLI 完成配置。
+
+当前 CLI（`crates/tiangong-entry`）只覆盖了 `cli`（交互式 REPL）、`server`（启停）、`mcp`、`skill`、`update` 五个子命令，**缺乏配置类能力**：
+
+- 无法在命令行配置模型供应商、模型与路由。
+- 无法修改 Server 监听地址、端口与鉴权 Token。
+- 无法启用/禁用 Memory 或调整 Memory 使用的模型。
+- 自定义 Prompt 只能通过桌面设置页编辑，CLI 无法触及。
+- 没有一站式诊断命令，纯服务端用户不知道当前环境缺什么。
+
+早期讨论曾考虑引入 `tiangong init` 一站式初始化向导，但该方案会把模型、Server、Memory、MCP、Prompt 混在一个流程里，违背"按需配置"的使用习惯，且对只想改单项配置的用户造成负担。
+
+## 2. 目标
+
+构建 **模块化 CLI 配置体系**，让模型、Server、Memory、自定义 Prompt 等配置可以独立查看、编辑、校验和测试，使纯服务端环境具备与桌面设置页等价的配置能力。
+
+必须达到：
+
+- 提供与桌面设置页等价的"分模块配置能力"，不依赖 GUI。
+- CLI 与 Desktop 共享同一份 `~/.tiangong/` 配置，CLI 改动桌面可见，反之亦然。
+- 每类配置由独立命令管理，用户按需配置，不强迫走初始化流程。
+- 提供 `doctor` 诊断命令，但不强制一次性初始化所有内容。
+
+## 3. 非目标
+
+- **不做 `tiangong init` 一站式初始化向导**：不把模型、Server、Memory、MCP、Prompt 混在一个流程里。
+- **不引入第二套 headless 配置格式**：不为服务端单独维护 `tiangong-headless.json`，避免三端行为不一致。
+- **不把所有配置塞进 `tiangong config set`**：避免变成"配置路径记忆游戏"，体验差。
+- **本 RFC 不新增 GUI 功能**：桌面设置页保持现状，后续如需联动 `custom-prompt.md` 另行评估。
+- **本 RFC 不改动 CI 发布流水线**：独立 CLI 二进制（tar.gz）发布产物列为后续候选任务。
+
+## 4. 设计原则
+
+1. **不做 `init`**：CLI 不负责一次性初始化所有东西，而是提供分模块配置能力。
+2. **每类配置独立命令管理**：模型归模型、Server 归 Server、Memory 归 Memory、Prompt 归 Prompt，MCP/Skill 沿用并增强现有命令。
+3. **CLI 与 Desktop 共享同一份配置**：CLI 修改后 Desktop 能看到，Desktop 修改后 CLI 能读取。
+4. **提供诊断，不提供强制初始化**：`doctor` 负责告诉用户还缺什么，但不强制一次性帮用户配置完所有东西。
+
+## 5. 命令结构
+
+最终设计的命令树如下：
+
+```text
+tiangong
+├── cli
+├── server
+│   ├── (无子命令，前台启动)
+│   ├── --daemon / -d
+│   ├── stop
+│   ├── status
+│   ├── config
+│   │   ├── show
+│   │   └── set
+│   └── token
+│       ├── show
+│       ├── set
+│       └── generate
+├── model
+│   ├── list [providers|models|routes]
+│   ├── add-provider
+│   ├── remove-provider
+│   ├── add-model
+│   ├── remove-model
+│   ├── route <capability> <model>
+│   ├── route list
+│   ├── validate
+│   └── test [target]
+├── memory
+│   ├── config show
+│   ├── config set
+│   ├── enable
+│   ├── disable
+│   ├── status
+│   └── test
+├── prompt
+│   ├── show
+│   ├── set
+│   ├── edit
+│   ├── clear
+│   └── path
+├── config
+│   ├── path
+│   ├── show
+│   └── validate
+├── doctor
+├── mcp
+├── skill
+└── update
+```
+
+## 6. 模块设计
+
+### 6.1 模型配置 `tiangong model`
+
+围绕现有 `ModelsConfig`（`crates/tiangong-core/src/models_config.rs`）的 Provider / Model / Routing 三层结构设计。
+
+**Provider 管理**：
+
+```bash
+# 推荐：用环境变量名，api_key 存为 ${VAR} 模板
+tiangong model add-provider deepseek \
+  --protocol deepseek \
+  --base-url https://api.deepseek.com \
+  --api-key-env DEEPSEEK_API_KEY
+
+# 或明文写入（不推荐）
+tiangong model add-provider deepseek \
+  --protocol deepseek \
+  --base-url https://api.deepseek.com \
+  --api-key sk-xxx
+```
+
+- `--api-key-env NAME`：写入配置时存为 `${NAME}` 模板，运行时由 `resolve_api_key` 解析环境变量（复用现有机制）。
+- `--api-key VALUE`：明文写入。
+- 二者互斥。
+
+**Model 管理**：
+
+```bash
+tiangong model add-model deepseek-chat \
+  --provider deepseek \
+  --model-id deepseek-chat \
+  --capability chat
+```
+
+支持多 `--capability`（chat / multimodal / image_generation / video_generation / stt / tts / embedding / rerank）。
+
+**Routing 管理**：
+
+```bash
+tiangong model route chat deepseek-chat
+tiangong model route lite deepseek-lite
+tiangong model route image_generation doubao-image
+tiangong model route list
+```
+
+`<capability>` 对应 `RoutingSlot`（chat / lite / multimodal / image_generation / video_generation / stt / tts / embedding / rerank）。
+
+**模型测试**：
+
+```bash
+tiangong model test chat        # 测试 chat 路由
+tiangong model test deepseek-chat  # 测试指定模型
+```
+
+真实请求模型，验证 API Key 读取、base_url、protocol、model id、返回是否正常。实现复用 `ModelsConfig::to_chat_provider_config()` 与 `SingleProviderClient::list_models(&cfg)`（`crates/tiangong-core/src/model.rs:270`），GET `/models` 作为连通性探针。
+
+### 6.2 Server 配置 `tiangong server`
+
+**查看配置**：
+
+```bash
+tiangong server config show
+```
+
+输出（Token 脱敏）：
+
+```text
+host: 127.0.0.1
+port: 8080
+auth_token: tg_****abcd
+```
+
+**修改配置**：
+
+```bash
+tiangong server config set --host 0.0.0.0 --port 8080
+tiangong server config set --port 9000
+```
+
+**Token 管理**：
+
+```bash
+tiangong server token generate          # 默认长度
+tiangong server token generate --length 48
+tiangong server token set tg_xxxxxxxxx
+tiangong server token show              # 脱敏显示
+```
+
+Token 生成使用 scru128 生成 `tg_` 前缀的随机串（不引入新 crate，避免触发 `deny.toml` 依赖审计）。
+
+**Server 状态**：
+
+```bash
+tiangong server status
+```
+
+检查：PID 文件是否存在、进程是否存活、端口是否监听、本地 API 是否可访问、当前 Token 是否配置。
+
+**ServerConfig 统一**：当前 `tiangong-config` 与 `tiangong-server` 各自定义同名 `ServerConfig`，是技术债。本 RFC 统一到 `tiangong-config` 版本，为其补齐 `enabled` 字段与 `load_server_config()` / `save_server_config()`，`tiangong-server` 改为 `pub use` 复用。
+
+### 6.3 Memory 配置 `tiangong memory`
+
+围绕现有 `MemoryConfig`（`crates/tiangong-memory/src/config.rs`）设计。该结构字段为 `model / embedding / rerank`（均为 Option 嵌套端点），无顶层 `enabled` 字段。
+
+**配置查看/设置**：
+
+```bash
+tiangong memory config show
+tiangong memory config set \
+  --llm deepseek-lite \
+  --embedding bge-embedding \
+  --rerank bge-reranker
+```
+
+`--llm <name>` 等参数是**模型名引用**：从 `models.json` 解析该模型及其 provider 端点（base_url / api_key / protocol），填充到 `MemoryConfig` 对应字段。模型不存在则报错并提示先执行 `tiangong model add-model`。这使 model 与 memory 两个模块联动，避免重复填写端点。
+
+**启用/禁用**：
+
+```bash
+tiangong memory enable
+tiangong memory disable
+```
+
+`MemoryConfig` 无 `enabled` 字段，且当前加载逻辑仅按端点是否有效判断是否启用。纯清空端点会导致配置丢失且无法重新 enable，因此本 RFC 采用**轻量标记文件** `~/.tiangong/memory/.disabled`（存在即禁用）实现对称开关，不破坏 `MemoryConfig` 结构、不丢失端点配置。
+
+`memory status` 的"启用状态" = `!标记文件存在 && model 端点有效`。
+
+**测试**：
+
+```bash
+tiangong memory test
+```
+
+检查配置存在性、模型能力匹配、端点有效性，并照搬 `crates/tiangong-memory/examples/memory_llm_smoke.rs` 模式发送测试请求。
+
+### 6.4 自定义 Prompt `tiangong prompt`
+
+自定义 Prompt 作为一级命令（不塞到 `config` 下），因为它是高频且语义独立的配置。
+
+**存储迁移**：当前 `custom_system_prompt` 存储在 `app.json` 的 `AgentConfig` 内（JSON 字符串）。长 Prompt 在 JSON 中难以编辑（换行、转义、diff 不友好）。本 RFC 将事实来源改为独立文件：
+
+```text
+~/.tiangong/custom-prompt.md
+```
+
+**加载优先级**：
+
+```text
+1. custom-prompt.md 存在且非空 → 读取它
+2. 否则读取 app.json 中 agent_config.custom_system_prompt（兼容旧配置）
+3. 再否则为空
+```
+
+**写入行为**：`prompt set` / `prompt edit` 写入 `custom-prompt.md` 时，同时清空 `app.json` 的 `custom_system_prompt` 旧字段，使 `custom-prompt.md` 成为唯一事实来源，消除歧义。
+
+下游注入逻辑（`crates/tiangong-core/src/prompt/sections.rs:172/200`）无需改动，只需在加载 `agent_config` 时用上述优先级回填 `custom_system_prompt` 字段。
+
+**命令**：
+
+```bash
+tiangong prompt show                 # 显示内容与字数
+tiangong prompt set "..."            # 直接设置
+tiangong prompt set --file ./p.md    # 从文件读取
+tiangong prompt edit                 # 优先 $EDITOR，回退 vim/nano
+tiangong prompt clear                # 清空（删 .md + 清空旧字段）
+tiangong prompt path                 # 显示存储路径
+```
+
+### 6.5 通用配置 `tiangong config`
+
+只负责通用查看、校验，不改所有东西。
+
+```bash
+tiangong config path       # 列出全部配置路径
+tiangong config show       # 概览（不展开 JSON）
+tiangong config validate   # 仅本地结构校验，不做外部连通性
+```
+
+`config validate` 与 `doctor` 区分：
+
+- `config validate`：只校验本地配置结构。
+- `doctor`：执行完整环境诊断，可能请求模型、检查端口、检查服务。
+
+`config export` / `config import`（从桌面配置迁移到 Linux Server）不在 0.12.0 清单，列为后续候选。
+
+### 6.6 诊断 `tiangong doctor`
+
+不修改配置，只告诉用户当前环境是否可用。
+
+```bash
+tiangong doctor        # 默认不做真实网络请求
+tiangong doctor --deep # 执行模型连通性 + 端口探活
+```
+
+默认输出：
+
+```text
+配置目录            ✅ /home/user/.tiangong
+模型配置            ✅ chat -> deepseek-chat
+模型连通性          ⏭️ 跳过（使用 --deep 启用）
+Server 配置         ✅ 127.0.0.1:8080
+Server Token        ✅ 已配置
+Memory 配置         ⚠️ 未启用
+MCP 配置            ✅ 2 个服务可解析
+Skill 目录          ✅ 5 个 Skill 可用
+自定义 Prompt       ✅ 已配置，128 字
+```
+
+缺配置时给出具体修复命令，例如：
+
+```text
+❌ 未配置 chat 模型
+
+可执行：
+
+  tiangong model add-provider deepseek \
+    --protocol deepseek \
+    --base-url https://api.deepseek.com \
+    --api-key-env DEEPSEEK_API_KEY
+
+  tiangong model add-model deepseek-chat \
+    --provider deepseek \
+    --model-id deepseek-chat \
+    --capability chat
+
+  tiangong model route chat deepseek-chat
+```
+
+## 7. 最终用户体验
+
+服务端用户不需要 `init`，按需配置：
+
+```bash
+# 1. 配模型供应商
+tiangong model add-provider deepseek \
+  --protocol deepseek \
+  --base-url https://api.deepseek.com \
+  --api-key-env DEEPSEEK_API_KEY
+
+# 2. 配模型
+tiangong model add-model deepseek-chat \
+  --provider deepseek \
+  --model-id deepseek-chat \
+  --capability chat
+
+# 3. 设置 chat 路由
+tiangong model route chat deepseek-chat
+
+# 4. 配 Server
+tiangong server config set --host 127.0.0.1 --port 8080
+tiangong server token generate
+
+# 5. 配自定义 Prompt
+tiangong prompt edit
+
+# 6. 检查
+tiangong doctor
+
+# 7. 启动
+tiangong server -d
+```
+
+只想改 Prompt：`tiangong prompt edit`；只想换模型：`tiangong model route chat glm-4.5`；只想关 Memory：`tiangong memory disable`。
+
+## 8. Linux 服务器支持
+
+本 RFC 的 CLI 模块化配置直接服务于此场景：让纯服务端环境具备完整可用的配置能力。
+
+当前 CI（`.github/workflows/release.yml`）只构建 Tauri 安装包（macOS dmg / Linux AppImage / Windows NSIS），根 `[[bin]]`（`src/main.rs`，纯 CLI 二进制）无独立发布产物。Linux 服务器用户需通过源码编译获得二进制：
+
+```bash
+cargo build --release
+# 产物：target/release/tiangong（无 Tauri/WebKit 依赖）
+```
+
+更新机制：`tiangong update --check`（`crates/tiangong-entry/src/update.rs`）仅检查版本，CLI 二进制不能自更新（仅桌面应用支持自动更新）。Linux 服务器需重新编译或下载新版本二进制替换；因配置独立存储在 `~/.tiangong/`，与二进制解耦，更新二进制不丢失配置。
+
+**后续候选**：
+
+- 在 CI 新增独立 build job，产出 `tiangong-<version>-<platform>-<arch>.tar.gz` 纯 CLI 二进制。
+- 扩展 `latest.json` 增加 CLI 通道，使 `tiangong update` 支持 CLI 二进制自更新（或提供 `tiangong update --apply` 下载替换）。
+
+详细部署指南见 `docs/linux-server-deployment.md`。
+
+## 9. 里程碑
+
+### M1：文档与 Roadmap（本 RFC + PLAN.md + TODO.md）
+
+锁定 0.12.0 设计方向，作为后续代码实现依据。
+
+### M2：Prompt 独立配置
+
+- `custom-prompt.md` 独立存储 + 加载优先级兼容
+- `tiangong prompt show/set/edit/clear/path`
+
+优先实现，因为改动独立、风险低、能快速验证"独立文件 + CLI 命令"模式。
+
+### M3：Server 配置 CLI
+
+- `tiangong server config show/set`
+- `tiangong server token show/set/generate`
+- `tiangong server status`
+- ServerConfig 统一
+
+### M4：模型配置 CLI
+
+- Provider / Model / Routing 增删改查
+- `model validate` 与 `model test` 连通性测试
+
+最重要也最复杂，需严谨处理 Provider / Model / Routing 三层。
+
+### M5：Memory 配置 CLI
+
+- `memory config show/set`
+- `memory enable/disable`（标记文件方案）
+- `memory status/test`
+
+### M6：config + doctor
+
+- `config path/show/validate`
+- `doctor` 聚合诊断
+
+前面模块完成后，doctor 才能整合诊断。
+
+## 10. 验收标准
+
+达到以下条件视为 RFC 0015 完成：
+
+- 在无桌面的 Linux 环境中，可通过 CLI 独立完成模型、Server、Memory、自定义 Prompt 等关键配置。
+- CLI 修改的配置能被桌面应用读取，桌面修改的配置能被 CLI 读取（同一份 `~/.tiangong/`）。
+- `tiangong doctor` 能准确报告环境缺失项并给出修复命令。
+- `custom-prompt.md` 成为自定义 Prompt 的事实来源，旧 `custom_system_prompt` 字段保持兼容。
+- 各命令具备相应单元测试（`ModelsConfig` 增删、custom-prompt 加载优先级、token 生成、ServerConfig load/save、MemoryConfig 标记文件开关）。
+- 通过完整检查链（`cargo fmt --check` + `cargo check --workspace` + `cargo clippy -D warnings` + `cargo nextest run`）。
+
+## 11. 与现有 RFC 的关系
+
+- **RFC 0002（CLI Agent 主线）**：本 RFC 与 0002 正交。0002 关注 CLI 的 Agent 执行能力（规划、工具、验证），本 RFC 关注 CLI 的配置能力。两者共同构成完整的 CLI 使用体验：先配置（本 RFC），再执行任务（0002）。
+- 本 RFC 不影响 RFC 0002 的任何里程碑，可并行推进。

--- a/docs/rfc/0015-cli-modular-config.md
+++ b/docs/rfc/0015-cli-modular-config.md
@@ -49,6 +49,7 @@
 2. **每类配置独立命令管理**：模型归模型、Server 归 Server、Memory 归 Memory、Prompt 归 Prompt，MCP/Skill 沿用并增强现有命令。
 3. **CLI 与 Desktop 共享同一份配置**：CLI 修改后 Desktop 能看到，Desktop 修改后 CLI 能读取。
 4. **提供诊断，不提供强制初始化**：`doctor` 负责告诉用户还缺什么，但不强制一次性帮用户配置完所有东西。
+5. **非交互式为主，交互式为辅**：所有配置命令均支持参数式（脚本/CI 友好）；`model`/`server`/`memory` 额外提供 `configure` 子命令作为交互式向导，引导不熟悉配置结构的用户完成配置。非 TTY 环境（脚本、管道、CI）下 `configure` 会检测到并退出，不会卡住自动化流程。
 
 ## 5. 命令结构
 
@@ -62,6 +63,7 @@ tiangong
 │   ├── --daemon / -d
 │   ├── stop
 │   ├── status
+│   ├── configure          # 交互式向导（监听地址 + Token）
 │   ├── config
 │   │   ├── show
 │   │   └── set
@@ -75,6 +77,7 @@ tiangong
 │   ├── remove-provider
 │   ├── add-model
 │   ├── remove-model
+│   ├── configure          # 交互式向导（provider → model → route）
 │   ├── route <capability> <model>
 │   ├── route list
 │   ├── validate
@@ -82,6 +85,7 @@ tiangong
 ├── memory
 │   ├── config show
 │   ├── config set
+│   ├── configure          # 交互式向导（端点模型选择）
 │   ├── enable
 │   ├── disable
 │   ├── status
@@ -159,6 +163,14 @@ tiangong model test deepseek-chat  # 测试指定模型
 
 真实请求模型，验证 API Key 读取、base_url、protocol、model id、返回是否正常。实现复用 `ModelsConfig::to_chat_provider_config()` 与 `SingleProviderClient::list_models(&cfg)`（`crates/tiangong-core/src/model.rs:270`），GET `/models` 作为连通性探针。
 
+**交互式向导**：
+
+```bash
+tiangong model configure
+```
+
+引导用户依次完成 provider → model → route 三步：选协议（DeepSeek/OpenAI 兼容/Anthropic）、输入供应商名称与 base_url、选择 API Key 方式（环境变量名或明文）、输入模型别名与能力、设置路由槽位。复用 `upsert_provider`/`upsert_model`/`set_route_by_name`（含 capability 校验）。适合首次配置或不熟悉参数结构的用户；脚本环境请用参数式命令。
+
 ### 6.2 Server 配置 `tiangong server`
 
 **查看配置**：
@@ -201,6 +213,14 @@ tiangong server status
 
 检查：PID 文件是否存在、进程是否存活、端口是否监听、本地 API 是否可访问、当前 Token 是否配置。
 
+**交互式向导**：
+
+```bash
+tiangong server configure
+```
+
+引导设置监听地址（默认 127.0.0.1）、端口（默认 8080）与 Token（生成随机/手动输入/跳过）。复用 `save_server_config`。
+
 **ServerConfig 统一**：当前 `tiangong-config` 与 `tiangong-server` 各自定义同名 `ServerConfig`，是技术债。本 RFC 统一到 `tiangong-config` 版本，为其补齐 `enabled` 字段与 `load_server_config()` / `save_server_config()`，`tiangong-server` 改为 `pub use` 复用。
 
 ### 6.3 Memory 配置 `tiangong memory`
@@ -237,6 +257,14 @@ tiangong memory test
 ```
 
 检查配置存在性、模型能力匹配、端点有效性，并照搬 `crates/tiangong-memory/examples/memory_llm_smoke.rs` 模式发送测试请求。
+
+**交互式向导**：
+
+```bash
+tiangong memory configure
+```
+
+引导选择 Memory 端点模型：先确认启用状态，再从 models.json 已注册模型中选择 Memory LLM（校验 chat 能力）、可选选择 Embedding/Rerank 模型（校验对应能力，可跳过）。复用 `lookup_model_for_llm`/capability 校验，确保不会把错误能力的模型配到对应端点。
 
 ### 6.4 自定义 Prompt `tiangong prompt`
 

--- a/docs/rfc/0015-cli-modular-config.md
+++ b/docs/rfc/0015-cli-modular-config.md
@@ -146,7 +146,7 @@ tiangong model add-model deepseek-chat \
 **Routing 管理**：
 
 ```bash
-tiangong model route chat deepseek-chat
+tiangong model route set chat deepseek-chat
 tiangong model route lite deepseek-lite
 tiangong model route image_generation doubao-image
 tiangong model route list
@@ -356,7 +356,7 @@ Skill 目录          ✅ 5 个 Skill 可用
     --model-id deepseek-chat \
     --capability chat
 
-  tiangong model route chat deepseek-chat
+  tiangong model route set chat deepseek-chat
 ```
 
 ## 7. 最终用户体验
@@ -377,7 +377,7 @@ tiangong model add-model deepseek-chat \
   --capability chat
 
 # 3. 设置 chat 路由
-tiangong model route chat deepseek-chat
+tiangong model route set chat deepseek-chat
 
 # 4. 配 Server
 tiangong server config set --host 127.0.0.1 --port 8080
@@ -393,7 +393,7 @@ tiangong doctor
 tiangong server -d
 ```
 
-只想改 Prompt：`tiangong prompt edit`；只想换模型：`tiangong model route chat glm-4.5`；只想关 Memory：`tiangong memory disable`。
+只想改 Prompt：`tiangong prompt edit`；只想换模型：`tiangong model route set chat glm-4.5`；只想关 Memory：`tiangong memory disable`。
 
 ## 8. Linux 服务器支持
 


### PR DESCRIPTION
## 概述

实现 RFC 0015（`docs/rfc/0015-cli-modular-config.md`）：让纯服务端环境（Linux 服务器、Docker、无桌面环境）具备与桌面设置页等价的分模块配置能力。Desktop 优先不变，CLI 与 Desktop 共享同一份 `~/.tiangong/` 配置。

不做 `tiangong init` 一站式向导，每类配置由独立命令管理，用户按需配置。

## 新增命令

| 模块 | 参数式命令 | 交互式向导 |
|------|-----------|-----------|
| **model** | `add-provider` / `add-model` / `route set` / `list` / `validate` / `test` | `model configure`（三步引导） |
| **server** | `config show/set` / `token show/set/generate` / `status` | `server configure` |
| **memory** | `config show/set` / `enable` / `disable` / `status` / `test` | `memory configure` |
| **prompt** | `show` / `set` / `edit` / `clear` / `path` | — |
| **config** | `path` / `show` / `validate` | — |
| **doctor** | 环境诊断（`--deep` 深度连通性） | — |

## 核心改动

- **自定义 Prompt 独立存储**：迁移到 `~/.tiangong/custom-prompt.md`（加载优先级兼容旧 `app.json` 字段），并接入 `CoreConfig` 使 CLI/Server 运行时生效。
- **Server 配置参与启动**：`tiangong server` 启动时合并 `server.json` 保存值（命令行 > 配置文件 > 默认值）。
- **ServerConfig 统一**：消除 `tiangong-config` 与 `tiangong-server` 两套同名结构的技术债。
- **Memory disable 运行时生效**：标记文件方案，CLI/Server/Desktop 全局尊重。
- **Capability 校验**：`model route` 与 `memory config set` 均校验模型能力匹配，避免错误路由。
- **ENV 诊断**：`doctor` / `test` 检查 `${VAR}` 环境变量可解析性，发现服务端最常见的密钥未设置问题。
- **交互式向导**：基于 `dialoguer`，非 TTY 环境自动降级退出，不卡脚本/CI/Docker。

## 文档

- 新增 `docs/cli-configuration-guide.md`：面向用户的 CLI 配置功能手册
- 新增 `docs/rfc/0015-cli-modular-config.md`：设计 RFC
- 新增 `docs/linux-server-deployment.md`：Linux 服务器部署/更新指南
- 更新 `README.md`：安装章节、模块化配置速览、文档链接

## 测试

- 完整检查链通过：`cargo fmt --check` + `cargo check --workspace` + `cargo clippy -D warnings` + `cargo nextest run`
- 数据层单元测试：ModelsConfig 增删/capability 校验、custom-prompt 加载优先级、ServerConfig serde、token 生成、Memory 标记开关、secrets ENV 解析
- 实测：Prompt 进入 CoreConfig、Server 启动用保存配置、Memory disable 运行时生效、capability 拒绝错误路由、ENV 检查、非 TTY 降级

## 关联

- 设计：`docs/rfc/0015-cli-modular-config.md`
- RFC 0002（CLI Agent 主线）：本 PR 与其正交，共同构成完整 CLI 体验

> 注：本 PR 不含版本号升级与发布配置（待 review 通过后单独处理）。