### PR TITLE
refactor(plugin/agent-team): #254 收紧 create_agent 提示词 + 移除 ChildPluginFactory

### DIFF
--- a/crates/plugins/tiangong-plugin-agent-team/src/adapter.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/adapter.rs
@@ -10,7 +10,6 @@ use tiangong_core::session::Session;
 use tiangong_core::tool::ToolResult;
 use tiangong_core::tool_override::{PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider};
 
-use crate::child_runtime::ChildPluginFactory;
 use crate::constants::{PLUGIN_ID, TOOL_CREATE_AGENT, TOOL_DISMISS_AGENT};
 use crate::coordinator::Coordinator;
 use crate::tools::{error_result, root_tool_specs};
@@ -21,7 +20,10 @@ pub struct AgentTeamPlugin {
 }
 
 impl AgentTeamPlugin {
-    pub fn new(storage_root: PathBuf, child_plugins: Arc<dyn ChildPluginFactory>) -> Self {
+    pub fn new(
+        storage_root: PathBuf,
+        child_plugins: Arc<dyn Fn() -> Vec<Arc<dyn Plugin>> + Send + Sync>,
+    ) -> Self {
         Self {
             coordinator: Coordinator::new(storage_root, child_plugins),
             feedback: RwLock::new(None),
@@ -80,12 +82,15 @@ impl ToolOverrideHandler for AgentTeamPlugin {
 impl PromptSectionProvider for AgentTeamPlugin {
     fn prompt_sections(&self) -> Vec<String> {
         vec![format!(
-            "团队协作能力（可选）：\n\
-             - create_agent 创建由独立 TiangongCore 承载的成员，最多 8 个；成员使用与当前 Core 相同的插件能力。\n\
-             - send_message 会投递到目标子 Core，并等待其外部 Done/Error 终态后返回。\n\
-             - 用户输入中的 @role 应调用 send_message，@all 应调用 broadcast_message；Core 本身不解析或改写 @ 消息。\n\
-             - 子 Agent 向 main 只能异步报告；同级等待只允许沿创建顺序向后。\n\
-             - 子 Agent 修改文件前必须加锁，命令必须前台、有限时。\n{}",
+            "团队协作能力（默认不创建子 Agent）：\n\
+             - create_agent 会启动一个全新的独立成员，它必须跑完自己的整轮后才能返回结果，开销显著。\n\
+             - **默认不要主动 create_agent**：单轮即可完成的任务一律自己处理。仅在用户明确要求并行、\n\
+               多角色协作或分工（显式提出“建团队 / 分派任务 / 并行处理”，或用 @role 提及尚未创建的成员）\n\
+               时才调用 create_agent，最多 8 个成员，成员拥有与你相同的工具能力。\n\
+             - send_message 向指定成员发送消息，并等待其跑完整轮后返回；发给 main 时仅投递、不等待。\n\
+             - 用户输入中的 @role 应调用 send_message，@all 应调用 broadcast_message；不要解析或改写 @ 消息。\n\
+             - 子 Agent 只能向 main 异步报告；同级之间的等待只允许沿创建顺序向后。\n\
+             - 子 Agent 修改文件前必须加锁，执行命令时必须前台运行并设置有限超时。\n{}",
             self.coordinator.roster_prompt()
         )]
     }
@@ -154,8 +159,8 @@ mod tests {
     use tiangong_core::session::Session;
     use tiangong_types::{ContentBlock, MessagePhase, MessageRole, StreamEvent};
 
+    use crate::build_plugin;
     use crate::test_support::storage_test_guard;
-    use crate::{build_plugin, ChildPluginFactory};
 
     struct ParentChildSseServer {
         base_url: String,
@@ -398,7 +403,8 @@ mod tests {
         parent_session.trust_mode = TrustMode::FullTrust;
         parent_session.bind_storage_root(storage.path());
         parent_session.try_persist_to_disk().unwrap();
-        let child_factory: Arc<dyn ChildPluginFactory> = Arc::new(Vec::<Arc<dyn Plugin>>::new);
+        let child_factory: Arc<dyn Fn() -> Vec<Arc<dyn Plugin>> + Send + Sync> =
+            Arc::new(Vec::<Arc<dyn Plugin>>::new);
         let plugin = build_plugin(storage.path().to_path_buf(), child_factory);
         let (event_tx, event_rx) = std::sync::mpsc::channel::<StreamEvent>();
         let parent_core = TiangongCore::builder()

--- a/crates/plugins/tiangong-plugin-agent-team/src/child_runtime.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/child_runtime.rs
@@ -14,20 +14,6 @@ use tiangong_types::{ContentBlock, StreamEvent, TokenUsage, TurnStatus};
 use crate::constants::{CHILD_PLUGIN_ID, PLUGIN_ID};
 use crate::state::AgentDescriptor;
 
-/// 每次为一个子 Core 创建全新的插件 facade。
-pub trait ChildPluginFactory: Send + Sync {
-    fn create_plugins(&self) -> Vec<Arc<dyn Plugin>>;
-}
-
-impl<F> ChildPluginFactory for F
-where
-    F: Fn() -> Vec<Arc<dyn Plugin>> + Send + Sync,
-{
-    fn create_plugins(&self) -> Vec<Arc<dyn Plugin>> {
-        self()
-    }
-}
-
 pub(crate) type SharedFeedback = Arc<RwLock<Option<PluginFeedbackTx>>>;
 
 #[derive(Debug, Clone)]

--- a/crates/plugins/tiangong-plugin-agent-team/src/coordinator.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/coordinator.rs
@@ -16,7 +16,7 @@ use tiangong_core::tool::ToolResult;
 use tiangong_core::tool_override::{PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider};
 use tiangong_types::{ContentBlock, StreamEvent};
 
-use crate::child_runtime::{child_config, ChildPluginFactory, ChildRuntime, SharedFeedback};
+use crate::child_runtime::{child_config, ChildRuntime, SharedFeedback};
 use crate::constants::*;
 use crate::manifest::{
     child_root, normalize_role, team_root, validate_role_identifier, AgentRecord, TeamManifest,
@@ -33,7 +33,7 @@ fn active_teams() -> &'static Mutex<HashMap<String, Weak<Coordinator>>> {
 
 pub(crate) struct Coordinator {
     storage_root: PathBuf,
-    child_plugins: Arc<dyn ChildPluginFactory>,
+    child_plugins: Arc<dyn Fn() -> Vec<Arc<dyn Plugin>> + Send + Sync>,
     manifest: Mutex<Option<TeamManifest>>,
     runtimes: Mutex<HashMap<String, Arc<ChildRuntime>>>,
     file_locks: Mutex<FileLockManager>,
@@ -95,7 +95,7 @@ impl PendingDismissal {
 impl Coordinator {
     pub(crate) fn new(
         storage_root: PathBuf,
-        child_plugins: Arc<dyn ChildPluginFactory>,
+        child_plugins: Arc<dyn Fn() -> Vec<Arc<dyn Plugin>> + Send + Sync>,
     ) -> Arc<Self> {
         Arc::new(Self {
             storage_root,
@@ -707,7 +707,7 @@ impl Coordinator {
     fn fresh_child_plugins(&self) -> Vec<Arc<dyn Plugin>> {
         // 子 Agent 与主 Agent 使用同一套插件工厂，直接获得独立但同构的插件实例。
         // ChildRuntime::start 会再剥离团队插件并注入团队客户端，这里无需额外过滤。
-        self.child_plugins.create_plugins()
+        (self.child_plugins)()
     }
 
     fn runtime(&self, agent_id: &str) -> Option<Arc<ChildRuntime>> {
@@ -1137,7 +1137,7 @@ fn validate_path_segment(value: &str, label: &str) -> Result<(), String> {
 mod tests {
     use super::*;
 
-    fn empty_factory() -> Arc<dyn ChildPluginFactory> {
+    fn empty_factory() -> Arc<dyn Fn() -> Vec<Arc<dyn Plugin>> + Send + Sync> {
         Arc::new(Vec::<Arc<dyn Plugin>>::new)
     }
 

--- a/crates/plugins/tiangong-plugin-agent-team/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/lib.rs
@@ -13,7 +13,6 @@ mod state;
 mod tools;
 
 pub use adapter::AgentTeamPlugin;
-pub use child_runtime::ChildPluginFactory;
 pub use constants::*;
 pub use state::{AgentDescriptor, AgentStatus, FileLock, FileLockManager};
 
@@ -27,7 +26,7 @@ use crate::coordinator::Coordinator;
 /// 构造一个父 Core 使用的 Agent Team 插件。
 pub fn build_plugin(
     storage_root: PathBuf,
-    child_plugins: Arc<dyn ChildPluginFactory>,
+    child_plugins: Arc<dyn Fn() -> Vec<Arc<dyn Plugin>> + Send + Sync>,
 ) -> Arc<dyn Plugin> {
     Arc::new(AgentTeamPlugin::new(storage_root, child_plugins))
 }
@@ -35,7 +34,7 @@ pub fn build_plugin(
 /// 返回默认插件集合。
 pub fn default_plugins(
     storage_root: PathBuf,
-    child_plugins: Arc<dyn ChildPluginFactory>,
+    child_plugins: Arc<dyn Fn() -> Vec<Arc<dyn Plugin>> + Send + Sync>,
 ) -> Vec<Arc<dyn Plugin>> {
     vec![build_plugin(storage_root, child_plugins)]
 }

--- a/crates/plugins/tiangong-plugin-agent-team/src/tools.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/tools.rs
@@ -11,7 +11,7 @@ pub(crate) fn root_tool_specs() -> Vec<ToolSpec> {
         [
             ToolSpec {
                 name: TOOL_CREATE_AGENT.to_string(),
-                description: "创建一个由独立 TiangongCore 承载的团队成员。".to_string(),
+                description: "创建一个新的团队成员，它将独立完成自己的一整轮任务后再返回结果。仅在用户明确要求并行、多角色协作或分工时调用；单轮可完成的任务请直接处理，不要创建子 Agent。".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -217,46 +217,43 @@ fn build_cli_plugins(
     plugins.push(skill_plugin.clone());
     plugins.push(mcp_plugin.clone());
 
-    let child_plugin_factory: std::sync::Arc<dyn tiangong_plugin_agent_team::ChildPluginFactory> =
-        std::sync::Arc::new({
-            let storage_root = storage_root.clone();
-            move || {
-                let mut child_plugins = tiangong_plugin_prompt::default_plugins();
-                child_plugins.extend(tiangong_plugin_fs::default_plugins());
-                child_plugins.extend(tiangong_plugin_index::default_plugins());
-                if let Some(ep) = image_endpoint.clone() {
-                    child_plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
-                }
-                if let Some(ep) = video_endpoint.clone() {
-                    child_plugins.push(tiangong_plugin_generate_video::build_plugin(ep));
-                }
-                if let Some(ep) = tts_endpoint.clone() {
-                    child_plugins.push(tiangong_plugin_text_to_speech::build_plugin(ep));
-                }
-                if let Some(ep) = stt_endpoint.clone() {
-                    child_plugins.push(tiangong_plugin_speech_to_text::build_plugin(ep));
-                }
-                child_plugins.extend(tiangong_plugin_memory::default_plugins(
-                    memory_handle.clone(),
-                ));
-                child_plugins.extend(tiangong_plugin_fetch::default_plugins());
-                child_plugins.extend(tiangong_plugin_command::default_plugins());
-                child_plugins.extend(tiangong_plugin_scheduler::default_plugins());
-                child_plugins.extend(tiangong_plugin_task::default_plugins());
-                if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new) {
-                    child_plugins.push(tiangong_plugin_analyze_attachment::build_plugin(client));
-                }
-                child_plugins.push(std::sync::Arc::new(
-                    tiangong_plugin_skill::SkillPlugin::with_storage_root(
-                        storage_root.join("skills"),
-                    ),
-                ));
-                child_plugins.push(std::sync::Arc::new(
-                    tiangong_plugin_mcp::McpPlugin::with_storage_root(storage_root.clone()),
-                ));
-                child_plugins
+    let child_plugin_factory = std::sync::Arc::new({
+        let storage_root = storage_root.clone();
+        move || {
+            let mut child_plugins = tiangong_plugin_prompt::default_plugins();
+            child_plugins.extend(tiangong_plugin_fs::default_plugins());
+            child_plugins.extend(tiangong_plugin_index::default_plugins());
+            if let Some(ep) = image_endpoint.clone() {
+                child_plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
             }
-        });
+            if let Some(ep) = video_endpoint.clone() {
+                child_plugins.push(tiangong_plugin_generate_video::build_plugin(ep));
+            }
+            if let Some(ep) = tts_endpoint.clone() {
+                child_plugins.push(tiangong_plugin_text_to_speech::build_plugin(ep));
+            }
+            if let Some(ep) = stt_endpoint.clone() {
+                child_plugins.push(tiangong_plugin_speech_to_text::build_plugin(ep));
+            }
+            child_plugins.extend(tiangong_plugin_memory::default_plugins(
+                memory_handle.clone(),
+            ));
+            child_plugins.extend(tiangong_plugin_fetch::default_plugins());
+            child_plugins.extend(tiangong_plugin_command::default_plugins());
+            child_plugins.extend(tiangong_plugin_scheduler::default_plugins());
+            child_plugins.extend(tiangong_plugin_task::default_plugins());
+            if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new) {
+                child_plugins.push(tiangong_plugin_analyze_attachment::build_plugin(client));
+            }
+            child_plugins.push(std::sync::Arc::new(
+                tiangong_plugin_skill::SkillPlugin::with_storage_root(storage_root.join("skills")),
+            ));
+            child_plugins.push(std::sync::Arc::new(
+                tiangong_plugin_mcp::McpPlugin::with_storage_root(storage_root.clone()),
+            ));
+            child_plugins
+        }
+    });
     plugins.extend(tiangong_plugin_agent_team::default_plugins(
         storage_root,
         child_plugin_factory,

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -404,45 +404,43 @@ impl ServerCoreManager {
             plugins.push(self.mcp_plugin.clone());
             // Agent Team 插件：子 Agent 管理 + 文件锁工具（issue #200）。
             // 子 Core 每次获得与该 Server Core 相同能力集合的全新插件外壳。
-            let child_plugin_factory: Arc<dyn tiangong_plugin_agent_team::ChildPluginFactory> =
-                Arc::new({
-                    let storage_root = storage_root.clone();
-                    move || {
-                        let mut child_plugins = tiangong_plugin_prompt::default_plugins();
-                        child_plugins.extend(tiangong_plugin_fs::default_plugins());
-                        child_plugins.extend(tiangong_plugin_index::default_plugins());
-                        if let Some(ep) = image_endpoint.clone() {
-                            child_plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
-                        }
-                        if let Some(ep) = video_endpoint.clone() {
-                            child_plugins.push(tiangong_plugin_generate_video::build_plugin(ep));
-                        }
-                        if let Some(ep) = tts_endpoint.clone() {
-                            child_plugins.push(tiangong_plugin_text_to_speech::build_plugin(ep));
-                        }
-                        if let Some(ep) = stt_endpoint.clone() {
-                            child_plugins.push(tiangong_plugin_speech_to_text::build_plugin(ep));
-                        }
-                        child_plugins.extend(tiangong_plugin_memory::default_plugins(
-                            memory_handle.clone(),
-                        ));
-                        child_plugins.extend(tiangong_plugin_fetch::default_plugins());
-                        child_plugins.extend(tiangong_plugin_command::default_plugins());
-                        child_plugins.extend(tiangong_plugin_scheduler::default_plugins());
-                        child_plugins.extend(tiangong_plugin_task::default_plugins());
-                        if let Some(client) =
-                            multimodal_endpoint.clone().map(SingleProviderClient::new)
-                        {
-                            child_plugins
-                                .push(tiangong_plugin_analyze_attachment::build_plugin(client));
-                        }
-                        child_plugins.extend(tiangong_plugin_skill::default_plugins());
-                        child_plugins.push(Arc::new(
-                            tiangong_plugin_mcp::McpPlugin::with_storage_root(storage_root.clone()),
-                        ));
-                        child_plugins
+            let child_plugin_factory = Arc::new({
+                let storage_root = storage_root.clone();
+                move || {
+                    let mut child_plugins = tiangong_plugin_prompt::default_plugins();
+                    child_plugins.extend(tiangong_plugin_fs::default_plugins());
+                    child_plugins.extend(tiangong_plugin_index::default_plugins());
+                    if let Some(ep) = image_endpoint.clone() {
+                        child_plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
                     }
-                });
+                    if let Some(ep) = video_endpoint.clone() {
+                        child_plugins.push(tiangong_plugin_generate_video::build_plugin(ep));
+                    }
+                    if let Some(ep) = tts_endpoint.clone() {
+                        child_plugins.push(tiangong_plugin_text_to_speech::build_plugin(ep));
+                    }
+                    if let Some(ep) = stt_endpoint.clone() {
+                        child_plugins.push(tiangong_plugin_speech_to_text::build_plugin(ep));
+                    }
+                    child_plugins.extend(tiangong_plugin_memory::default_plugins(
+                        memory_handle.clone(),
+                    ));
+                    child_plugins.extend(tiangong_plugin_fetch::default_plugins());
+                    child_plugins.extend(tiangong_plugin_command::default_plugins());
+                    child_plugins.extend(tiangong_plugin_scheduler::default_plugins());
+                    child_plugins.extend(tiangong_plugin_task::default_plugins());
+                    if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new)
+                    {
+                        child_plugins
+                            .push(tiangong_plugin_analyze_attachment::build_plugin(client));
+                    }
+                    child_plugins.extend(tiangong_plugin_skill::default_plugins());
+                    child_plugins.push(Arc::new(
+                        tiangong_plugin_mcp::McpPlugin::with_storage_root(storage_root.clone()),
+                    ));
+                    child_plugins
+                }
+            });
             plugins.extend(tiangong_plugin_agent_team::default_plugins(
                 storage_root.clone(),
                 child_plugin_factory,

--- a/src-tauri/src/core_factory.rs
+++ b/src-tauri/src/core_factory.rs
@@ -113,57 +113,53 @@ impl DesktopCoreFactory {
         plugins.push(self.skill_plugin.clone());
         plugins.push(self.mcp_plugin.clone());
         // Agent Team 插件：子 Agent 管理 + 文件锁工具（issue #200）。
-        let child_plugin_factory: Arc<dyn tiangong_plugin_agent_team::ChildPluginFactory> =
-            Arc::new({
-                let app_handle = app_handle.clone();
-                let storage_root = storage_root.clone();
-                move || {
-                    let mut child_plugins: Vec<Arc<dyn Plugin>> = Vec::new();
-                    child_plugins.extend(tiangong_plugin_prompt::default_plugins());
-                    if browser_available {
-                        if let Some(browser) = tiangong_plugin_browser::build_plugin(&app_handle) {
-                            child_plugins.push(browser);
-                        }
+        let child_plugin_factory = Arc::new({
+            let app_handle = app_handle.clone();
+            let storage_root = storage_root.clone();
+            move || {
+                let mut child_plugins: Vec<Arc<dyn Plugin>> = Vec::new();
+                child_plugins.extend(tiangong_plugin_prompt::default_plugins());
+                if browser_available {
+                    if let Some(browser) = tiangong_plugin_browser::build_plugin(&app_handle) {
+                        child_plugins.push(browser);
                     }
-                    if terminal_available {
-                        if let Some(terminal) = tiangong_plugin_terminal::build_plugin(&app_handle)
-                        {
-                            child_plugins.push(terminal);
-                        }
-                    }
-                    child_plugins.push(tiangong_plugin_fs::build_plugin());
-                    child_plugins.push(tiangong_plugin_index::build_plugin());
-                    if let Some(ep) = image_endpoint.clone() {
-                        child_plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
-                    }
-                    if let Some(ep) = video_endpoint.clone() {
-                        child_plugins.push(tiangong_plugin_generate_video::build_plugin(ep));
-                    }
-                    if let Some(ep) = tts_endpoint.clone() {
-                        child_plugins.push(tiangong_plugin_text_to_speech::build_plugin(ep));
-                    }
-                    if let Some(ep) = stt_endpoint.clone() {
-                        child_plugins.push(tiangong_plugin_speech_to_text::build_plugin(ep));
-                    }
-                    child_plugins.push(tiangong_plugin_memory::build_plugin(memory_handle.clone()));
-                    child_plugins.push(tiangong_plugin_scheduler::build_plugin());
-                    child_plugins.push(tiangong_plugin_task::build_plugin());
-                    if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new)
-                    {
-                        child_plugins
-                            .push(tiangong_plugin_analyze_attachment::build_plugin(client));
-                    }
-                    child_plugins.push(Arc::new(
-                        tiangong_plugin_skill::SkillPlugin::with_storage_root(
-                            storage_root.join("skills"),
-                        ),
-                    ));
-                    child_plugins.push(Arc::new(
-                        tiangong_plugin_mcp::McpPlugin::with_storage_root(storage_root.clone()),
-                    ));
-                    child_plugins
                 }
-            });
+                if terminal_available {
+                    if let Some(terminal) = tiangong_plugin_terminal::build_plugin(&app_handle) {
+                        child_plugins.push(terminal);
+                    }
+                }
+                child_plugins.push(tiangong_plugin_fs::build_plugin());
+                child_plugins.push(tiangong_plugin_index::build_plugin());
+                if let Some(ep) = image_endpoint.clone() {
+                    child_plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
+                }
+                if let Some(ep) = video_endpoint.clone() {
+                    child_plugins.push(tiangong_plugin_generate_video::build_plugin(ep));
+                }
+                if let Some(ep) = tts_endpoint.clone() {
+                    child_plugins.push(tiangong_plugin_text_to_speech::build_plugin(ep));
+                }
+                if let Some(ep) = stt_endpoint.clone() {
+                    child_plugins.push(tiangong_plugin_speech_to_text::build_plugin(ep));
+                }
+                child_plugins.push(tiangong_plugin_memory::build_plugin(memory_handle.clone()));
+                child_plugins.push(tiangong_plugin_scheduler::build_plugin());
+                child_plugins.push(tiangong_plugin_task::build_plugin());
+                if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new) {
+                    child_plugins.push(tiangong_plugin_analyze_attachment::build_plugin(client));
+                }
+                child_plugins.push(Arc::new(
+                    tiangong_plugin_skill::SkillPlugin::with_storage_root(
+                        storage_root.join("skills"),
+                    ),
+                ));
+                child_plugins.push(Arc::new(tiangong_plugin_mcp::McpPlugin::with_storage_root(
+                    storage_root.clone(),
+                )));
+                child_plugins
+            }
+        });
         plugins.push(tiangong_plugin_agent_team::build_plugin(
             storage_root.clone(),
             child_plugin_factory,


### PR DESCRIPTION
## 背景

Closes #254

Agent Team 插件上线后暴露两类可优化点:

1. **主 Agent 自主创建子 Agent 的倾向过强**——父侧提示词只把 `create_agent` 当常规能力罗列,没有「何时该建团队」的约束,模型在单轮任务上也倾向 spawn 子 Core,徒增独立 runtime/会话的启动与等待开销。
2. **`ChildPluginFactory` trait 是冗余抽象**——只有一个方法且已有 blanket impl,不提供任何额外约束,只是给函数类型起个名字。

## 变更

### A. 提示词:默认不创建子 Agent

- `adapter.rs::PromptSectionProvider`:开头点明「`create_agent` 会启动一个全新的独立成员,必须跑完整轮才能返回,开销显著」;**默认不主动创建**,仅在用户明确要求并行 / 多角色协作 / 分工(显式措辞或用 `@role` 提及尚未存在的成员)时才调用,最多 8 个成员。同时去掉 `TiangongCore`/`worker`/`Tokio runtime`/`Session`/`Done`/`Error 终态` 等实现细节,只保留对模型决策有用的行为语义。其余能力(`send_message`/`@role`/`@all`/同级等待顺序/子 Agent 加锁与命令规范)保持不变。
- `tools.rs::create_agent` 工具描述同步收紧,口径与提示词一致。

### B. 删除 `ChildPluginFactory`,直接用函数类型

- 删除 `child_runtime.rs` 里的 trait 与 blanket impl,删除 `lib.rs` 的 `pub use ChildPluginFactory`。
- `build_plugin` / `default_plugins` 形参、`Coordinator.child_plugins` 字段、`AgentTeamPlugin::new` 形参统一改为 `Arc<dyn Fn() -> Vec<Arc<dyn Plugin>> + Send + Sync>`。
- `fresh_child_plugins()` 体改为 `(self.child_plugins)()`(原 `create_plugins()` 的等价展开)。
- 宿主全部三个调用点(`src-tauri/src/core_factory.rs`、`crates/tiangong-cli/src/repl.rs`、`crates/tiangong-server/src/remote/core.rs`)去掉 `Arc<dyn ChildPluginFactory>` 显式标注,直接 `Arc::new(move || {...})` 传入,类型由 `build_plugin` 形参推导。

> 注:issue 原文只列出 `core_factory.rs` 一个外部消费点,但实际还有 `tiangong-cli` 与 `tiangong-server` 两处同样依赖该 trait,本次一并迁移,确保 workspace 编译通过。

## 兼容性

- `ChildPluginFactory` 虽是 `pub use`,但全仓仅上述三处外部消费点,已全部迁移。
- trait 删除属内部 API 收敛,**无运行时行为变化**:重构前后是同一个闭包的两种写法(blanket impl 体本来就是 `self()`)。

## 验收

- [x] 父侧提示词明确「默认不创建子 Agent,需用户显式要求」,`create_agent` 工具描述同步。
- [x] `ChildPluginFactory` trait 及导出删除;`build_plugin` / `default_plugins` / `Coordinator` 直接使用 `Arc<dyn Fn() -> Vec<Arc<dyn Plugin>> + Send + Sync>`。
- [x] 全部宿主调用点更新(桌面 / CLI / Server),子 Agent 仍能拿到与主 Agent 同构的插件集。
- [x] agent-team 测试套件 13/13 全绿。

## 测试

```
cargo test -p tiangong-plugin-agent-team
test result: ok. 13 passed; 0 failed; 0 ignored
cargo check --workspace        # 通过
```