### PR TITLE
refactor(core): #236 精简 Plugin trait hooks

### DIFF
--- a/crates/plugins/tiangong-plugin-command/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-command/src/plugin.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::RwLock;
 
 use tiangong_core::core::Plugin;
 use tiangong_core::permission::{TrustMode, TrustModeHandle};
@@ -11,11 +11,11 @@ use tiangong_core::permission::{TrustMode, TrustModeHandle};
 pub struct CommandPlugin {
     workspace: RwLock<Option<PathBuf>>,
     trust_mode: RwLock<Option<TrustModeHandle>>,
-    /// 各插件贡献的环境变量共享句柄（register 时从 engine 获取）。
+    /// 各插件贡献的汇总环境变量（由 core 经 set_exec_env 回注）。
     ///
-    /// core 在「所有插件注册完成后」汇总各插件的 `collect_exec_env` 写入同一句柄，
+    /// core 在「所有插件注册完成后」汇总各插件的 `exec_env` 回注，
     /// command 执行子进程时读取即为最新值，无需 snapshot 刷新。
-    runtime_env: RwLock<Arc<Mutex<BTreeMap<String, String>>>>,
+    runtime_env: RwLock<BTreeMap<String, String>>,
     /// 用户自定义的允许命令列表（扩展内置白名单）。
     ///
     /// 由 core 在 engine rebuild 时通过 `on_config_updated` 从 `CoreConfig` 注入。
@@ -28,7 +28,7 @@ impl Default for CommandPlugin {
         Self {
             workspace: RwLock::new(None),
             trust_mode: RwLock::new(None),
-            runtime_env: RwLock::new(Arc::new(Mutex::new(BTreeMap::new()))),
+            runtime_env: RwLock::new(BTreeMap::new()),
             allowed_commands: RwLock::new(Vec::new()),
         }
     }
@@ -43,14 +43,12 @@ impl CommandPlugin {
         self.workspace.read().ok()?.clone()
     }
 
-    /// 读取当前环境变量快照（从共享句柄取最新值）。
+    /// 读取当前环境变量快照（从回注的汇总值取最新值）。
     pub(crate) fn runtime_env(&self) -> BTreeMap<String, String> {
-        let handle = self
-            .runtime_env
+        self.runtime_env
             .read()
             .map(|g| g.clone())
-            .unwrap_or_else(|_| Arc::new(Mutex::new(BTreeMap::new())));
-        handle.lock().map(|g| g.clone()).unwrap_or_default()
+            .unwrap_or_default()
     }
 
     pub(crate) fn is_full_trust(&self) -> bool {
@@ -99,11 +97,10 @@ impl Plugin for CommandPlugin {
         }
     }
 
-    fn register(&self, engine: &tiangong_core::runtime::RuntimeEngine) {
-        // 持有 engine 的 runtime_env 共享句柄——core 在所有插件注册完成后会汇总
-        // 各插件的 collect_exec_env 写入同一句柄，此处读取即为最新值。
+    fn set_exec_env(&self, env: BTreeMap<String, String>) {
+        // 接收 core 汇总后的全部插件环境变量，run_command/run_shell 执行子进程时注入。
         if let Ok(mut guard) = self.runtime_env.write() {
-            *guard = engine.runtime_env_handle();
+            *guard = env;
         }
     }
 }

--- a/crates/plugins/tiangong-plugin-index/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-index/src/plugin.rs
@@ -4,8 +4,8 @@
 //! 注入的会话上下文；[`IndexManager`] 在 [`IndexPlugin::new`] 时自建并私有持有。
 //!
 //! 生命周期钩子接管原 core 对 `IndexManager` 的全部写入与维护：
+//! - [`Plugin::set_workspace`]：工作区变更后重扫索引（原 `on_cwd_changed` 的职责）。
 //! - [`Plugin::on_session_ready`]：首次全量扫描工作区索引（原 core/mod.rs 初始扫描）。
-//! - [`Plugin::on_cwd_changed`]：CWD 变更后重扫工作区索引。
 //! - [`Plugin::on_turn_finished`]：批量写入本轮对话索引（原 `index_turn_messages`）。
 //! - [`Plugin::on_session_ended`]：finalize Session 索引。
 
@@ -26,6 +26,8 @@ use tiangong_core::tool_override::PromptSectionProvider;
 pub struct IndexPlugin {
     /// 当前会话工作目录（可变，由 core 注入）。
     workspace: RwLock<Option<PathBuf>>,
+    /// 上次已扫描的工作目录（避免同一目录重复扫描）。
+    last_scanned: RwLock<Option<PathBuf>>,
     /// 信任模式解析句柄（FullTrust 时放宽 search_code 路径校验）。
     trust_mode: RwLock<Option<TrustModeHandle>>,
     /// 自建并私有持有的 IndexManager（core 不感知）。
@@ -44,6 +46,7 @@ impl IndexPlugin {
             .ok();
         Self {
             workspace: RwLock::new(None),
+            last_scanned: RwLock::new(None),
             trust_mode: RwLock::new(None),
             index_manager: RwLock::new(im),
         }
@@ -77,15 +80,20 @@ impl IndexPlugin {
         Some(f(im))
     }
 
-    /// 对工作区做全量扫描（用于 on_session_ready / on_cwd_changed）。
+    /// 对工作区做全量扫描（用于 on_session_ready）。
     ///
     /// - 索引不存在：同步全量扫描（首次使用，阻塞直到完成）。
     /// - 索引过期（>1 小时）：后台重建，不阻塞当前搜索。
     /// - 索引新鲜：跳过。
+    ///
+    /// 无论走哪个分支都会置位 `last_scanned`，使后续 `set_workspace` 对同一目录不再重复扫描。
     fn full_scan_workspace(&self, cwd: &str) {
         let root = PathBuf::from(cwd);
         if !root.is_dir() {
             return;
+        }
+        if let Ok(mut scanned) = self.last_scanned.write() {
+            scanned.clone_from(&Some(root.clone()));
         }
         if !crate::index::workspace_index_exists(&root) {
             // 首次：同步全量扫描
@@ -126,8 +134,29 @@ impl Plugin for IndexPlugin {
     }
 
     fn set_workspace(&self, workspace: Option<&std::path::Path>) {
+        let new_path = workspace.map(|p| p.to_path_buf());
         if let Ok(mut guard) = self.workspace.write() {
-            *guard = workspace.map(|p| p.to_path_buf());
+            *guard = new_path.clone();
+        }
+        // 工作区变更后重扫索引（原 on_cwd_changed 的职责）。
+        // 仅当新路径与上次已扫描路径不同且是有效目录时才扫描，避免重复。
+        if let Some(ref root) = new_path
+            && root.is_dir()
+        {
+            let need_scan = self
+                .last_scanned
+                .read()
+                .map(|g| g.as_ref() != Some(root))
+                .unwrap_or(true);
+            if need_scan && let Ok(mut scanned) = self.last_scanned.write() {
+                scanned.clone_from(&Some(root.clone()));
+            }
+            if need_scan {
+                self.with_index_manager(|im| match im.full_scan(root) {
+                    Ok(count) => tracing::info!(count, "Workspace 索引扫描完成"),
+                    Err(e) => tracing::warn!("Workspace 索引扫描失败: {e}"),
+                });
+            }
         }
     }
 
@@ -141,18 +170,20 @@ impl Plugin for IndexPlugin {
     // 由 core 通过 supertrait 自动收集。
 
     fn on_session_ready(&self, session: &mut Session) {
-        self.full_scan_workspace(&session.cwd);
-    }
-
-    fn on_cwd_changed(&self, session: &mut Session) {
+        // set_workspace 可能已在 engine 初始化时对当前 cwd 触发过扫描（last_scanned
+        // 已置位）。若已扫描过同一目录则跳过，否则做首次全量扫描。
         let root = PathBuf::from(&session.cwd);
-        if !root.is_dir() {
-            return;
+        if root.is_dir() {
+            let already_scanned = self
+                .last_scanned
+                .read()
+                .map(|g| g.as_ref() == Some(&root))
+                .unwrap_or(false);
+            if already_scanned {
+                return;
+            }
         }
-        self.with_index_manager(|im| match im.full_scan(&root) {
-            Ok(count) => tracing::info!(count, "Workspace 索引扫描完成"),
-            Err(e) => tracing::warn!("Workspace 索引扫描失败: {e}"),
-        });
+        self.full_scan_workspace(&session.cwd);
     }
 
     fn on_turn_finished(&self, session: &mut Session, turn_start_idx: usize) {

--- a/crates/plugins/tiangong-plugin-index/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-index/src/plugin.rs
@@ -80,28 +80,41 @@ impl IndexPlugin {
         Some(f(im))
     }
 
-    /// 对工作区做全量扫描（用于 on_session_ready）。
+    /// 对工作区做全量扫描（供 set_workspace / on_session_ready 共用）。
     ///
     /// - 索引不存在：同步全量扫描（首次使用，阻塞直到完成）。
     /// - 索引过期（>1 小时）：后台重建，不阻塞当前搜索。
     /// - 索引新鲜：跳过。
     ///
-    /// 无论走哪个分支都会置位 `last_scanned`，使后续 `set_workspace` 对同一目录不再重复扫描。
+    /// 仅在索引已存在（复用或后台重建）或同步首次扫描成功时置位 `last_scanned`，
+    /// 使后续 `set_workspace` 对同一目录不再重复扫描；扫描失败时不置位，允许下次重试。
     fn full_scan_workspace(&self, cwd: &str) {
         let root = PathBuf::from(cwd);
         if !root.is_dir() {
             return;
         }
-        if let Ok(mut scanned) = self.last_scanned.write() {
-            scanned.clone_from(&Some(root.clone()));
-        }
         if !crate::index::workspace_index_exists(&root) {
-            // 首次：同步全量扫描
-            self.with_index_manager(|im| match im.full_scan(&root) {
-                Ok(count) => tracing::info!(count, "Workspace 初始索引扫描完成"),
-                Err(e) => tracing::warn!("Workspace 初始索引扫描失败: {e}"),
+            // 首次：同步全量扫描。仅在成功后置位 last_scanned，失败则允许下次重试。
+            let scanned = self.with_index_manager(|im| match im.full_scan(&root) {
+                Ok(count) => {
+                    tracing::info!(count, "Workspace 初始索引扫描完成");
+                    true
+                }
+                Err(e) => {
+                    tracing::warn!("Workspace 初始索引扫描失败: {e}");
+                    false
+                }
             });
+            if scanned.unwrap_or(false)
+                && let Ok(mut guard) = self.last_scanned.write()
+            {
+                guard.clone_from(&Some(root));
+            }
             return;
+        }
+        // 索引已存在——复用，置位 last_scanned。
+        if let Ok(mut guard) = self.last_scanned.write() {
+            guard.clone_from(&Some(root.clone()));
         }
         // 检查索引年龄，过期则后台重建（不阻塞搜索）
         const STALE_THRESHOLD_SECS: u64 = 3600; // 1 小时
@@ -139,23 +152,18 @@ impl Plugin for IndexPlugin {
             *guard = new_path.clone();
         }
         // 工作区变更后重扫索引（原 on_cwd_changed 的职责）。
-        // 仅当新路径与上次已扫描路径不同且是有效目录时才扫描，避免重复。
+        // 仅当新路径与上次已扫描路径不同时才触发，避免重复扫描。
+        // 复用 full_scan_workspace 的检查策略：索引已存在则复用，不存在才同步全量扫描。
         if let Some(ref root) = new_path
             && root.is_dir()
         {
-            let need_scan = self
+            let already_scanned = self
                 .last_scanned
                 .read()
-                .map(|g| g.as_ref() != Some(root))
-                .unwrap_or(true);
-            if need_scan && let Ok(mut scanned) = self.last_scanned.write() {
-                scanned.clone_from(&Some(root.clone()));
-            }
-            if need_scan {
-                self.with_index_manager(|im| match im.full_scan(root) {
-                    Ok(count) => tracing::info!(count, "Workspace 索引扫描完成"),
-                    Err(e) => tracing::warn!("Workspace 索引扫描失败: {e}"),
-                });
+                .map(|g| g.as_ref() == Some(root))
+                .unwrap_or(false);
+            if !already_scanned {
+                self.full_scan_workspace(&root.display().to_string());
             }
         }
     }
@@ -170,8 +178,8 @@ impl Plugin for IndexPlugin {
     // 由 core 通过 supertrait 自动收集。
 
     fn on_session_ready(&self, session: &mut Session) {
-        // set_workspace 可能已在 engine 初始化时对当前 cwd 触发过扫描（last_scanned
-        // 已置位）。若已扫描过同一目录则跳过，否则做首次全量扫描。
+        // set_workspace 已在 engine 初始化时对当前 cwd 触发过扫描（last_scanned 已置位）。
+        // 若 set_workspace 因扫描失败未置位，此处兜底重试一次。
         let root = PathBuf::from(&session.cwd);
         if root.is_dir() {
             let already_scanned = self
@@ -179,11 +187,10 @@ impl Plugin for IndexPlugin {
                 .read()
                 .map(|g| g.as_ref() == Some(&root))
                 .unwrap_or(false);
-            if already_scanned {
-                return;
+            if !already_scanned {
+                self.full_scan_workspace(&session.cwd);
             }
         }
-        self.full_scan_workspace(&session.cwd);
     }
 
     fn on_turn_finished(&self, session: &mut Session, turn_start_idx: usize) {

--- a/crates/plugins/tiangong-plugin-mcp/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-mcp/src/plugin.rs
@@ -16,7 +16,6 @@ use anyhow::{Context, Result};
 use tiangong_core::core::Plugin;
 use tiangong_core::core::plugin::PluginFeedbackTx;
 use tiangong_core::permission::TrustModeHandle;
-use tiangong_core::runtime::RuntimeEngine;
 
 use crate::capability::McpCapabilityIndex;
 use crate::config::McpConfig;
@@ -66,10 +65,13 @@ impl McpPlugin {
     /// 用显式路径构造（主要供测试使用，capability 状态实例隔离）。
     pub fn with_paths(mcp_config_path: PathBuf, capability_cache_path: PathBuf) -> Self {
         let mcp_config = load_mcp_config_from_path(&mcp_config_path);
+        let capability = McpCapabilityIndex::new();
+        // 加载 capability 缓存（原 register 逻辑，迁入构造期完成）。
+        let _ = capability.load_cache(&capability_cache_path);
         Self {
             mcp_config: RwLock::new(mcp_config),
             mcp_targets: RwLock::new(HashMap::new()),
-            capability: McpCapabilityIndex::new(),
+            capability,
             capability_cache_path,
             mcp_config_path,
             workspace: RwLock::new(None),
@@ -193,12 +195,6 @@ impl Plugin for McpPlugin {
         "mcp"
     }
 
-    fn register(&self, _engine: &RuntimeEngine) {
-        // 加载 capability 缓存 + 启动后台调度器 + 异步预热 + 重建 targets。
-        let _ = self.capability.load_cache(&self.capability_cache_path);
-        self.reconfigure();
-    }
-
     fn set_workspace(&self, workspace: Option<&std::path::Path>) {
         if let Ok(mut guard) = self.workspace.write() {
             *guard = workspace.map(|p| p.to_path_buf());
@@ -215,7 +211,7 @@ impl Plugin for McpPlugin {
         }
     }
 
-    fn collect_exec_env(&self) -> std::collections::BTreeMap<String, String> {
+    fn exec_env(&self) -> std::collections::BTreeMap<String, String> {
         // 贡献启用 MCP server 的环境变量（API keys 等），供 run_command 子进程注入。
         self.collect_runtime_env()
     }

--- a/crates/plugins/tiangong-plugin-mcp/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-mcp/src/plugin.rs
@@ -220,8 +220,9 @@ impl Plugin for McpPlugin {
         self.collect_runtime_env()
     }
 
-    fn on_engine_rebuilt(&self, _session: &mut tiangong_core::session::Session) {
+    fn on_config_updated(&self, _config: &tiangong_core::core_config::CoreConfig) {
         // engine 重建（配置变更）后，capability scheduler 重配 + targets 重建。
+        // 原 on_engine_rebuilt 的职责由配置变更钩子统一承载。
         self.reconfigure();
     }
 }

--- a/crates/plugins/tiangong-plugin-prompt/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-prompt/src/lib.rs
@@ -19,7 +19,7 @@ use tiangong_core::tool_override::PromptSectionProvider;
 ///
 /// 注入 identity（产品身份）、通用 rules（回复风格 / 格式规范）与用户自定义指令外围包装。
 ///
-/// `custom_prompt` 在 `register` 时从 `AgentConfig.custom_system_prompt` 读取并缓存，
+/// `custom_prompt` 在 `on_config_updated` 时从 `CoreConfig.custom_system_prompt` 读取并缓存，
 /// 覆盖两种场景：
 /// - 主 Agent：值为宿主全局用户自定义指令（经 `to_core_config` 从 registry 落入 CoreConfig）；
 /// - 子 Agent：值为「用户自定义指令 + 角色 prompt」组合（经 agent-team 插件的 `child_config` 写入）。
@@ -54,10 +54,10 @@ impl Plugin for PromptPlugin {
         "prompt"
     }
 
-    fn register(&self, engine: &tiangong_core::runtime::RuntimeEngine) {
+    fn on_config_updated(&self, config: &tiangong_core::core_config::CoreConfig) {
         // 缓存当前 Core 的自定义指令：主 Agent 取宿主全局值，子 Agent 取角色 prompt。
-        // engine 每次 build / rebuild 都会重新调 register，故配置变更后缓存自动刷新。
-        let custom = engine.agent_config().custom_system_prompt.clone();
+        // engine 每次 build / rebuild 都会重新调 on_config_updated，故配置变更后缓存自动刷新。
+        let custom = config.custom_system_prompt.clone();
         if let Ok(mut guard) = self.custom_prompt.write() {
             *guard = custom;
         }

--- a/crates/plugins/tiangong-plugin-skill/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-skill/src/plugin.rs
@@ -13,7 +13,6 @@ use crate::paths::default_skills_storage_dir_path;
 use crate::skill_registry::SkillRegistry;
 use tiangong_core::core::Plugin;
 use tiangong_core::core::plugin::PluginFeedbackTx;
-use tiangong_core::runtime::RuntimeEngine;
 
 /// Skill 插件。
 ///
@@ -38,8 +37,11 @@ impl SkillPlugin {
 
     /// 用指定存储根目录构造（主要供测试或自定义路径使用）。
     pub fn with_storage_root(root: PathBuf) -> Self {
+        let skill_registry = Arc::new(SkillRegistry::new(root));
+        // 构造时刷新 registry 缓存，确保读到最新磁盘状态（原 register 逻辑迁入）。
+        skill_registry.refresh();
         Self {
-            skill_registry: Arc::new(SkillRegistry::new(root)),
+            skill_registry,
             workspace: RwLock::new(None),
             feedback_tx: RwLock::new(None),
         }
@@ -74,12 +76,7 @@ impl Plugin for SkillPlugin {
         }
     }
 
-    fn register(&self, _engine: &RuntimeEngine) {
-        // 刷新 registry 缓存，确保读到最新磁盘状态。
-        self.skill_registry.refresh();
-    }
-
-    fn collect_exec_env(&self) -> std::collections::BTreeMap<String, String> {
+    fn exec_env(&self) -> std::collections::BTreeMap<String, String> {
         // 贡献 enabled skill 目录的 .env.local 环境变量，供 run_command 子进程注入。
         let registry = self.registry();
         let view = registry.view();

--- a/crates/plugins/tiangong-plugin-skill/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-skill/src/plugin.rs
@@ -99,12 +99,6 @@ impl Plugin for SkillPlugin {
         env
     }
 
-    fn allowed_file_roots(&self) -> Vec<std::path::PathBuf> {
-        // 贡献 skills 存储目录（~/.tiangong/skills），供 fs 工具写权限校验，
-        // 让 Agent 能创建/编辑 skill 文件。core 不再硬编码此路径。
-        vec![crate::paths::default_skills_storage_dir_path()]
-    }
-
     fn tool_permission_overrides(
         &self,
     ) -> std::collections::BTreeMap<String, tiangong_core::permission::PermissionLevel> {

--- a/crates/plugins/tiangong-plugin-task/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-task/src/plugin.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::RwLock;
 
 use serde_json::json;
 use tiangong_core::core::Plugin;
@@ -18,15 +18,15 @@ use tiangong_core::tool_override::{PromptSectionProvider, ToolOverrideHandler, T
 use crate::handler::{TaskStatus, task_registry, wait_tasks};
 
 pub struct TaskPlugin {
-    /// 各插件贡献的环境变量共享句柄（register 时从 engine 获取）。
-    runtime_env: RwLock<Arc<Mutex<BTreeMap<String, String>>>>,
+    /// 各插件贡献的汇总环境变量（由 core 经 set_exec_env 回注）。
+    runtime_env: RwLock<BTreeMap<String, String>>,
     workspace: RwLock<Option<PathBuf>>,
 }
 
 impl Default for TaskPlugin {
     fn default() -> Self {
         Self {
-            runtime_env: RwLock::new(Arc::new(Mutex::new(BTreeMap::new()))),
+            runtime_env: RwLock::new(BTreeMap::new()),
             workspace: RwLock::new(None),
         }
     }
@@ -39,13 +39,8 @@ impl TaskPlugin {
 
     /// 读取当前环境变量快照（spawn_task 时注入子进程）。
     fn env_snapshot(&self) -> Vec<(String, String)> {
-        let handle = self
-            .runtime_env
+        self.runtime_env
             .read()
-            .map(|g| g.clone())
-            .unwrap_or_else(|_| Arc::new(Mutex::new(BTreeMap::new())));
-        handle
-            .lock()
             .map(|g| g.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
             .unwrap_or_default()
     }
@@ -329,11 +324,10 @@ impl Plugin for TaskPlugin {
         }
     }
 
-    fn register(&self, engine: &tiangong_core::runtime::RuntimeEngine) {
-        // 持有 engine 的 runtime_env 共享句柄——core 在所有插件注册完成后会汇总
-        // 各插件的 collect_exec_env 写入同一句柄，spawn_task 时读取即为最新值。
+    fn set_exec_env(&self, env: BTreeMap<String, String>) {
+        // 接收 core 汇总后的全部插件环境变量，spawn_task 执行子进程时注入。
         if let Ok(mut guard) = self.runtime_env.write() {
-            *guard = engine.runtime_env_handle();
+            *guard = env;
         }
     }
 

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -582,19 +582,6 @@ async fn worker_loop_async(
                 }
                 e.set_runtime_env(exec_env);
             }
-            // 汇总插件贡献的允许文件根目录，
-            // 写入 process-level 允许表供 tool/common.rs 写权限校验，避免 core 硬编码。
-            {
-                let mut extra_roots: Vec<std::path::PathBuf> = Vec::new();
-                for plugin in &plugins {
-                    for root in plugin.allowed_file_roots() {
-                        if !extra_roots.contains(&root) {
-                            extra_roots.push(root);
-                        }
-                    }
-                }
-                tiangong_toolkit::set_extra_allowed_roots(extra_roots);
-            }
             // 汇总插件贡献的工具权限覆盖，
             // 写入 PermissionGate 覆盖表，避免 core classify_tool 硬编码插件工具名。
             {

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -528,11 +528,11 @@ async fn worker_loop_async(
             // 遍历插件自注册（issue #156）：在 worker 接收任何用户消息前完成，
             // 根治「注册竞态窗口」。
             //
-            // register_plugin 内部先注入上下文（workspace/trust_mode/feedback_tx），
-            // 再调 Plugin::register 初始化插件内部状态或注入 engine 依赖（如克隆
-            // models_config），最后才收集 tool_specs 并注册 override handler——保证
-            // handler 注册到正确的工具名上。返回的 specs 累积到 plugin_specs，供后续
-            // 同名工具冲突避让与 tools 合并使用。
+            // on_config_updated 已在上文统一触发（插件内部状态已就绪）。
+            // register_plugin 内部注入上下文（workspace/trust_mode/feedback_tx）后，
+            // 收集 tool_specs 并注册 override handler——保证 handler 注册到正确的
+            // 工具名上。返回的 specs 累积到 plugin_specs，供后续同名工具冲突避让
+            // 与 tools 合并使用。
             let e = engine.as_ref().unwrap();
             let workspace = std::path::Path::new(&session.cwd);
             let workspace = if workspace.is_dir() {
@@ -571,16 +571,19 @@ async fn worker_loop_async(
                 }
             }
             // 汇总所有插件贡献的子进程环境变量，
-            // 写入 engine 供 command 插件在 on_engine_rebuilt 时读取注入子进程。
+            // 回注给需要消费合并 env 的插件（command / task 执行子进程时注入）。
             // 每次 engine rebuild 都重走此段，保证配置变化后 env 刷新。
             {
                 let mut exec_env = std::collections::BTreeMap::new();
                 for plugin in &plugins {
-                    for (key, value) in plugin.collect_exec_env() {
+                    for (key, value) in plugin.exec_env() {
                         exec_env.insert(key, value);
                     }
                 }
-                e.set_runtime_env(exec_env);
+                e.set_runtime_env(exec_env.clone());
+                for plugin in &plugins {
+                    plugin.set_exec_env(exec_env.clone());
+                }
             }
             // 汇总插件贡献的工具权限覆盖，
             // 写入 PermissionGate 覆盖表，避免 core classify_tool 硬编码插件工具名。

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -606,26 +606,23 @@ async fn worker_loop_async(
             last_cfg_gen = cfg_gen;
 
             // 首次 engine build + 插件注册完成后触发一次 on_session_ready
-            //（此时 workspace / trust_mode / feedback 已注入）；后续重建只调 on_engine_rebuilt。
+            //（此时 workspace / trust_mode / feedback 已注入）；engine 重建后的再配置
+            // 由各插件在 on_config_updated 中统一承载。
             if !session_ready_fired {
                 session_ready_fired = true;
                 for plugin in &plugins {
                     plugin.on_session_ready(&mut session);
                 }
             }
-            // engine 创建/重建完成：回调插件生命周期钩子
-            for plugin in &plugins {
-                plugin.on_engine_rebuilt(&mut session);
-            }
         }
 
         match cmd {
             Command::UpdateCwd { cwd } => {
-                let cwd_changed = cwd != session.cwd;
                 session.cwd = cwd;
                 apply_session_cwd(&session);
                 // 同步把新的工作目录注入到所有插件（文件类插件据此感知会话 workspace）。
                 // cwd 无效时传 None，让插件清空缓存的旧 workspace，避免在旧目录上继续操作。
+                // index 插件在 set_workspace 内对变更目录触发重扫，无需单独的 cwd 钩子。
                 let workspace = std::path::Path::new(&session.cwd);
                 let workspace = if workspace.is_dir() {
                     Some(workspace)
@@ -634,12 +631,6 @@ async fn worker_loop_async(
                 };
                 for plugin in &plugins {
                     plugin.set_workspace(workspace);
-                }
-                // CWD 变更：回调插件生命周期钩子（index 插件在此重扫工作区索引）
-                if cwd_changed {
-                    for plugin in &plugins {
-                        plugin.on_cwd_changed(&mut session);
-                    }
                 }
 
                 continue;
@@ -744,7 +735,6 @@ async fn worker_loop_async(
                     let workspace = workspace_path.is_dir().then_some(workspace_path.as_path());
                     for plugin in &plugins {
                         plugin.set_workspace(workspace);
-                        plugin.on_cwd_changed(&mut session);
                     }
                 }
 

--- a/crates/tiangong-core/src/core/plugin/mod.rs
+++ b/crates/tiangong-core/src/core/plugin/mod.rs
@@ -6,10 +6,10 @@
 //! 设计要点：
 //! - [`Plugin`] 是能力的声明式聚合：通过 supertrait 约束同时要求实现工具规格、
 //!   工具覆盖与 Prompt 段落三种能力（均提供默认空实现，插件按需覆写）。
-//! - [`Plugin::register`] 接收 `&RuntimeEngine`（engine 内部用 `Arc` + interior
-//!   mutability，`&self` 即可修改），core 在调用前会先通过 [`Plugin::set_workspace`]
-//!   注入当前会话工作目录、通过 [`Plugin::set_trust_mode`] 注入会话信任解析句柄、
-//!   并通过 [`Plugin::set_feedback_tx`] 注入反馈通道。
+//! - core 在收集 tool_specs 前会先通过 [`Plugin::set_workspace`] 注入当前会话
+//!   工作目录、通过 [`Plugin::set_trust_mode`] 注入会话信任解析句柄、通过
+//!   [`Plugin::set_feedback_tx`] 注入反馈通道，并在配置变更时调
+//!   [`Plugin::on_config_updated`] 让插件初始化内部状态。
 //! - `PageFetcher` / `TerminalProvider` 等外部能力 trait 已随能力下沉重构（#225）
 //!   迁入对应插件 crate，core 不再持有这些 trait；插件经 [`Plugin::set_feedback_tx`]
 //!   注入的通道自行向会话投递外部事件（如浏览器页面快照）。

--- a/crates/tiangong-core/src/core/plugin/registry.rs
+++ b/crates/tiangong-core/src/core/plugin/registry.rs
@@ -1,7 +1,7 @@
 //! 进程内插件的注册编排逻辑。
 //!
 //! [`register_plugin`] 把一个 [`Plugin`] 的全部能力（工具规格 / 工具覆盖 / Prompt 段落
-//! / 外部能力 / 工作目录 / 信任模式 / 反馈通道）按统一顺序注册到 [`RuntimeEngine`]，
+//! / 工作目录 / 信任模式 / 反馈通道）按统一顺序注册到 [`RuntimeEngine`]，
 //! 并返回该插件声明的工具规格，供调用方（worker_loop）做全局编排（同名工具冲突避让、
 //! tools 合并等）。
 //!
@@ -9,15 +9,12 @@
 //! 1. `set_workspace` — 注入会话工作目录；
 //! 2. `set_trust_mode` — 注入会话信任模式解析句柄；
 //! 3. `set_feedback_tx` — 注入状态反馈通道（复用 worker 命令通道）；
-//! 4. `Plugin::register` — 让插件初始化内部状态或注入 engine 依赖
-//!    （如克隆 models_config、初始化插件内部状态等）。必须在收集
-//!    tool_specs 前，确保插件已就绪；
-//! 5. 收集 `tool_specs` 并注册为 `ToolSpecProvider`；
-//! 6. 按 spec.name 逐个注册 `ToolOverrideHandler`（基于 register 之后的正确 specs）；
-//! 7. 注册 `PromptSectionProvider`。
+//! 4. 收集 `tool_specs` 并注册为 `ToolSpecProvider`；
+//! 5. 按 spec.name 逐个注册 `ToolOverrideHandler`；
+//! 6. 注册 `PromptSectionProvider`。
 //!
-//! 步骤 4-6 的顺序至关重要：`register` 先执行，确保插件内部状态就绪，
-//! 此后 `tool_specs()` 读到的才是最新值，override handler 才会注册到正确的工具名上。
+//! 插件的内部状态初始化（如读取配置、启动后台调度器）在 worker_loop 调用本函数
+//! 之前已完成——经由 `on_config_updated`（在收集 specs 前由 core 统一调用）。
 //!
 //! engine 仅暴露原子能力槽位（`register_tool_*`），全部编排逻辑集中在此。
 
@@ -39,7 +36,7 @@ use super::trait_def::Plugin;
 /// 在 engine 创建/重建时由 `worker_loop` 逐个插件调用。`cmd_tx` 为 worker 的命令通道
 /// 发送端，会包装成 [`PluginFeedbackTx`] 注入给插件（复用同一通道，避免新增 channel）。
 ///
-/// 返回值是该插件经 `register` 初始化后、由 `tool_specs()` 产出的工具规格快照，
+/// 返回值是该插件由 `tool_specs()` 产出的工具规格快照，
 /// 供调用方做全局编排（构建 reserved_names 避让同名工具冲突、合并到最终 tools 列表）。
 /// 注入与编排顺序见[模块文档]。
 ///
@@ -53,7 +50,7 @@ pub(crate) fn register_plugin(
     // 1) 注入当前会话工作目录（None 表示无有效 cwd，插件应清空缓存的旧值）
     plugin.set_workspace(workspace);
 
-    // 2) 注入信任模式解析句柄（在 register 之前，让 register 内可读）
+    // 2) 注入信任模式解析句柄（在收集 tool_specs 前注入，让插件 handler 可读）
     let trust_mode = engine.permission_gate().trust_mode_handle();
     plugin.set_trust_mode(trust_mode);
 
@@ -63,22 +60,19 @@ pub(crate) fn register_plugin(
         engine.turn_usage_sink().clone(),
     ));
 
-    // 4) 让插件初始化内部状态并注入外部能力（如克隆 models_config 供 handler 使用）。
-    //    必须在收集 tool_specs 前，确保插件已就绪。
-    plugin.register(engine);
-
-    // 5) 工具规格：register 之后收集，确保读到插件初始化后的最新值。
+    // 4) 工具规格：on_config_updated 已由 worker_loop 在调用本函数前统一触发，
+    //    插件内部状态已就绪，直接收集 specs。
     let specs = plugin.tool_specs();
     let plugin_as_spec: Arc<dyn ToolSpecProvider> = plugin.clone();
     engine.register_tool_spec_provider(plugin_as_spec);
 
-    // 6) 工具覆盖：按 spec 中的工具名逐个注册，路由到同一 plugin 的 handle。
+    // 5) 工具覆盖：按 spec 中的工具名逐个注册，路由到同一 plugin 的 handle。
     let plugin_as_handler: Arc<dyn ToolOverrideHandler> = plugin.clone();
     for spec in &specs {
         engine.register_tool_override(&spec.name, plugin_as_handler.clone());
     }
 
-    // 7) Prompt 段落
+    // 6) Prompt 段落
     let plugin_as_prompt: Arc<dyn PromptSectionProvider> = plugin.clone();
     engine.register_prompt_section_provider(plugin_as_prompt);
 

--- a/crates/tiangong-core/src/core/plugin/trait_def.rs
+++ b/crates/tiangong-core/src/core/plugin/trait_def.rs
@@ -146,12 +146,6 @@ pub trait Plugin: ToolSpecProvider + ToolOverrideHandler + PromptSectionProvider
     /// 目录做首次全量扫描）。仅触发一次；后续 engine 重建只回调 [`Plugin::on_engine_rebuilt`]。
     fn on_session_ready(&self, _session: &mut crate::session::Session) {}
 
-    /// engine 创建或重建（配置变更）完成后调用。
-    fn on_engine_rebuilt(&self, _session: &mut crate::session::Session) {}
-
-    /// 会话工作目录变更后调用（core 已更新 `session.cwd` 并重注入 `set_workspace`）。
-    fn on_cwd_changed(&self, _session: &mut crate::session::Session) {}
-
     /// 一个对话轮次开始前调用：用户消息已写入 session，`execute_turn` 调用前。
     ///
     /// `turn_start_idx` 为本轮用户消息在 `session.messages` 中的起始索引，

--- a/crates/tiangong-core/src/core/plugin/trait_def.rs
+++ b/crates/tiangong-core/src/core/plugin/trait_def.rs
@@ -91,19 +91,6 @@ pub trait Plugin: ToolSpecProvider + ToolOverrideHandler + PromptSectionProvider
         std::collections::BTreeMap::new()
     }
 
-    /// 贡献插件允许文件操作的额外根目录（供 fs 工具写权限校验）。
-    ///
-    /// core 在「所有插件注册完成时」以及「配置变化导致 engine rebuild 时」统一
-    /// 遍历所有插件调用此方法，合并结果写入 process-level 的允许根目录表，
-    /// 供 tool/common.rs 的 `write_allowed_roots_with` 读取——避免 core 硬编码
-    /// 任何领域目录（如插件自管的存储目录）。
-    ///
-    /// 默认返回空——不贡献额外文件根的插件无需覆写。需要贡献的插件
-    /// 覆写此方法返回自己的领域存储目录。
-    fn allowed_file_roots(&self) -> Vec<std::path::PathBuf> {
-        Vec::new()
-    }
-
     /// 贡献插件工具的权限等级覆盖（供 core 权限门统一汇总）。
     ///
     /// core 在「所有插件注册完成时」统一遍历所有插件调用此方法，合并到

--- a/crates/tiangong-core/src/core/plugin/trait_def.rs
+++ b/crates/tiangong-core/src/core/plugin/trait_def.rs
@@ -3,11 +3,12 @@
 //! [`Plugin`] 是能力的声明式聚合：通过 supertrait 约束同时要求实现工具规格、
 //! 工具覆盖与 Prompt 段落三种能力（均提供默认空实现，插件按需覆写）。
 //!
-//! core 通过 trait 默认方法统一注入两类运行时上下文（均在 `register` 之前调用）：
+//! core 通过 trait 默认方法统一注入运行时上下文（均在收集 tool_specs 前调用）：
+//! - [`Plugin::set_workspace`]：会话工作目录（文件类工具据此感知 cwd）。
 //! - [`Plugin::set_trust_mode`]：会话信任模式解析句柄（插件可据此放宽校验）。
 //! - [`Plugin::set_feedback_tx`]：状态反馈通道（插件可向 session 投递外部事件）。
 //!
-//! 两者都带默认实现，不需要的插件无需任何改动。其中信任模式的**查询**（如
+//! 三者都带默认实现，不需要的插件无需任何改动。其中信任模式的**查询**（如
 //! 各插件自定义的 `is_full_trust` 固有方法）是插件内部工具，不作为 trait 能力暴露，
 //! 插件按需读取注入的解析句柄即可。
 
@@ -15,7 +16,6 @@ use std::path::Path;
 
 use crate::core::plugin::feedback::PluginFeedbackTx;
 use crate::permission::TrustModeHandle;
-use crate::runtime::RuntimeEngine;
 use crate::tool_override::{PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider};
 
 /// 进程内插件：封装自己的全部能力，在 engine 创建/重建时自行注册。
@@ -27,8 +27,10 @@ use crate::tool_override::{PromptSectionProvider, ToolOverrideHandler, ToolSpecP
 /// 1. [`set_workspace`](Plugin::set_workspace) 注入会话工作目录；
 /// 2. [`set_trust_mode`](Plugin::set_trust_mode) 注入信任模式解析句柄；
 /// 3. [`set_feedback_tx`](Plugin::set_feedback_tx) 注入状态反馈通道；
-/// 4. [`register`](Plugin::register) 让插件初始化内部状态（如克隆配置）。
+/// 4. 收集 `tool_specs` / 注册 override handler / 注册 prompt section。
 ///
+/// 插件初始化自身状态（如读取配置、启动后台调度器）在 [`Plugin::on_config_updated`]
+/// 中完成（core 在收集 specs 前调用）。
 /// 工具规格 / 工具覆盖 / Prompt 段落由 core 根据 supertrait 自动收集，无需插件手动注册。
 ///
 /// 此外，core 在 worker_loop 的关键生命周期节点遍历插件，回调下述生命周期钩子
@@ -38,14 +40,6 @@ pub trait Plugin: ToolSpecProvider + ToolOverrideHandler + PromptSectionProvider
     /// 插件唯一标识（日志/调试用）。
     fn id(&self) -> &str;
 
-    /// 在 engine 创建/重建时调用，插件初始化内部状态（如克隆配置）。
-    ///
-    /// 工具规格、工具覆盖、Prompt 段落由 core 通过 supertrait 自动收集，无需在此手动注册。
-    /// 调用此方法前，core 已通过 [`set_workspace`](Plugin::set_workspace)、
-    /// [`set_trust_mode`](Plugin::set_trust_mode) 与 [`set_feedback_tx`](Plugin::set_feedback_tx)
-    /// 注入会话工作目录、信任模式解析句柄与状态反馈通道，插件可在此安全读取/存储。
-    fn register(&self, _engine: &RuntimeEngine) {}
-
     /// 注入当前会话的工作目录。
     ///
     /// core 在 engine 创建时以及每次会话工作目录变更（`Command::UpdateCwd`）时调用。
@@ -53,12 +47,13 @@ pub trait Plugin: ToolSpecProvider + ToolOverrideHandler + PromptSectionProvider
     /// 之前缓存的 workspace，避免在旧目录上继续操作。
     ///
     /// 默认实现为空操作；需要感知工作目录的插件（如文件工具）应覆写此方法，将路径
-    /// 存入内部状态，供后续工具调用使用。
+    /// 存入内部状态，供后续工具调用使用。工作区变更后的副作用（如重建索引）也应
+    /// 在此方法内触发，避免职责分散到多个钩子。
     fn set_workspace(&self, _workspace: Option<&Path>) {}
 
     /// 注入信任模式解析句柄（与 [`crate::permission::PermissionGate`] 共享同一解析器）。
     ///
-    /// core 在 engine 创建时于 [`Plugin::register`] 之前调用一次。需要感知信任模式的
+    /// core 在 engine 创建时、收集 tool_specs 之前调用一次。需要感知信任模式的
     /// 插件（如 `fs` / `command` / `fetch`）应覆写此方法，把入参存入内部字段，
     /// 之后在其自身的固有方法里读取（例如 `is_full_trust`）。
     ///
@@ -71,25 +66,32 @@ pub trait Plugin: ToolSpecProvider + ToolOverrideHandler + PromptSectionProvider
 
     /// 注入状态反馈通道（复用 worker 的命令通道）。
     ///
-    /// core 在 engine 创建时于 [`Plugin::register`] 之前调用一次。需要向 session 主动
+    /// core 在 engine 创建时、收集 tool_specs 之前调用一次。需要向 session 主动
     /// 投递外部事件（如浏览器页面变化、终端用户操作）的插件应覆写此方法，把入参
     /// clone 后存入内部字段，之后通过 [`PluginFeedbackTx::send`] 投递
     /// [`PluginFeedback`]，core 会统一注入到 session（以 tool result 形式）。
     ///
     /// 默认实现为空操作——不需要主动投递外部事件的插件无需覆写。
     fn set_feedback_tx(&self, _tx: PluginFeedbackTx) {}
-    /// 收集插件贡献的子进程环境变量（供 run_command 等子进程执行注入）。
+
+    /// 贡献插件自身的子进程环境变量。
     ///
     /// core 在「所有插件注册完成时」以及「配置变化导致 engine rebuild 时」统一
-    /// 遍历所有插件调用此方法，合并结果写入 RuntimeEngine 的 runtime_env，
-    /// 供 command 插件在执行子进程时注入。
+    /// 遍历所有插件调用此方法，合并全部贡献后通过 [`Plugin::set_exec_env`] 回注。
     ///
     /// 默认返回空——不贡献环境变量的插件（fs / fetch / memory / scheduler 等）
     /// 无需覆写。需要贡献 env 的插件（如注入外部服务 env、读取 .env.local 等）
     /// 覆写此方法返回自己的环境变量。
-    fn collect_exec_env(&self) -> std::collections::BTreeMap<String, String> {
+    fn exec_env(&self) -> std::collections::BTreeMap<String, String> {
         std::collections::BTreeMap::new()
     }
+
+    /// 回注全部插件汇总后的子进程环境变量。
+    ///
+    /// core 在汇总全部插件的 [`exec_env`](Plugin::exec_env) 后遍历所有插件调用此方法，
+    /// 传入合并后的完整 env。需要读取合并 env 的插件（如 `command` / `task`，在
+    /// 执行子进程时注入）应覆写此方法存储。默认空操作——不消费 env 的插件无需覆写。
+    fn set_exec_env(&self, _env: std::collections::BTreeMap<String, String>) {}
 
     /// 贡献插件工具的权限等级覆盖（供 core 权限门统一汇总）。
     ///
@@ -127,9 +129,8 @@ pub trait Plugin: ToolSpecProvider + ToolOverrideHandler + PromptSectionProvider
     /// Core 配置快照更新后调用。
     ///
     /// worker_loop 在首次 build engine 以及 config generation 变化导致 engine rebuild 时
-    /// 调用（在 [`Plugin::register`] 之后、[`Plugin::on_engine_rebuilt`] 之前）。插件可
-    /// 按需读取模型配置、memory 配置等，执行热更新（如 reconfigure memory actor）。
-    /// 默认实现为空。
+    /// 调用（在收集 tool_specs 之前）。插件可按需读取模型配置、memory 配置等，执行
+    /// 热更新或初始化（如 reconfigure memory actor、启动后台调度器）。默认实现为空。
     fn on_config_updated(&self, _config: &crate::core_config::CoreConfig) {}
 
     // ── 生命周期钩子 ──
@@ -143,7 +144,8 @@ pub trait Plugin: ToolSpecProvider + ToolOverrideHandler + PromptSectionProvider
     /// build engine），并非在接收命令前。此时 [`set_workspace`](Plugin::set_workspace) /
     /// [`set_trust_mode`](Plugin::set_trust_mode) / [`set_feedback_tx`](Plugin::set_feedback_tx)
     /// 均已注入，插件可安全读取已存储的上下文。适合做一次性的会话级初始化（如对工作
-    /// 目录做首次全量扫描）。仅触发一次；后续 engine 重建只回调 [`Plugin::on_engine_rebuilt`]。
+    /// 目录做首次全量扫描）。仅触发一次；后续 engine 重建由 [`Plugin::on_config_updated`]
+    /// 承载再配置语义。
     fn on_session_ready(&self, _session: &mut crate::session::Session) {}
 
     /// 一个对话轮次开始前调用：用户消息已写入 session，`execute_turn` 调用前。

--- a/crates/tiangong-core/src/prompt/sections.rs
+++ b/crates/tiangong-core/src/prompt/sections.rs
@@ -55,8 +55,12 @@ fn collect_environment_parts(session: &Session) -> Vec<String> {
     let workspace = session_working_directory(session);
     parts.push(format!("当前会话：{}", session.title));
     parts.push(format!("当前工作目录：{}", workspace));
-    // 允许文件操作目录：仅工作空间。插件贡献的额外根目录由各插件自行注入。
-    parts.push(format!("允许文件操作目录：{}", workspace));
+    // 允许文件操作目录：工作空间 + 应用存储根（由 toolkit 硬编码为始终允许）。
+    parts.push(format!(
+        "允许文件操作目录：{}；{}",
+        workspace,
+        tiangong_toolkit::app_storage_root().display()
+    ));
     parts
 }
 

--- a/crates/tiangong-core/src/runtime.rs
+++ b/crates/tiangong-core/src/runtime.rs
@@ -255,17 +255,8 @@ impl RuntimeEngine {
             .unwrap_or_default()
     }
 
-    /// 返回 runtime_env 的共享句柄（`Arc<Mutex>`）。
-    ///
-    /// 供 command 插件在 register 时持有，core 在「所有插件注册完成后」汇总各插件
-    /// 的 `collect_exec_env` 写入同一句柄——command 插件执行子进程时读取即为最新值，
-    /// 无需 snapshot 刷新。
-    pub fn runtime_env_handle(&self) -> Arc<Mutex<std::collections::BTreeMap<String, String>>> {
-        Arc::clone(&self.runtime_env)
-    }
-
-    /// 写入由各插件 collect_exec_env 汇总的环境变量（供 core/mod.rs 在所有插件
-    /// 注册完成后统一调用）。
+    /// 写入由各插件 exec_env 汇总的环境变量（供 core/mod.rs 在所有插件
+    /// 注册完成后统一调用，并经 `Plugin::set_exec_env` 回注给消费方插件）。
     pub fn set_runtime_env(&self, env: std::collections::BTreeMap<String, String>) {
         if let Ok(mut guard) = self.runtime_env.lock() {
             *guard = env;

--- a/crates/tiangong-core/src/runtime_env.rs
+++ b/crates/tiangong-core/src/runtime_env.rs
@@ -1,8 +1,8 @@
 //! 子进程环境变量加载工具。
 //!
-//! 插件通过 [`crate::core::Plugin::collect_exec_env`] 贡献子进程环境变量，core 在
-//! 所有插件注册完成后统一汇总写入 RuntimeEngine。本模块仅保留 `.env` / `.env.local`
-//! 文件解析工具，供插件复用。
+//! 插件通过 [`crate::core::Plugin::exec_env`] 贡献子进程环境变量，core 在
+//! 所有插件注册完成后统一汇总并经 [`crate::core::Plugin::set_exec_env`] 回注给
+//! 消费方插件。本模块仅保留 `.env` / `.env.local` 文件解析工具，供插件复用。
 
 use std::path::Path;
 

--- a/crates/tiangong-llm/src/provider_client.rs
+++ b/crates/tiangong-llm/src/provider_client.rs
@@ -976,8 +976,6 @@ fn build_provider_messages(req: &ModelRequest) -> Result<(String, Vec<ChatMessag
         SYSTEM_IDENTITY.to_string(),
         SYSTEM_RULES.to_string(),
         format!("当前会话：{}", req.session_title),
-        format!("当前工作目录：{}", current_working_directory_text()),
-        format!("允许文件操作目录：{}", allowed_file_roots_text()),
     ];
     let mut has_context_system = false;
     for msg in &req.context {
@@ -1681,18 +1679,6 @@ fn block_on_provider_stream(
 
 fn map_llm_error(error: crate::error::LlmError) -> anyhow::Error {
     anyhow!(error.to_string())
-}
-
-fn current_working_directory_text() -> String {
-    std::env::current_dir()
-        .map(|path| path.display().to_string())
-        .unwrap_or_else(|_| ".".to_string())
-}
-
-fn allowed_file_roots_text() -> String {
-    let workspace = current_working_directory_text();
-    let temp = std::env::temp_dir().display().to_string();
-    format!("{workspace}；{temp}")
 }
 
 // ── 重试相关 ──────────────────────────────────────────────

--- a/crates/tiangong-toolkit/src/lib.rs
+++ b/crates/tiangong-toolkit/src/lib.rs
@@ -14,7 +14,7 @@ use std::cell::RefCell;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
-use std::sync::{Arc, Mutex, OnceLock, RwLock};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -52,40 +52,50 @@ pub fn session_workspace_root() -> Option<PathBuf> {
     SESSION_CWD.with(|cell| cell.borrow().as_ref().filter(|cwd| cwd.is_dir()).cloned())
 }
 
-/// 插件贡献的额外允许文件根目录（process-level，由 core/mod.rs 汇总各插件的
-/// `Plugin::allowed_file_roots` 写入）。
-static EXTRA_ALLOWED_ROOTS: OnceLock<RwLock<Vec<PathBuf>>> = OnceLock::new();
-
-fn extra_allowed_roots() -> &'static RwLock<Vec<PathBuf>> {
-    EXTRA_ALLOWED_ROOTS.get_or_init(|| RwLock::new(Vec::new()))
-}
-
-/// 写入插件贡献的额外允许文件根目录（供 core/mod.rs 在汇总插件能力时调用）。
-pub fn set_extra_allowed_roots(roots: Vec<PathBuf>) {
-    if let Ok(mut guard) = extra_allowed_roots().write() {
-        *guard = roots;
+/// 应用自管存储根目录：`~/.tiangong/`。
+///
+/// 该目录承载 skills / MCP 锁等插件自管数据，天然属于应用可信存储区，
+/// 始终允许 fs 工具写入（如 Agent 创建/编辑 skill 文件），无需经插件 hook 声明。
+pub fn app_storage_root() -> PathBuf {
+    fn user_home_dir() -> Option<PathBuf> {
+        if let Some(home) = std::env::var_os("HOME").filter(|v| !v.is_empty()) {
+            return Some(PathBuf::from(home));
+        }
+        if let Some(profile) = std::env::var_os("USERPROFILE").filter(|v| !v.is_empty()) {
+            return Some(PathBuf::from(profile));
+        }
+        let drive = std::env::var_os("HOMEDRIVE").filter(|v| !v.is_empty());
+        let path = std::env::var_os("HOMEPATH").filter(|v| !v.is_empty());
+        match (drive, path) {
+            (Some(drive), Some(path)) => {
+                let mut buf = PathBuf::from(drive);
+                buf.push(path);
+                Some(buf)
+            }
+            _ => None,
+        }
     }
+    user_home_dir()
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+        .join(".tiangong")
 }
 
-/// 计算允许写入的根目录列表（工作空间 + 插件贡献的额外根目录）。
+/// 计算允许写入的根目录列表（工作空间 + 应用存储根）。
 ///
 /// 显式传入 `workspace`，供无 thread-local CWD 的插件 handler 调用，
-/// 避免隐式依赖 `SESSION_CWD`。额外根目录由各插件经
-/// `Plugin::allowed_file_roots` 贡献，由 core 汇总后通过 `set_extra_allowed_roots` 注入。
+/// 避免隐式依赖 `SESSION_CWD`。应用存储根（`~/.tiangong/`）天然可信，
+/// 始终追加，无需插件经 hook 声明。
 fn write_allowed_roots_with(workspace: &Path) -> Result<Vec<PathBuf>> {
     let workspace_canonical = workspace
         .canonicalize()
         .with_context(|| format!("解析工作目录失败：{}", workspace.display()))?;
 
     let mut roots = vec![workspace_canonical];
-    // 插件贡献的额外允许目录（如 skill plugin 的 ~/.tiangong/skills）。
-    if let Ok(extra) = extra_allowed_roots().read() {
-        for root in extra.iter() {
-            let canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
-            if !roots.iter().any(|r| r == &canonical) {
-                roots.push(canonical);
-            }
-        }
+    // 应用自管存储根（~/.tiangong/），始终允许。
+    let storage = app_storage_root();
+    let storage_canonical = storage.canonicalize().unwrap_or(storage);
+    if !roots.iter().any(|r| r == &storage_canonical) {
+        roots.push(storage_canonical);
     }
     Ok(roots)
 }


### PR DESCRIPTION
## 概述

借 #234 收尾之机，把 `Plugin` trait 的生命周期/能力 hook 精简为职责不重叠、命名一致、无空实现占位的最小集合，降低插件实现成本和 Core 调度复杂度。

## 变更内容

### 删除 4 个 hook

| hook | 删除理由 | 替代方案 |
|---|---|---|
| `allowed_file_roots` | 写权限校验不再需要插件贡献额外文件根 | toolkit 层硬编码 `~/.tiangong` 为始终允许的应用存储根 |
| `on_cwd_changed` | 与 `set_workspace` 职责重叠 | index 插件在 `set_workspace` 内对变更目录触发重扫，用 `last_scanned` 去重 |
| `on_engine_rebuilt` | 与 `on_config_updated` 职责重叠 | mcp 插件的 reconfigure 迁入 `on_config_updated` |
| `register` | 全部 5 个实现可被替代（见下） | 见下表 |

### `register` 5 个实现的替代

| 插件 | 原 register 逻辑 | 替代方案 |
|---|---|---|
| prompt | 读 `engine.agent_config().custom_system_prompt` | 迁入 `on_config_updated`（从 `CoreConfig` 读取） |
| mcp | `load_cache` + `reconfigure()` | load_cache 移入构造期；reconfigure 由 `on_config_updated` 承载 |
| skill | `skill_registry.refresh()` | 移入构造期 |
| task/command | 持有 engine.runtime_env 句柄 | `exec_env` 双向回注（见下） |

### `collect_exec_env` → `exec_env` / `set_exec_env` 双向化

- `exec_env()`：贡献方（mcp/skill）覆写，返回自身环境变量
- `set_exec_env()`：消费方（command/task）覆写，接收 core 汇总后的完整 env
- core 汇总后新增回注循环，task/command 的 `runtime_env` 字段从 `Arc<Mutex<..>>` 简化为 `BTreeMap`

### 索引构建修复（审查反馈）

- `set_workspace` 复用 `full_scan_workspace` 的检查策略（索引已存在则复用，避免重复全量扫描）
- `last_scanned` 仅在扫描成功后置位，失败时保留可重试状态，`on_session_ready` 兜底重试

## 最终 Plugin trait

保留的 hook（除 `id` 外）：`set_workspace`、`set_trust_mode`、`set_feedback_tx`、`exec_env`、`set_exec_env`、`tool_permission_overrides`（待 #214 权限简化）、`on_config_updated`、`on_session_ready`、`on_cancel`、`on_turn_started`、`on_turn_finished`、`on_session_ended`。

## 不做

- 不删 `tool_permission_overrides`（待 #214 权限/审核简化方案落地）
- 不重构 13 处 `set_workspace` 重复样板（超出本 issue 范围）
- 不移除 `RuntimeEngine`（后续计划）

## 验证

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run`（528 passed）

Closes #236