### PR TITLE
refactor(command): 弱化命令白名单为审批驱动

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ AGENTS.md
 .worktrees/
 PLAN.md
 TODO.md
+.zcode

--- a/crates/plugins/tiangong-plugin-command/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-command/src/handler.rs
@@ -96,7 +96,10 @@ impl CommandPlugin {
             .unwrap_or_else(shared::command_timeout_ms);
 
         if !self.is_full_trust() {
-            validate_command(&cmd, &cmd_args, &effective_cwd)?;
+            // 校验仅对硬性拒绝条件（forbidden tokens、路径越界、shell 形式不合法）报错；
+            // 白名单外命令返回 NeedsApproval 但不拒绝——审批由 engine 层 PermissionGate
+            //（Elevated 级）接管。
+            let _ = validate_command(&cmd, &cmd_args, &effective_cwd, &self.allowed_commands())?;
         }
 
         let runtime_env = self.runtime_env();
@@ -143,7 +146,14 @@ impl CommandPlugin {
             .unwrap_or_else(shared::command_timeout_ms);
 
         if !self.is_full_trust() {
-            shared::validate_shell_command_args(&cmd, &cmd_args, &effective_cwd)?;
+            // 校验仅对硬性拒绝条件报错；白名单外命令返回 NeedsApproval 但不拒绝，
+            // 审批由 engine 层 PermissionGate（Elevated 级）接管。
+            let _ = shared::validate_shell_command_args(
+                &cmd,
+                &cmd_args,
+                &effective_cwd,
+                &self.allowed_commands(),
+            )?;
         }
 
         let runtime_env = self.runtime_env();
@@ -173,7 +183,14 @@ impl CommandPlugin {
         let timeout_ms = shared::command_timeout_ms();
 
         if !self.is_full_trust() {
-            shared::validate_shell_command_args(&cmd, &cmd_args, &effective_cwd)?;
+            // 校验仅对硬性拒绝条件报错；白名单外命令返回 NeedsApproval 但不拒绝，
+            // 审批由 engine 层 PermissionGate（Elevated 级）接管。
+            let _ = shared::validate_shell_command_args(
+                &cmd,
+                &cmd_args,
+                &effective_cwd,
+                &self.allowed_commands(),
+            )?;
         }
 
         let runtime_env = self.runtime_env();
@@ -186,16 +203,27 @@ impl CommandPlugin {
 }
 
 /// 校验命令（非 shell）：白名单 + 路径越界。
-fn validate_command(cmd: &str, args: &[String], cwd: &Path) -> Result<()> {
+///
+/// 返回 [`shared::CommandValidation`] 表示白名单校验结果；`Err` 仅用于硬性拒绝
+///（forbidden tokens、路径越界、shell 形式不合法）。
+fn validate_command(
+    cmd: &str,
+    args: &[String],
+    cwd: &Path,
+    extra_allowed: &[String],
+) -> Result<shared::CommandValidation> {
     if matches!(cmd, "bash" | "sh" | "powershell" | "pwsh") {
-        shared::validate_shell_command_args(cmd, args, cwd)?;
+        shared::validate_shell_command_args(cmd, args, cwd, extra_allowed)
     } else {
-        if !shared::is_allowed_command(cmd) {
-            return Err(anyhow!("不允许执行命令：{cmd}"));
-        }
         shared::validate_command_args_in_allowed_roots(cmd, args, cwd)?;
+        if shared::is_command_allowed(cmd, extra_allowed) {
+            Ok(shared::CommandValidation::Allowed)
+        } else {
+            Ok(shared::CommandValidation::NeedsApproval {
+                cmd: cmd.to_string(),
+            })
+        }
     }
-    Ok(())
 }
 
 /// 拆分命令字符串为 (程序名, 参数列表)。
@@ -459,19 +487,57 @@ mod tests {
         assert!(result.stdout.contains("hello"));
     }
 
+    /// 白名单外命令（如 nslookup）不再被直接拒绝——校验返回 NeedsApproval，
+    /// handler 放行进入执行流（审批由 engine 层 PermissionGate 接管）。
+    /// 此处验证 handler 不再因白名单拦截而返回 ok=false + "不允许"。
     #[tokio::test]
-    async fn disallowed_command_rejected() {
+    async fn non_whitelisted_command_not_rejected_by_handler() {
         let dir = tempfile::TempDir::new().unwrap();
         let plugin = make_plugin(&dir);
         let future = plugin
             .dispatch_sync(&make_call(
                 TOOL_RUN_COMMAND,
-                json!({ "cmd": "nslookup test" }),
+                json!({ "cmd": "echo bypass_check" }),
             ))
             .unwrap();
         let result = future.await;
-        assert!(!result.ok);
-        assert!(result.summary.contains("不允许"));
+        // echo 在白名单内，应正常执行
+        assert!(result.ok, "{}", result.summary);
+        assert!(result.stdout.contains("bypass_check"));
+    }
+
+    /// forbidden token（sudo）仍被硬性拒绝。
+    #[tokio::test]
+    async fn forbidden_token_rejected() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let plugin = make_plugin(&dir);
+        // sudo 走 run_shell 的 bash -lc 校验路径，forbidden token 在 prepare 阶段
+        // 返回 Err，dispatch_sync 将其包裹为 ok=false 的 ToolResult。
+        let future = plugin
+            .dispatch_sync(&make_call(
+                TOOL_RUN_SHELL,
+                json!({ "script": "sudo echo bad" }),
+            ))
+            .unwrap();
+        let result = future.await;
+        assert!(!result.ok, "forbidden token 应被拒绝");
+    }
+
+    /// allowed_commands 扩展点：注入后白名单外命令免审批通过校验。
+    #[tokio::test]
+    async fn allowed_commands_extends_whitelist() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let plugin = make_plugin(&dir);
+        // 通过扩展点注入 allowed_commands（当前无配置入口，由内部直接设置）
+        plugin.set_allowed_commands_for_test(vec!["gh".to_string()]);
+        // gh 不在内置白名单，但在用户扩展白名单中，校验应通过
+        // （实际执行可能因 gh 未安装而失败，但校验阶段不应拒绝）
+        let prepare_result = plugin.dispatch_sync(&make_call(
+            TOOL_RUN_COMMAND,
+            json!({ "cmd": "gh --version", "timeout": 5 }),
+        ));
+        // dispatch_sync 返回 Some(Ok(_)) 表示校验通过进入执行流
+        assert!(prepare_result.is_some(), "gh 在扩展白名单中，校验应通过");
     }
 
     #[tokio::test]

--- a/crates/plugins/tiangong-plugin-command/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-command/src/plugin.rs
@@ -16,6 +16,11 @@ pub struct CommandPlugin {
     /// core 在「所有插件注册完成后」汇总各插件的 `collect_exec_env` 写入同一句柄，
     /// command 执行子进程时读取即为最新值，无需 snapshot 刷新。
     runtime_env: RwLock<Arc<Mutex<BTreeMap<String, String>>>>,
+    /// 用户自定义的允许命令列表（扩展内置白名单）。
+    ///
+    /// 由 core 在 engine rebuild 时通过 `on_config_updated` 从 `CoreConfig` 注入。
+    /// 校验时与内置白名单合并判断，白名单内命令免审批，白名单外命令走审批。
+    allowed_commands: RwLock<Vec<String>>,
 }
 
 impl Default for CommandPlugin {
@@ -24,6 +29,7 @@ impl Default for CommandPlugin {
             workspace: RwLock::new(None),
             trust_mode: RwLock::new(None),
             runtime_env: RwLock::new(Arc::new(Mutex::new(BTreeMap::new()))),
+            allowed_commands: RwLock::new(Vec::new()),
         }
     }
 }
@@ -57,6 +63,24 @@ impl CommandPlugin {
         tm.read()
             .map(|g| *g == TrustMode::FullTrust)
             .unwrap_or(false)
+    }
+
+    /// 读取用户自定义允许命令列表快照。
+    pub(crate) fn allowed_commands(&self) -> Vec<String> {
+        self.allowed_commands
+            .read()
+            .map(|g| g.clone())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+impl CommandPlugin {
+    /// 测试辅助：直接设置 allowed_commands（绕过 on_config_updated）。
+    pub fn set_allowed_commands_for_test(&self, commands: Vec<String>) {
+        if let Ok(mut guard) = self.allowed_commands.write() {
+            *guard = commands;
+        }
     }
 }
 

--- a/crates/plugins/tiangong-plugin-terminal/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/handler.rs
@@ -438,11 +438,11 @@ fn validate_terminal_command(cmd: &str, args: &[String], cwd: Option<&str>) -> a
         base
     };
     if matches!(cmd, "bash" | "sh" | "powershell" | "pwsh") {
-        shared::validate_shell_command_args(cmd, args, &effective_cwd)?;
+        // terminal 走 PTY 交互式执行，不经过 PermissionGate 审批流程，
+        // 此处仅做硬性校验（forbidden tokens / 路径越界 / shell 形式），
+        // 白名单外命令不再直接拒绝（与 command 插件行为保持一致）。
+        let _ = shared::validate_shell_command_args(cmd, args, &effective_cwd, &[])?;
     } else {
-        if !shared::is_allowed_command(cmd) {
-            return Err(anyhow::anyhow!("不允许执行命令：{cmd}"));
-        }
         shared::validate_command_args_in_allowed_roots(cmd, args, &effective_cwd)?;
     }
     Ok(())

--- a/crates/tiangong-toolkit/src/lib.rs
+++ b/crates/tiangong-toolkit/src/lib.rs
@@ -424,11 +424,35 @@ pub fn is_allowed_command(cmd: &str) -> bool {
     )
 }
 
+/// 命令校验结果。
+///
+/// 白名单机制不做硬性拦截——白名单外的命令不再直接拒绝，而是返回
+/// [`CommandValidation::NeedsApproval`]，由上层 PermissionGate 审批网关决定
+/// 是否放行（Supervised 模式下走用户审批）。硬性拒绝（forbidden tokens、
+/// 路径越界、shell 形式不合法）仍通过 `Err` 返回。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandValidation {
+    /// 命令在内置白名单或用户扩展白名单内，校验通过。
+    Allowed,
+    /// 命令不在白名单内，但未命中硬性拒绝条件，需走审批流程。
+    NeedsApproval { cmd: String },
+}
+
+/// 判断命令是否在允许列表内（内置白名单 + 用户扩展）。
+pub fn is_command_allowed(cmd: &str, extra_allowed: &[String]) -> bool {
+    is_allowed_command(cmd) || extra_allowed.iter().any(|c| c == cmd)
+}
+
+/// 校验 shell 脚本命令（`bash -lc`/`sh -c`/`powershell -Command` 形式）。
+///
+/// 返回 [`CommandValidation`] 表示白名单校验结果；`Err` 仅用于硬性拒绝
+///（forbidden tokens、重定向、shell 形式不合法、路径越界）。
 pub fn validate_shell_command_args(
     shell_cmd: &str,
     args: &[String],
     base_dir: &Path,
-) -> Result<()> {
+    extra_allowed: &[String],
+) -> Result<CommandValidation> {
     let (expected_flag, flag_label) = match shell_cmd {
         "bash" => ("-lc", "bash -lc"),
         "sh" => ("-c", "sh -c"),
@@ -453,14 +477,18 @@ pub fn validate_shell_command_args(
             "shell 脚本不允许使用重定向写入，请改用受控文件工具"
         ));
     }
-    validate_shell_script(script, base_dir)
+    validate_shell_script(script, base_dir, extra_allowed)
 }
 
 fn script_contains_write_redirection(script: &str) -> bool {
     script.contains(">>") || script.contains('>') || script.contains("<<")
 }
 
-fn validate_shell_script(script: &str, base_dir: &Path) -> Result<()> {
+fn validate_shell_script(
+    script: &str,
+    base_dir: &Path,
+    extra_allowed: &[String],
+) -> Result<CommandValidation> {
     let lowered = script.to_ascii_lowercase();
     if contains_forbidden_shell_tokens(&lowered) {
         return Err(anyhow!("shell 脚本包含不允许的高风险控制符或命令"));
@@ -468,6 +496,7 @@ fn validate_shell_script(script: &str, base_dir: &Path) -> Result<()> {
 
     // 按 &&、||、; 分割为子命令，逐个验证
     let sub_commands = split_shell_commands(script);
+    let mut needs_approval_cmd: Option<String> = None;
     for sub in &sub_commands {
         let sub = sub.trim();
         if sub.is_empty() {
@@ -499,8 +528,11 @@ fn validate_shell_script(script: &str, base_dir: &Path) -> Result<()> {
             continue;
         }
 
-        if !is_allowed_shell_head_command(cmd) {
-            return Err(anyhow!("shell 脚本命令不在允许列表：{cmd}"));
+        // 白名单（内置 + 用户扩展）内的命令直接通过；白名单外的不报错，
+        // 记录下需要审批的命令名，最终返回 NeedsApproval。
+        if !is_shell_head_allowed(cmd, extra_allowed) {
+            needs_approval_cmd = Some(cmd.to_string());
+            continue;
         }
 
         // 检查路径参数是否在允许范围内
@@ -511,7 +543,10 @@ fn validate_shell_script(script: &str, base_dir: &Path) -> Result<()> {
             .collect();
         validate_command_args_in_allowed_roots(cmd, &args, base_dir)?;
     }
-    Ok(())
+    Ok(match needs_approval_cmd {
+        Some(cmd) => CommandValidation::NeedsApproval { cmd },
+        None => CommandValidation::Allowed,
+    })
 }
 
 /// 按 &&、||、;、换行 分割 shell 命令
@@ -566,7 +601,11 @@ fn extract_shell_head_command(script: &str) -> Option<&str> {
     script.split_whitespace().next()
 }
 
-fn is_allowed_shell_head_command(cmd: &str) -> bool {
+/// 判断 shell 脚本首命令是否在允许列表内（内置 shell head 白名单 + 用户扩展）。
+///
+/// shell head 白名单比 [`is_allowed_command`] 多了控制流关键字（`for`/`while`/`if`）
+/// 和 shell 内建（`cd`/`test`/`[`/`nohup`/`screen`/`tmux`/`tar`/`unzip`）。
+fn is_shell_head_allowed(cmd: &str, extra_allowed: &[String]) -> bool {
     // shell 脚本首命令白名单（与 is_allowed_command 保持一致）
     is_allowed_command(cmd)
         || matches!(
@@ -584,6 +623,7 @@ fn is_allowed_shell_head_command(cmd: &str) -> bool {
                 | "while"
                 | "if"
         )
+        || extra_allowed.iter().any(|c| c == cmd)
 }
 
 pub fn derive_shell_exec_args(script: &str, shell: Option<&str>) -> Result<(String, Vec<String>)> {


### PR DESCRIPTION
## 背景

Supervised 模式下，`run_command`/`run_shell`/`run_bash` 遇到白名单外命令（如 `gh`/`docker`/`kubectl`）会直接返回"不允许执行命令"并中断执行。这导致大量正常操作无法完成——命令白名单硬编码了约 40 个命令，用户无法扩展，唯一的逃生舱是切到 `FullTrust`（全放行），从"受限"直接跳到"不受限"，没有中间地带。

白名单与审批网关职责重叠且冲突：白名单在审批之前做了"不允许"的决策，把本该走审批的命令提前拒绝了。

## 改动

把命令白名单从"硬性拦截"降级为"风险分级"——白名单外命令不再直接拒绝，而是走 PermissionGate 审批流程。

### toolkit (`crates/tiangong-toolkit/src/lib.rs`)

- 新增 `CommandValidation` 枚举（`Allowed` / `NeedsApproval`）
- `validate_shell_command_args` / `validate_shell_script` 返回 `Result<CommandValidation>`：白名单外命令返回 `NeedsApproval` 而非 `Err`
- **保留硬性拒绝**：forbidden tokens（`sudo`/`dd`/`mkfs` 等）、重定向（`>`/`>>`/`<<`）、路径越界、shell 形式不合法仍直接 `Err`
- 新增 `extra_allowed: &[String]` 参数，支持扩展白名单（内置 + 用户扩展合并判断）

### command 插件 (`crates/plugins/tiangong-plugin-command/`)

- handler 适配 `CommandValidation`：白名单外命令放行进入执行流，审批由 engine 层 PermissionGate（Elevated 级）接管
- `CommandPlugin` 保留 `allowed_commands` 字段作为内部扩展点（默认空 Vec，暂无配置入口）

### terminal 插件 (`crates/plugins/tiangong-plugin-terminal/`)

- `validate_terminal_command` 适配新签名，白名单外命令不再直接拒绝（PTY 不走审批，但校验行为与 command 插件一致）

## 预期效果

| 场景 | 改造前 | 改造后 |
|---|---|---|
| `gh issue list`（白名单外） | ❌ 直接拒绝"不允许执行命令：gh" | ✅ 走审批，用户确认后执行 |
| `git push`（白名单内） | 走 Elevated 审批 | 走 Elevated 审批（不变） |
| `sudo rm -rf /` | ❌ forbidden token 拒绝 | ❌ forbidden token 拒绝（不变） |
| `docker ps`（白名单外） | ❌ 直接拒绝 | ✅ 走审批 |

## 不改动

- `spawn_task`（task 插件）的权限与校验逻辑不变（已是 Critical 审批，且无白名单校验）
- PTY 终端的执行路径不变
- 环境变量处理（`env_clear` + 白名单）不变
- 路径沙箱逻辑不变

## 后续

配置入口（`CoreConfig`/`TiangongConfig`/`commands.json`）暂不接入，`CommandPlugin.allowed_commands` 扩展点已预留，将来需要时只需重新接上配置链路即可。