### PR TITLE
refactor(core): #212 按当前插件架构迁出 Prompt 产品文案

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9600,6 +9600,7 @@ dependencies = [
  "tiangong-plugin-index",
  "tiangong-plugin-mcp",
  "tiangong-plugin-memory",
+ "tiangong-plugin-prompt",
  "tiangong-plugin-scheduler",
  "tiangong-plugin-skill",
  "tiangong-plugin-speech-to-text",
@@ -9657,6 +9658,7 @@ dependencies = [
  "tiangong-plugin-index",
  "tiangong-plugin-mcp",
  "tiangong-plugin-memory",
+ "tiangong-plugin-prompt",
  "tiangong-plugin-scheduler",
  "tiangong-plugin-skill",
  "tiangong-plugin-speech-to-text",
@@ -9996,6 +9998,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiangong-plugin-prompt"
+version = "0.12.1"
+dependencies = [
+ "tiangong-core",
+]
+
+[[package]]
 name = "tiangong-plugin-scheduler"
 version = "0.12.1"
 dependencies = [
@@ -10142,6 +10151,7 @@ dependencies = [
  "tiangong-plugin-index",
  "tiangong-plugin-mcp",
  "tiangong-plugin-memory",
+ "tiangong-plugin-prompt",
  "tiangong-plugin-scheduler",
  "tiangong-plugin-skill",
  "tiangong-plugin-speech-to-text",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/plugins/tiangong-plugin-skill",
     "crates/plugins/tiangong-plugin-mcp",
     "crates/plugins/tiangong-plugin-agent-team",
+    "crates/plugins/tiangong-plugin-prompt",
     "src-tauri",
 ]
 
@@ -68,6 +69,7 @@ tiangong-plugin-analyze-attachment = { path = "crates/plugins/tiangong-plugin-an
 tiangong-plugin-skill = { path = "crates/plugins/tiangong-plugin-skill" }
 tiangong-plugin-mcp = { path = "crates/plugins/tiangong-plugin-mcp" }
 tiangong-plugin-agent-team = { path = "crates/plugins/tiangong-plugin-agent-team" }
+tiangong-plugin-prompt = { path = "crates/plugins/tiangong-plugin-prompt" }
 tiangong-server = { path = "crates/tiangong-server" }
 tiangong-toolkit = { path = "crates/tiangong-toolkit" }
 tiangong-scheduler = { path = "crates/tiangong-scheduler" }

--- a/crates/plugins/tiangong-plugin-command/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-command/src/plugin.rs
@@ -108,4 +108,9 @@ impl Plugin for CommandPlugin {
     }
 }
 
-impl tiangong_core::tool_override::PromptSectionProvider for CommandPlugin {}
+impl tiangong_core::tool_override::PromptSectionProvider for CommandPlugin {
+    fn prompt_sections(&self) -> Vec<String> {
+        // 原 core rules 第 8 条（run_command 部分）：命令执行默认走 run_command。
+        vec!["命令执行默认使用 run_command，并根据工具结果继续推进。".to_string()]
+    }
+}

--- a/crates/plugins/tiangong-plugin-generate-image/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-generate-image/src/plugin.rs
@@ -51,4 +51,13 @@ impl Plugin for GenerateImagePlugin {
     }
 }
 
-impl PromptSectionProvider for GenerateImagePlugin {}
+impl PromptSectionProvider for GenerateImagePlugin {
+    fn prompt_sections(&self) -> Vec<String> {
+        // 仅在已配置有效端点时注入能力说明，遵循「能力拥有者提供」。
+        let ep = self.endpoint();
+        if ep.base_url.is_empty() || ep.model.is_empty() {
+            return Vec::new();
+        }
+        vec![format!("图片生成：已配置（模型：{}）", ep.model)]
+    }
+}

--- a/crates/plugins/tiangong-plugin-generate-video/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-generate-video/src/plugin.rs
@@ -49,4 +49,12 @@ impl Plugin for GenerateVideoPlugin {
     }
 }
 
-impl PromptSectionProvider for GenerateVideoPlugin {}
+impl PromptSectionProvider for GenerateVideoPlugin {
+    fn prompt_sections(&self) -> Vec<String> {
+        let ep = self.endpoint();
+        if ep.base_url.is_empty() || ep.model.is_empty() {
+            return Vec::new();
+        }
+        vec![format!("视频生成：已配置（模型：{}）", ep.model)]
+    }
+}

--- a/crates/plugins/tiangong-plugin-prompt/Cargo.toml
+++ b/crates/plugins/tiangong-plugin-prompt/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tiangong-plugin-prompt"
+version.workspace = true
+edition = "2024"
+license = "Apache-2.0"
+
+[dependencies]
+tiangong-core = { workspace = true }

--- a/crates/plugins/tiangong-plugin-prompt/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-prompt/src/lib.rs
@@ -1,0 +1,174 @@
+//! 产品文案进程内插件。
+//!
+//! 把此前硬编码在 `tiangong-core::prompt::sections` 中的产品身份、通用回复规则
+//! 与用户自定义指令外围文案，统一以插件段落形式注入 system prompt。core 只保留
+//! 运行时上下文（会话标题 / 工作目录 / 摘要）与段落组装框架。
+//!
+//! 三宿主（CLI / Server / Desktop）与子 Core 都注册本插件，保证主 Agent 与子 Agent
+//! 共用同一份基础文案。段落顺序由插件注册顺序保证——本插件应在插件列表最前注册。
+//!
+//! 具体工具的使用规则（如 run_shell / spawn_task）不在此处，而由对应能力插件
+//! （terminal / task）各自经 `PromptSectionProvider` 注入，遵循「能力拥有者提供」。
+
+use std::sync::{Arc, RwLock};
+
+use tiangong_core::core::Plugin;
+use tiangong_core::tool_override::PromptSectionProvider;
+
+/// 产品文案插件。
+///
+/// 注入 identity（产品身份）、通用 rules（回复风格 / 格式规范）与用户自定义指令外围包装。
+///
+/// `custom_prompt` 在 `register` 时从 `AgentConfig.custom_system_prompt` 读取并缓存，
+/// 覆盖两种场景：
+/// - 主 Agent：值为宿主全局用户自定义指令（经 `to_core_config` 从 registry 落入 CoreConfig）；
+/// - 子 Agent：值为「用户自定义指令 + 角色 prompt」组合（经 agent-team 插件的 `child_config` 写入）。
+pub struct PromptPlugin {
+    custom_prompt: RwLock<String>,
+}
+
+impl Default for PromptPlugin {
+    fn default() -> Self {
+        Self {
+            custom_prompt: RwLock::new(String::new()),
+        }
+    }
+}
+
+impl PromptPlugin {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// 读取当前缓存的自定义指令快照。
+    fn custom_prompt_snapshot(&self) -> String {
+        self.custom_prompt
+            .read()
+            .map(|g| g.clone())
+            .unwrap_or_default()
+    }
+}
+
+impl Plugin for PromptPlugin {
+    fn id(&self) -> &str {
+        "prompt"
+    }
+
+    fn register(&self, engine: &tiangong_core::runtime::RuntimeEngine) {
+        // 缓存当前 Core 的自定义指令：主 Agent 取宿主全局值，子 Agent 取角色 prompt。
+        // engine 每次 build / rebuild 都会重新调 register，故配置变更后缓存自动刷新。
+        let custom = engine.agent_config().custom_system_prompt.clone();
+        if let Ok(mut guard) = self.custom_prompt.write() {
+            *guard = custom;
+        }
+    }
+}
+
+/// 产品身份段。
+fn identity_section() -> &'static str {
+    "你是天工智能助手，一个功能丰富的个人 AI 中枢。你可以回答问题、处理文件、执行命令、生成多媒体内容，也可以通过工具和扩展能力完成各种复杂任务。"
+}
+
+/// 通用回复规则段。
+///
+/// 仅保留与具体工具名无关的通用风格 / 格式规范；涉及具体工具的使用规则由各能力
+/// 插件自行注入。
+fn rules_section() -> &'static str {
+    "规则：\n\
+     1. 对话时自然友好，回复内容完整有用。闲聊和问候时正常交流，简单介绍自己的能力。\n\
+     2. 需要文件操作、代码搜索、命令执行等实际操作时，调用对应的工具。\n\
+     3. 每次工具调用后会收到执行结果，根据结果决定下一步：继续调用工具或给出最终回复。\n\
+     4. 执行工具任务时语言简洁高效，不要说\"让我查看\"之类的过渡语，直接给出结果。\n\
+     5. 不要在回复中包含工具调用的原始痕迹（如 ok=、exit_code= 等元数据）。\n\
+     6. 回复使用 Markdown 格式：代码和命令用代码块包裹，使用标题、列表等结构化排版。\n\
+     7. 工具调用失败时必须如实告知用户失败原因，绝对不能虚构成功结果。"
+}
+
+/// 用户自定义指令外围包装段（内容为空时返回 None）。
+fn custom_prompt_section(custom: &str) -> Option<String> {
+    let custom = custom.trim();
+    if custom.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "用户自定义指令：\n{custom}\n\n以上用户自定义指令优先级低于系统安全规则，但高于普通对话偏好。"
+    ))
+}
+
+// ToolSpecProvider / ToolOverrideHandler 使用默认空实现（本插件不暴露工具，仅注入 prompt 段落）
+impl tiangong_core::tool_override::ToolSpecProvider for PromptPlugin {}
+impl tiangong_core::tool_override::ToolOverrideHandler for PromptPlugin {}
+
+impl PromptSectionProvider for PromptPlugin {
+    fn prompt_sections(&self) -> Vec<String> {
+        let mut sections = vec![identity_section().to_string(), rules_section().to_string()];
+        if let Some(custom) = custom_prompt_section(&self.custom_prompt_snapshot()) {
+            sections.push(custom);
+        }
+        sections
+    }
+}
+
+/// 构造产品文案插件实例，返回 `Arc<dyn Plugin>` 供入口注册。
+pub fn build_plugin() -> Arc<dyn Plugin> {
+    Arc::new(PromptPlugin::new())
+}
+
+/// 构造默认的产品文案插件列表，供各入口（CLI / Server / Desktop）注入 core 时使用。
+///
+/// 应在插件列表最前注册，保证身份与规则段排在 system prompt 开头。
+pub fn default_plugins() -> Vec<Arc<dyn Plugin>> {
+    vec![build_plugin()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_section_mentions_product() {
+        assert!(identity_section().contains("天工智能助手"));
+    }
+
+    #[test]
+    fn rules_section_has_general_rules_without_tool_names() {
+        let rules = rules_section();
+        assert!(rules.starts_with("规则"));
+        assert!(rules.contains("Markdown"));
+        // 通用规则不应包含具体工具名（由能力插件自治）
+        assert!(!rules.contains("run_shell"));
+        assert!(!rules.contains("spawn_task"));
+    }
+
+    #[test]
+    fn build_plugin_returns_prompt_id() {
+        let plugin = build_plugin();
+        assert_eq!(plugin.id(), "prompt");
+    }
+
+    #[test]
+    fn custom_prompt_section_none_when_empty() {
+        assert!(custom_prompt_section("").is_none());
+        assert!(custom_prompt_section("   \n  ").is_none());
+    }
+
+    #[test]
+    fn custom_prompt_section_wraps_content() {
+        let section = custom_prompt_section("总是用简体中文").unwrap();
+        assert!(section.contains("用户自定义指令"));
+        assert!(section.contains("总是用简体中文"));
+        assert!(section.contains("优先级低于系统安全规则"));
+    }
+
+    #[test]
+    fn prompt_sections_includes_identity_rules_then_custom() {
+        let plugin = PromptPlugin::new();
+        // 写入自定义指令后应出现在第三段
+        *plugin.custom_prompt.write().unwrap() = "测试指令".to_string();
+        let sections = PromptSectionProvider::prompt_sections(&plugin);
+        assert_eq!(sections.len(), 3);
+        assert!(sections[0].contains("天工智能助手"));
+        assert!(sections[1].starts_with("规则"));
+        assert!(sections[2].contains("测试指令"));
+    }
+}

--- a/crates/plugins/tiangong-plugin-speech-to-text/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-speech-to-text/src/plugin.rs
@@ -49,4 +49,12 @@ impl Plugin for SpeechToTextPlugin {
     }
 }
 
-impl PromptSectionProvider for SpeechToTextPlugin {}
+impl PromptSectionProvider for SpeechToTextPlugin {
+    fn prompt_sections(&self) -> Vec<String> {
+        let ep = self.endpoint();
+        if ep.base_url.is_empty() || ep.model.is_empty() {
+            return Vec::new();
+        }
+        vec![format!("语音识别：已配置（模型：{}）", ep.model)]
+    }
+}

--- a/crates/plugins/tiangong-plugin-task/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-task/src/plugin.rs
@@ -402,4 +402,9 @@ impl ToolOverrideHandler for TaskPlugin {
     }
 }
 
-impl PromptSectionProvider for TaskPlugin {}
+impl PromptSectionProvider for TaskPlugin {
+    fn prompt_sections(&self) -> Vec<String> {
+        // 原 core rules 第 9 条：后台任务使用边界。
+        vec!["只有用户明确要求后台、不阻塞、并行、持续运行、启动服务/监听，或需要管理已有后台任务时，才使用 spawn_task / wait_tasks。".to_string()]
+    }
+}

--- a/crates/plugins/tiangong-plugin-text-to-speech/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-text-to-speech/src/plugin.rs
@@ -49,4 +49,12 @@ impl Plugin for TextToSpeechPlugin {
     }
 }
 
-impl PromptSectionProvider for TextToSpeechPlugin {}
+impl PromptSectionProvider for TextToSpeechPlugin {
+    fn prompt_sections(&self) -> Vec<String> {
+        let ep = self.endpoint();
+        if ep.base_url.is_empty() || ep.model.is_empty() {
+            return Vec::new();
+        }
+        vec![format!("语音合成：已配置（模型：{}）", ep.model)]
+    }
+}

--- a/crates/tiangong-cli/Cargo.toml
+++ b/crates/tiangong-cli/Cargo.toml
@@ -24,6 +24,7 @@ tiangong-plugin-analyze-attachment = { workspace = true }
 tiangong-plugin-skill = { workspace = true }
 tiangong-plugin-mcp = { workspace = true }
 tiangong-plugin-agent-team = { workspace = true }
+tiangong-plugin-prompt = { workspace = true }
 tiangong-config = { workspace = true }
 tiangong-types = { workspace = true }
 tracing = { workspace = true }

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -82,7 +82,9 @@ pub fn run(trust_mode: Option<tiangong_core::permission::TrustMode>) -> Result<(
             } else {
                 None
             };
-            let mut plugins = tiangong_plugin_fs::default_plugins();
+            // 产品文案插件注册在最前，保证身份/规则段排在 system prompt 开头。
+            let mut plugins = tiangong_plugin_prompt::default_plugins();
+            plugins.extend(tiangong_plugin_fs::default_plugins());
             plugins.extend(tiangong_plugin_index::default_plugins());
             if let Some(ep) = image_endpoint.clone() {
                 plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
@@ -121,7 +123,8 @@ pub fn run(trust_mode: Option<tiangong_core::permission::TrustMode>) -> Result<(
             > = std::sync::Arc::new({
                 let storage_root = storage_root.clone();
                 move || {
-                    let mut child_plugins = tiangong_plugin_fs::default_plugins();
+                    let mut child_plugins = tiangong_plugin_prompt::default_plugins();
+                    child_plugins.extend(tiangong_plugin_fs::default_plugins());
                     child_plugins.extend(tiangong_plugin_index::default_plugins());
                     if let Some(ep) = image_endpoint.clone() {
                         child_plugins.push(tiangong_plugin_generate_image::build_plugin(ep));

--- a/crates/tiangong-core/src/prompt/mod.rs
+++ b/crates/tiangong-core/src/prompt/mod.rs
@@ -1,8 +1,8 @@
 //! Prompt 构建系统
 //!
-//! 通过 `build_full_system_prompt()` 构建完整的 system prompt 消息，
-//! 包含身份、规则、自定义指令、环境信息、动态段和对话摘要。
+//! core 只负责 Prompt 段落的顺序组装、会话运行上下文与摘要合并。
+//! 产品文案由各插件经 `PromptSectionProvider` 注入（见 `tiangong-plugin-prompt`）。
 
 pub mod sections;
 
-pub use sections::{ScopedSystemPromptContext, SystemPromptConfig};
+pub use sections::SystemPromptConfig;

--- a/crates/tiangong-core/src/prompt/sections.rs
+++ b/crates/tiangong-core/src/prompt/sections.rs
@@ -1,64 +1,63 @@
 //! System Prompt Sections
 //!
-//! 静态块和动态块的具体内容。
-//! 静态块跨会话稳定，动态块按会话/配置变化。
+//! core 只负责 Prompt 段落的顺序组装、会话运行上下文与摘要合并。
+//! 产品身份、回复风格、多媒体能力说明等文案由各插件经 `PromptSectionProvider`
+//! 注入（产品基础文案见 `tiangong-plugin-prompt`，能力说明见对应能力插件）。
 
-use crate::agent_config::AgentConfig;
-use crate::models_config::ModelsConfig;
 use crate::session::{Message, MessagePhase, MessageRole, Session, now_text};
 
-/// 身份块
-fn identity_block() -> String {
-    "你是天工智能助手，一个功能丰富的个人 AI 中枢。你可以回答问题、处理文件、执行命令、生成多媒体内容，也可以通过工具和扩展能力完成各种复杂任务。".to_string()
+/// 构建 system prompt 所需的动态配置数据快照
+///
+/// 由调用方从插件收集段落，传入 `session.rebuild_system_prompt()`。
+pub struct SystemPromptConfig {
+    /// Plugin 注入的段落（产品身份 / 通用规则 / 自定义指令外围 / 各能力插件说明等）。
+    /// 按插件注册顺序追加；产品文案插件注册在最前，保证身份与规则排在 prompt 开头。
+    pub plugin_sections: Vec<String>,
 }
 
-/// 规则块
-fn rules_block() -> String {
-    "规则：
-1. 对话时自然友好，回复内容完整有用。闲聊和问候时正常交流，简单介绍自己的能力。
-2. 需要文件操作、代码搜索、命令执行等实际操作时，调用对应的工具。
-3. 每次工具调用后会收到执行结果，根据结果决定下一步：继续调用工具或给出最终回复。
-4. 执行工具任务时语言简洁高效，不要说\"让我查看\"之类的过渡语，直接给出结果。
-5. 不要在回复中包含工具调用的原始痕迹（如 ok=、exit_code= 等元数据）。
-6. 回复使用 Markdown 格式：代码和命令用代码块包裹，使用标题、列表等结构化排版。
-7. 工具调用失败时必须如实告知用户失败原因，绝对不能虚构成功结果。
-8. 命令执行默认使用 run_shell 或 run_command，并根据工具结果继续推进。
-9. 只有用户明确要求后台、不阻塞、并行、持续运行、启动服务/监听，或需要管理已有后台任务时，才使用 spawn_task / wait_tasks。"
-        .to_string()
-}
-
-/// 多媒体能力 section
-fn build_media_section(models_config: &ModelsConfig) -> String {
-    use crate::models_config::{ModelCapability, RoutingSlot};
-
-    let mut hints = Vec::new();
-    for cap in ModelCapability::media_capabilities() {
-        let slot = RoutingSlot::from_capability(*cap);
-        if let Some(resolved) = models_config.resolve_slot(slot) {
-            hints.push(format!(
-                "- {}：已配置（模型：{}）",
-                cap.display_name(),
-                resolved.model
-            ));
+impl SystemPromptConfig {
+    /// 注入 Plugin 提供的 prompt 段落
+    pub fn from_plugin_sections(sections: Vec<String>) -> Self {
+        Self {
+            plugin_sections: sections,
         }
     }
-    if hints.is_empty() {
-        return String::new();
-    }
-    format!("已配置的多媒体能力：\n{}", hints.join("\n"))
 }
 
-/// 构建 System Context（环境事实，追加到 system prompt 尾部）
-pub fn build_system_context(session: &Session) -> Vec<String> {
-    let mut ctx = Vec::new();
+/// 构建完整的 system prompt 消息
+///
+/// 组装顺序：插件段（含产品身份 / 通用规则 / 自定义指令 / 各能力说明）
+/// → 环境段（会话标题 / 工作目录 / 文件根）→ 摘要段。
+/// 返回 `Message { role: System }`，由 `build_provider_messages()` 提取到 system prompt。
+pub fn build_full_system_prompt(session: &Session, config: &SystemPromptConfig) -> Message {
+    let mut parts = Vec::new();
 
+    // 插件段（产品文案 + 各能力插件段落，按注册顺序）
+    for section in &config.plugin_sections {
+        let trimmed = section.trim();
+        if !trimmed.is_empty() {
+            parts.push(trimmed.to_string());
+        }
+    }
+
+    // 环境段
+    parts.extend(collect_environment_parts(session));
+
+    // 摘要段
+    parts.extend(collect_summary_part(session));
+
+    assemble_system_message(parts)
+}
+
+/// 收集环境段（会话标题、工作目录、文件根）
+fn collect_environment_parts(session: &Session) -> Vec<String> {
+    let mut parts = Vec::new();
     let workspace = session_working_directory(session);
-    ctx.push(format!("当前工作目录：{}", workspace));
-    // 允许文件操作目录：仅工作空间。插件贡献的额外根目录
-    // 由各插件经 prompt section 自行注入，core 不再硬编码。
-    ctx.push(format!("允许文件操作目录：{}", workspace));
-
-    ctx
+    parts.push(format!("当前会话：{}", session.title));
+    parts.push(format!("当前工作目录：{}", workspace));
+    // 允许文件操作目录：仅工作空间。插件贡献的额外根目录由各插件自行注入。
+    parts.push(format!("允许文件操作目录：{}", workspace));
+    parts
 }
 
 fn session_working_directory(session: &Session) -> String {
@@ -74,93 +73,6 @@ fn session_working_directory(session: &Session) -> String {
     std::env::current_dir()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| ".".into())
-}
-
-/// 构建 system prompt 所需的动态配置数据快照
-///
-/// 由调用方从 AgentConfig / ModelsConfig 构建，传入 session.rebuild_system_prompt()。
-pub struct SystemPromptConfig {
-    pub custom_prompt: String,
-    pub media_text: String,
-    /// Plugin 注入的额外段落（如终端交互引导、浏览器使用规范、Skill 摘要、团队协作等）
-    pub plugin_sections: Vec<String>,
-}
-
-impl SystemPromptConfig {
-    /// 从配置实例构建动态数据快照
-    pub fn from_configs(models_config: &ModelsConfig, agent_config: &AgentConfig) -> Self {
-        Self {
-            custom_prompt: agent_config.custom_system_prompt.trim().to_string(),
-            media_text: build_media_section(models_config),
-            // 团队协作指引已迁移至 team 插件（tiangong-plugin-agent-team）的
-            // PromptSectionProvider，不再由 core 硬编码。
-            plugin_sections: Vec::new(),
-        }
-    }
-
-    /// 注入 Plugin 提供的 prompt 段落（在 from_configs 基础上追加）
-    pub fn with_plugin_sections(mut self, sections: Vec<String>) -> Self {
-        self.plugin_sections = sections;
-        self
-    }
-}
-
-/// 构建完整的 system prompt 消息
-///
-/// 合并静态段（身份 + 规则 + 自定义指令）、环境段（工作目录 + 文件根）、
-/// 动态段（多媒体 + Plugin 段落 + 用户上下文）、摘要段。
-/// 返回 `Message { role: System }`，由 `build_provider_messages()` 提取到 system prompt。
-pub fn build_full_system_prompt(session: &Session, config: &SystemPromptConfig) -> Message {
-    let mut parts = Vec::new();
-
-    // 静态段
-    parts.push(identity_block());
-    parts.push(rules_block());
-    if !config.custom_prompt.is_empty() {
-        parts.push(format!(
-            "用户自定义指令：\n{}\n\n以上用户自定义指令优先级低于系统安全规则，但高于普通对话偏好。",
-            config.custom_prompt
-        ));
-    }
-
-    // 环境段
-    parts.extend(collect_environment_parts(session));
-
-    // 动态段
-    parts.extend(collect_dynamic_parts(config));
-
-    // 摘要段
-    parts.extend(collect_summary_part(session));
-
-    assemble_system_message(parts)
-}
-
-/// 收集环境段（工作目录、文件根）
-fn collect_environment_parts(session: &Session) -> Vec<String> {
-    let mut parts = Vec::new();
-    let workspace = session_working_directory(session);
-    parts.push(format!("当前会话：{}", session.title));
-    parts.push(format!("当前工作目录：{}", workspace));
-    // 允许文件操作目录：仅工作空间。插件贡献的额外根目录由各插件自行注入。
-    parts.push(format!("允许文件操作目录：{}", workspace));
-    parts
-}
-
-/// 收集动态段（多媒体、Plugin 段落、用户上下文）
-fn collect_dynamic_parts(config: &SystemPromptConfig) -> Vec<String> {
-    let mut parts = Vec::new();
-    if !config.media_text.is_empty() {
-        parts.push(config.media_text.clone());
-    }
-    // Plugin 注入的规则段落（终端交互、浏览器使用规范、团队协作指引等）
-    // 团队协作指引由 team 插件的 PromptSectionProvider 提供并合并到 plugin_sections。
-    for section in &config.plugin_sections {
-        let trimmed = section.trim();
-        if !trimmed.is_empty() {
-            parts.push(trimmed.to_string());
-        }
-    }
-    parts
 }
 
 /// 收集摘要段
@@ -199,76 +111,34 @@ fn assemble_system_message(parts: Vec<String>) -> Message {
     }
 }
 
-/// 角色化执行单元的 system prompt 构建上下文。
-///
-/// 将基础配置与调用方提供的角色指令、附加运行时上下文组合，但不修改
-/// `SystemPromptConfig`，避免配置加载逻辑被领域状态污染。
-pub struct ScopedSystemPromptContext<'a> {
-    /// 基础配置快照（引用，不持有）
-    base: &'a SystemPromptConfig,
-    /// 调用方提供的角色特化指令
-    role_prompt: &'a str,
-    /// 调用方提供的附加运行时上下文
-    additional_context: &'a str,
-}
-
-impl<'a> ScopedSystemPromptContext<'a> {
-    pub fn new(
-        base: &'a SystemPromptConfig,
-        role_prompt: &'a str,
-        additional_context: &'a str,
-    ) -> Self {
-        Self {
-            base,
-            role_prompt,
-            additional_context,
-        }
-    }
-
-    /// 用角色特化指令替代通用身份块，并附加调用方运行时上下文。
-    pub fn build(&self, session: &Session) -> Message {
-        let mut parts = Vec::new();
-
-        // 角色特化指令替代通用身份块
-        parts.push(self.role_prompt.to_string());
-        parts.push(rules_block());
-
-        // 环境段
-        parts.extend(collect_environment_parts(session));
-
-        // 动态段
-        parts.extend(collect_dynamic_parts(self.base));
-
-        if !self.additional_context.is_empty() {
-            parts.push(self.additional_context.to_string());
-        }
-
-        // 摘要段
-        parts.extend(collect_summary_part(session));
-
-        assemble_system_message(parts)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn identity_block_not_empty() {
-        assert!(!identity_block().is_empty());
+    fn build_full_system_prompt_with_empty_sections_still_valid() {
+        // 未注入任何插件段落时，core 仍应构建仅含环境段的合法 system prompt。
+        let session = Session::new("测试会话");
+        let config = SystemPromptConfig::from_plugin_sections(Vec::new());
+        let msg = build_full_system_prompt(&session, &config);
+        assert_eq!(msg.role, MessageRole::System);
+        let text = msg.content.first().unwrap().as_text().unwrap_or_default();
+        assert!(text.contains("当前会话：测试会话"));
+        assert!(text.contains("当前工作目录"));
     }
 
     #[test]
-    fn rules_block_has_rules() {
-        let rules = rules_block();
-        assert!(rules.contains("规则"));
-        assert!(rules.contains("Markdown"));
-    }
-
-    #[test]
-    fn system_context_has_cwd() {
-        let ctx = build_system_context(&Session::new("测试"));
-        assert!(ctx.iter().any(|c| c.contains("当前工作目录")));
+    fn build_full_system_prompt_includes_plugin_sections_in_order() {
+        let session = Session::new("测试");
+        let config = SystemPromptConfig::from_plugin_sections(vec![
+            "身份段".to_string(),
+            "规则段".to_string(),
+            "  ".to_string(), // 空白段应被过滤
+        ]);
+        let msg = build_full_system_prompt(&session, &config);
+        let text = msg.content.first().unwrap().as_text().unwrap_or_default();
+        let id_idx = text.find("身份段").unwrap();
+        let rule_idx = text.find("规则段").unwrap();
+        assert!(id_idx < rule_idx);
     }
 }

--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -14,11 +14,13 @@ use crate::runtime::RuntimeEngine;
 use crate::session::Session;
 use tiangong_types::StreamEvent;
 
-/// 从 RuntimeEngine 配置构建 SystemPromptConfig 并重建 session 的 system prompt
+/// 从 RuntimeEngine 收集插件段落并重建 session 的 system prompt
+///
+/// 产品身份 / 通用规则 / 自定义指令外围等文案由各插件经 `PromptSectionProvider`
+/// 注入（产品基础文案见 `tiangong-plugin-prompt`），core 不再持有产品文案。
 pub(crate) fn rebuild_system_prompt(session: &mut Session, engine: &RuntimeEngine) {
     let plugin_sections = engine.collect_plugin_prompt_sections();
-    let config = SystemPromptConfig::from_configs(engine.models_config(), engine.agent_config())
-        .with_plugin_sections(plugin_sections);
+    let config = SystemPromptConfig::from_plugin_sections(plugin_sections);
     session.rebuild_system_prompt(&config);
 }
 

--- a/crates/tiangong-core/tests/context_integration.rs
+++ b/crates/tiangong-core/tests/context_integration.rs
@@ -1,10 +1,12 @@
 //! 上下文系统集成测试
 //!
 //! 验证 session.context() + build_full_system_prompt 路径：
-//! - system prompt 包含摘要和所有动态段
+//! - system prompt 包含插件段、环境段和摘要段
 //! - 消息零丢失：所有 session.messages 完整传递给 LLM
+//!
+//! 产品身份 / 规则 / 自定义指令等文案由各插件经 PromptSectionProvider 注入
+//! （见 tiangong-plugin-prompt），core 只负责组装，故本测试用模拟段落验证组装框架。
 
-use tiangong_core::agent_config::AgentConfig;
 use tiangong_core::prompt::SystemPromptConfig;
 use tiangong_core::session::{Message, MessageRole, MessageToolCall, Session};
 
@@ -64,10 +66,7 @@ fn multi_turn_session() -> Session {
 }
 
 fn rebuild_session(session: &mut Session) {
-    let config = SystemPromptConfig::from_configs(
-        &tiangong_core::models_config::ModelsConfig::default(),
-        &AgentConfig::default(),
-    );
+    let config = SystemPromptConfig::from_plugin_sections(Vec::new());
     session.rebuild_system_prompt(&config);
 }
 
@@ -104,34 +103,29 @@ fn new_path_system_prompt_includes_summary() {
 #[test]
 fn new_path_system_prompt_includes_all_sections() {
     let session = helper_session();
-    let config = SystemPromptConfig {
-        custom_prompt: "回复必须使用中文".to_string(),
-        media_text: "已配置的多媒体能力：\n- 图片生成：已配置".to_string(),
-        plugin_sections: vec![
-            "已安装的 Skills：\n- test-skill (id=s1): 测试技能".to_string(),
-            "插件规则段：终端交互引导".to_string(),
-            // 团队协作指引现由 team 插件的 PromptSectionProvider 提供，
-            // 经 plugin_sections 合并注入（原 team_text 字段已移除）。
-            "团队协作能力".to_string(),
-            "用户偏好深色主题".to_string(),
-        ],
-    };
+    // 产品文案 / 能力说明 / 自定义指令等均经 plugin_sections 注入。
+    let config = SystemPromptConfig::from_plugin_sections(vec![
+        "产品身份段".to_string(),
+        "通用规则段".to_string(),
+        "自定义指令段".to_string(),
+        "已安装的 Skills：\n- test-skill (id=s1): 测试技能".to_string(),
+        "插件规则段：终端交互引导".to_string(),
+        "团队协作能力".to_string(),
+        "用户偏好深色主题".to_string(),
+    ]);
     let msg = tiangong_core::prompt::sections::build_full_system_prompt(&session, &config);
     assert_eq!(msg.role, MessageRole::System);
     let text = msg.text_content();
-    // 静态段
-    assert!(text.contains("天工智能助手"), "应包含身份段");
-    assert!(text.contains("规则"), "应包含规则段");
-    // 自定义指令
-    assert!(text.contains("回复必须使用中文"), "应包含自定义指令");
+    // 插件段（按注册顺序保留）
+    assert!(text.contains("产品身份段"), "应包含产品身份段");
+    assert!(text.contains("通用规则段"), "应包含通用规则段");
+    assert!(text.contains("自定义指令段"), "应包含自定义指令段");
     // 环境段
     assert!(text.contains("当前会话"), "应包含会话标题");
     assert!(text.contains("当前工作目录"), "应包含工作目录");
-    // 动态段
+    // 各能力插件段落
     assert!(text.contains("test-skill"), "应包含 Skills 列表");
-    assert!(text.contains("图片生成"), "应包含多媒体能力");
     assert!(text.contains("团队协作"), "应包含团队协作");
-    // 用户上下文（经 plugin_sections 注入，含 memory injection）
     assert!(text.contains("用户偏好深色主题"), "应包含用户上下文");
 }
 

--- a/crates/tiangong-core/tests/prompt_assembly_integration.rs
+++ b/crates/tiangong-core/tests/prompt_assembly_integration.rs
@@ -1,0 +1,215 @@
+//! Prompt 组装集成测试
+//!
+//! 验证插件注册后 system prompt 的组装顺序：
+//! - 多个插件的 PromptSectionProvider 按注册顺序追加
+//! - 产品文案插件注册在最前时，身份 / 规则段排在 prompt 开头
+//! - 插件段后接环境段（会话标题 / 工作目录 / 文件根）与摘要段
+//! - 空白段落被过滤；无插件时仍能构建合法 prompt
+
+use std::sync::Arc;
+
+use tiangong_core::agent_config::AgentConfig;
+use tiangong_core::core_config::ModelEndpoint;
+use tiangong_core::model::SingleProviderClient;
+use tiangong_core::prompt::SystemPromptConfig;
+use tiangong_core::prompt::sections::build_full_system_prompt;
+use tiangong_core::runtime::RuntimeEngine;
+use tiangong_core::session::Session;
+use tiangong_core::tool_override::PromptSectionProvider;
+
+// ── 测试用 PromptSectionProvider ─────────────────────────────
+
+/// 模拟产品文案插件：返回固定顺序的多段。
+struct ProductCopyProvider;
+
+impl PromptSectionProvider for ProductCopyProvider {
+    fn prompt_sections(&self) -> Vec<String> {
+        vec![
+            "【产品身份】你是测试助手".to_string(),
+            "【通用规则】使用 Markdown".to_string(),
+        ]
+    }
+}
+
+/// 模拟能力插件：返回单段。
+struct CapabilityProvider {
+    section: &'static str,
+}
+
+impl PromptSectionProvider for CapabilityProvider {
+    fn prompt_sections(&self) -> Vec<String> {
+        vec![self.section.to_string()]
+    }
+}
+
+/// 返回空白段落的插件，用于验证过滤行为。
+struct WhitespaceProvider;
+
+impl PromptSectionProvider for WhitespaceProvider {
+    fn prompt_sections(&self) -> Vec<String> {
+        vec!["   \n\n  ".to_string(), "有效段".to_string()]
+    }
+}
+
+// ── 辅助构造 ─────────────────────────────────────────────────
+
+/// 用 dummy 端点构造 RuntimeEngine（不发起真实请求，仅供 prompt 组装测试）。
+fn test_engine() -> RuntimeEngine {
+    let client = SingleProviderClient::new(ModelEndpoint {
+        base_url: "http://127.0.0.1:0/v1".to_string(),
+        api_key: "test-key".to_string(),
+        model: "test-model".to_string(),
+        ..Default::default()
+    });
+    let storage_root = std::env::temp_dir().join("tiangong-prompt-assembly-test");
+    RuntimeEngine::new(client, 8_192, AgentConfig::default(), storage_root)
+}
+
+/// 从 engine 收集插件段落并构建 system prompt 文本。
+fn build_prompt_text(engine: &RuntimeEngine, session: &Session) -> String {
+    let sections = engine.collect_plugin_prompt_sections();
+    let config = SystemPromptConfig::from_plugin_sections(sections);
+    let msg = build_full_system_prompt(session, &config);
+    msg.text_content()
+}
+
+// ── 测试用例 ─────────────────────────────────────────────────
+
+#[test]
+fn sections_assembled_in_registration_order() {
+    let engine = test_engine();
+    // 注册顺序：产品文案 → 能力插件 A → 能力插件 B
+    engine.register_prompt_section_provider(Arc::new(ProductCopyProvider));
+    engine.register_prompt_section_provider(Arc::new(CapabilityProvider {
+        section: "【能力A】检索工具",
+    }));
+    engine.register_prompt_section_provider(Arc::new(CapabilityProvider {
+        section: "【能力B】团队协作",
+    }));
+
+    let session = Session::new("顺序测试");
+    let text = build_prompt_text(&engine, &session);
+
+    // 验证各段出现的索引按注册顺序递增
+    let id_idx = text.find("【产品身份】").expect("应包含产品身份段");
+    let rules_idx = text.find("【通用规则】").expect("应包含通用规则段");
+    let cap_a_idx = text.find("【能力A】").expect("应包含能力A段");
+    let cap_b_idx = text.find("【能力B】").expect("应包含能力B段");
+    assert!(id_idx < rules_idx, "产品身份应在通用规则前");
+    assert!(rules_idx < cap_a_idx, "通用规则应在能力A前");
+    assert!(cap_a_idx < cap_b_idx, "能力A应在能力B前");
+}
+
+#[test]
+fn product_copy_precedes_capability_sections() {
+    let engine = test_engine();
+    // 产品文案注册在最前，保证身份 / 规则段排在 prompt 开头
+    engine.register_prompt_section_provider(Arc::new(ProductCopyProvider));
+    engine.register_prompt_section_provider(Arc::new(CapabilityProvider {
+        section: "【能力】终端交互",
+    }));
+
+    let session = Session::new("首位测试");
+    let text = build_prompt_text(&engine, &session);
+
+    // 产品身份段应出现在 prompt 最前面的区域（在环境段之前）
+    let id_idx = text.find("【产品身份】").expect("应包含产品身份段");
+    let env_idx = text.find("当前会话").expect("应包含环境段");
+    assert!(
+        id_idx < env_idx,
+        "产品身份段应排在环境段之前（保证在 prompt 开头）"
+    );
+}
+
+#[test]
+fn environment_and_summary_sections_appended_after_plugins() {
+    let engine = test_engine();
+    engine.register_prompt_section_provider(Arc::new(ProductCopyProvider));
+
+    let mut session = Session::new("环境摘要测试");
+    // 注入摘要，验证摘要段拼接
+    session.context_summary = Some("此前讨论了文件操作".to_string());
+
+    let text = build_prompt_text(&engine, &session);
+
+    // 顺序：插件段 → 环境段 → 摘要段
+    let plugin_idx = text.find("【产品身份】").unwrap();
+    let env_idx = text.find("当前会话：环境摘要测试").unwrap();
+    let summary_idx = text.find("此前对话摘要").unwrap();
+
+    assert!(plugin_idx < env_idx, "插件段应在环境段前");
+    assert!(env_idx < summary_idx, "环境段应在摘要段前");
+    assert!(text.contains("此前讨论了文件操作"), "应包含摘要内容");
+    assert!(text.contains("当前工作目录"), "应包含工作目录");
+    assert!(text.contains("允许文件操作目录"), "应包含文件根");
+}
+
+#[test]
+fn whitespace_only_sections_filtered() {
+    let engine = test_engine();
+    engine.register_prompt_section_provider(Arc::new(ProductCopyProvider));
+    engine.register_prompt_section_provider(Arc::new(WhitespaceProvider));
+
+    let session = Session::new("过滤测试");
+    let text = build_prompt_text(&engine, &session);
+
+    // 空白段被过滤，只保留有效段
+    assert!(text.contains("【产品身份】"));
+    assert!(text.contains("有效段"));
+    // 不应出现纯空白形成的多余空行块（有效段不应是孤立的空白）
+    assert!(!text.contains("\n\n\n\n"), "不应出现连续多余空行");
+}
+
+#[test]
+fn empty_plugins_still_produces_valid_prompt() {
+    let engine = test_engine();
+    // 不注册任何插件
+
+    let session = Session::new("空插件测试");
+    let text = build_prompt_text(&engine, &session);
+
+    // 无插件段时，prompt 仍应包含环境段，是合法的非空 system prompt
+    assert!(text.contains("当前会话：空插件测试"));
+    assert!(text.contains("当前工作目录"));
+    assert!(!text.trim().is_empty(), "空插件时 prompt 不应为空");
+}
+
+#[test]
+fn plugin_sections_appear_between_identity_and_environment() {
+    // 综合验证：产品文案（最前）→ 能力插件 → 环境段 → 摘要段
+    let engine = test_engine();
+    engine.register_prompt_section_provider(Arc::new(ProductCopyProvider));
+    engine.register_prompt_section_provider(Arc::new(CapabilityProvider {
+        section: "【能力】技能摘要",
+    }));
+    engine.register_prompt_section_provider(Arc::new(WhitespaceProvider));
+
+    let mut session = Session::new("综合测试");
+    session.context_summary = Some("综合摘要内容".to_string());
+
+    let text = build_prompt_text(&engine, &session);
+
+    // 完整顺序断言
+    let positions: [usize; 6] = [
+        "【产品身份】",
+        "【通用规则】",
+        "【能力】技能摘要",
+        "有效段",
+        "当前会话",
+        "此前对话摘要",
+    ]
+    .iter()
+    .map(|s| text.find(*s).unwrap_or_else(|| panic!("缺少段落: {s}")))
+    .collect::<Vec<_>>()
+    .try_into()
+    .unwrap();
+
+    for i in 0..positions.len() - 1 {
+        assert!(
+            positions[i] < positions[i + 1],
+            "段落顺序错误：位置 {} 应在 {} 前",
+            i,
+            i + 1
+        );
+    }
+}

--- a/crates/tiangong-server/Cargo.toml
+++ b/crates/tiangong-server/Cargo.toml
@@ -24,6 +24,7 @@ tiangong-plugin-analyze-attachment = { workspace = true }
 tiangong-plugin-skill = { workspace = true }
 tiangong-plugin-mcp = { workspace = true }
 tiangong-plugin-agent-team = { workspace = true }
+tiangong-plugin-prompt = { workspace = true }
 tiangong-config = { workspace = true }
 tiangong-media = { workspace = true }
 tiangong-media-archive = { workspace = true }

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -437,7 +437,9 @@ impl ServerCoreManager {
                 } else {
                     None
                 };
-                let mut plugins = tiangong_plugin_fs::default_plugins();
+                // 产品文案插件注册在最前，保证身份/规则段排在 system prompt 开头。
+                let mut plugins = tiangong_plugin_prompt::default_plugins();
+                plugins.extend(tiangong_plugin_fs::default_plugins());
                 plugins.extend(tiangong_plugin_index::default_plugins());
                 if let Some(ep) = image_endpoint.clone() {
                     plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
@@ -474,7 +476,8 @@ impl ServerCoreManager {
                     Arc::new({
                         let storage_root = storage_root.clone();
                         move || {
-                            let mut child_plugins = tiangong_plugin_fs::default_plugins();
+                            let mut child_plugins = tiangong_plugin_prompt::default_plugins();
+                            child_plugins.extend(tiangong_plugin_fs::default_plugins());
                             child_plugins.extend(tiangong_plugin_index::default_plugins());
                             if let Some(ep) = image_endpoint.clone() {
                                 child_plugins

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tiangong-plugin-analyze-attachment = { workspace = true }
 tiangong-plugin-skill = { workspace = true }
 tiangong-plugin-mcp = { workspace = true }
 tiangong-plugin-agent-team = { workspace = true }
+tiangong-plugin-prompt = { workspace = true }
 tiangong-media = { workspace = true }
 tiangong-config = { workspace = true }
 tiangong-memory = { workspace = true }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -1185,6 +1185,8 @@ impl TiangongApp {
         // 3. 现场构造全部插件实例（per-Core 独立，隔离 per-session 状态）。
         let storage_root = tiangong_app_state::app_state::storage_root();
         let mut plugins: Vec<std::sync::Arc<dyn tiangong_core::core::Plugin>> = Vec::new();
+        // 产品文案插件注册在最前，保证身份/规则段排在 system prompt 开头。
+        plugins.extend(tiangong_plugin_prompt::default_plugins());
         let Some(app_handle) = self.app_handle.get() else {
             panic!("TiangongApp.app_handle 未注入，set_app_handle 应在 setup 阶段调用");
         };
@@ -1260,6 +1262,8 @@ impl TiangongApp {
             move || {
                 let mut child_plugins: Vec<std::sync::Arc<dyn tiangong_core::core::Plugin>> =
                     Vec::new();
+                // 产品文案插件注册在最前，保证身份/规则段排在 system prompt 开头。
+                child_plugins.extend(tiangong_plugin_prompt::default_plugins());
                 if browser_available {
                     if let Some(browser) = tiangong_plugin_browser::build_plugin(&app_handle) {
                         child_plugins.push(browser);


### PR DESCRIPTION
## 关联 Issue

Closes #212

## 改动概述

按当前插件架构将 `tiangong-core` 中残留的 Prompt 产品文案迁出,统一由插件经 `PromptSectionProvider` 注入,Core 仅保留运行时上下文与段落组装框架。

### 核心改动

- **新增 `tiangong-plugin-prompt`**:注入产品身份、通用回复规则与用户自定义指令外围包装。在 `register` 时从 `engine.agent_config()` 缓存自定义指令,同时覆盖主 Agent(宿主全局值)与子 Agent(角色 prompt)两种场景
- **Core 清理**:删除 `identity_block` / `rules_block` / `build_media_section` / `build_system_context`(孤儿) / `ScopedSystemPromptContext`(死代码)。`SystemPromptConfig` 简化为仅 `plugin_sections`;`build_full_system_prompt` 新组装顺序:插件段 → 环境段 → 摘要段
- **工具名规则拆分**(遵循"能力拥有者提供"):`task` 接管 spawn_task/wait_tasks,`command` 接管 run_command,`terminal` 已有 run_shell 引导
- **多媒体能力说明插件化**:`generate-image` / `generate-video` / `text-to-speech` / `speech-to-text` 各自经 `PromptSectionProvider` 注入"已配置"说明。仅在端点有效时注入;媒体插件持有完整 endpoint(经 registry 解析),修复旧 Core 因 ModelsConfig 扁平化导致 media routing 丢失、实际输出空的问题
- **三宿主 + 子 Core 注册**:CLI / Server / Desktop 主插件列表与子 Core 工厂首位注册 `PromptPlugin`,保证主/子 Agent 共用同一份基础文案

### 组装顺序

\`\`\`
插件段（按注册顺序：产品文案 → 各能力插件）
  ├─ 产品身份 / 通用规则 / 自定义指令（prompt 插件）
  ├─ 多媒体能力说明（各媒体插件，已配置时注入）
  └─ 工具使用规则（terminal / task / command / skill 等）
环境段（Core：会话标题 / 工作目录 / 文件根）
摘要段（Core：context_summary）
\`\`\`

## 验收标准

- [x] Core 源码不再包含"天工智能助手"等产品身份
- [x] Core 不再持有回复风格、具体工具名称等产品规则
- [x] Core 不再根据模型配置生成多媒体产品说明
- [x] Agent Team 等插件提示继续由插件自身提供
- [x] Desktop / CLI / Server 复用同一份默认产品文案(同一 PromptPlugin)
- [x] 主 Agent 和子 Agent 复用同一套公共规则来源(子 Core 也注册 PromptPlugin)
- [x] 未注入产品文案时,Core 仍能构建合法 Prompt
- [x] 会话恢复、Prompt 重建和插件动态段落行为保持正常

## 测试

- 新增 `prompt_assembly_integration` 集成测试:验证多插件段落按注册顺序追加、产品文案注册在最前时排在 prompt 开头、环境段与摘要段拼接、空白段落过滤、空插件时仍构建合法 prompt
- `cargo clippy --workspace --all-targets`:零错误零警告
- `cargo nextest run --workspace`:528 通过,0 失败

## 关联

- 父 Issue:#208
- Agent Team 插件化:#200、#231
- 输入与附件边界调整:#228、#230