### PR TITLE
feat(settings): #249 关于与更新页 title 右侧增加 GitHub 入口

### DIFF
--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -10,7 +10,7 @@ import { Card, CardContent } from './ui/card';
 import { Switch } from './ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
-import { Settings, Eye, EyeOff, Server, Puzzle, Plus, Trash2, Loader2, Globe, Edit2, KeyRound, RefreshCw, Info, FolderOpen, Save, ShieldCheck, Database, X, HardDrive, Clock } from 'lucide-react';
+import { Settings, Eye, EyeOff, Server, Puzzle, Plus, Trash2, Loader2, Github, Globe, Edit2, KeyRound, RefreshCw, Info, FolderOpen, Save, ShieldCheck, Database, X, HardDrive, Clock } from 'lucide-react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import type { DownloadEvent, Update } from '@tauri-apps/plugin-updater';
 import { getCurrentWindow } from '@tauri-apps/api/window';
@@ -2634,8 +2634,18 @@ function AppUpdateSettings() {
 
   return (
     <div className="space-y-4 p-4">
-      <div>
+      <div className="flex items-center justify-between gap-4">
         <h3 className="text-lg font-medium">关于与更新</h3>
+        <a
+          href="https://github.com/silent-rs/silent-Tiangong"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          title="在 GitHub 上查看本项目"
+        >
+          <Github className="h-4 w-4" />
+          <span>GitHub</span>
+        </a>
       </div>
 
       <Card>


### PR DESCRIPTION
## 关联 issue

Closes #249（父 issue #243 中的建议 1）

## 背景

「关于与更新」页面此前缺少跳转到本项目 GitHub 仓库的入口，用户无法方便地查看项目动向、提 issue 或参与贡献。

## 改动

- 在「关于与更新」标题右侧新增一个 GitHub 入口，点击在新窗口打开项目仓库（`https://github.com/silent-rs/silent-Tiangong`）
- 入口样式：`Github` 图标 + 「GitHub」文字，`text-muted-foreground`，hover 时 `hover:bg-accent hover:text-foreground`，与项目既有 icon-button 风格一致

## 技术选择

采用原生 `<a target="_blank" rel="noopener noreferrer">` 而非 `@tauri-apps/plugin-shell` 的 `open()`：
- 无需改动 `src-tauri/capabilities/default.json`（当前仅 `shell:default`，不含 `shell:allow-open`）
- 与项目内已有的外部链接写法（`frontend/src/components/message/ContentMedia.tsx`）保持一致

## 校验

- [x] `tsc -b` 类型检查通过
- [x] pre-commit hooks 通过
- [x] 远端 CI（`yarn build` / `yarn test`）通过

## 截图位置

入口位于设置对话框 → 「关于与更新」tab → 页面标题「关于与更新」文字的右侧。