### PR TITLE
fix(frontend): 收敛会话列表刷新状态

### DIFF
--- a/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
+++ b/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
@@ -1,0 +1,262 @@
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Session } from '@/api/tauri';
+
+const mocks = vi.hoisted(() => {
+  const eventHandlers = new Map<string, Set<(event: { payload: unknown }) => void>>();
+  const unlisteners: ReturnType<typeof vi.fn>[] = [];
+  const makeUnlistener = () => {
+    const unlisten = vi.fn();
+    unlisteners.push(unlisten);
+    return unlisten;
+  };
+  const appWindow = {
+    scaleFactor: vi.fn(() => Promise.resolve(1)),
+    innerSize: vi.fn(() => Promise.resolve({ width: 1200, height: 800 })),
+    setSize: vi.fn(() => Promise.resolve()),
+    onResized: vi.fn(() => Promise.resolve(makeUnlistener())),
+  };
+  const api = {
+    getSessions: vi.fn(),
+    getReasoningEffort: vi.fn(() => Promise.resolve('medium')),
+    getWorkspaceDir: vi.fn(() => Promise.resolve('/workspace')),
+    onStreamEvent: vi.fn(() => Promise.resolve(makeUnlistener())),
+    browserHide: vi.fn(() => Promise.resolve()),
+  };
+  const listen = vi.fn((eventName: string, handler: (event: { payload: unknown }) => void) => {
+    let handlers = eventHandlers.get(eventName);
+    if (!handlers) {
+      handlers = new Set();
+      eventHandlers.set(eventName, handlers);
+    }
+    handlers.add(handler);
+    const unlisten = vi.fn(() => handlers!.delete(handler));
+    unlisteners.push(unlisten);
+    return Promise.resolve(unlisten);
+  });
+  return { api, appWindow, eventHandlers, listen, makeUnlistener, unlisteners };
+});
+
+vi.mock('@/api/tauri', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/tauri')>();
+  return { ...actual, api: { ...actual.api, ...mocks.api } };
+});
+
+vi.mock('@tauri-apps/api/event', () => ({ listen: mocks.listen }));
+vi.mock('@tauri-apps/api/window', () => ({
+  currentMonitor: vi.fn(() => Promise.resolve(null)),
+  getCurrentWindow: vi.fn(() => mocks.appWindow),
+  LogicalSize: class LogicalSize {
+    constructor(public width: number, public height: number) {}
+  },
+}));
+vi.mock('@/components/AppSidebar', () => ({ AppSidebar: () => null }));
+vi.mock('@/components/LazyComponents', () => ({
+  LazyMessageInput: () => null,
+  LazyMessageList: () => null,
+  LazyStatusPanel: () => null,
+}));
+vi.mock('@/components/TabsContainer', () => ({ TabsContainer: () => null }));
+vi.mock('@/components/ui/sidebar', () => ({
+  SidebarProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('@/hooks/useUpdateCheck', () => ({ useUpdateCheck: () => undefined }));
+vi.mock('@/utils/desktopNotification', () => ({
+  ensureDesktopNotificationPermission: vi.fn(() => Promise.resolve()),
+}));
+
+const { MainApp } = await import('@/pages/MainApp');
+const { useStore } = await import('@/store/useStore');
+const initialState = useStore.getInitialState();
+const getSessionsMock = vi.mocked(mocks.api.getSessions);
+
+function session(id: string, messageCount: number): Session {
+  return {
+    id,
+    title: id,
+    created_at: '2026-07-21 00:00:00',
+    updated_at: '2026-07-21 00:00:00',
+    message_count: messageCount,
+    cwd: '/tmp',
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flushMicrotasks() {
+  for (let index = 0; index < 30; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+function emitSessionsUpdated() {
+  for (const handler of mocks.eventHandlers.get('sessions_updated') ?? []) {
+    handler({ payload: undefined });
+  }
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+async function mountMainApp() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<MainApp />);
+    await flushMicrotasks();
+  });
+  expect(mocks.eventHandlers.get('sessions_updated')?.size).toBe(1);
+  getSessionsMock.mockClear();
+}
+
+describe('MainApp sessions_updated scheduling contract', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mocks.eventHandlers.clear();
+    mocks.unlisteners.length = 0;
+    mocks.listen.mockClear();
+    mocks.appWindow.onResized.mockClear();
+    mocks.api.onStreamEvent.mockClear();
+    mocks.api.getWorkspaceDir.mockClear();
+    mocks.api.getReasoningEffort.mockClear();
+    mocks.api.getReasoningEffort.mockResolvedValue('medium');
+    getSessionsMock.mockReset();
+    getSessionsMock.mockResolvedValue([session('a', 1)]);
+    useStore.setState({
+      ...initialState,
+      sessions: [session('a', 1)],
+      activeSessionId: 'a',
+      isNewConversation: false,
+    }, true);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root!.unmount());
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('一次事件突发只触发一次 protective 刷新', async () => {
+    await mountMainApp();
+
+    act(() => emitSessionsUpdated());
+    await advance(40);
+    act(() => emitSessionsUpdated());
+    await advance(79);
+    act(() => emitSessionsUpdated());
+    // 尾沿去抖：最后一次事件静默 120ms 后才触发，故需再推进一个完整窗口。
+    await advance(120);
+
+    expect(getSessionsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('去抖应等待最后一个事件静默 120ms 后再刷新', async () => {
+    await mountMainApp();
+
+    act(() => emitSessionsUpdated());
+    await advance(119);
+    act(() => emitSessionsUpdated());
+    await advance(1);
+    const callsAtFirstWindow = getSessionsMock.mock.calls.length;
+    await advance(119);
+
+    expect(callsAtFirstWindow).toBe(0);
+    expect(getSessionsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('后端返回错误时保留旧列表，下一次事件重新刷新后收敛', async () => {
+    // 请求失败时保留旧列表，收敛由下一次 sessions_updated 事件自然触发。
+    await mountMainApp();
+    getSessionsMock
+      .mockRejectedValueOnce(new Error('read_dir failed'))
+      .mockResolvedValueOnce([session('a', 2)]);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    act(() => emitSessionsUpdated());
+    await advance(120);
+    // 失败时保留挂载时的旧列表，不被错误清空。
+    expect(useStore.getState().sessions[0].message_count).toBe(1);
+    expect(getSessionsMock).toHaveBeenCalledTimes(1);
+
+    act(() => emitSessionsUpdated());
+    await advance(120);
+    expect(getSessionsMock).toHaveBeenCalledTimes(2);
+    expect(useStore.getState().sessions[0].message_count).toBe(2);
+    consoleError.mockRestore();
+  });
+
+  it('刷新进行中收到新事件时不并发读取，并在 settle 后执行一次 dirty rerun', async () => {
+    await mountMainApp();
+    const first = deferred<Session[]>();
+    const second = deferred<Session[]>();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    getSessionsMock
+      .mockImplementationOnce(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        const result = await first.promise;
+        inFlight -= 1;
+        return result;
+      })
+      .mockImplementationOnce(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        const result = await second.promise;
+        inFlight -= 1;
+        return result;
+      });
+
+    act(() => emitSessionsUpdated());
+    await advance(120);
+    act(() => emitSessionsUpdated());
+    await advance(120);
+    const observedMaxInFlight = maxInFlight;
+
+    first.resolve([session('a', 2)]);
+    second.resolve([session('a', 3)]);
+    await act(async () => flushMicrotasks());
+
+    expect(observedMaxInFlight).toBe(1);
+    expect(getSessionsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('unmount 会取消 pending timer 并注销所有已注册 listener', async () => {
+    await mountMainApp();
+    act(() => emitSessionsUpdated());
+    const registeredUnlisteners = [...mocks.unlisteners];
+
+    await act(async () => root!.unmount());
+    root = null;
+    await advance(120);
+
+    expect(getSessionsMock).not.toHaveBeenCalled();
+    expect(registeredUnlisteners.length).toBe(6);
+    for (const unlisten of registeredUnlisteners) {
+      expect(unlisten).toHaveBeenCalledTimes(1);
+    }
+    expect(mocks.eventHandlers.get('sessions_updated')?.size ?? 0).toBe(0);
+  });
+});

--- a/frontend/src/__tests__/sessionsRefresh.test.ts
+++ b/frontend/src/__tests__/sessionsRefresh.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LoadedSession, Session } from '@/api/tauri';
+
+vi.mock('@/api/tauri', () => {
+  const api = {
+    getSessions: vi.fn(),
+    getReasoningEffort: vi.fn(),
+    newSessionId: vi.fn(),
+    loadSession: vi.fn(),
+    getInputCache: vi.fn(),
+    switchSession: vi.fn(),
+    setInputCache: vi.fn(),
+    removeInputCache: vi.fn(),
+    terminalDestroySession: vi.fn(),
+  };
+  return { api };
+});
+
+const { useStore } = await import('@/store/useStore');
+const { api } = await import('@/api/tauri');
+const getSessionsMock = vi.mocked(api.getSessions);
+const getReasoningEffortMock = vi.mocked(api.getReasoningEffort);
+const newSessionIdMock = vi.mocked(api.newSessionId);
+const loadSessionMock = vi.mocked(api.loadSession);
+const getInputCacheMock = vi.mocked(api.getInputCache);
+const switchSessionMock = vi.mocked(api.switchSession);
+const setInputCacheMock = vi.mocked(api.setInputCache);
+const removeInputCacheMock = vi.mocked(api.removeInputCache);
+const terminalDestroySessionMock = vi.mocked(api.terminalDestroySession);
+const initialState = useStore.getInitialState();
+
+type StoreState = ReturnType<typeof useStore.getState>;
+
+function session(id: string, messageCount: number): Session {
+  return {
+    id,
+    title: id,
+    created_at: '2026-07-21 00:00:00',
+    updated_at: '2026-07-21 00:00:00',
+    message_count: messageCount,
+    cwd: '/tmp',
+  };
+}
+
+function loadedSession(id: string): LoadedSession {
+  return {
+    id,
+    messages: [{
+      id: `${id}-message`,
+      role: 'assistant',
+      content: [{ type: 'text', text: `message from ${id}` }],
+      reasoning_content: '',
+      created_at: '2026-07-21 00:00:00',
+    }],
+    token_stats: {
+      current_tokens: 1,
+      compression_threshold_tokens: 100,
+      context_limit_tokens: 200,
+      total_prompt_tokens: 1,
+      total_completion_tokens: 1,
+      total_tokens: 2,
+      active_agent_current_tokens: 0,
+      active_agent_id: null,
+      agent_current_tokens: {},
+      agent_token_usage: {},
+    },
+    cwd: `/workspace/${id}`,
+    reasoning_effort: 'high',
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function resetStore(overrides: Partial<StoreState> = {}) {
+  useStore.setState({
+    ...initialState,
+    isNewConversation: false,
+    ...overrides,
+  }, true);
+}
+
+describe('loadSessions refresh contract', () => {
+  beforeEach(() => {
+    getSessionsMock.mockReset();
+    getReasoningEffortMock.mockReset();
+    newSessionIdMock.mockReset();
+    loadSessionMock.mockReset();
+    getInputCacheMock.mockReset();
+    switchSessionMock.mockReset();
+    setInputCacheMock.mockReset();
+    removeInputCacheMock.mockReset();
+    terminalDestroySessionMock.mockReset();
+    getReasoningEffortMock.mockResolvedValue('medium');
+    newSessionIdMock.mockResolvedValue('new-session');
+    getInputCacheMock.mockResolvedValue({
+      text: '',
+      attachments: [],
+      is_sending: false,
+      revision: 0,
+    });
+    switchSessionMock.mockResolvedValue(undefined);
+    setInputCacheMock.mockImplementation(async (_cacheKey, cache) => cache);
+    removeInputCacheMock.mockResolvedValue(undefined);
+    terminalDestroySessionMock.mockResolvedValue(undefined);
+    resetStore();
+  });
+
+  it('普通刷新失败时保留现有列表和 active，并结束 loading', async () => {
+    const existing = [session('a', 5), session('b', 3)];
+    resetStore({ sessions: existing, activeSessionId: 'a' });
+    getSessionsMock.mockRejectedValue(new Error('scan failed'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await useStore.getState().loadSessions();
+
+    const state = useStore.getState();
+    expect(state.sessions).toBe(existing);
+    expect(state.activeSessionId).toBe('a');
+    expect(state.isLoadingSessions).toBe(false);
+    consoleError.mockRestore();
+  });
+
+  it('合法 Ok([]) 应清空失效 active 并初始化可发送的新对话', async () => {
+    resetStore({ sessions: [session('a', 5)], activeSessionId: 'a' });
+    getSessionsMock.mockResolvedValue([]);
+
+    await useStore.getState().loadSessions({ protective: true });
+
+    const state = useStore.getState();
+    expect(state.sessions).toEqual([]);
+    expect(state.activeSessionId).toBeNull();
+    expect(state.isNewConversation).toBe(true);
+    expect(state.newConversationId).toBe('new-session');
+    expect(state.inputCaches['new-session']).toEqual({
+      text: '',
+      attachments: [],
+      is_sending: false,
+      revision: 0,
+    });
+    expect(newSessionIdMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('active 被删除但仍有其他会话时执行完整切换并 hydration', async () => {
+    resetStore({
+      sessions: [session('a', 5), session('refresh-target', 3)],
+      activeSessionId: 'a',
+      messages: [{
+        id: 'old-message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'old message' }],
+        reasoning_content: '',
+        created_at: '2026-07-21 00:00:00',
+      }],
+      sessionCwd: '/workspace/a',
+    });
+    getSessionsMock.mockResolvedValue([session('refresh-target', 3)]);
+    loadSessionMock.mockResolvedValue(loadedSession('refresh-target'));
+
+    await useStore.getState().loadSessions({ protective: true });
+
+    const state = useStore.getState();
+    expect(state.sessions.map((item) => item.id)).toEqual(['refresh-target']);
+    expect(loadSessionMock).toHaveBeenCalledWith('refresh-target');
+    expect(switchSessionMock).toHaveBeenCalledWith('refresh-target');
+    expect(state.activeSessionId).toBe('refresh-target');
+    expect(state.isNewConversation).toBe(false);
+    expect(state.messages.map((message) => message.id)).toEqual(['refresh-target-message']);
+    expect(state.sessionCwd).toBe('/workspace/refresh-target');
+    expect(state.reasoningEffort).toBe('high');
+  });
+
+  it('edit 重发导致 message_count 合法下降时接受权威结果', async () => {
+    resetStore({
+      sessions: [session('a', 5), session('b', 3)],
+      activeSessionId: 'a',
+    });
+    getSessionsMock.mockResolvedValue([session('a', 2), session('b', 3)]);
+
+    await useStore.getState().loadSessions({ protective: true });
+
+    expect(useStore.getState().sessions.map((item) => item.message_count)).toEqual([2, 3]);
+  });
+
+  it('protective 刷新 pending 期间不翻转 loading', async () => {
+    const request = deferred<Session[]>();
+    resetStore({ sessions: [session('a', 1)], activeSessionId: 'a' });
+    getSessionsMock.mockReturnValue(request.promise);
+
+    const load = useStore.getState().loadSessions({ protective: true });
+    expect(useStore.getState().isLoadingSessions).toBe(false);
+
+    request.resolve([session('a', 2)]);
+    await load;
+    expect(useStore.getState().isLoadingSessions).toBe(false);
+  });
+
+  it('非 protective 刷新 pending 期间翻转 loading 并在完成后复位', async () => {
+    const request = deferred<Session[]>();
+    resetStore({ sessions: [session('a', 1)], activeSessionId: 'a' });
+    getSessionsMock.mockReturnValue(request.promise);
+
+    const load = useStore.getState().loadSessions();
+    expect(useStore.getState().isLoadingSessions).toBe(true);
+
+    request.resolve([session('a', 2)]);
+    await load;
+    expect(useStore.getState().isLoadingSessions).toBe(false);
+    expect(useStore.getState().sessions.map((item) => item.message_count)).toEqual([2]);
+  });
+
+  it('旧刷新晚到时不能覆盖较新的权威结果', async () => {
+    const older = deferred<Session[]>();
+    const newer = deferred<Session[]>();
+    resetStore({ sessions: [session('a', 1)], activeSessionId: 'a' });
+    getSessionsMock
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    const olderLoad = useStore.getState().loadSessions({ protective: true });
+    const newerLoad = useStore.getState().loadSessions({ protective: true });
+
+    newer.resolve([session('a', 3)]);
+    await newerLoad;
+    older.resolve([session('a', 2)]);
+    await olderLoad;
+
+    expect(useStore.getState().sessions[0].message_count).toBe(3);
+  });
+
+  it('并发普通刷新中任一请求仍 pending 时保持 loading', async () => {
+    const first = deferred<Session[]>();
+    const second = deferred<Session[]>();
+    resetStore({ sessions: [session('a', 1)], activeSessionId: 'a' });
+    getSessionsMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const firstLoad = useStore.getState().loadSessions();
+    const secondLoad = useStore.getState().loadSessions();
+    expect(useStore.getState().isLoadingSessions).toBe(true);
+
+    first.resolve([session('a', 2)]);
+    await firstLoad;
+    expect(useStore.getState().isLoadingSessions).toBe(true);
+
+    second.resolve([session('a', 3)]);
+    await secondLoad;
+    expect(useStore.getState().isLoadingSessions).toBe(false);
+  });
+
+  it('protective 请求不能清除另一个普通刷新持有的 loading', async () => {
+    const ordinary = deferred<Session[]>();
+    const protective = deferred<Session[]>();
+    resetStore({ sessions: [session('a', 1)], activeSessionId: 'a' });
+    getSessionsMock
+      .mockReturnValueOnce(ordinary.promise)
+      .mockReturnValueOnce(protective.promise);
+
+    const ordinaryLoad = useStore.getState().loadSessions();
+    const protectiveLoad = useStore.getState().loadSessions({ protective: true });
+    expect(useStore.getState().isLoadingSessions).toBe(true);
+
+    protective.resolve([session('a', 2)]);
+    await protectiveLoad;
+    expect(useStore.getState().isLoadingSessions).toBe(true);
+
+    ordinary.resolve([session('a', 3)]);
+    await ordinaryLoad;
+    expect(useStore.getState().isLoadingSessions).toBe(false);
+  });
+});

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -122,6 +122,11 @@ export function MainApp() {
   const unlistenRef = useRef<UnlistenFn | null>(null);
   const streamEventQueueRef = useRef<SessionStreamEvent[]>([]);
   const streamEventTimerRef = useRef<number | null>(null);
+  // sessions_updated 在一次 done 后会被连续 emit 多次（done/标题生成/Core 退役），
+  // 用尾沿去抖合并刷新，并在刷新期间收到新事件时串行补跑一次。
+  const sessionsRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sessionsRefreshInFlightRef = useRef(false);
+  const sessionsRefreshDirtyRef = useRef(false);
   const savedWindowWidthRef = useRef<number | null>(null);
   const workspaceExpandedForBrowserRef = useRef(false);
   const preferredSidebarOpenRef = useRef(true);
@@ -342,8 +347,38 @@ export function MainApp() {
       const unlistenStream = await api.onStreamEvent(scheduleStreamEvent);
 
       const { listen } = await import('@tauri-apps/api/event');
+      // 尾沿去抖 + in-flight 串行化 + dirty rerun。
+      // - 每次事件都重置 120ms 计时器，等事件静默后再刷新；
+      // - 刷新进行中来的事件标记 dirty，settle 后 rerun 一次，避免并发读取。
+      // 刷新失败时由 store 保留旧列表，后续事件会再次触发收敛。
+      const runProtectiveRefresh = async () => {
+        if (sessionsRefreshInFlightRef.current) {
+          sessionsRefreshDirtyRef.current = true;
+          return;
+        }
+        sessionsRefreshInFlightRef.current = true;
+        sessionsRefreshDirtyRef.current = false;
+        try {
+          await loadSessions({ protective: true });
+        } finally {
+          sessionsRefreshInFlightRef.current = false;
+          if (sessionsRefreshDirtyRef.current) {
+            sessionsRefreshDirtyRef.current = false;
+            runProtectiveRefresh();
+          }
+        }
+      };
+      const scheduleSessionsRefresh = () => {
+        if (sessionsRefreshTimerRef.current !== null) {
+          clearTimeout(sessionsRefreshTimerRef.current);
+        }
+        sessionsRefreshTimerRef.current = setTimeout(() => {
+          sessionsRefreshTimerRef.current = null;
+          runProtectiveRefresh();
+        }, 120);
+      };
       const unlistenSessions = await listen('sessions_updated', () => {
-        loadSessions();
+        scheduleSessionsRefresh();
       });
       const unlistenOpenSession = await listen<string>('desktop_notification_open_session', (event) => {
         const sessionId = event.payload;
@@ -463,6 +498,10 @@ export function MainApp() {
         streamEventTimerRef.current = null;
       }
       streamEventQueueRef.current = [];
+      if (sessionsRefreshTimerRef.current !== null) {
+        clearTimeout(sessionsRefreshTimerRef.current);
+        sessionsRefreshTimerRef.current = null;
+      }
       window.removeEventListener('tiangong:open-browser', onOpenBrowser);
       unlistenRef.current?.();
     };

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -31,6 +31,11 @@ let switchRequestVersion = 0;
 let newConversationRequestVersion = 0;
 const inputCacheSyncRequestVersions = new Map<string, number>();
 let switchCommitQueue: Promise<void> = Promise.resolve();
+// loadSessions 的请求版本：旧请求晚到时放弃写入，避免覆盖较新的权威结果。
+let loadSessionsRequestVersion = 0;
+// 普通刷新的 in-flight 计数：任一普通请求未结束时保持 loading，
+// protective 刷新不参与计数，避免它提前清除普通刷新持有的 loading。
+let ordinaryLoadInFlight = 0;
 
 interface SessionViewCache {
   hydrated: boolean;
@@ -826,7 +831,11 @@ export interface AppState {
   setPendingSettingsTab: (tab: string | null) => void;
 
   // 操作
-  loadSessions: () => Promise<void>;
+  // options.protective=true 用于 sessions_updated 触发的刷新：
+  // - 不参与 loading 引用计数（避免侧栏闪「加载中」，也不清除普通刷新持有的 loading）；
+  // - 旧请求晚到时放弃写入；active 不在权威列表时执行完整的会话切换或新对话初始化。
+  // 前端在 getSessions 失败时保留旧列表，避免瞬时请求错误清空侧栏。
+  loadSessions: (options?: { protective?: boolean }) => Promise<void>;
   startNewConversation: (targetCwd?: string) => Promise<void>;
   switchSession: (id: string) => Promise<void>;
   deleteSession: () => Promise<void>;
@@ -964,16 +973,52 @@ export const useStore = create<AppState>((set, get) => ({
   selectedAgentTab: null,
 
   // 加载会话列表
-  loadSessions: async () => {
-    set({ isLoadingSessions: true });
+  loadSessions: async (options?: { protective?: boolean }) => {
+    const isProtective = options?.protective === true;
+    // 普通刷新用引用计数维护 loading：任一普通请求未结束都保持 loading；
+    // protective 刷新（sessions_updated 触发）不参与计数，避免侧栏闪「加载中」，
+    // 也避免它提前清除普通刷新持有的 loading。
+    if (!isProtective) {
+      ordinaryLoadInFlight += 1;
+      if (ordinaryLoadInFlight === 1) {
+        set({ isLoadingSessions: true });
+      }
+    }
+    const requestVersion = ++loadSessionsRequestVersion;
+    const finishOrdinary = () => {
+      if (!isProtective) {
+        ordinaryLoadInFlight -= 1;
+        if (ordinaryLoadInFlight === 0) {
+          set({ isLoadingSessions: false });
+        }
+      }
+    };
     try {
       const sessions = await api.getSessions();
-      const { activeSessionId, isNewConversation } = get();
-      let newConversationId = get().newConversationId;
-      if (!activeSessionId && isNewConversation && !newConversationId) {
-        const requestVersion = ++newConversationRequestVersion;
+      // 旧请求晚到时放弃写入，避免覆盖较新的权威结果。
+      if (requestVersion !== loadSessionsRequestVersion) {
+        finishOrdinary();
+        return;
+      }
+      const prev = get();
+      const activeSessionId = prev.activeSessionId;
+      const activeSessionInvalid = !!activeSessionId
+        && !sessions.some((session) => session.id === activeSessionId);
+      let newConversationId = prev.newConversationId;
+      // 普通加载时为尚未初始化的新对话预生成 ID。active 失效由下方完整迁移处理。
+      if (
+        !isProtective &&
+        !activeSessionId &&
+        prev.isNewConversation &&
+        !newConversationId
+      ) {
+        const idRequestVersion = ++newConversationRequestVersion;
         const generatedId = await api.newSessionId();
-        newConversationId = requestVersion === newConversationRequestVersion
+        if (requestVersion !== loadSessionsRequestVersion) {
+          finishOrdinary();
+          return;
+        }
+        newConversationId = idRequestVersion === newConversationRequestVersion
           ? generatedId
           : get().newConversationId;
       }
@@ -982,10 +1027,9 @@ export const useStore = create<AppState>((set, get) => ({
         : null;
       set((state) => ({
         sessions,
-        isLoadingSessions: false,
-        isNewConversation: state.activeSessionId ? state.isNewConversation : true,
+        isLoadingSessions: ordinaryLoadInFlight === 0 ? false : state.isLoadingSessions,
         newConversationId,
-        sessionCwd: state.activeSessionId ? state.sessionCwd : state.workspaceDir,
+        sessionCwd: activeSessionId ? state.sessionCwd : state.workspaceDir,
         inputCaches: newConversationId && initialCache
           ? { ...state.inputCaches, [newConversationId]: initialCache }
           : state.inputCaches,
@@ -994,13 +1038,22 @@ export const useStore = create<AppState>((set, get) => ({
         syncInputCacheInBackground(get().syncInputCache(newConversationId, initialCache));
       }
 
-      // 从后端恢复思考强度设置
-      api.getReasoningEffort().then((effort) => {
-        set({ reasoningEffort: effort });
-      }).catch(console.error);
+      if (activeSessionInvalid) {
+        const nextSessionId = sessions[0]?.id;
+        if (nextSessionId) await get().switchSession(nextSessionId);
+        else await get().startNewConversation();
+      } else {
+        // 从后端恢复思考强度设置
+        api.getReasoningEffort().then((effort) => {
+          set({ reasoningEffort: effort });
+        }).catch(console.error);
+      }
+      finishOrdinary();
+      return;
     } catch (error) {
       console.error('加载会话失败:', error);
-      set({ isLoadingSessions: false });
+      finishOrdinary();
+      return;
     }
   },
 
@@ -1150,9 +1203,9 @@ export const useStore = create<AppState>((set, get) => ({
         return { sessions, inputCaches, sessionRunStatuses };
       });
 
-      const nextSessionId = sessions[0]?.id;
-      if (nextSessionId) await get().switchSession(nextSessionId);
-      else await get().startNewConversation();
+      // 删除任意会话后统一进入新对话态，而不是切到剩余列表的第一个——
+      // 用户主动删除通常意味着想开启新的上下文。
+      await get().startNewConversation();
     } catch (error) {
       console.error('删除会话失败:', error);
     }


### PR DESCRIPTION
## Summary

- 对连续 `sessions_updated` 事件做尾沿去抖，并串行执行刷新期间的 dirty rerun
- 为会话列表请求增加版本与 loading 引用计数，避免旧响应覆盖新列表或 protective 刷新提前结束 loading
- active 会话失效时复用完整的会话切换/新对话生命周期，确保消息、缓存、工作目录和后端 active 状态一致
- 增加列表刷新状态机和事件调度测试，覆盖失败保留、请求乱序、事件突发与卸载清理

## Testing

- `yarn --cwd frontend test`
- `yarn --cwd frontend build`
- `git diff --check`