### PR TITLE
ci: 并行执行 check/clippy/nextest

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,81 @@
+name: Setup Rust environment
+description: >
+  为 clippy / nextest 等并行 Rust 作业准备共享的运行环境：释放磁盘空间、
+  checkout、安装工具链与系统依赖、可选安装 cargo-nextest、缓存 target/、
+  并把受影响 crate 列表展开成 "-p a -p b ..." 供后续 cargo 命令复用。
+
+inputs:
+  components:
+    description: 传给 dtolnay/rust-toolchain 的 components（如 clippy），留空则不追加。
+    default: ""
+  install-nextest:
+    description: 是否安装 cargo-nextest。
+    type: boolean
+    default: false
+  matrix:
+    description: 受影响 crate 的 JSON 数组（来自 changes 作业的 matrix 输出）。
+    required: true
+
+outputs:
+  pkgs:
+    description: 展开后的 "-p a -p b ..." 参数串。
+    value: ${{ steps.pkgs.outputs.pkgs }}
+
+runs:
+  using: composite
+  steps:
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
+    - uses: actions/checkout@v4
+
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: ${{ inputs.components }}
+
+    - name: Install Linux system dependencies
+      # tiangong-core / tiangong-memory 间接引入 tantivy/lancedb/rusqlite/scraper，
+      # tiangong-plugin-* 与 tiangong-app 引入 tauri，均需下列系统库。
+      shell: bash
+      run: |
+        # GitHub runner 预装的 Microsoft apt 源偶发 403，提前移除避免污染 apt-get update
+        sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get update
+        sudo apt-get install -y \
+          protobuf-compiler \
+          pkg-config \
+          libglib2.0-dev \
+          libwebkit2gtk-4.1-dev \
+          libgtk-3-dev \
+          libayatana-appindicator3-dev \
+          librsvg2-dev \
+          patchelf
+
+    - name: Install cargo-nextest
+      if: ${{ inputs.install-nextest == 'true' }}
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest
+
+    - name: Cache Rust artifacts
+      uses: Swatinem/rust-cache@v2
+
+    - name: Resolve package args
+      id: pkgs
+      shell: bash
+      env:
+        MATRIX: ${{ inputs.matrix }}
+      run: |
+        # 把受影响 crate 的 JSON 数组展开为 "-p a -p b ..." 形式，
+        # 后续 cargo 命令通过 $PKGS 复用，确保依赖闭包在同一 target/ 下只编译一次。
+        pkgs="$(printf '%s' "$MATRIX" | jq -r '.[] | "-p \(.)"' | paste -sd ' ' -)"
+        echo "pkgs=$pkgs" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,82 +162,58 @@ jobs:
         # 格式校验必须保证整个 workspace 一致，因此仅做一次、不按 crate 拆分
         run: cargo fmt --all -- --check
 
-  # 单作业批量校验所有受影响 crate：changes 作业已筛出被直接改动的 crate，
-  # 这里把它们合并到同一条 cargo 命令（cargo -p a -p b ...）。
-  # 合并后所有 crate 共享同一个 target/ 目录与 rust-cache，共享依赖只编译一次，
-  # 避免「逐 crate 矩阵作业各自全量编译依赖闭包」导致的重复构建。
-  rust-crate:
-    name: Rust (affected crates)
+  # check / clippy / nextest 三条作业并行调度、互不阻塞，wall-clock 取最慢的一条。
+  # 三者均把受影响 crate 合并成「-p a -p b ...」，共享同一 target/ 与 rust-cache，
+  # 公共依赖只编译一次；共享 .github/actions/setup-rust 复合 action，避免磁盘释放、
+  # 工具链、系统依赖、缓存、package 解析等步骤重复书写。
+  rust-check:
+    name: Rust check (affected crates)
     needs: changes
     if: needs.changes.outputs.matrix != '[]' && needs.changes.outputs.matrix != ''
     runs-on: ubuntu-latest
     steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+      - id: setup
+        uses: ./.github/actions/setup-rust
         with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
-
-      - uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
-      - name: Install Linux system dependencies
-        # tiangong-core / tiangong-memory 间接引入 tantivy/lancedb/rusqlite/scraper，
-        # tiangong-plugin-* 与 tiangong-app 引入 tauri，均需下列系统库。
-        run: |
-          # GitHub runner 预装的 Microsoft apt 源偶发 403，提前移除避免污染 apt-get update
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
-          sudo apt-get install -y \
-            protobuf-compiler \
-            pkg-config \
-            libglib2.0-dev \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            patchelf
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
-
-      - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Resolve package args
-        id: pkgs
-        env:
-          MATRIX: ${{ needs.changes.outputs.matrix }}
-        run: |
-          # 把受影响 crate 的 JSON 数组展开为 "-p a -p b ..." 形式，
-          # 后续 cargo 命令通过 $PKGS 复用，确保依赖闭包在同一 target/ 下只编译一次。
-          pkgs="$(printf '%s' "$MATRIX" | jq -r '.[] | "-p \(.)"' | paste -sd ' ' -)"
-          echo "pkgs=$pkgs" >> "$GITHUB_OUTPUT"
+          matrix: ${{ needs.changes.outputs.matrix }}
 
       - name: Check crate
         env:
-          PKGS: ${{ steps.pkgs.outputs.pkgs }}
+          PKGS: ${{ steps.setup.outputs.pkgs }}
         run: cargo check $PKGS
+
+  rust-clippy:
+    name: Rust clippy (affected crates)
+    needs: changes
+    if: needs.changes.outputs.matrix != '[]' && needs.changes.outputs.matrix != ''
+    runs-on: ubuntu-latest
+    steps:
+      - id: setup
+        uses: ./.github/actions/setup-rust
+        with:
+          matrix: ${{ needs.changes.outputs.matrix }}
+          components: clippy
 
       - name: Run clippy
         env:
-          PKGS: ${{ steps.pkgs.outputs.pkgs }}
+          PKGS: ${{ steps.setup.outputs.pkgs }}
         run: cargo clippy $PKGS --all-targets --tests --benches -- -D warnings
+
+  rust-test:
+    name: Rust nextest (affected crates)
+    needs: changes
+    if: needs.changes.outputs.matrix != '[]' && needs.changes.outputs.matrix != ''
+    runs-on: ubuntu-latest
+    steps:
+      - id: setup
+        uses: ./.github/actions/setup-rust
+        with:
+          matrix: ${{ needs.changes.outputs.matrix }}
+          install-nextest: true
 
       - name: Run nextest
         env:
-          PKGS: ${{ steps.pkgs.outputs.pkgs }}
+          PKGS: ${{ steps.setup.outputs.pkgs }}
           CARGO_BUILD_JOBS: "1"
           RUSTFLAGS: "-C linker-features=-lld"
         run: cargo nextest run $PKGS --no-tests pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,10 @@ jobs:
   tauri:
     name: Tauri Shell Check
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    # 仅当 src-tauri/ 本身被直接改动时才跑。matrix 把 src-tauri/ 映射成包名
+    # tiangong-app，所以判断 matrix 是否含该包即可；避免仅改 ci.yml / Cargo.lock
+    # 等无关 Rust 改动也拉起 tauri 校验。
+    if: contains(fromJson(needs.changes.outputs.matrix), 'tiangong-app')
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space


### PR DESCRIPTION
## 背景

原 `rust-crate` 单作业串行执行 `cargo check → clippy → nextest`,wall-clock 是三者之和。

## 改动

- 将 `rust-crate` 拆成 `rust-check` / `rust-clippy` / `rust-test` 三条作业,均 `needs: changes`、彼此无依赖,**并行调度**,wall-clock 压缩到最慢的一条。
- 提取 \`.github/actions/setup-rust\` 复合 action,收纳磁盘释放、checkout、工具链、系统依赖、rust-cache、package 解析等共享步骤,避免三个作业各抄一遍 ~40 行 setup 代码。
- 受影响 crate 仍合并成 \`-p a -p b ...\`,共享同一 \`target/\`,公共依赖只编译一次。

## 行为说明

三条作业并行启动,彼此无依赖。任一条失败仅标记本次 workflow 失败,其余继续跑完;分支保护规则仍会把这三条作为必须通过的检查。

## 测试

- [x] YAML 解析通过(ruby YAML.load_file)
- [x] pre-commit / pre-push hook 全部通过