### PR TITLE
fix(scheduler): executor 测试状态污染导致 flaky

### DIFF
--- a/crates/tiangong-scheduler/src/executor.rs
+++ b/crates/tiangong-scheduler/src/executor.rs
@@ -418,10 +418,10 @@ mod tests {
         }
     }
 
-    fn setup_job_store(dir: &TempDir) -> (JobStore, Job) {
+    fn setup_job_store(dir: &TempDir, job_id: &str) -> (JobStore, Job) {
         let store = JobStore::open_at(dir.path().to_path_buf()).unwrap();
         let job = Job {
-            id: "test-job-1".to_string(),
+            id: job_id.to_string(),
             name: "测试任务".to_string(),
             description: "测试".to_string(),
             trigger_type: crate::model::TriggerType::Cron,
@@ -439,14 +439,14 @@ mod tests {
     #[tokio::test]
     async fn execute_succeeds_and_records_run() {
         let dir = TempDir::new().unwrap();
-        let (store, _job) = setup_job_store(&dir);
+        let (store, _job) = setup_job_store(&dir, "test-job-succeed");
         let store_path = dir.path().to_path_buf();
 
         let ctx = Arc::new(MockContext {
             sessions: StdMutex::new(vec![]),
         });
         let params = ExecuteParams {
-            trigger_id: "test-job-1".to_string(),
+            trigger_id: "test-job-succeed".to_string(),
             trigger_name: "测试任务".to_string(),
             trigger_description: "测试".to_string(),
             session_id: None,
@@ -462,7 +462,7 @@ mod tests {
         .await;
 
         let reader = JobStore::open_at(store_path).unwrap();
-        let runs = reader.list_job_runs("test-job-1", 10).unwrap();
+        let runs = reader.list_job_runs("test-job-succeed", 10).unwrap();
         assert_eq!(runs.len(), 1);
         assert!(matches!(runs[0].status, JobRunStatus::Succeeded));
         assert!(runs[0].finished_at.is_some());
@@ -471,14 +471,14 @@ mod tests {
     #[tokio::test]
     async fn execute_failure_records_run_as_failed() {
         let dir = TempDir::new().unwrap();
-        let (store, _) = setup_job_store(&dir);
+        let (store, _) = setup_job_store(&dir, "test-job-failure");
         let store_path = dir.path().to_path_buf();
 
         let ctx = Arc::new(MockContext {
             sessions: StdMutex::new(vec![]),
         });
         let params = ExecuteParams {
-            trigger_id: "test-job-1".to_string(),
+            trigger_id: "test-job-failure".to_string(),
             trigger_name: "测试任务".to_string(),
             trigger_description: "测试".to_string(),
             session_id: None,
@@ -494,7 +494,7 @@ mod tests {
         .await;
 
         let reader = JobStore::open_at(store_path).unwrap();
-        let runs = reader.list_job_runs("test-job-1", 10).unwrap();
+        let runs = reader.list_job_runs("test-job-failure", 10).unwrap();
         assert_eq!(runs.len(), 1);
         assert!(matches!(runs[0].status, JobRunStatus::Failed));
         assert!(
@@ -509,7 +509,7 @@ mod tests {
     #[tokio::test]
     async fn concurrent_execution_is_skipped() {
         let dir = TempDir::new().unwrap();
-        let (_store, _) = setup_job_store(&dir);
+        let (_store, _) = setup_job_store(&dir, "test-job-concurrent");
         let store_path = dir.path().to_path_buf();
 
         let slow_sender: MessageSender = Box::new(|_sid, _msg| {
@@ -524,14 +524,14 @@ mod tests {
         });
 
         let params1 = ExecuteParams {
-            trigger_id: "test-job-1".to_string(),
+            trigger_id: "test-job-concurrent".to_string(),
             trigger_name: "测试任务".to_string(),
             trigger_description: "测试".to_string(),
             session_id: None,
             payload: "hello".to_string(),
         };
         let params2 = ExecuteParams {
-            trigger_id: "test-job-1".to_string(),
+            trigger_id: "test-job-concurrent".to_string(),
             trigger_name: "测试任务".to_string(),
             trigger_description: "测试".to_string(),
             session_id: None,
@@ -569,7 +569,7 @@ mod tests {
         h2.await.unwrap();
 
         let reader = JobStore::open_at(store_path).unwrap();
-        let runs = reader.list_job_runs("test-job-1", 10).unwrap();
+        let runs = reader.list_job_runs("test-job-concurrent", 10).unwrap();
         assert_eq!(runs.len(), 1, "并发执行应被跳过，只有一条记录");
     }
 }


### PR DESCRIPTION
## 关联 issue
Closes #216

## 根因
`crates/tiangong-scheduler/src/executor.rs` 的进程级全局静态集合：

```rust
static RUNNING: LazyLock<Mutex<HashSet<String>>> = ...;
```

`execute_core` 用它做"同一 trigger 不重叠执行"的判断。三个测试都硬编码了 `trigger_id = "test-job-1"`，并行执行时，先抢到锁的测试把该 id 插入 `RUNNING`，其他测试命中 `contains` → 直接 return → 不写入 run 记录 → `runs.len() == 0` → 断言失败。

这正是 issue 报告的典型现象：两次 workspace 跑失败的测试**不同**，单独跑均通过。

## 修复
为每个测试分配唯一 trigger_id：

| 测试 | 修改前 | 修改后 |
|------|--------|--------|
| `execute_succeeds_and_records_run` | `test-job-1` | `test-job-succeed` |
| `execute_failure_records_run_as_failed` | `test-job-1` | `test-job-failure` |
| `concurrent_execution_is_skipped` | `test-job-1` | `test-job-concurrent`（内部两并发分支仍共用，保留"同任务并发跳过"语义） |

`setup_job_store` 改为接收 `job_id` 参数，保证 job id 与 trigger_id 一致。

## 设计取舍
issue 建议了 `serial_test`，本 PR **未采用**——那会让三个测试强制串行（慢），且掩盖了"全局状态污染"的本质。唯一化 trigger_id：
- 保留 `RUNNING` 重叠保护的生产语义
- `concurrent_execution_is_skipped` 仍能真实验证并发跳过
- 所有测试可自由并行

`RUNNING` 全局集合在生产环境是合理的（跨 `execute_job`/`execute_webhook` 调用共享，确需进程级单例），故未改动。

## 验证
- 修复前首次单跑即复现失败（`left: 0, right: 1`）
- 修复后：默认并行 ×10、`--test-threads=8` ×10，共 **20/20 通过**
- `cargo clippy -p tiangong-scheduler --all-targets` 干净