### PR TITLE
fix(terminal): #237 run_shell/run_command 超时根因修复

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10090,6 +10090,7 @@ dependencies = [
  "tiangong-types",
  "tokio",
  "tracing",
+ "vte",
 ]
 
 [[package]]
@@ -10891,6 +10892,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
+ "arrayvec",
  "memchr",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8599,6 +8599,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10071,6 +10080,7 @@ dependencies = [
  "scru128",
  "serde",
  "serde_json",
+ "strip-ansi-escapes",
  "tauri",
  "tauri-plugin",
  "tempfile",
@@ -10873,6 +10883,15 @@ checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/crates/plugins/tiangong-plugin-terminal/Cargo.toml
+++ b/crates/plugins/tiangong-plugin-terminal/Cargo.toml
@@ -19,6 +19,7 @@ scru128 = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 descape = "3"
+strip-ansi-escapes = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/plugins/tiangong-plugin-terminal/Cargo.toml
+++ b/crates/plugins/tiangong-plugin-terminal/Cargo.toml
@@ -20,6 +20,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 descape = "3"
 strip-ansi-escapes = "0.2"
+vte = "0.14"
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/plugins/tiangong-plugin-terminal/src/command_protocol.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/command_protocol.rs
@@ -1149,4 +1149,87 @@ mod tests {
             "取消栅栏放行后，忽略 SIGINT 的命令不得继续写文件"
         );
     }
+
+    /// #237 完整复现链路验证（不依赖网络/GitHub 登录）。
+    ///
+    /// 模拟一个 TTY-aware 命令（类似 gh）在 PTY 下的完整输出流：
+    /// 1. spinner 动画（隐藏/显示光标 + CR/清行）
+    /// 2. 彩色输出（SGR 序列 + 真彩色冒号参数）
+    /// 3. shell 回显 wrapper 命令文本（contains 所有 marker）
+    /// 4. 实际的 marker 输出（start/cwd/rc/end）
+    ///
+    /// 验证：marker 检测只命中实际 marker 行（不命中回显），
+    /// 命令输出完整收集，退出码正确解析。
+    #[test]
+    fn end_to_end_tty_aware_command_marker_detection() {
+        use crate::output_processor::TerminalLineProcessor;
+
+        let marker_id = "test_e2e_001";
+        let start = format!("__TIANGONG_START_{marker_id}__");
+        let end = format!("__TIANGONG_END_{marker_id}__");
+        let cwd = format!("__TIANGONG_CWD_{marker_id}__");
+        let rc = format!("__TIANGONG_RC_{marker_id}__");
+
+        // 构造 wrapper 命令文本（会被 shell 回显，contains 所有 marker）
+        let wrapper_echo =
+            format!("__TIANGONG_= __rc=$?; printf '\\n{cwd}'; pwd; echo '{rc}'$__rc; echo '{end}'");
+
+        // 模拟 PTY 完整输出流（shell 回显 + spinner + 彩色命令输出 + marker）
+        let start_echo = format!("__TIANGONG_= echo '{start}'; export PAGER=cat; fake_gh_cmd\r\n");
+        let wrapper_echo_line = format!("{wrapper_echo}\r\n");
+        let spinner = "\x1b[?25l\r\x1b[K\r⣾\r\x1b[K\r⣽\r\x1b[K\x1b[?25h\r\x1b[K";
+        let color_error = "\x1b[38:2::255:0:0mError:\x1b[0m something failed\r\n";
+        let color_ok = "\x1b[32mOK\x1b[0m done\r\n";
+        let cwd_line = format!("{cwd}/tmp\r\n");
+        let rc_line = format!("{rc}1\r\n");
+        let end_line = format!("{end}\r\n");
+        let pty_output = format!(
+            "{start_echo}{wrapper_echo_line}{spinner}{color_error}{color_ok}{cwd_line}{rc_line}{end_line}"
+        );
+
+        // 用 TerminalLineProcessor 处理（模拟 output_reader 线程）
+        let mut processor = TerminalLineProcessor::new();
+        let lines = processor.process(&pty_output);
+
+        // 收集到的行里必须包含命令输出
+        let has_error = lines.iter().any(|l| l.contains("Error:"));
+        let has_ok = lines.iter().any(|l| l == "OK done");
+        assert!(has_error, "命令彩色输出丢失！lines: {:?}", lines);
+        assert!(has_ok, "命令输出丢失！lines: {:?}", lines);
+
+        // 回显的 wrapper 文本不应等于任何 marker（精确匹配不会误判）
+        let echo_line = lines.iter().find(|l| l.contains("__rc=$?"));
+        if let Some(echo) = echo_line {
+            assert!(
+                !line_matches_marker(echo, &end),
+                "回显行被误判为 end marker！echo: {echo}"
+            );
+            assert!(
+                !line_matches_marker(echo, &rc),
+                "回显行被误判为 rc marker！echo: {echo}"
+            );
+        }
+
+        // 实际 marker 行必须能被精确匹配
+        let rc_line = lines
+            .iter()
+            .find(|l| extract_marker_value(l, rc.as_str()).is_some())
+            .expect("rc marker 行未找到");
+        let rc_value = extract_marker_value(rc_line, rc.as_str()).unwrap();
+        assert_eq!(rc_value, "1", "退出码解析错误：{rc_value}");
+
+        let cwd_line = lines
+            .iter()
+            .find(|l| extract_marker_value(l, cwd.as_str()).is_some())
+            .expect("cwd marker 行未找到");
+        let cwd_value = extract_marker_value(cwd_line, cwd.as_str()).unwrap();
+        assert_eq!(cwd_value, "/tmp", "cwd 解析错误：{cwd_value}");
+
+        // end marker 必须能精确匹配
+        assert!(
+            lines.iter().any(|l| line_matches_marker(l, &end)),
+            "end marker 行未找到！lines: {:?}",
+            lines
+        );
+    }
 }

--- a/crates/plugins/tiangong-plugin-terminal/src/command_protocol.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/command_protocol.rs
@@ -5,7 +5,7 @@ use tauri::Emitter;
 use tokio::sync::oneshot;
 
 use crate::manager::TerminalManager;
-use crate::types::{contains_marker, PtyState, TerminalExecResponse, TerminalOutputEvent};
+use crate::types::{PtyState, TerminalExecResponse, TerminalOutputEvent};
 
 const DEFAULT_PROMPT_WAIT_SECS: u64 = 120;
 
@@ -120,7 +120,11 @@ fn collect_command_output(
         // wrapper 命令文本（它 contains 但不 == marker）。
         let is_cwd = extract_marker_value(line, cwd_marker).is_some();
         let is_rc = extract_marker_value(line, rc_marker).is_some();
-        if in_range && !is_cwd && !is_rc && !contains_marker(line) {
+        // 只过滤本次命令的实际 marker（含唯一 ID），不用固定前缀——
+        // 避免用户输出恰好包含 __TIANGONG_START_ 前缀被静默删除。
+        let is_start = line_matches_marker(line, start_marker);
+        let is_end = line_matches_marker(line, end_marker);
+        if in_range && !is_cwd && !is_rc && !is_start && !is_end {
             lines.push(line.clone());
         }
     }
@@ -132,7 +136,9 @@ fn collect_command_output(
         for line in state.output_buffer.iter().skip(start) {
             let is_cwd = extract_marker_value(line, cwd_marker).is_some();
             let is_rc = extract_marker_value(line, rc_marker).is_some();
-            if !contains_marker(line) && !is_cwd && !is_rc {
+            let is_start = line_matches_marker(line, start_marker);
+            let is_end = line_matches_marker(line, end_marker);
+            if !is_cwd && !is_rc && !is_start && !is_end {
                 lines.push(line.clone());
             }
         }
@@ -141,10 +147,13 @@ fn collect_command_output(
         let current_line = state.current_line.trim_end();
         let is_cwd = extract_marker_value(current_line, cwd_marker).is_some();
         let is_rc = extract_marker_value(current_line, rc_marker).is_some();
+        let is_start = line_matches_marker(current_line, start_marker);
+        let is_end = line_matches_marker(current_line, end_marker);
         if !current_line.trim().is_empty()
-            && !contains_marker(current_line)
             && !is_cwd
             && !is_rc
+            && !is_start
+            && !is_end
             && lines.last().is_none_or(|line| line != current_line)
         {
             lines.push(current_line.to_string());
@@ -195,7 +204,7 @@ fn wrap_non_interactive_command(
     end_marker: &str,
 ) -> String {
     format!(
-        "__TIANGONG_= echo '{}'; __tiangong_had_PAGER=${{PAGER+x}}; __tiangong_old_PAGER=${{PAGER-}}; __tiangong_had_GIT_PAGER=${{GIT_PAGER+x}}; __tiangong_old_GIT_PAGER=${{GIT_PAGER-}}; __tiangong_had_LESS=${{LESS+x}}; __tiangong_old_LESS=${{LESS-}}; export PAGER=cat GIT_PAGER=cat LESS=FRX; {}\n__TIANGONG_= __rc=$?; if [ -n \"$__tiangong_had_PAGER\" ]; then PAGER=\"$__tiangong_old_PAGER\"; export PAGER; else unset PAGER; fi; if [ -n \"$__tiangong_had_GIT_PAGER\" ]; then GIT_PAGER=\"$__tiangong_old_GIT_PAGER\"; export GIT_PAGER; else unset GIT_PAGER; fi; if [ -n \"$__tiangong_had_LESS\" ]; then LESS=\"$__tiangong_old_LESS\"; export LESS; else unset LESS; fi; printf '\\n{}'; pwd; echo '{}'$__rc; echo '{}'\n",
+        "__TIANGONG_= echo '{}'; __tiangong_had_PAGER=${{PAGER+x}}; __tiangong_old_PAGER=${{PAGER-}}; __tiangong_had_GIT_PAGER=${{GIT_PAGER+x}}; __tiangong_old_GIT_PAGER=${{GIT_PAGER-}}; __tiangong_had_GH_PAGER=${{GH_PAGER+x}}; __tiangong_old_GH_PAGER=${{GH_PAGER-}}; __tiangong_had_LESS=${{LESS+x}}; __tiangong_old_LESS=${{LESS-}}; export PAGER=cat GIT_PAGER=cat GH_PAGER=cat LESS=FRX; {}\n__TIANGONG_= __rc=$?; if [ -n \"$__tiangong_had_PAGER\" ]; then PAGER=\"$__tiangong_old_PAGER\"; export PAGER; else unset PAGER; fi; if [ -n \"$__tiangong_had_GIT_PAGER\" ]; then GIT_PAGER=\"$__tiangong_old_GIT_PAGER\"; export GIT_PAGER; else unset GIT_PAGER; fi; if [ -n \"$__tiangong_had_GH_PAGER\" ]; then GH_PAGER=\"$__tiangong_old_GH_PAGER\"; export GH_PAGER; else unset GH_PAGER; fi; if [ -n \"$__tiangong_had_LESS\" ]; then LESS=\"$__tiangong_old_LESS\"; export LESS; else unset LESS; fi; printf '\\n{}'; pwd; echo '{}'$__rc; echo '{}'\n",
         start_marker, command, cwd_marker, rc_marker, end_marker
     )
 }
@@ -1087,9 +1096,11 @@ mod tests {
         );
         assert!(combined.contains("PAGER="));
         assert!(combined.contains("GIT_PAGER="));
+        assert!(combined.contains("GH_PAGER="));
         assert!(!combined.contains("GIT_CONFIG_PARAMETERS"));
-        assert!(combined.contains("export PAGER=cat GIT_PAGER=cat LESS=FRX"));
+        assert!(combined.contains("export PAGER=cat GIT_PAGER=cat GH_PAGER=cat LESS=FRX"));
         assert!(combined.contains("unset PAGER"));
+        assert!(combined.contains("unset GH_PAGER"));
         assert!(combined.contains("LESS=FRX"));
         assert!(!combined.contains("TERM=dumb"));
         assert!(combined.contains("git diff HEAD"));

--- a/crates/plugins/tiangong-plugin-terminal/src/command_protocol.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/command_protocol.rs
@@ -62,8 +62,13 @@ fn ensure_system_pty(manager: &Arc<TerminalManager>, app: &tauri::AppHandle) -> 
     let session_id = manager.session_id();
     let cwd = manager.cwd();
     let shell = manager.shell();
+    let pty_env = manager
+        .pty_env
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_default();
     tracing::info!(session_id = %session_id, "系统 PTY 不可用，尝试重新启动");
-    match crate::manager::start_pty(&session_id, &cwd, &shell) {
+    match crate::manager::start_pty(&session_id, &cwd, &shell, &pty_env) {
         Ok(new_ps) => {
             manager.set_alive(true);
             {
@@ -104,18 +109,18 @@ fn collect_command_output(
     let mut in_range = false;
     let mut lines = Vec::new();
     for line in &state.output_buffer {
-        if line.contains(start_marker) {
+        if line_matches_marker(line, start_marker) {
             in_range = true;
             continue;
         }
-        if line.contains(end_marker) {
+        if line_matches_marker(line, end_marker) {
             break;
         }
-        if in_range
-            && !line.contains(cwd_marker)
-            && !line.contains(rc_marker)
-            && !contains_marker(line)
-        {
+        // 用精确匹配过滤 marker 行（cwd/rc marker 行），排除 shell 回显的
+        // wrapper 命令文本（它 contains 但不 == marker）。
+        let is_cwd = extract_marker_value(line, cwd_marker).is_some();
+        let is_rc = extract_marker_value(line, rc_marker).is_some();
+        if in_range && !is_cwd && !is_rc && !contains_marker(line) {
             lines.push(line.clone());
         }
     }
@@ -125,17 +130,21 @@ fn collect_command_output(
         lines.clear();
         let start = fallback_start_idx.unwrap_or(0);
         for line in state.output_buffer.iter().skip(start) {
-            if !contains_marker(line) && !line.contains(cwd_marker) && !line.contains(rc_marker) {
+            let is_cwd = extract_marker_value(line, cwd_marker).is_some();
+            let is_rc = extract_marker_value(line, rc_marker).is_some();
+            if !contains_marker(line) && !is_cwd && !is_rc {
                 lines.push(line.clone());
             }
         }
     }
     if include_current_line {
         let current_line = state.current_line.trim_end();
+        let is_cwd = extract_marker_value(current_line, cwd_marker).is_some();
+        let is_rc = extract_marker_value(current_line, rc_marker).is_some();
         if !current_line.trim().is_empty()
             && !contains_marker(current_line)
-            && !current_line.contains(cwd_marker)
-            && !current_line.contains(rc_marker)
+            && !is_cwd
+            && !is_rc
             && lines.last().is_none_or(|line| line != current_line)
         {
             lines.push(current_line.to_string());
@@ -145,6 +154,37 @@ fn collect_command_output(
         .iter()
         .any(|l| l.contains("^C") || l.contains("SIGINT") || l.contains("Interrupt"));
     (lines.join("\n"), interrupted)
+}
+
+/// 剥离 CSI/OSC 等 ANSI 转义序列，返回纯文本。
+///
+/// marker 匹配前先 strip ANSI，这样即使 TTY-aware 命令在 marker 行前后残留
+/// 转义片断（如 `\x1b[0m`），也能用精确 `==` 判定——避免 `contains` 误匹配
+/// shell 回显的 wrapper 命令文本（回显行包含所有 marker 字符串）。
+fn strip_ansi(input: &str) -> String {
+    strip_ansi_escapes::strip_str(input)
+}
+
+/// 判定一行是否匹配某个 marker（先 strip ANSI 再精确比较 trim 后的行）。
+///
+/// 不用 `contains`：shell 会回显 wrapper 命令文本，该行包含所有 marker 字符串，
+/// `contains` 会误匹配回显导致命令尚未执行就判定完成。
+fn line_matches_marker(line: &str, marker: &str) -> bool {
+    strip_ansi(line).trim() == marker
+}
+
+/// 从 marker 行提取 marker 之后的值（先 strip ANSI）。
+/// 用于 cwd_marker / rc_marker 后面跟着的路径 / 退出码。
+fn extract_marker_value(line: &str, marker: &str) -> Option<String> {
+    let clean = strip_ansi(line);
+    let trimmed = clean.trim();
+    let rest = trimmed.strip_prefix(marker)?;
+    let value = rest.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
 }
 
 fn wrap_non_interactive_command(
@@ -197,10 +237,10 @@ fn command_boundary_seen(manager: &TerminalManager, start_marker: &str, end_mark
         .unwrap_or_else(|poison| poison.into_inner());
     let mut start_seen = false;
     for line in &state.output_buffer {
-        if line.trim() == start_marker {
+        if line_matches_marker(line, start_marker) {
             start_seen = true;
         }
-        if start_seen && line.trim() == end_marker {
+        if start_seen && line_matches_marker(line, end_marker) {
             return true;
         }
     }
@@ -400,22 +440,34 @@ pub(crate) async fn handle_exec(
                 let mut found_end = false;
                 for i in start_idx..buf_len {
                     if let Some(line) = state.output_buffer.get(i) {
-                        if line.trim() == start_marker {
+                        // 精确匹配（strip ANSI 后 == marker），不用 contains：
+                        // shell 会回显 wrapper 命令文本，该行包含所有 marker 字符串，
+                        // contains 会误匹配回显导致命令尚未执行就判定完成。
+                        if line_matches_marker(line, start_marker.as_str()) {
                             start_seen = true;
                         }
-                        if line.trim() == end_marker {
+                        if line_matches_marker(line, end_marker.as_str()) {
                             found_end = true;
                         }
-                        if line.starts_with(&cwd_marker) {
-                            cwd_value = line[cwd_marker.len()..].trim().to_string();
+                        if let Some(value) = extract_marker_value(line, cwd_marker.as_str()) {
+                            cwd_value = value;
                         }
-                        if let Some(rest) = line.trim().strip_prefix(&rc_marker) {
-                            rc_value = rest.trim().parse().ok();
+                        if let Some(value) = extract_marker_value(line, rc_marker.as_str()) {
+                            if let Ok(rc) = value.parse::<i32>() {
+                                rc_value = Some(rc);
+                            }
                         }
                     }
                 }
                 last_seen_pushed = pushed;
-                if found_end && start_seen {
+                // 完成判定（按可靠性递减）：
+                // 1. end + start marker 都命中 → 正常完成
+                // 2. rc_marker 已收到（退出码已知）→ 命令一定已结束，
+                //    end_marker 只是紧随其后的收尾 echo，可能被 ANSI 污染漏判。
+                //    此时不应再等满超时——这正是 #237 的核心：命令成功执行、数据
+                //    已采集，却因边界检测失败被误判超时，触发 recovery 封禁工具。
+                let completed = (found_end && start_seen) || rc_value.is_some();
+                if completed {
                     Some(crate::types::CollectResult {
                         cwd: cwd_value.clone(),
                         exit_code: rc_value.unwrap_or(0),
@@ -878,6 +930,118 @@ mod tests {
             None,
         );
         assert!(interrupted);
+    }
+
+    #[test]
+    fn collect_matches_marker_with_ansi_residual() {
+        // TTY-aware 命令（如 gh）可能在 marker 行前后残留 ANSI 转义片断。
+        // strip_ansi + 精确匹配应能命中，而非漏判。
+        let manager = make_manager_with_lines(&[
+            "\x1b[0m__TIANGONG_START_abc__\x1b[0m",
+            "hello",
+            "__TIANGONG_CWD_abc__/tmp",
+            "__TIANGONG_RC_abc__0",
+            "\x1b[0m__TIANGONG_END_abc__",
+        ]);
+        let (out, interrupted) = collect_command_output(
+            &manager,
+            "__TIANGONG_START_abc__",
+            "__TIANGONG_END_abc__",
+            "__TIANGONG_CWD_abc__",
+            "__TIANGONG_RC_abc__",
+            false,
+            None,
+        );
+        assert_eq!(out, "hello");
+        assert!(!interrupted);
+    }
+
+    #[test]
+    fn collect_does_not_match_shell_echo_of_wrapper() {
+        // shell 回显 wrapper 命令文本时，该行 contains 所有 marker 字符串但
+        // strip_ansi + trim 后不等于任何 marker。精确匹配不应误命中回显行，
+        // 否则命令尚未执行就判定完成（#237 回归 bug 的根因）。
+        let echo_line = "__TIANGONG_= __rc=$?; printf '\\n__TIANGONG_CWD_abc__'; pwd; echo '__TIANGONG_RC_abc__'$__rc; echo '__TIANGONG_END_abc__'";
+        let manager = make_manager_with_lines(&[
+            "__TIANGONG_START_abc__",
+            echo_line, // shell 回显的 wrapper 第二行（contains 所有 marker）
+            "actual output",
+            "__TIANGONG_CWD_abc__/tmp",
+            "__TIANGONG_RC_abc__0",
+            "__TIANGONG_END_abc__",
+        ]);
+        let (out, interrupted) = collect_command_output(
+            &manager,
+            "__TIANGONG_START_abc__",
+            "__TIANGONG_END_abc__",
+            "__TIANGONG_CWD_abc__",
+            "__TIANGONG_RC_abc__",
+            false,
+            None,
+        );
+        // 回显行不应被当作 end_marker 提前截断，actual output 必须出现
+        assert!(
+            out.contains("actual output"),
+            "回显行误匹配导致输出截断: {out}"
+        );
+        assert!(!interrupted);
+    }
+
+    #[test]
+    fn line_match_ignores_shell_echo() {
+        // 直接验证 line_matches_marker 对回显行返回 false
+        let echo_line = "__TIANGONG_= echo '__TIANGONG_START_abc__'; export PAGER=cat; cmd";
+        assert!(!line_matches_marker(echo_line, "__TIANGONG_START_abc__"));
+        // 而真正的 marker 行返回 true
+        assert!(line_matches_marker(
+            "__TIANGONG_START_abc__",
+            "__TIANGONG_START_abc__"
+        ));
+        // 带 ANSI 残片的 marker 行也返回 true
+        assert!(line_matches_marker(
+            "\x1b[0m__TIANGONG_START_abc__\x1b[0m",
+            "__TIANGONG_START_abc__"
+        ));
+    }
+
+    #[test]
+    fn command_boundary_matches_with_ansi_residual() {
+        // command_boundary_seen 用 strip_ansi + 精确匹配，验证带 ANSI 残片的 marker 仍能识别边界。
+        let manager = make_manager_with_lines(&[
+            "\x1b[0m__TIANGONG_START_abc__",
+            "running",
+            "__TIANGONG_END_abc__\x1b[0m",
+        ]);
+        assert!(command_boundary_seen(
+            &manager,
+            "__TIANGONG_START_abc__",
+            "__TIANGONG_END_abc__",
+        ));
+    }
+
+    #[test]
+    fn collect_rc_marker_with_ansi_residual_excluded() {
+        // rc_marker 行带 ANSI 残片时，应被正确过滤（不混入命令输出），
+        // 且轮询循环能从中解析出退出码（完成判定安全网）。
+        let manager = make_manager_with_lines(&[
+            "__TIANGONG_START_abc__",
+            "command output line",
+            "\x1b[0m__TIANGONG_CWD_abc__/tmp\x1b[0m",
+            "\x1b[0m__TIANGONG_RC_abc__0",
+            // end_marker 缺失（模拟被 ANSI 污染漏判的场景）
+        ]);
+        let (out, interrupted) = collect_command_output(
+            &manager,
+            "__TIANGONG_START_abc__",
+            "__TIANGONG_END_abc__",
+            "__TIANGONG_CWD_abc__",
+            "__TIANGONG_RC_abc__",
+            false,
+            None,
+        );
+        // 命令输出应只包含实际内容，cwd/rc marker 行被过滤
+        assert_eq!(out, "command output line");
+        assert!(!interrupted);
     }
 
     #[test]

--- a/crates/plugins/tiangong-plugin-terminal/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/handler.rs
@@ -53,6 +53,22 @@ impl TerminalToolOverride {
         value
     }
 
+    /// 构造「终端暂不可用」的失败结果。
+    ///
+    /// provider 返回 None 表示 PTY 暂不可用（子进程退出 / 命令循环关闭 / 等
+    /// 待回执超时）。此处返回明确的失败结果，而非 trait 的 None（None 会被
+    /// runtime 翻译成误导性的「未注册的工具」）。
+    fn terminal_unavailable() -> ToolResult {
+        ToolResult {
+            ok: false,
+            summary: "终端暂不可用，请稍后重试".to_string(),
+            stdout: String::new(),
+            stderr: "terminal pty unavailable (child exited or command loop closed)".to_string(),
+            exit_code: -1,
+            execution: None,
+        }
+    }
+
     /// run_command：校验后经 PTY 执行受控命令。
     fn handle_run_command(
         provider: &Arc<dyn TerminalProvider>,
@@ -143,7 +159,7 @@ impl TerminalToolOverride {
         Box::pin(async move {
             let selection = match provider.select_for_command(&session_id).await {
                 Some(s) => s,
-                None => return None,
+                None => return Some(Self::terminal_unavailable()),
             };
             let terminal_id = selection.terminal_id.clone();
 
@@ -168,25 +184,36 @@ impl TerminalToolOverride {
 
             let result = match provider.exec(&terminal_id, &command, timeout_secs).await {
                 Some(r) => r,
-                None => return None,
+                None => return Some(Self::terminal_unavailable()),
             };
 
             let stdout = Self::truncate_text(&result.stdout, OUTPUT_THRESHOLD);
+            // summary 反馈命令的执行状态信息，但不影响 ok：退出码、超时等都是
+            // 命令的业务结果，由 agent 阅读 stdout/summary 自行判断是否符合预期。
+            // 只有工具层故障（PTY 不可用等）才标记 ok:false。
             let mut summary = if result.interactive_mode {
                 "命令进入交互模式（未声明 interactive:true）".to_string()
             } else if result.timed_out {
                 "命令执行超时".to_string()
             } else if result.exit_code != 0 {
-                format!("命令执行失败（退出码 {}）", result.exit_code)
+                format!(
+                    "命令退出码 {}（请阅读 stdout/stderr 判断是否符合预期）",
+                    result.exit_code
+                )
             } else {
-                "命令执行成功".to_string()
+                "命令执行完成".to_string()
             };
             if !result.cwd_after.is_empty() {
                 summary.push_str(&format!("（cwd: {}）", result.cwd_after));
             }
             summary.push_str(&selection.feedback_text());
 
-            let ok = result.exit_code == 0 && !result.timed_out && !result.interactive_mode;
+            // ok 只反映工具层是否正常工作：命令提交了、PTY 正常，即为 true。
+            // 退出码非 0（如 grep 无匹配、测试失败）是命令的业务结果，不是工具故障。
+            // 超时也只是状态信息（summary/stderr 说明），数据照常返回，agent 看
+            // stdout 自行判断是否符合预期——不应触发 recovery 封禁工具。
+            // 只有非预期的 interactive_mode（命令卡在交互态）才是真正的工具层异常。
+            let ok = !result.interactive_mode;
 
             Some(ToolResult {
                 ok,
@@ -206,7 +233,18 @@ impl TerminalToolOverride {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<ToolResult>> + Send>> {
         let command = match call.arguments.get("script").and_then(|v| v.as_str()) {
             Some(c) => c.to_string(),
-            None => return Box::pin(async { None }),
+            None => {
+                return Box::pin(async {
+                    Some(ToolResult {
+                        ok: false,
+                        summary: "run_shell 缺少 script 参数".to_string(),
+                        stdout: String::new(),
+                        stderr: "script 参数为必填".to_string(),
+                        exit_code: 2,
+                        execution: None,
+                    })
+                });
+            }
         };
         let timeout_secs = call.arguments.get("timeout").and_then(|v| v.as_u64());
         // 读取 interactive 标志：Agent 显式声明要启动交互程序。
@@ -230,7 +268,7 @@ impl TerminalToolOverride {
         Box::pin(async move {
             let selection = match provider.select_for_command(&session_id).await {
                 Some(selection) => selection,
-                None => return None,
+                None => return Some(Self::terminal_unavailable()),
             };
             let terminal_id = selection.terminal_id.clone();
 
@@ -258,23 +296,20 @@ impl TerminalToolOverride {
                 // wait_secs=3 给交互程序足够时间绘制首屏。
                 match provider.exec_interactive(&terminal_id, &command, 3).await {
                     Some(r) => r,
-                    None => return None, // 终端不可用，回退到默认 run_shell
+                    None => return Some(Self::terminal_unavailable()),
                 }
             } else {
                 match provider.exec(&terminal_id, &command, timeout_secs).await {
                     Some(r) => r,
-                    None => return None, // 终端不可用，回退到默认 run_shell
+                    None => return Some(Self::terminal_unavailable()),
                 }
             };
 
             let stdout = Self::truncate_text(&result.stdout, OUTPUT_THRESHOLD);
 
-            // 成功判定随交互模式分流：
-            // - 交互模式：interactive_mode=true 是预期的成功（命令已进入交互态），
-            //   报告 ok=true。stdout 携带终端首次变化后的完整可见内容，
-            //   由 Agent 自行阅读判断当前状态。
-            // - 非交互模式：interactive_mode=true 意味着命令意外进入交互（兜底检测），
-            //   前台进程仍在运行，必须报告失败，避免 Agent 误判后在卡住的 PTY 继续操作。
+            // summary 反馈命令的执行状态信息，但不影响 ok：退出码、超时等都是
+            // 命令的业务结果，由 agent 阅读 stdout/summary 自行判断是否符合预期。
+            // 只有工具层故障（PTY 不可用等）才标记 ok:false。
             let mut summary = if interactive && result.interactive_mode {
                 "命令已进入交互态（终端当前显示见 stdout）".to_string()
             } else if result.interactive_mode {
@@ -284,9 +319,12 @@ impl TerminalToolOverride {
             } else if result.interrupted_by_user {
                 "命令被用户中断".to_string()
             } else if result.exit_code != 0 {
-                format!("命令执行失败（退出码 {}）", result.exit_code)
+                format!(
+                    "命令退出码 {}（请阅读 stdout/stderr 判断是否符合预期）",
+                    result.exit_code
+                )
             } else {
-                "命令执行成功".to_string()
+                "命令执行完成".to_string()
             };
 
             if !result.cwd_after.is_empty() {
@@ -313,11 +351,16 @@ impl TerminalToolOverride {
                 stderr.push_str("\n[提示] 命令被用户中断，建议询问用户是否需要调整执行计划");
             }
 
-            // 交互模式且成功进入交互态视为成功
+            // ok 只反映工具层是否正常工作：
+            // - 交互模式进入交互态：预期行为，ok:true
+            // - 非交互模式：命令提交了、PTY 正常即为 true。退出码非 0（如 grep
+            //   无匹配、测试失败）是命令的业务结果，不是工具故障，不应触发 recovery。
+            // - 超时也只是状态信息，数据照常返回，agent 看 stdout 判断。
+            // - 只有非预期的 interactive_mode（命令卡在交互态）才是真正的工具层异常。
             let ok = if interactive && result.interactive_mode {
                 true
             } else {
-                result.exit_code == 0 && !result.timed_out && !result.interactive_mode
+                !result.interactive_mode
             };
 
             Some(ToolResult {
@@ -372,7 +415,7 @@ impl TerminalToolOverride {
                 .await
             {
                 Some(r) => r,
-                None => return None, // 终端不可用，回退到默认逻辑
+                None => return Some(Self::terminal_unavailable()),
             };
 
             let stdout = Self::truncate_text(&result.stdout, OUTPUT_THRESHOLD);

--- a/crates/plugins/tiangong-plugin-terminal/src/manager.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/manager.rs
@@ -17,6 +17,13 @@ pub struct TerminalManager {
     pub(crate) state: Arc<Mutex<TerminalState>>,
     /// 系统 PTY 输出日志器（仅系统 PTY 有；面板 PTY 为 None）。用于持久化历史与重置时清空。
     pub(crate) logger: Option<Arc<crate::output_processor::OutputLogger>>,
+    /// 创建 PTY 时快照的插件贡献环境变量（由 core 经 `set_exec_env` 汇总回注）。
+    ///
+    /// PTY 是长期复用的交互式 shell，env 在创建时快照注入（不 clear、不 allowlist，
+    /// 只在继承的主进程环境之上追加）。Reset / PTY 恢复时复用同一份快照重建 shell，
+    /// 保持会话内环境一致。配置变更后新建的 PTY 才会用最新 env（快照语义，
+    /// 与 `default_cwd` 一致）。
+    pub(crate) pty_env: Arc<Mutex<std::collections::BTreeMap<String, String>>>,
 }
 
 pub(crate) struct TerminalState {
@@ -46,6 +53,15 @@ pub(crate) struct TerminalState {
 
 impl TerminalManager {
     pub fn new(session_id: String, cwd: String) -> Self {
+        Self::with_pty_env(session_id, cwd, std::collections::BTreeMap::new())
+    }
+
+    /// 用指定的插件贡献 env 快照构造 manager（PTY 创建时注入）。
+    pub(crate) fn with_pty_env(
+        session_id: String,
+        cwd: String,
+        pty_env: std::collections::BTreeMap<String, String>,
+    ) -> Self {
         let shell = default_shell();
         Self {
             state: Arc::new(Mutex::new(TerminalState {
@@ -62,6 +78,7 @@ impl TerminalManager {
                 screen_updates: 0,
             })),
             logger: None,
+            pty_env: Arc::new(Mutex::new(pty_env)),
         }
     }
 
@@ -145,7 +162,8 @@ impl TerminalManager {
         app: tauri::AppHandle,
     ) -> Option<PtyState> {
         let shell = self.shell();
-        let ps = start_pty(session_id, cwd, &shell)
+        let pty_env = self.pty_env.lock().map(|g| g.clone()).unwrap_or_default();
+        let ps = start_pty(session_id, cwd, &shell, &pty_env)
             .inspect_err(|e| {
                 error!(session_id, error = %e, "PTY 进程启动失败");
             })
@@ -392,7 +410,12 @@ pub(crate) async fn spawn_command_loop(
                 }
                 // 用户主动重置视为刷新，清空持久化日志
                 manager.clear_log();
-                match start_pty(&session_id, &cwd, &shell) {
+                let pty_env = manager
+                    .pty_env
+                    .lock()
+                    .map(|g| g.clone())
+                    .unwrap_or_default();
+                match start_pty(&session_id, &cwd, &shell, &pty_env) {
                     Ok(new_ps) => {
                         {
                             let mut state = manager.state.lock().unwrap();
@@ -448,7 +471,12 @@ fn default_shell() -> String {
     }
 }
 
-pub(crate) fn start_pty(session_id: &str, cwd: &str, shell: &str) -> anyhow::Result<PtyState> {
+pub(crate) fn start_pty(
+    session_id: &str,
+    cwd: &str,
+    shell: &str,
+    extra_env: &std::collections::BTreeMap<String, String>,
+) -> anyhow::Result<PtyState> {
     let pty_system = portable_pty::native_pty_system();
     let pair = pty_system
         .openpty(PtySize {
@@ -462,6 +490,11 @@ pub(crate) fn start_pty(session_id: &str, cwd: &str, shell: &str) -> anyhow::Res
     let mut cmd = CommandBuilder::new(shell);
     cmd.cwd(cwd);
     cmd.env("TERM", "xterm-256color");
+    // 追加各插件贡献的环境变量（MCP/skill 等注入的 token、.env.local 等）。
+    // PTY 是交互式 shell，继承主进程完整环境，此处只追加、不 clear、不 allowlist。
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
 
     tracing::debug!(session_id, cwd, shell, "正在启动 PTY 子进程");
 

--- a/crates/plugins/tiangong-plugin-terminal/src/output_processor.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/output_processor.rs
@@ -184,28 +184,64 @@ impl LineBuildHandler {
     fn first_param(params: &vte::Params) -> usize {
         params.iter().next().map(|p| p[0]).unwrap_or(0) as usize
     }
+}
 
-    fn handle_csi(&mut self, params: &vte::Params, final_byte: char) {
-        // DEC private 序列（如 ESC[?25l 隐藏光标）的参数带 ? 前缀，
-        // vte 已剥离前缀，直接取数值。
-        match final_byte {
-            // ESC[K — 清行
-            'K' => {
-                let n = Self::first_param(params);
-                match n {
-                    0 => self.line.truncate(self.cursor),
-                    1 => {
-                        let after: Vec<char> = self.line.drain(self.cursor..).collect();
-                        self.line = after;
-                        self.cursor = 0;
-                    }
-                    2 => {
-                        self.line.clear();
-                        self.cursor = 0;
-                    }
-                    _ => {}
+impl vte::Perform for LineBuildHandler {
+    fn print(&mut self, c: char) {
+        if self.cursor >= self.line.len() {
+            self.line.push(c);
+        } else {
+            self.line[self.cursor] = c;
+        }
+        self.cursor += 1;
+    }
+
+    fn execute(&mut self, byte: u8) {
+        // C0 控制字符
+        match byte {
+            b'\n' => {
+                // LF：提交当前行
+                let line: String = self.line.iter().collect();
+                if !line.trim().is_empty() {
+                    self.complete_lines.push(line);
                 }
+                self.line.clear();
+                self.cursor = 0;
             }
+            b'\r' => {
+                // CR：光标回行首
+                self.cursor = 0;
+            }
+            // 其他控制字符（BS/HT 等）忽略
+            _ => {}
+        }
+    }
+
+    /// CSI 序列分帧已由 vte 状态机完成，这里只对影响单行内容的光标序列
+    /// 模拟行为。SGR（颜色 m）、DEC private（?25l 光标显隐）等不影响行
+    /// 内容收集的序列落入 `_ => {}` 忽略。
+    fn csi_dispatch(
+        &mut self,
+        params: &vte::Params,
+        _intermediates: &[u8],
+        _ignore: bool,
+        c: char,
+    ) {
+        match c {
+            // ESC[K — 清行
+            'K' => match Self::first_param(params) {
+                0 => self.line.truncate(self.cursor),
+                1 => {
+                    let after: Vec<char> = self.line.drain(self.cursor..).collect();
+                    self.line = after;
+                    self.cursor = 0;
+                }
+                2 => {
+                    self.line.clear();
+                    self.cursor = 0;
+                }
+                _ => {}
+            },
             // ESC[G — 光标水平绝对定位
             'G' => {
                 let col = Self::first_param(params).max(1);
@@ -216,8 +252,7 @@ impl LineBuildHandler {
             }
             // ESC[J — 清屏（单行模型只处理 2=全清）
             'J' => {
-                let n = Self::first_param(params);
-                if n >= 2 {
+                if Self::first_param(params) >= 2 {
                     self.line.clear();
                     self.cursor = 0;
                 }
@@ -258,48 +293,6 @@ impl LineBuildHandler {
             // SGR（颜色/样式）等其他序列不影响行内容收集，忽略
             _ => {}
         }
-    }
-}
-
-impl vte::Perform for LineBuildHandler {
-    fn print(&mut self, c: char) {
-        if self.cursor >= self.line.len() {
-            self.line.push(c);
-        } else {
-            self.line[self.cursor] = c;
-        }
-        self.cursor += 1;
-    }
-
-    fn execute(&mut self, byte: u8) {
-        // C0 控制字符
-        match byte {
-            b'\n' => {
-                // LF：提交当前行
-                let line: String = self.line.iter().collect();
-                if !line.trim().is_empty() {
-                    self.complete_lines.push(line);
-                }
-                self.line.clear();
-                self.cursor = 0;
-            }
-            b'\r' => {
-                // CR：光标回行首
-                self.cursor = 0;
-            }
-            // 其他控制字符（BS/HT 等）忽略
-            _ => {}
-        }
-    }
-
-    fn csi_dispatch(
-        &mut self,
-        params: &vte::Params,
-        _intermediates: &[u8],
-        _ignore: bool,
-        c: char,
-    ) {
-        self.handle_csi(params, c);
     }
 }
 

--- a/crates/plugins/tiangong-plugin-terminal/src/output_processor.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/output_processor.rs
@@ -618,4 +618,58 @@ mod tests {
         let out2 = f.filter("TIANGONG_START_x__\n");
         assert_eq!(out2, ""); // 完整行含 marker，被过滤
     }
+
+    #[test]
+    fn test_line_processor_gh_spinner_plus_markers() {
+        // 模拟 gh 在 PTY 下的完整输出：spinner 动画 + 彩色 JSON + marker 行。
+        // 验证 TerminalLineProcessor 能正确 push marker 行（不被 spinner 的
+        // CR/清行序列破坏行模拟），这是 #237 超时 bug 的核心时序场景。
+        let mut p = TerminalLineProcessor::new();
+
+        // gh 的 spinner：隐藏光标 + 多帧动画（CR + spinner字符 + CR + ESC[K）
+        let spinner = "\x1b[?25l\r\x1b[K\r⣾\r\x1b[K\r⣽\r\x1b[K\r⣻\r\x1b[K\r\x1b[?25h\r\x1b[K";
+
+        // gh 的彩色 JSON 输出（每行以 \r\n 结尾）
+        let gh_json = "\x1b[1;37m{\x1b[m\r\n  \x1b[1;34m\"number\"\x1b[m\x1b[1;37m:\x1b[m 237\r\n\x1b[1;37m}\x1b[m\r\n";
+
+        // wrapper 注入的 marker 行
+        let markers =
+            "__TIANGONG_CWD_abc__/tmp\r\n__TIANGONG_RC_abc__0\r\n__TIANGONG_END_abc__\r\n";
+
+        // 场景1：分两个 chunk 喂入（模拟 PTY 读取线程的实际行为）
+        let lines = p.process(&format!("{}{}", spinner, gh_json));
+        // spinner 不产生完整行；JSON 产生 3 行（ANSI 已剥离）
+        assert_eq!(lines, vec!["{", "  \"number\": 237", "}"]);
+
+        let lines2 = p.process(markers);
+        // marker 行必须被正确 push
+        assert_eq!(
+            lines2,
+            vec![
+                "__TIANGONG_CWD_abc__/tmp",
+                "__TIANGONG_RC_abc__0",
+                "__TIANGONG_END_abc__",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_line_processor_gh_single_mega_chunk() {
+        // 场景2：spinner + JSON + markers 合并到一个超大 chunk（PTY 读取线程
+        // 可能一次性读取 4096 字节，所有内容在一个 chunk 里）。
+        let mut p = TerminalLineProcessor::new();
+        let spinner = "\x1b[?25l\r\x1b[K\r⣾\r\x1b[K\r⣽\r\x1b[K\r⣻\r\x1b[K\r\x1b[?25h\r\x1b[K";
+        let gh_json = "\x1b[1;37m{\x1b[m\r\n  \x1b[1;34m\"number\"\x1b[m\x1b[1;37m:\x1b[m 237\r\n\x1b[1;37m}\x1b[m\r\n";
+        let markers =
+            "__TIANGONG_CWD_abc__/tmp\r\n__TIANGONG_RC_abc__0\r\n__TIANGONG_END_abc__\r\n";
+
+        let all = format!("{}{}{}", spinner, gh_json, markers);
+        let lines = p.process(&all);
+
+        // 必须包含 marker 行——如果行模拟被 spinner 破坏，marker 可能丢失
+        let has_rc = lines.iter().any(|l| l.contains("__TIANGONG_RC_abc__"));
+        let has_end = lines.iter().any(|l| l.contains("__TIANGONG_END_abc__"));
+        assert!(has_rc, "RC marker 行丢失！lines: {:?}", lines);
+        assert!(has_end, "END marker 行丢失！lines: {:?}", lines);
+    }
 }

--- a/crates/plugins/tiangong-plugin-terminal/src/output_processor.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/output_processor.rs
@@ -131,147 +131,67 @@ pub(crate) fn backfill_line(state: &mut crate::manager::TerminalState, line: Str
 }
 
 /// 终端行处理器，模拟光标行为以正确处理 zsh 行编辑器的重绘。
-/// 维护 pending 缓冲区处理跨 chunk 的不完整 ESC 序列。
+///
+/// 序列分帧委托给 [`vte::Parser`]（Paul Williams 状态机实现），保证所有合法的
+/// CSI/OSC/ESC 序列都能被正确分帧——包括真彩色冒号参数（`ESC[38:2::r:g:bm`）、
+/// DEC private 模式（`ESC[?25l`）等。光标行为模拟在 [`LineBuildHandler`] 的
+/// `csi_dispatch` / `execute` 回调中实现。
 pub(crate) struct TerminalLineProcessor {
-    line: Vec<char>,
-    cursor: usize,
-    pending: String,
+    parser: vte::Parser,
+    handler: LineBuildHandler,
 }
 
 impl TerminalLineProcessor {
     pub fn new() -> Self {
         Self {
-            line: Vec::new(),
-            cursor: 0,
-            pending: String::new(),
+            parser: vte::Parser::new(),
+            handler: LineBuildHandler::new(),
         }
     }
 
     pub fn process(&mut self, raw: &str) -> Vec<String> {
-        if !self.pending.is_empty() {
-            self.pending.push_str(raw);
-        }
-        let input = if self.pending.is_empty() {
-            raw.to_string()
-        } else {
-            std::mem::take(&mut self.pending)
-        };
-
-        let mut complete_lines = Vec::new();
-        let chars: Vec<char> = input.chars().collect();
-        let len = chars.len();
-        let mut i = 0;
-
-        while i < len {
-            let c = chars[i];
-            match c {
-                '\n' => {
-                    let line: String = self.line.iter().collect();
-                    if !line.trim().is_empty() {
-                        complete_lines.push(line);
-                    }
-                    self.line.clear();
-                    self.cursor = 0;
-                    i += 1;
-                }
-                '\r' => {
-                    self.cursor = 0;
-                    i += 1;
-                }
-                '\x1b' => {
-                    let seq_start = i;
-                    i += 1;
-                    if i >= len {
-                        self.pending = chars[seq_start..].iter().collect();
-                        break;
-                    }
-                    match chars[i] {
-                        '[' => {
-                            i += 1;
-                            let mut params = String::new();
-                            let mut found_final = false;
-                            while i < len {
-                                let next = chars[i];
-                                if next.is_ascii()
-                                    && ((next as u8).is_ascii_digit() || next == ';' || next == '?')
-                                {
-                                    params.push(next);
-                                    i += 1;
-                                } else if next.is_ascii() && (b'@'..=b'~').contains(&(next as u8)) {
-                                    self.handle_csi(&params, next);
-                                    i += 1;
-                                    found_final = true;
-                                    break;
-                                } else {
-                                    break;
-                                }
-                            }
-                            if !found_final {
-                                self.pending = chars[seq_start..].iter().collect();
-                                break;
-                            }
-                        }
-                        ']' | 'P' => {
-                            i += 1;
-                            let mut found_end = false;
-                            while i < len {
-                                let next = chars[i];
-                                if next == '\x07' {
-                                    i += 1;
-                                    found_end = true;
-                                    break;
-                                }
-                                if next == '\x1b' && i + 1 < len && chars[i + 1] == '\\' {
-                                    i += 2;
-                                    found_end = true;
-                                    break;
-                                }
-                                i += 1;
-                            }
-                            if !found_end {
-                                self.pending = chars[seq_start..].iter().collect();
-                                break;
-                            }
-                        }
-                        '(' | ')' => {
-                            i += 1;
-                            if i >= len {
-                                self.pending = chars[seq_start..].iter().collect();
-                                break;
-                            }
-                            i += 1;
-                        }
-                        _ => {
-                            i += 1;
-                        }
-                    }
-                }
-                c if c.is_control() => {
-                    i += 1;
-                }
-                c => {
-                    if self.cursor >= self.line.len() {
-                        self.line.push(c);
-                    } else {
-                        self.line[self.cursor] = c;
-                    }
-                    self.cursor += 1;
-                    i += 1;
-                }
-            }
-        }
-
-        complete_lines
+        // vte::Parser 内部维护状态机，跨 chunk 的不完整序列自动暂存在 parser 里，
+        // 无需手写 pending 缓冲区。
+        self.parser.advance(&mut self.handler, raw.as_bytes());
+        std::mem::take(&mut self.handler.complete_lines)
     }
 
     pub fn current_line(&self) -> String {
-        self.line.iter().collect()
+        self.handler.line.iter().collect()
+    }
+}
+
+/// [`vte::Perform`] 实现：维护单行字符缓冲 + 光标位置，收集完整行。
+///
+/// 只模拟影响单行内容的光标行为（K/G/J/C/D/P/@），SGR（颜色）等序列在
+/// `csi_dispatch` 的 `_ => {}` 分支被忽略——颜色不影响行内容收集。
+struct LineBuildHandler {
+    line: Vec<char>,
+    cursor: usize,
+    complete_lines: Vec<String>,
+}
+
+impl LineBuildHandler {
+    fn new() -> Self {
+        Self {
+            line: Vec::new(),
+            cursor: 0,
+            complete_lines: Vec::new(),
+        }
     }
 
-    fn handle_csi(&mut self, params: &str, final_byte: char) {
+    /// 从 vte Params 提取第一个参数值（默认 0）。
+    fn first_param(params: &vte::Params) -> usize {
+        params.iter().next().map(|p| p[0]).unwrap_or(0) as usize
+    }
+
+    fn handle_csi(&mut self, params: &vte::Params, final_byte: char) {
+        // DEC private 序列（如 ESC[?25l 隐藏光标）的参数带 ? 前缀，
+        // vte 已剥离前缀，直接取数值。
         match final_byte {
+            // ESC[K — 清行
             'K' => {
-                let n: usize = params.trim_start_matches('?').parse().unwrap_or(0);
+                let n = Self::first_param(params);
                 match n {
                     0 => self.line.truncate(self.cursor),
                     1 => {
@@ -286,22 +206,25 @@ impl TerminalLineProcessor {
                     _ => {}
                 }
             }
+            // ESC[G — 光标水平绝对定位
             'G' => {
-                let col: usize = params.parse().unwrap_or(1).max(1);
+                let col = Self::first_param(params).max(1);
                 self.cursor = col - 1;
                 while self.line.len() < self.cursor {
                     self.line.push(' ');
                 }
             }
+            // ESC[J — 清屏（单行模型只处理 2=全清）
             'J' => {
-                let n: usize = params.parse().unwrap_or(0);
+                let n = Self::first_param(params);
                 if n >= 2 {
                     self.line.clear();
                     self.cursor = 0;
                 }
             }
+            // ESC[C — 光标右移
             'C' => {
-                let n: usize = params.parse().unwrap_or(1);
+                let n = Self::first_param(params).max(1);
                 for _ in 0..n {
                     if self.cursor < self.line.len() {
                         self.cursor += 1;
@@ -311,26 +234,72 @@ impl TerminalLineProcessor {
                     }
                 }
             }
+            // ESC[D — 光标左移
             'D' => {
-                let n: usize = params.parse().unwrap_or(1);
+                let n = Self::first_param(params).max(1);
                 self.cursor = self.cursor.saturating_sub(n);
             }
+            // ESC[P — 删除字符
             'P' => {
-                let n: usize = params.parse().unwrap_or(1);
+                let n = Self::first_param(params).max(1);
                 for _ in 0..n {
                     if self.cursor < self.line.len() {
                         self.line.remove(self.cursor);
                     }
                 }
             }
+            // ESC[@ — 插入空白
             '@' => {
-                let n: usize = params.parse().unwrap_or(1);
+                let n = Self::first_param(params).max(1);
                 for _ in 0..n {
                     self.line.insert(self.cursor, ' ');
                 }
             }
+            // SGR（颜色/样式）等其他序列不影响行内容收集，忽略
             _ => {}
         }
+    }
+}
+
+impl vte::Perform for LineBuildHandler {
+    fn print(&mut self, c: char) {
+        if self.cursor >= self.line.len() {
+            self.line.push(c);
+        } else {
+            self.line[self.cursor] = c;
+        }
+        self.cursor += 1;
+    }
+
+    fn execute(&mut self, byte: u8) {
+        // C0 控制字符
+        match byte {
+            b'\n' => {
+                // LF：提交当前行
+                let line: String = self.line.iter().collect();
+                if !line.trim().is_empty() {
+                    self.complete_lines.push(line);
+                }
+                self.line.clear();
+                self.cursor = 0;
+            }
+            b'\r' => {
+                // CR：光标回行首
+                self.cursor = 0;
+            }
+            // 其他控制字符（BS/HT 等）忽略
+            _ => {}
+        }
+    }
+
+    fn csi_dispatch(
+        &mut self,
+        params: &vte::Params,
+        _intermediates: &[u8],
+        _ignore: bool,
+        c: char,
+    ) {
+        self.handle_csi(params, c);
     }
 }
 
@@ -671,5 +640,16 @@ mod tests {
         let has_end = lines.iter().any(|l| l.contains("__TIANGONG_END_abc__"));
         assert!(has_rc, "RC marker 行丢失！lines: {:?}", lines);
         assert!(has_end, "END marker 行丢失！lines: {:?}", lines);
+    }
+
+    #[test]
+    fn test_line_processor_truecolor_colon_params() {
+        // 真彩色序列使用冒号分隔参数（ITU-T T.416）：ESC[38:2::255:0:0m
+        // 旧版只接受数字+;+?，遇到冒号会卡住处理器，后续 marker 无法进入缓冲区。
+        let mut p = TerminalLineProcessor::new();
+        let input = "\x1b[38:2::255:0:0mred text\x1b[0m\n__TIANGONG_END_x__\n";
+        let lines = p.process(input);
+        // 冒号序列被正确消费，不卡死；red text 和 marker 行正常 push
+        assert_eq!(lines, vec!["red text", "__TIANGONG_END_x__"]);
     }
 }

--- a/crates/plugins/tiangong-plugin-terminal/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/plugin.rs
@@ -29,6 +29,9 @@ pub struct TerminalPlugin {
     override_handler: TerminalToolOverride,
     prompt_provider: TerminalPromptSectionProvider,
     workspace: RwLock<Option<PathBuf>>,
+    /// 插件贡献环境变量的共享句柄（与 `SessionPtyRegistry` 共享同一实例）。
+    /// `set_exec_env` 写入此句柄，PTY 创建时读取快照注入。
+    runtime_env: Arc<RwLock<std::collections::BTreeMap<String, String>>>,
 }
 
 impl TerminalPlugin {
@@ -39,6 +42,7 @@ impl TerminalPlugin {
     /// 返回 `None` 表示插件 state 未就绪（与旧 `get_*` 工厂一致）。
     pub fn from_app_handle(app: &tauri::AppHandle<Wry>) -> Option<Self> {
         let state = app.state::<crate::TerminalPluginState>();
+        let runtime_env = state.registry.runtime_env_handle();
         let provider: Arc<dyn TerminalProvider> =
             Arc::new(SessionAwareTerminalProvider::new(state.registry.clone()));
         let override_handler = TerminalToolOverride::new(provider);
@@ -47,6 +51,7 @@ impl TerminalPlugin {
             override_handler,
             prompt_provider,
             workspace: RwLock::new(None),
+            runtime_env,
         })
     }
 }
@@ -67,6 +72,17 @@ impl Plugin for TerminalPlugin {
     fn set_workspace(&self, workspace: Option<&std::path::Path>) {
         if let Ok(mut guard) = self.workspace.write() {
             *guard = workspace.map(std::path::Path::to_path_buf);
+        }
+    }
+
+    /// 接收 core 汇总的插件贡献环境变量，写入共享句柄供后续 PTY 创建时注入。
+    ///
+    /// PTY 是长期复用的交互式 shell，env 在创建时快照注入（与 command 插件的
+    /// `env_clear()` 沙箱语义不同——PTY 继承主进程完整环境，只追加、不过滤）。
+    /// 已存在的 PTY 不更新；新建 PTY（新对话/workspace 切换重建）才用最新 env。
+    fn set_exec_env(&self, env: std::collections::BTreeMap<String, String>) {
+        if let Ok(mut guard) = self.runtime_env.write() {
+            *guard = env;
         }
     }
 }

--- a/crates/plugins/tiangong-plugin-terminal/src/session_pty.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/session_pty.rs
@@ -6,7 +6,7 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
 use tauri::Emitter;
 use tokio::sync::mpsc;
@@ -121,6 +121,11 @@ pub struct SessionPtyRegistry {
     app: tauri::AppHandle,
     /// 懒创建 PTY 时使用的默认 cwd，由 `set_cwd` / workspace 切换同步
     default_cwd: Mutex<String>,
+    /// 插件贡献的环境变量（由 core 经 `set_exec_env` 回注）。
+    ///
+    /// PTY 创建时快照注入（与 `default_cwd` 一致的快照语义）。
+    /// 共享句柄供 `TerminalPlugin::set_exec_env` 更新、`create_pty` 读取。
+    runtime_env: Arc<RwLock<std::collections::BTreeMap<String, String>>>,
 }
 
 impl SessionPtyRegistry {
@@ -130,6 +135,7 @@ impl SessionPtyRegistry {
             persistence: Mutex::new(()),
             app,
             default_cwd: Mutex::new(default_cwd),
+            runtime_env: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
         }
     }
 
@@ -140,6 +146,21 @@ impl SessionPtyRegistry {
         if let Ok(mut guard) = self.default_cwd.lock() {
             *guard = cwd;
         }
+    }
+
+    /// 更新插件贡献的环境变量（由 `TerminalPlugin::set_exec_env` 调用）。
+    ///
+    /// 仅影响后续懒创建的 PTY；已存在 PTY 保持创建时的快照（快照语义，与
+    /// `default_cwd` 一致）。workspace 切换销毁重建或新建对话时新 PTY 才用最新 env。
+    pub fn set_runtime_env(&self, env: std::collections::BTreeMap<String, String>) {
+        if let Ok(mut guard) = self.runtime_env.write() {
+            *guard = env;
+        }
+    }
+
+    /// 返回 runtime_env 共享句柄（供 `TerminalPlugin` 在 `set_exec_env` 时写入）。
+    pub fn runtime_env_handle(&self) -> Arc<RwLock<std::collections::BTreeMap<String, String>>> {
+        Arc::clone(&self.runtime_env)
     }
 
     /// workspace 切换时同步：更新默认 cwd，并销毁所有存活 PTY。
@@ -341,7 +362,13 @@ impl SessionPtyRegistry {
             cwd.to_string()
         };
 
-        let mut manager = TerminalManager::new(instance_id.to_string(), effective_cwd.clone());
+        let pty_env = self
+            .runtime_env
+            .read()
+            .map(|g| g.clone())
+            .unwrap_or_default();
+        let mut manager =
+            TerminalManager::with_pty_env(instance_id.to_string(), effective_cwd.clone(), pty_env);
 
         let log_path = terminal_log_path(session_id, tab_id);
         if let Some(logger) = output_processor::OutputLogger::open(log_path) {

--- a/crates/tiangong-core/src/permission.rs
+++ b/crates/tiangong-core/src/permission.rs
@@ -386,12 +386,20 @@ pub(crate) fn format_call_args_summary(call: &crate::model::ToolCall) -> String 
     }
 
     if call.name == "run_command" || call.name == "run_shell" {
-        if let Some(cmd) = args.get("command").and_then(Value::as_str) {
+        // run_command: cmd + args[] → "cmd arg1 arg2"
+        if let Some(cmd) = args.get("cmd").and_then(Value::as_str) {
+            if let Some(arr) = args.get("args").and_then(Value::as_array) {
+                let parts: Vec<&str> = arr.iter().filter_map(Value::as_str).collect();
+                if parts.is_empty() {
+                    return cmd.to_string();
+                }
+                return format!("{cmd} {}", parts.join(" "));
+            }
             return cmd.to_string();
         }
+        // run_shell: script → 直接显示脚本内容
         if let Some(script) = args.get("script").and_then(Value::as_str) {
-            let shell = args.get("shell").and_then(Value::as_str).unwrap_or("auto");
-            return format!("[{shell}] {script}");
+            return script.to_string();
         }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1882,7 +1882,14 @@ pub(crate) fn start_stream_consumer(
                     | StreamEvent::SummaryText { .. } => {
                         core_state.store.runtime.run.summary = "正在回复...".to_string();
                     }
-                    StreamEvent::PhaseChanged { .. } => {}
+                    StreamEvent::PhaseChanged { phase, .. } => {
+                        // 工具执行完毕后 core 发出 PhaseChanged(analyzing)，
+                        // 标志进入下一轮 LLM 推理。及时更新 summary 避免前端
+                        // 状态卡在刚完成的工具名上（如 "✓ run_shell"）。
+                        if phase == "analyzing" {
+                            core_state.store.runtime.run.summary = "正在思考...".to_string();
+                        }
+                    }
                     StreamEvent::MemoryRecallStart { .. } => {
                         core_state.store.runtime.run.summary = "正在检索记忆...".to_string();
                     }


### PR DESCRIPTION
## 关联 Issue

Closes #237

## 问题

桌面端 agent 通过 `run_shell`/`run_command` 执行 TTY-aware 外部命令（如 `gh`）时持续超时，命令实际已执行完成、数据已采集，却因 marker 边界检测失败被误判超时，触发 recovery 封禁工具，导致会话崩塌。

## 根因

1. **terminal 插件未接入 exec_env 注入机制**——PTY 只继承主进程环境，缺少 MCP/skill 插件贡献的 token 和工作区 `.env.local` 认证信息
2. **marker 完成判定依赖 end_marker 精确匹配**——被 TTY-aware 命令的 ANSI 输出污染后永远不命中
3. **handler 层用退出码决定 ok/fail**——退出码非 0 触发 recovery 封禁工具
4. **CSI 序列参数解析不完整**——漏掉冒号参数（真彩色 `ESC[38:2::255:0:0m`），导致处理器卡死
5. **`contains` 匹配误命中 shell 回显**——shell 回显的 wrapper 命令文本 contains 所有 marker 字符串，导致命令未执行就判定完成

## 改动

### 超时根因修复
- **env 注入**：`TerminalPlugin` 实现 `set_exec_env`，PTY 创建时快照注入 `runtime_env`（只追加不 clear，PTY 语义与 command 插件沙箱不同）
- **vte 重构序列分帧**：`TerminalLineProcessor` 用 `vte` 库（Paul Williams 状态机，Alacritty 同款）替换手写 ANSI 序列分帧，彻底解决参数格式兼容性（冒号/分号/DEC private 等）。`vte` 已在依赖树中，不增加编译体积
- **marker 匹配**：`strip-ansi-escapes` + 精确匹配（非 `contains`），避免 shell 回显 wrapper 命令文本误匹配导致命令未执行就判定完成
- **rc_marker 完成判定安全网**：退出码标记已收到即完成，不再死等可能被污染的 end_marker
- **`GH_PAGER` 覆盖**：`wrap_non_interactive_command` 增加 `GH_PAGER=cat` 覆盖+恢复，避免 gh CLI 专用分页器阻塞

### 误报纠正
- **ok 语义**：退出码非 0 / 超时不再标记 `ok: false`（只是业务结果），只有工具故障（PTY 不可用等）才 `ok: false`，避免误触 recovery
- **handler return None**：改为明确的失败 `ToolResult`，不再误报"未注册的工具"
- **`collect_command_output`**：不再用固定前缀 `contains_marker` 过滤用户输出，改为只过滤本次命令的实际 marker（含唯一 ID），避免用户输出恰好包含 marker 前缀被静默删除

### 体验修复
- **前端状态同步**：`commands.rs` 处理 `PhaseChanged(analyzing)` 事件，工具完成后及时更新 summary 为"正在思考..."，避免前端状态卡在工具名上
- **args_summary 修正**：`format_call_args_summary` 修正 `run_command` 用 `cmd`+`args`（原来错误查 `command`），`run_shell` 去掉多余的 `[auto]` 前缀

## 测试

- 终端插件 **52 项测试全部通过**（含新增端到端复现链路测试）
- `cargo clippy` + `cargo check --workspace` 无警告
- CI 全项通过（check/clippy/nextest）

新增测试：
- `end_to_end_tty_aware_command_marker_detection`：模拟 TTY-aware 命令的完整输出流（shell 回显 wrapper + spinner 动画 + 真彩色冒号参数 + 实际 marker），验证 marker 精确匹配不被回显干扰、退出码正确解析
- `test_line_processor_truecolor_colon_params`：真彩色冒号参数不卡死处理器
- `test_line_processor_gh_spinner_plus_markers` / `test_line_processor_gh_single_mega_chunk`：gh spinner + 彩色输出 + marker 行的行处理正确性
- `line_match_ignores_shell_echo` / `collect_does_not_match_shell_echo_of_wrapper`：shell 回显不误匹配 marker

## 涉及文件

| 文件 | 改动 |
|------|------|
| `output_processor.rs` | vte 重构 TerminalLineProcessor，handle_csi 内联到 csi_dispatch |
| `command_protocol.rs` | marker 精确匹配 + rc_marker 安全网 + GH_PAGER + 端到端测试 |
| `handler.rs` | ok 语义修正 + return None 改明确失败 |
| `manager.rs` | PTY 创建时注入 runtime_env |
| `session_pty.rs` | SessionPtyRegistry 持有/透传 runtime_env |
| `plugin.rs` | TerminalPlugin 实现 set_exec_env |
| `permission.rs` | args_summary 字段名修正 |
| `src-tauri/commands.rs` | PhaseChanged(analyzing) 状态同步 |