### PR TITLE
perf(app): send 路径移除多余的全量 session metadata 加载

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -845,33 +845,17 @@ impl TiangongApp {
             .unwrap_or_default();
         let mut session_config = app_config.to_core_config();
         session_config.default_trust_mode = app_config.default_trust_mode;
-        let metadata = self
-            .core_manager
-            .list_session_metadata()
-            .into_iter()
-            .find(|metadata| metadata.id == session_id);
-        let workspace_dir = metadata
-            .as_ref()
-            .map(|metadata| metadata.cwd.trim())
-            .filter(|cwd| !cwd.is_empty())
-            .map(ToOwned::to_owned)
-            .or_else(|| workspace_dir.filter(|cwd| !cwd.trim().is_empty()))
+        // trust_mode / reasoning_effort / cwd 都由 Core 从磁盘 session 真相源自行读取
+        // （core/mod.rs:load_session / build_turn_context）。host 这里只用调用方传入的
+        // 初始值（全新对话首次创建时由前端提供），不再全量加载所有 session metadata。
+        // 详见 ensure.rs:41 注释“cwd 由磁盘真相源维护，无需投递”。
+        let workspace_dir = workspace_dir
+            .filter(|cwd| !cwd.trim().is_empty())
             .unwrap_or(default_workspace_dir);
-        if let Some(metadata) = metadata {
-            session_config.trust_mode = metadata.trust_mode;
-            session_config.reasoning_effort = metadata
-                .reasoning_effort
-                .as_deref()
-                .map(str::trim)
-                .filter(|effort| !effort.is_empty())
-                .unwrap_or(&agent_config.reasoning_effort)
-                .to_string();
-        } else {
-            session_config.trust_mode = initial_trust_mode.unwrap_or(app_config.default_trust_mode);
-            session_config.reasoning_effort = initial_reasoning_effort
-                .filter(|effort| !effort.trim().is_empty())
-                .unwrap_or(agent_config.reasoning_effort);
-        }
+        session_config.trust_mode = initial_trust_mode.unwrap_or(app_config.default_trust_mode);
+        session_config.reasoning_effort = initial_reasoning_effort
+            .filter(|effort| !effort.trim().is_empty())
+            .unwrap_or(agent_config.reasoning_effort);
         // 桌面插件集合由 DesktopCoreFactory 构造（host 专属）。
         let plugins = self.desktop_factory.build_plugins(app_config.models).await;
         let ensured = self

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -758,10 +758,9 @@ async fn send_message_inner(
         return Err("该版本输入已成功发送，已拒绝重复投递".to_string());
     }
 
-    if let Err(error) = state.sync_core_config_from_state().await {
-        abort_session_send(state, &session_id, revision, false).await;
-        return Err(error);
-    }
+    // 注：发送消息不改变任何配置（trust_mode/reasoning_effort/model 由用户在设置页
+    // 手动变更，那些路径自行调用 sync_core_config_from_state）。ensure_core 内部对既有
+    // Core 已做 replace_config（ensure.rs），无需在此全量加载所有 session metadata。
     if let Err(error) = state
         .with_state(|core_state| {
             crate::state_ops::begin_input_send(core_state, &session_id, revision)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1193,7 +1193,8 @@ pub async fn edit_and_resend(
     if has_pending_turn {
         return Err("目标会话正在执行，暂时不能编辑重发".to_string());
     }
-    state.sync_core_config_from_state().await?;
+    // 注：编辑重发不改变配置；ensure_core 内部对既有 Core 已做 replace_config，
+    // 无需在此全量加载所有 session metadata（与 send_message 同理）。
 
     // 第一遍只读校验发生在任何附件 IO 之前。
     state
@@ -1394,7 +1395,8 @@ async fn run_context_slash_command(
 ) -> Result<bool, String> {
     use std::sync::mpsc;
 
-    state.sync_core_config_from_state().await?;
+    // 注：compress/reset 不改变配置；ensure_core 内部对既有 Core 已做 replace_config，
+    // 无需在此全量加载所有 session metadata（与 send_message 同理）。
     loop {
         let expected_session_id = state
             .with_state_read(|core_state| Ok(core_state.active_session_id.as_str().to_string()))


### PR DESCRIPTION
## 背景

用户反馈发送消息后处理不会立即开始。排查发现发送路径上存在多余的全量 session metadata 加载,每次发送都把磁盘上所有 session 文件全量反序列化两遍,随 session 数量 / 历史长度线性增长。

## 问题

### `ensure_core` 全量加载只为找一个 session(app.rs:848-874,已删)

```rust
let metadata = self.core_manager
    .list_session_metadata()        // 全量反序列化所有 session(含所有 messages)
    .into_iter()
    .find(|metadata| metadata.id == session_id);  // 只为找当前一个
```

拿到的 `cwd` / `trust_mode` / `reasoning_effort` 其实 Core 内部都会自行从磁盘 session 真相源读取:
- **cwd**:`load_session`(core/mod.rs:102)从磁盘读;core-manager 注释也明确"cwd 由磁盘真相源维护,无需投递"(ensure.rs:41)
- **trust_mode**:Core 有独立字段(mod.rs:42),`build_turn_context` 直接用(mod.rs:147)
- **reasoning_effort**:Core 从 config 读(mod.rs:176)

### `sync_core_config_from_state` 每次发送热更所有 Core 配置(3 处发送命令,已移除)

`send_message` / `edit_and_resend` / `run_context_slash_command`(compress/reset)每次都调,内部全量反序列化所有 session 给所有存活 Core 热更配置。但**发送消息不改变任何配置**——配置变更有专用路径(`set_trust_mode` / `set_models_config` / MCP / skill 增删等)自行调用 `sync_core_config_from_state`。

且 `ensure_core` 内部对既有 Core 已做 `replace_config`(ensure.rs:45),配置热更在该处已完成。

## 改动

| 文件 | 改动 |
|---|---|
| `src-tauri/src/app.rs` | `ensure_core` 删掉 `list_session_metadata().find()`,直接用调用方传入的初始值 |
| `src-tauri/src/commands.rs` | `send_message_inner`(send 路径)、`edit_and_resend`、`run_context_slash_command` 三处移除 `sync_core_config_from_state` 调用 |

配置变更路径(`set_trust_mode` / `set_default_trust_mode` / `set_custom_system_prompt` / `set_reasoning_effort` / MCP 增删 / skill 管理 / `set_models_config` / `set_memory_config`)全部保留,不受影响。

净减 17 行。

## 效果

每次发送省掉:**N 个 session 的全量 JSON 反序列化 × 2 次**(`sync_core_config_from_state` 一次 + `ensure_core` 内 `list_session_metadata` 一次)。session 越多、历史越长,收益越大。

## 验证

- `cargo check --workspace` ✅
- `cargo test`:core 81 + core-manager 5 + tiangong-app 21 全过 ✅
- pre-commit hooks(cargo fmt / clippy / nextest)全过 ✅
- 远端 pre-push hooks(cargo check / clippy / nextest)全过 ✅

## 后续

全新对话首次发送的 ~2s 延迟(IndexPlugin 同步全量扫描工作区)属另一问题,将另开 issue 跟进。