### PR TITLE
fix(plugin): 补回 stdio MCP 子进程与 terminal 命令校验的会话工作目录注入

### DIFF
--- a/crates/plugins/tiangong-plugin-fs/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-fs/src/handler.rs
@@ -4,7 +4,7 @@
 //! JSON（`call.arguments`）按 key 取参，绕开旧的「位置参数数组」模式。
 //!
 //! 路径解析使用 core 暴露的 `*_with_base` 变体，显式传入由 core 注入的会话工作目录，
-//! 不依赖 thread-local SESSION_CWD。
+//! 不依赖任何隐式全局状态。
 
 use std::fs;
 use std::path::Path;

--- a/crates/plugins/tiangong-plugin-mcp/src/capability.rs
+++ b/crates/plugins/tiangong-plugin-mcp/src/capability.rs
@@ -399,7 +399,8 @@ fn persist_mcp_capabilities_cache(
 }
 
 fn probe_server_capability(server: &McpServerConfig, timeout_ms: u64) -> McpServerCapability {
-    let client = LocalMcpClient;
+    // capability 探测无会话上下文，workspace=None：子进程继承宿主 cwd。
+    let client = LocalMcpClient::default();
     let server_name = server.name.clone();
     let server_transport = server.resolved_transport();
     let server = server.clone();

--- a/crates/plugins/tiangong-plugin-mcp/src/client.rs
+++ b/crates/plugins/tiangong-plugin-mcp/src/client.rs
@@ -3,6 +3,7 @@
 //! 原属 `tiangong-core::mcp::client`，MCP 管理插件化后整块迁入本 crate。
 
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Duration;
@@ -22,7 +23,6 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 
 use crate::config::{McpServerConfig, ResolvedMcpTransport};
-use tiangong_toolkit::session_workspace_root;
 use tiangong_types::process::configure_tokio_no_window;
 
 const MAX_LIST_PAGES: usize = 8;
@@ -152,7 +152,14 @@ pub fn get_cached_server_version(name: &str) -> Option<String> {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct LocalMcpClient;
+pub struct LocalMcpClient {
+    /// 工具执行时携带的会话工作目录，供 stdio MCP 子进程设置 `current_dir`。
+    ///
+    /// 由 `McpPlugin.workspace`（经 core 的 `set_workspace` 注入）在工具执行入口
+    /// 快照后传入。capability 探测等无会话上下文的路径用 [`Default`]（`None`），
+    /// 子进程自然继承宿主 cwd。
+    pub workspace: Option<PathBuf>,
+}
 
 impl McpClient for LocalMcpClient {
     async fn list_tools(
@@ -184,7 +191,7 @@ impl McpClient for LocalMcpClient {
                 .collect());
         }
 
-        list_tools_via_rmcp(server, timeout_ms).await
+        list_tools_via_rmcp(server, timeout_ms, self.workspace.clone()).await
     }
 
     async fn list_resources(
@@ -213,7 +220,7 @@ impl McpClient for LocalMcpClient {
                 .collect());
         }
 
-        list_resources_via_rmcp(server, timeout_ms).await
+        list_resources_via_rmcp(server, timeout_ms, self.workspace.clone()).await
     }
 
     async fn read_resource(
@@ -245,6 +252,7 @@ impl McpClient for LocalMcpClient {
             timeout_ms,
             "resources/read",
             Some(json!({ "uri": resource.uri })),
+            self.workspace.clone(),
         )
         .await?;
         Ok(parse_read_resource_result(&result))
@@ -275,6 +283,7 @@ impl McpClient for LocalMcpClient {
                 "name": tool_name,
                 "arguments": arguments,
             })),
+            self.workspace.clone(),
         )
         .await?;
         parse_call_tool_result(&result)
@@ -285,6 +294,7 @@ impl McpClient for LocalMcpClient {
 async fn list_resources_via_rmcp(
     server: &McpServerConfig,
     timeout_ms: u64,
+    workspace: Option<PathBuf>,
 ) -> Result<Vec<McpResourceMeta>> {
     let mut resources = Vec::new();
     let mut seen = HashSet::new();
@@ -292,7 +302,14 @@ async fn list_resources_via_rmcp(
 
     for _ in 0..MAX_LIST_PAGES {
         let params = cursor.as_ref().map(|cursor| json!({ "cursor": cursor }));
-        let result = run_mcp_request(server, timeout_ms, "resources/list", params).await?;
+        let result = run_mcp_request(
+            server,
+            timeout_ms,
+            "resources/list",
+            params,
+            workspace.clone(),
+        )
+        .await?;
         let (page, next_cursor) = parse_resource_page(&server.name, &result);
         for resource in page {
             if seen.insert(resource.uri.clone()) {
@@ -322,6 +339,7 @@ async fn list_resources_via_rmcp(
 async fn list_tools_via_rmcp(
     server: &McpServerConfig,
     timeout_ms: u64,
+    workspace: Option<PathBuf>,
 ) -> Result<Vec<McpToolMeta>> {
     let mut tools = Vec::new();
     let mut seen = HashSet::new();
@@ -329,7 +347,8 @@ async fn list_tools_via_rmcp(
 
     for _ in 0..MAX_LIST_PAGES {
         let params = cursor.as_ref().map(|cursor| json!({ "cursor": cursor }));
-        let result = run_mcp_request(server, timeout_ms, "tools/list", params).await?;
+        let result =
+            run_mcp_request(server, timeout_ms, "tools/list", params, workspace.clone()).await?;
         let (page, next_cursor) = parse_tool_page(&server.name, &result);
         for tool in page {
             if seen.insert(tool.name.clone()) {
@@ -361,6 +380,7 @@ async fn run_mcp_request(
     timeout_ms: u64,
     method: &str,
     params: Option<Value>,
+    workspace: Option<PathBuf>,
 ) -> Result<Value> {
     match server.resolved_transport() {
         ResolvedMcpTransport::Metadata => {
@@ -380,7 +400,7 @@ async fn run_mcp_request(
 
     let result = timeout(
         Duration::from_millis(timeout_ms),
-        run_mcp_request_async(server, method, params),
+        run_mcp_request_async(server, method, params, workspace),
     )
     .await;
 
@@ -405,10 +425,13 @@ async fn run_mcp_request_async(
     server: &McpServerConfig,
     method: &str,
     params: Option<Value>,
+    workspace: Option<PathBuf>,
 ) -> Result<Value> {
     match server.resolved_transport() {
         ResolvedMcpTransport::Http => run_http_mcp_request_async(server, method, params).await,
-        ResolvedMcpTransport::Stdio => run_stdio_mcp_request_async(server, method, params).await,
+        ResolvedMcpTransport::Stdio => {
+            run_stdio_mcp_request_async(server, method, params, workspace).await
+        }
         ResolvedMcpTransport::Metadata => {
             Err(anyhow!("MCP server 未配置可连接传输：{}", server.name))
         }
@@ -419,6 +442,7 @@ async fn run_stdio_mcp_request_async(
     server: &McpServerConfig,
     method: &str,
     params: Option<Value>,
+    workspace: Option<PathBuf>,
 ) -> Result<Value> {
     let command = server.command_text();
     let args_desc = if server.args.is_empty() {
@@ -430,9 +454,10 @@ async fn run_stdio_mcp_request_async(
         TokioChildProcess::builder(Command::new(command).configure(|cmd| {
             configure_tokio_no_window(cmd);
             cmd.args(&server.args);
-            // stdio MCP 跟随当前会话工作目录（与 run_command 一致）；能力探测等无会话上下文
-            // 的路径下此值为 None，子进程自然继承宿主进程 cwd。
-            if let Some(cwd) = session_workspace_root() {
+            // stdio MCP 跟随当前会话工作目录（与 run_command 一致）。workspace 由
+            // 工具执行入口从 McpPlugin 注入；capability 探测等无会话上下文的路径
+            // 传 None，子进程自然继承宿主进程 cwd。
+            if let Some(cwd) = workspace.as_deref() {
                 cmd.current_dir(cwd);
             }
             for (key, value) in &server.env {

--- a/crates/plugins/tiangong-plugin-mcp/src/execution.rs
+++ b/crates/plugins/tiangong-plugin-mcp/src/execution.rs
@@ -5,6 +5,7 @@
 //! `(server, tool)` 目标。
 
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::time::Instant;
 
 use anyhow::{Result, anyhow};
@@ -143,14 +144,22 @@ pub async fn execute_mcp_tool_call(
     call: &ToolCall,
     target: &McpFunctionTarget,
     mcp_config: &McpConfig,
+    workspace: Option<PathBuf>,
 ) -> Result<ToolResult> {
-    execute_mcp_tool_call_with_args(target, normalize_mcp_call_arguments(call), mcp_config).await
+    execute_mcp_tool_call_with_args(
+        target,
+        normalize_mcp_call_arguments(call),
+        mcp_config,
+        workspace,
+    )
+    .await
 }
 
 pub async fn execute_mcp_tool_call_with_args(
     target: &McpFunctionTarget,
     args: Value,
     mcp_config: &McpConfig,
+    workspace: Option<PathBuf>,
 ) -> Result<ToolResult> {
     let started = Instant::now();
     let server = find_mcp_server(mcp_config, &target.server_name).ok_or_else(|| {
@@ -160,7 +169,7 @@ pub async fn execute_mcp_tool_call_with_args(
             target.tool_name
         )
     })?;
-    let client = LocalMcpClient;
+    let client = LocalMcpClient { workspace };
     match client
         .call_tool(
             server,

--- a/crates/plugins/tiangong-plugin-mcp/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-mcp/src/handler.rs
@@ -28,11 +28,14 @@ impl McpPlugin {
     ) -> Option<Pin<Box<dyn Future<Output = ToolResult> + Send>>> {
         let config = self.config_snapshot();
         let targets = self.targets_snapshot();
+        // 快照当前会话工作目录（由 core 的 set_workspace 注入），随调用传入
+        // stdio MCP 子进程。RwLock 只在此处短暂读取，不持有跨 await。
+        let workspace = self.workspace.read().ok().and_then(|guard| guard.clone());
 
         let target = targets.get(&call.name)?.clone();
         let call = call.clone();
         Some(Box::pin(async move {
-            match execute_mcp_tool_call(&call, &target, &config).await {
+            match execute_mcp_tool_call(&call, &target, &config, workspace).await {
                 Ok(result) => result,
                 Err(err) => ToolResult {
                     ok: false,

--- a/crates/plugins/tiangong-plugin-terminal/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/plugin.rs
@@ -101,7 +101,8 @@ impl ToolOverrideHandler for TerminalPlugin {
             call,
             session.parent_session_id.is_some(),
             workspace.as_deref(),
-        );
+        )
+        .or_else(|| fill_default_cwd(call, workspace.as_deref()));
         ToolOverrideHandler::handle(
             &self.override_handler,
             normalized.as_ref().unwrap_or(call),
@@ -124,6 +125,34 @@ fn normalize_nested_terminal_call(
         normalized.arguments["cwd"] = serde_json::Value::String(workspace.display().to_string());
         normalized
     })
+}
+
+/// 主对话 `run_command`/`run_shell` 的 cwd 兜底。
+///
+/// LLM 未显式传 `cwd` 时，用 core 经 `set_workspace` 注入的会话工作目录填充，
+/// 使 [`crate::handler::validate_terminal_command`] 的路径越界校验和 PTY 执行
+/// 都落在会话 workspace 上，而非进程 cwd（Tauri 主进程启动目录）。
+///
+/// 仅当 call 未携带有效 `cwd` 时生效；LLM 显式传值时不覆盖。
+/// 子 session 走 [`normalize_nested_terminal_call`] 的强制覆盖语义，不会走到这里。
+fn fill_default_cwd(call: &ToolCall, workspace: Option<&std::path::Path>) -> Option<ToolCall> {
+    if !matches!(call.name.as_str(), "run_command" | "run_shell") {
+        return None;
+    }
+    let workspace = workspace?;
+    let already_has_cwd = call
+        .arguments
+        .get("cwd")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .is_some();
+    if already_has_cwd {
+        return None;
+    }
+    let mut filled = call.clone();
+    filled.arguments["cwd"] = serde_json::Value::String(workspace.display().to_string());
+    Some(filled)
 }
 
 impl tiangong_core::tool_override::ToolSpecProvider for TerminalPlugin {
@@ -204,5 +233,57 @@ mod tests {
 
         assert_eq!(normalized.arguments["cwd"], "/workspace");
         assert!(normalize_nested_terminal_call(&call, false, None).is_none());
+    }
+
+    #[test]
+    fn fill_default_cwd_fills_when_missing() {
+        let call = ToolCall {
+            id: "call".to_string(),
+            name: "run_command".to_string(),
+            arguments: serde_json::json!({ "cmd": "ls" }),
+        };
+
+        let filled = fill_default_cwd(&call, Some(std::path::Path::new("/workspace"))).unwrap();
+        assert_eq!(filled.arguments["cwd"], "/workspace");
+    }
+
+    #[test]
+    fn fill_default_cwd_does_not_override_explicit_cwd() {
+        let call = ToolCall {
+            id: "call".to_string(),
+            name: "run_command".to_string(),
+            arguments: serde_json::json!({ "cmd": "ls", "cwd": "/explicit" }),
+        };
+
+        assert_eq!(
+            fill_default_cwd(&call, Some(std::path::Path::new("/workspace"))),
+            None,
+            "LLM 显式传 cwd 时不应覆盖"
+        );
+    }
+
+    #[test]
+    fn fill_default_cwd_noop_without_workspace() {
+        let call = ToolCall {
+            id: "call".to_string(),
+            name: "run_command".to_string(),
+            arguments: serde_json::json!({ "cmd": "ls" }),
+        };
+
+        assert_eq!(fill_default_cwd(&call, None), None);
+    }
+
+    #[test]
+    fn fill_default_cwd_ignores_unrelated_tools() {
+        let call = ToolCall {
+            id: "call".to_string(),
+            name: "terminal_send".to_string(),
+            arguments: serde_json::json!({ "text": "hello" }),
+        };
+
+        assert_eq!(
+            fill_default_cwd(&call, Some(std::path::Path::new("/workspace"))),
+            None
+        );
     }
 }

--- a/crates/tiangong-toolkit/src/lib.rs
+++ b/crates/tiangong-toolkit/src/lib.rs
@@ -4,13 +4,11 @@
 //! 作为路径沙箱安全基础设施，供 core 与各进程内插件 crate（fs / command / fetch /
 //! index / terminal）共用，避免重复实现安全逻辑。
 //!
-//! 路径解析相关 helper 提供两套 API：
-//! - 隐式 thread-local 版本（`resolve_workspace_path` 等）：依赖 `SESSION_CWD`，
-//!   供 core 沿用旧行为；
-//! - 显式注入版本（`*_with_base`）：接收 `base: &Path` 参数，供插件 handler 使用，
-//!   无需关心调用方是否设置了 thread-local CWD。
+//! 会话工作目录的注入采用显式传递：core 在 `prepare_plugins` 阶段把 `Session.cwd`
+//! 经各插件的 `set_workspace` 注入；stdio MCP 子进程等需要 cwd 的执行路径由
+//! 插件沿调用链显式携带（见 `LocalMcpClient.workspace`），不依赖 thread-local。
+//! [`workspace_root`] 仅作无显式 base 时的回退，读进程 cwd。
 
-use std::cell::RefCell;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -22,34 +20,13 @@ use anyhow::{Context, Result, anyhow};
 
 use tiangong_types::process::configure_no_window;
 
-thread_local! {
-    /// 当前执行的会话工作目录，由 RuntimeEngine 在执行前设置
-    static SESSION_CWD: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
-}
-
-/// 设置当前线程的会话工作目录
-pub fn set_session_cwd(cwd: Option<PathBuf>) {
-    SESSION_CWD.with(|cell| *cell.borrow_mut() = cwd);
-}
-
-pub fn workspace_root() -> Result<PathBuf> {
-    // 优先使用会话级工作目录，回退到进程工作目录
-    SESSION_CWD.with(|cell| {
-        if let Some(ref cwd) = *cell.borrow()
-            && cwd.is_dir()
-        {
-            return Ok(cwd.clone());
-        }
-        std::env::current_dir().context("读取当前工作目录失败")
-    })
-}
-
-/// 读取当前线程的会话工作目录，供需要跟随会话 workspace 的子系统（如 stdio MCP 子进程）使用。
+/// 读取进程当前工作目录，供无显式 base 注入的回退路径使用。
 ///
-/// 仅当线程已通过 [`set_session_cwd`] 设置过有效目录时返回 `Some`；否则返回 `None`，
-/// 由调用方自行决定回退策略（典型做法是不设置 `current_dir`，让子进程继承宿主 cwd）。
-pub fn session_workspace_root() -> Option<PathBuf> {
-    SESSION_CWD.with(|cell| cell.borrow().as_ref().filter(|cwd| cwd.is_dir()).cloned())
+/// 历史上这里曾优先读取 thread-local `SESSION_CWD`，但该机制在 Core 重构
+/// （`fe5b026c`）后不再有注入方；会话工作目录改由插件显式注入，此函数仅作
+/// 进程 cwd 兜底。
+pub fn workspace_root() -> Result<PathBuf> {
+    std::env::current_dir().context("读取当前工作目录失败")
 }
 
 /// 应用自管存储根目录：`~/.tiangong/`。


### PR DESCRIPTION
## 背景

PR #247（fe5b026c）Core 资源模型重构删除了 \`apply_session_cwd\` 函数及其全部 6 处调用，导致 thread-local \`SESSION_CWD\` 恒为 \`None\`。依赖它的执行路径失效——最典型的是 stdio MCP 子进程的 \`cmd.current_dir()\` 永不执行，子进程（文件系统 / git 等 MCP）在错误的 cwd 下运行。

## 根因

thread-local 方案在当前架构下本就不可靠：共享 tokio runtime 仅 2 个 worker 线程，会被多个并发 turn task 复用；且 task 跨 await 点会切换线程。thread-local 状态完全不确定，即使补回注入点也无效。

正确做法是**显式注入**（与 command / fs 插件一致的模式）：\`McpPlugin.workspace\` / \`TerminalPlugin.workspace\` 字段本就由 core 的 \`set_workspace\` 注入，只是没被实际执行路径使用。

## 改动

### 1. stdio MCP 子进程 workspace 注入（\`cadca37e\`）

\`McpPlugin.workspace\` 沿调用链显式传递到 stdio 子进程：

\`\`\`
dispatch（快照 self.workspace）
  → execute_mcp_tool_call(workspace)
    → LocalMcpClient { workspace }
      → run_mcp_request(workspace)
        → run_stdio_mcp_request_async(workspace)
          → cmd.current_dir(workspace)
\`\`\`

- 在 \`dispatch\` 入口一次性快照（值传递），并发安全，不受 worker 线程复用影响
- capability 探测路径用 \`LocalMcpClient::default()\`（workspace=None），子进程继承宿主 cwd，行为不变
- 顺带清理失效的 thread-local 死代码（唯一调用方移除后）：删除 \`SESSION_CWD\` / \`set_session_cwd\` / \`session_workspace_root\`；\`workspace_root()\` 简化为只读进程 cwd

### 2. terminal 命令校验 workspace 兜底（\`eebd2e46\`）

\`TerminalPlugin.workspace\` 此前只服务于 \`normalize_nested_terminal_call\`（子 agent 嵌套调用的 cwd 强制改写）。主对话的 \`run_command\` 在 LLM 未传 cwd 时，\`validate_terminal_command\` 会回落到进程 cwd，路径越界 / 白名单校验用错误的 base——与 MCP 问题同构。

新增 \`fill_default_cwd\`：主对话 \`run_command\` / \`run_shell\` 在 LLM 未显式传 cwd 时，用 \`self.workspace\` 填充 \`call.arguments[\"cwd\"]\`，校验与 PTY 执行都落到会话 workspace。

- 仅当 call 未携带有效 cwd 时生效，LLM 显式传值不覆盖
- 子 session 仍走 \`normalize_nested_terminal_call\` 的强制覆盖语义（优先级更高，通过 \`or_else\` 短路）
- workspace 为 None 时不动（无会话上下文，保持原行为）

## 不在本次范围

调查中发现但**经确认不修**的问题：

- **PTY 创建用全局 default_cwd（缺陷 B）**：仅影响 GUI 桌面端，且只在「session 有独立 cwd + 没先打开终端面板 + Agent 直接执行命令」的边缘组合下，表现为 PTY shell 提示符的视觉不一致。Agent 命令执行的正确性已由本次的 \`fill_default_cwd\` + handler 既有的 \`cd\` 包装双层兜底保证。修复涉及 PTY 长存活模型的设计权衡，风险高于收益。
- **command 插件（CLI / Server 路径）**：经核实 workspace 注入链路完整正确（\`set_workspace\` → \`base()\` → \`current_dir\`，缺 workspace 硬报错），无需改动。

## 验证

- ✅ \`cargo check --workspace\`
- ✅ \`cargo clippy\`（无警告）
- ✅ \`cargo test\`：tiangong-core（81）+ tiangong-plugin-terminal（56，含新增 4 个 \`fill_default_cwd\` 单测）全通过
- ✅ \`cargo fmt --check\`
- ✅ pre-commit / pre-receive hooks 全通过