### PR TITLE
fix(bots): 修复并发发布索引覆盖并开放第三方目录接入

### DIFF
--- a/.github/workflows/publish-bots-catalog.yml
+++ b/.github/workflows/publish-bots-catalog.yml
@@ -1,0 +1,64 @@
+name: Publish Bots Catalog
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "bots/index-catalog.json"
+      - ".github/workflows/publish-bots-catalog.yml"
+
+concurrency:
+  group: publish-bots-catalog
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish:
+    name: Publish catalog to Aliyun OSS
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate catalog
+        run: |
+          jq -e '
+            .version == 1 and
+            (.indexes | type == "array" and length > 0) and
+            all(.indexes[]; type == "string" and startswith("https://"))
+          ' bots/index-catalog.json >/dev/null
+
+      - name: Install ossutil
+        run: |
+          curl --connect-timeout 10 --max-time 120 -fsSL \
+            https://gosspublic.alicdn.com/ossutil/1.7.18/ossutil-v1.7.18-linux-amd64.zip \
+            -o /tmp/ossutil.zip
+          unzip -o /tmp/ossutil.zip -d /tmp/ossutil
+          sudo cp /tmp/ossutil/ossutil-v1.7.18-linux-amd64/ossutil /usr/local/bin/ossutil
+
+      - name: Configure ossutil
+        run: |
+          ossutil config \
+            -e oss-cn-hangzhou.aliyuncs.com \
+            -i "${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}" \
+            -k "${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}"
+
+      - name: Upload catalog
+        run: |
+          ossutil cp bots/index-catalog.json \
+            oss://silent-tiangong/bots-index/catalog.json -f
+
+      - name: Verify published catalog
+        run: |
+          curl --connect-timeout 10 --max-time 30 -fsSL \
+            https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/catalog.json \
+            -o /tmp/published-bots-catalog.json
+          cmp bots/index-catalog.json /tmp/published-bots-catalog.json

--- a/.github/workflows/release-feishu.yml
+++ b/.github/workflows/release-feishu.yml
@@ -4,8 +4,8 @@ name: Release Feishu Bot
 #
 # - tag 约定：bot-feishu-v<version>（如 bot-feishu-v0.1.0）
 # - 制品挂在独立的 GitHub Release（bot-feishu-v*）
-# - bots-index.json 采用 merge 式更新：只替换/新增飞书条目，保留其他 bot 不变
-# - OSS 根目录的 bots-index.json 为权威源
+# - Release 附带只包含飞书条目的 bots-index.json
+# - OSS 使用 bots-index/feishu.json，发布时不读写其他 bot 的索引
 
 on:
   workflow_dispatch:
@@ -82,7 +82,7 @@ jobs:
         include:
           - platform: macos-latest
             target: aarch64-apple-darwin
-          - platform: macos-13
+          - platform: macos-15-intel
             target: x86_64-apple-darwin
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
@@ -156,37 +156,24 @@ jobs:
             ${{ runner.temp }}/tiangong-bot-feishu-*
 
   generate-bots-index:
-    name: Update bots-index.json
+    name: Generate bots-index.json
     needs: [resolve, publish-bot]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download current bots-index.json from OSS
-        id: current
-        continue-on-error: true
-        run: |
-          mkdir -p artifacts
-          curl -fsSL -o artifacts/bots-index.json \
-            "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index.json" || true
-          if [[ -f artifacts/bots-index.json ]]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo '{"version":1,"bots":[]}' > artifacts/bots-index.json
-          fi
-
       - name: Download bot artifacts + checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          mkdir -p artifacts
           cd artifacts
           gh release download "${{ needs.resolve.outputs.tag }}" --repo "${{ github.repository }}" \
             --pattern "tiangong-bot-feishu-*" \
             --clobber
 
-      - name: Build merged bots-index.json
+      - name: Build bots-index.json
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
           TAG: ${{ needs.resolve.outputs.tag }}
@@ -194,7 +181,14 @@ jobs:
           oss_base="https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots/${TAG}"
           bot_id="feishu"
 
-          read_sha() { cat "artifacts/$1.sha256" 2>/dev/null || echo ""; }
+          read_sha() {
+            local checksum_file="artifacts/$1.sha256"
+            if [[ ! -s "$checksum_file" ]]; then
+              echo "::error::缺少校验文件：$checksum_file" >&2
+              exit 1
+            fi
+            tr -d '\r\n' < "$checksum_file"
+          }
 
           darwin_aarch64_sha=$(read_sha tiangong-bot-${bot_id}-aarch64-apple-darwin)
           darwin_x86_64_sha=$(read_sha tiangong-bot-${bot_id}-x86_64-apple-darwin)
@@ -235,13 +229,10 @@ jobs:
               min_app_version: $min_app_version
             }')
 
-          # Merge：从现有 index 中移除同 id 条目，追加当前条目
-          jq --argjson entry "$current_entry" --arg id "$bot_id" \
-            '.bots = ((.bots // []) | map(select(.id != $id))) + [$entry]' \
-            artifacts/bots-index.json > artifacts/bots-index.json.new
-          mv artifacts/bots-index.json.new artifacts/bots-index.json
+          jq -n --argjson entry "$current_entry" \
+            '{version: 1, bots: [$entry]}' > artifacts/bots-index.json
 
-          echo "--- merged bots-index.json ---"
+          echo "--- bots-index.json ---"
           cat artifacts/bots-index.json
 
       - name: Attach bots-index.json to Release
@@ -297,8 +288,8 @@ jobs:
             fi
           done
 
-      - name: Upload bots-index.json (root)
+      - name: Upload bot index
         working-directory: oss-upload
         run: |
-          echo "Uploading bots-index.json to OSS root"
-          ossutil cp bots-index.json "oss://silent-tiangong/bots-index.json" -f
+          echo "Uploading bots-index.json to OSS: bots-index/${BOT_ID}.json"
+          ossutil cp bots-index.json "oss://silent-tiangong/bots-index/${BOT_ID}.json" -f

--- a/.github/workflows/release-qq.yml
+++ b/.github/workflows/release-qq.yml
@@ -4,8 +4,8 @@ name: Release QQ Bot
 #
 # - tag 约定：bot-qq-v<version>（如 bot-qq-v0.1.0）
 # - 制品挂在独立的 GitHub Release（bot-qq-v*）
-# - bots-index.json 采用 merge 式更新：只替换/新增 QQ 条目，保留其他 bot 不变
-# - OSS 根目录的 bots-index.json 为权威源
+# - Release 附带只包含 QQ 条目的 bots-index.json
+# - OSS 使用 bots-index/qq.json，发布时不读写其他 bot 的索引
 
 on:
   workflow_dispatch:
@@ -82,7 +82,7 @@ jobs:
         include:
           - platform: macos-latest
             target: aarch64-apple-darwin
-          - platform: macos-13
+          - platform: macos-15-intel
             target: x86_64-apple-darwin
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
@@ -156,37 +156,24 @@ jobs:
             ${{ runner.temp }}/tiangong-bot-qq-*
 
   generate-bots-index:
-    name: Update bots-index.json
+    name: Generate bots-index.json
     needs: [resolve, publish-bot]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download current bots-index.json from OSS
-        id: current
-        continue-on-error: true
-        run: |
-          mkdir -p artifacts
-          curl -fsSL -o artifacts/bots-index.json \
-            "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index.json" || true
-          if [[ -f artifacts/bots-index.json ]]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo '{"version":1,"bots":[]}' > artifacts/bots-index.json
-          fi
-
       - name: Download bot artifacts + checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          mkdir -p artifacts
           cd artifacts
           gh release download "${{ needs.resolve.outputs.tag }}" --repo "${{ github.repository }}" \
             --pattern "tiangong-bot-qq-*" \
             --clobber
 
-      - name: Build merged bots-index.json
+      - name: Build bots-index.json
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
           TAG: ${{ needs.resolve.outputs.tag }}
@@ -194,7 +181,14 @@ jobs:
           oss_base="https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots/${TAG}"
           bot_id="qq"
 
-          read_sha() { cat "artifacts/$1.sha256" 2>/dev/null || echo ""; }
+          read_sha() {
+            local checksum_file="artifacts/$1.sha256"
+            if [[ ! -s "$checksum_file" ]]; then
+              echo "::error::缺少校验文件：$checksum_file" >&2
+              exit 1
+            fi
+            tr -d '\r\n' < "$checksum_file"
+          }
 
           darwin_aarch64_sha=$(read_sha tiangong-bot-${bot_id}-aarch64-apple-darwin)
           darwin_x86_64_sha=$(read_sha tiangong-bot-${bot_id}-x86_64-apple-darwin)
@@ -235,13 +229,10 @@ jobs:
               min_app_version: $min_app_version
             }')
 
-          # Merge：从现有 index 中移除同 id 条目，追加当前条目
-          jq --argjson entry "$current_entry" --arg id "$bot_id" \
-            '.bots = ((.bots // []) | map(select(.id != $id))) + [$entry]' \
-            artifacts/bots-index.json > artifacts/bots-index.json.new
-          mv artifacts/bots-index.json.new artifacts/bots-index.json
+          jq -n --argjson entry "$current_entry" \
+            '{version: 1, bots: [$entry]}' > artifacts/bots-index.json
 
-          echo "--- merged bots-index.json ---"
+          echo "--- bots-index.json ---"
           cat artifacts/bots-index.json
 
       - name: Attach bots-index.json to Release
@@ -297,8 +288,8 @@ jobs:
             fi
           done
 
-      - name: Upload bots-index.json (root)
+      - name: Upload bot index
         working-directory: oss-upload
         run: |
-          echo "Uploading bots-index.json to OSS root"
-          ossutil cp bots-index.json "oss://silent-tiangong/bots-index.json" -f
+          echo "Uploading bots-index.json to OSS: bots-index/${BOT_ID}.json"
+          ossutil cp bots-index.json "oss://silent-tiangong/bots-index/${BOT_ID}.json" -f

--- a/.github/workflows/release-weixin.yml
+++ b/.github/workflows/release-weixin.yml
@@ -4,8 +4,8 @@ name: Release Weixin Bot
 #
 # - tag 约定：bot-weixin-v<version>（如 bot-weixin-v0.1.0）
 # - 制品挂在独立的 GitHub Release（bot-weixin-v*）
-# - bots-index.json 采用 merge 式更新：只替换/新增微信条目，保留其他 bot 不变
-# - OSS 根目录的 bots-index.json 为权威源
+# - Release 附带只包含微信条目的 bots-index.json
+# - OSS 使用 bots-index/weixin.json，发布时不读写其他 bot 的索引
 
 on:
   workflow_dispatch:
@@ -82,7 +82,7 @@ jobs:
         include:
           - platform: macos-latest
             target: aarch64-apple-darwin
-          - platform: macos-13
+          - platform: macos-15-intel
             target: x86_64-apple-darwin
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
@@ -156,37 +156,24 @@ jobs:
             ${{ runner.temp }}/tiangong-bot-weixin-*
 
   generate-bots-index:
-    name: Update bots-index.json
+    name: Generate bots-index.json
     needs: [resolve, publish-bot]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download current bots-index.json from OSS
-        id: current
-        continue-on-error: true
-        run: |
-          mkdir -p artifacts
-          curl -fsSL -o artifacts/bots-index.json \
-            "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index.json" || true
-          if [[ -f artifacts/bots-index.json ]]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo '{"version":1,"bots":[]}' > artifacts/bots-index.json
-          fi
-
       - name: Download bot artifacts + checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          mkdir -p artifacts
           cd artifacts
           gh release download "${{ needs.resolve.outputs.tag }}" --repo "${{ github.repository }}" \
             --pattern "tiangong-bot-weixin-*" \
             --clobber
 
-      - name: Build merged bots-index.json
+      - name: Build bots-index.json
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
           TAG: ${{ needs.resolve.outputs.tag }}
@@ -194,7 +181,14 @@ jobs:
           oss_base="https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots/${TAG}"
           bot_id="weixin"
 
-          read_sha() { cat "artifacts/$1.sha256" 2>/dev/null || echo ""; }
+          read_sha() {
+            local checksum_file="artifacts/$1.sha256"
+            if [[ ! -s "$checksum_file" ]]; then
+              echo "::error::缺少校验文件：$checksum_file" >&2
+              exit 1
+            fi
+            tr -d '\r\n' < "$checksum_file"
+          }
 
           darwin_aarch64_sha=$(read_sha tiangong-bot-${bot_id}-aarch64-apple-darwin)
           darwin_x86_64_sha=$(read_sha tiangong-bot-${bot_id}-x86_64-apple-darwin)
@@ -235,13 +229,10 @@ jobs:
               min_app_version: $min_app_version
             }')
 
-          # Merge：从现有 index 中移除同 id 条目，追加当前条目
-          jq --argjson entry "$current_entry" --arg id "$bot_id" \
-            '.bots = ((.bots // []) | map(select(.id != $id))) + [$entry]' \
-            artifacts/bots-index.json > artifacts/bots-index.json.new
-          mv artifacts/bots-index.json.new artifacts/bots-index.json
+          jq -n --argjson entry "$current_entry" \
+            '{version: 1, bots: [$entry]}' > artifacts/bots-index.json
 
-          echo "--- merged bots-index.json ---"
+          echo "--- bots-index.json ---"
           cat artifacts/bots-index.json
 
       - name: Attach bots-index.json to Release
@@ -297,8 +288,8 @@ jobs:
             fi
           done
 
-      - name: Upload bots-index.json (root)
+      - name: Upload bot index
         working-directory: oss-upload
         run: |
-          echo "Uploading bots-index.json to OSS root"
-          ossutil cp bots-index.json "oss://silent-tiangong/bots-index.json" -f
+          echo "Uploading bots-index.json to OSS: bots-index/${BOT_ID}.json"
+          ossutil cp bots-index.json "oss://silent-tiangong/bots-index/${BOT_ID}.json" -f

--- a/bots/README.md
+++ b/bots/README.md
@@ -41,7 +41,8 @@ bots/
 - tag 约定：`bot-<bot-id>-v<version>`，如 `bot-feishu-v0.1.0`、`bot-weixin-v0.1.0`、`bot-qq-v0.1.0`。
 - 新增 bot 时复制一个已有的 workflow，把 bot id、名称、描述改为新 bot 即可。
 - 每个 bot 在 OSS 使用独立索引对象：`bots-index/<bot-id>.json`。发布流程只写自己的对象，不读取或覆盖其他 bot 的索引。
-- 主程序从 `crates/tiangong-bots/src/manifest.rs` 声明的端点读取并合并索引；新增 bot 时需要同时补充该端点。
+- `bots-index/catalog.json` 是索引目录，只列出各独立索引地址；主程序固定读取这一个目录，再读取并合并其中的索引。
+- 索引目录的源码是 `bots/index-catalog.json`，由 `.github/workflows/publish-bots-catalog.yml` 独立发布。新增或下线 bot 时只更新目录，不需要发布主程序。
 - GitHub Release 作为产物归档（人可查、CI 可用），每个 Release 只附带本 bot 的 `bots-index.json`。
 
 ### 发版流程
@@ -50,6 +51,7 @@ bots/
 2. CI 交叉编译该 bot 的 4 平台制品 → 上传到对应 Release。
 3. `generate-bots-index` job 汇总该 bot 各平台 SHA256，生成只包含当前 bot 的索引并附到 Release。
 4. `upload-to-oss` job 上传该 bot 制品到 `bots/bot-<bot-id>-v0.1.0/`，并把索引上传到 `bots-index/<bot-id>.json`。
+5. 新增或下线 bot 时修改 `bots/index-catalog.json`；合并到主分支后，目录发布流程会更新 `bots-index/catalog.json`。
 
 ## 凭证注入约定
 

--- a/bots/README.md
+++ b/bots/README.md
@@ -40,17 +40,16 @@ bots/
 - 每个 bot 对应一个 workflow：`.github/workflows/release-<bot-id>.yml`（如 `release-feishu.yml`、`release-weixin.yml`、`release-qq.yml`）。
 - tag 约定：`bot-<bot-id>-v<version>`，如 `bot-feishu-v0.1.0`、`bot-weixin-v0.1.0`、`bot-qq-v0.1.0`。
 - 新增 bot 时复制一个已有的 workflow，把 bot id、名称、描述改为新 bot 即可。
-- `bots-index.json` 采用 **merge 式更新**：发版时从 OSS 拉取现有 index，替换/新增当前 bot 条目，保留其他 bot 条目不变。
-- `bots-index.json` 以**阿里云 OSS 根目录为权威源**（`silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index.json`），
-  因为 GitHub 的 `releases/latest` 指向主程序 tag，无法用于解析 bot 的最新版本。
-  GitHub Release 作为产物归档（人可查、CI 可用）。格式见 `crates/tiangong-bots/src/manifest.rs`。
+- 每个 bot 在 OSS 使用独立索引对象：`bots-index/<bot-id>.json`。发布流程只写自己的对象，不读取或覆盖其他 bot 的索引。
+- 主程序从 `crates/tiangong-bots/src/manifest.rs` 声明的端点读取并合并索引；新增 bot 时需要同时补充该端点。
+- GitHub Release 作为产物归档（人可查、CI 可用），每个 Release 只附带本 bot 的 `bots-index.json`。
 
 ### 发版流程
 
 1. 推送 `bot-<bot-id>-v0.1.0` tag（如 `bot-weixin-v0.1.0`），或 Actions 页面手动触发对应 bot 的 workflow 并输入 tag。
 2. CI 交叉编译该 bot 的 4 平台制品 → 上传到对应 Release。
-3. `generate-bots-index` job 汇总该 bot 各平台 SHA256 → 从 OSS 拉取现有 index → merge 当前 bot 条目 → 附到 Release。
-4. `upload-to-oss` job 上传该 bot 制品到 `bots/bot-<bot-id>-v0.1.0/` + 更新后的 `bots-index.json` 到 OSS 根。
+3. `generate-bots-index` job 汇总该 bot 各平台 SHA256，生成只包含当前 bot 的索引并附到 Release。
+4. `upload-to-oss` job 上传该 bot 制品到 `bots/bot-<bot-id>-v0.1.0/`，并把索引上传到 `bots-index/<bot-id>.json`。
 
 ## 凭证注入约定
 

--- a/bots/README.md
+++ b/bots/README.md
@@ -53,6 +53,19 @@ bots/
 4. `upload-to-oss` job 上传该 bot 制品到 `bots/bot-<bot-id>-v0.1.0/`，并把索引上传到 `bots-index/<bot-id>.json`。
 5. 新增或下线 bot 时修改 `bots/index-catalog.json`；合并到主分支后，目录发布流程会更新 `bots-index/catalog.json`。
 
+## 第三方 Bot 接入
+
+第三方 Bot 的源码和发布流程可以完全放在自己的仓库中，也不限制实现语言。接入时需要满足以下约定：
+
+1. 提供 Windows、macOS 和 Linux 对应平台的独立可执行文件及 SHA-256。
+2. 可执行文件支持 `--describe`，输出天工可识别的配置 schema；需要扫码时可选支持 `--provision-begin` 和 `--provision-poll`。
+3. 正常运行时读取天工注入的 `TIANGONG_URL`、`TIANGONG_TOKEN` 及 schema 声明的配置环境变量，并通过 Server API 收发消息。
+4. 在第三方自己的 HTTPS 地址发布独立 `bots-index.json`；索引中的 `id` 必须与 `--describe` 的 `artifact_id` 一致、全局唯一，并符合小写字母和数字组成、总长 1～64 位的规则。
+5. 向 `bots/index-catalog.json` 提交该索引地址。目录合并并发布后，天工会自动发现该 Bot；后续版本只需更新第三方自己的索引，不需要再次修改天工或发布主程序。
+
+官方目录中的第三方 Bot 需要经过代码与制品来源审核。允许用户自行添加未经审核索引源属于另一项安全边界更大的功能，不在当前发布流程内。
+多个索引声明相同 `id` 时按目录顺序保留第一项，后续同名项不会覆盖已有 Bot；官方索引应排在第三方索引之前。
+
 ## 凭证注入约定
 
 主程序 spawn bot 时按 schema 注入手工配置的环境变量，并始终自动注入天工连接信息：

--- a/bots/index-catalog.json
+++ b/bots/index-catalog.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "indexes": [
+    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/feishu.json",
+    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/weixin.json",
+    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/qq.json"
+  ]
+}

--- a/crates/tiangong-bots/src/downloader.rs
+++ b/crates/tiangong-bots/src/downloader.rs
@@ -1,5 +1,6 @@
 //! bot 制品下载器——合并独立 bot 索引、下载平台制品、SHA256 校验。
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -34,32 +35,41 @@ impl Downloader {
             .map(|endpoint| async move { (endpoint, self.fetch_index_from(endpoint).await) });
         let results = futures_util::future::join_all(requests).await;
 
-        let mut merged: Option<BotsIndex> = None;
+        let mut version: Option<u32> = None;
+        let mut bots = Vec::new();
+        let mut seen_ids = HashSet::new();
         let mut last_err: Option<anyhow::Error> = None;
         for (endpoint, result) in results {
             match result {
-                Ok(index) => match &mut merged {
-                    Some(current) => {
-                        if current.version != index.version {
+                Ok(index) => {
+                    if let Some(current_version) = version {
+                        if current_version != index.version {
                             tracing::warn!(
                                 "忽略 bot 索引格式版本差异（{endpoint}）：期望 {}，实际 {}",
-                                current.version,
+                                current_version,
                                 index.version
                             );
                         }
-                        current.bots.extend(index.bots);
+                    } else {
+                        version = Some(index.version);
                     }
-                    None => merged = Some(index),
-                },
+                    for bot in index.bots {
+                        if seen_ids.insert(bot.id.clone()) {
+                            bots.push(bot);
+                        } else {
+                            tracing::warn!("忽略 bot 索引中的重复 id（{endpoint}）：{}", bot.id);
+                        }
+                    }
+                }
                 Err(err) => {
                     tracing::warn!("拉取 bots-index 失败（{endpoint}）：{err}");
                     last_err = Some(err);
                 }
             }
         }
-        if let Some(mut index) = merged {
-            index.bots.sort_by(|left, right| left.id.cmp(&right.id));
-            return Ok(index);
+        if let Some(version) = version {
+            bots.sort_by(|left, right| left.id.cmp(&right.id));
+            return Ok(BotsIndex { version, bots });
         }
 
         Err(last_err.unwrap_or_else(|| anyhow!("无可用 bot 索引端点")))

--- a/crates/tiangong-bots/src/downloader.rs
+++ b/crates/tiangong-bots/src/downloader.rs
@@ -1,6 +1,4 @@
-//! bot 制品下载器——拉取 bots-index.json、下载平台制品、SHA256 校验。
-//!
-//! 端点复用 `tiangong-entry::update` 的 GitHub + 阿里云 OSS 双端点 fallback。
+//! bot 制品下载器——合并独立 bot 索引、下载平台制品、SHA256 校验。
 
 use std::path::Path;
 
@@ -27,19 +25,43 @@ impl Downloader {
         Ok(Self { http })
     }
 
-    /// 拉取 bots-index.json（双端点 fallback）。
+    /// 并行拉取各 bot 的独立索引，返回所有成功结果的合集。
     pub async fn fetch_index(&self) -> Result<BotsIndex> {
+        let requests = BOTS_INDEX_ENDPOINTS
+            .iter()
+            .copied()
+            .map(|endpoint| async move { (endpoint, self.fetch_index_from(endpoint).await) });
+        let results = futures_util::future::join_all(requests).await;
+
+        let mut merged: Option<BotsIndex> = None;
         let mut last_err: Option<anyhow::Error> = None;
-        for endpoint in BOTS_INDEX_ENDPOINTS {
-            match self.fetch_index_from(endpoint).await {
-                Ok(index) => return Ok(index),
+        for (endpoint, result) in results {
+            match result {
+                Ok(index) => match &mut merged {
+                    Some(current) => {
+                        if current.version != index.version {
+                            tracing::warn!(
+                                "忽略 bot 索引格式版本差异（{endpoint}）：期望 {}，实际 {}",
+                                current.version,
+                                index.version
+                            );
+                        }
+                        current.bots.extend(index.bots);
+                    }
+                    None => merged = Some(index),
+                },
                 Err(err) => {
                     tracing::warn!("拉取 bots-index 失败（{endpoint}）：{err}");
                     last_err = Some(err);
                 }
             }
         }
-        Err(last_err.unwrap_or_else(|| anyhow!("无可用 bots-index 端点")))
+        if let Some(mut index) = merged {
+            index.bots.sort_by(|left, right| left.id.cmp(&right.id));
+            return Ok(index);
+        }
+
+        Err(last_err.unwrap_or_else(|| anyhow!("无可用 bot 索引端点")))
     }
 
     async fn fetch_index_from(&self, endpoint: &str) -> Result<BotsIndex> {
@@ -56,6 +78,9 @@ impl Downloader {
             .json()
             .await
             .with_context(|| format!("解析 bots-index 失败：{endpoint}"))?;
+        if index.bots.is_empty() {
+            bail!("bots-index 不含任何 bot：{endpoint}");
+        }
         Ok(index)
     }
 

--- a/crates/tiangong-bots/src/downloader.rs
+++ b/crates/tiangong-bots/src/downloader.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use anyhow::{Context, Result, anyhow, bail};
 use sha2::{Digest, Sha256};
 
-use crate::manifest::{BOTS_INDEX_ENDPOINTS, BotManifest, BotsIndex};
+use crate::manifest::{BOTS_INDEX_CATALOG_ENDPOINT, BotManifest, BotsIndex, BotsIndexCatalog};
 use crate::paths;
 
 /// 下载进度回调：`(已下载字节数, 总字节数)`。
@@ -27,9 +27,10 @@ impl Downloader {
 
     /// 并行拉取各 bot 的独立索引，返回所有成功结果的合集。
     pub async fn fetch_index(&self) -> Result<BotsIndex> {
-        let requests = BOTS_INDEX_ENDPOINTS
+        let catalog = self.fetch_index_catalog().await?;
+        let requests = catalog
+            .indexes
             .iter()
-            .copied()
             .map(|endpoint| async move { (endpoint, self.fetch_index_from(endpoint).await) });
         let results = futures_util::future::join_all(requests).await;
 
@@ -62,6 +63,30 @@ impl Downloader {
         }
 
         Err(last_err.unwrap_or_else(|| anyhow!("无可用 bot 索引端点")))
+    }
+
+    async fn fetch_index_catalog(&self) -> Result<BotsIndexCatalog> {
+        let endpoint = BOTS_INDEX_CATALOG_ENDPOINT;
+        let resp = self
+            .http
+            .get(endpoint)
+            .send()
+            .await
+            .with_context(|| format!("请求 bot 索引目录失败：{endpoint}"))?;
+        if !resp.status().is_success() {
+            bail!("bot 索引目录响应非 2xx：{} {endpoint}", resp.status());
+        }
+        let catalog: BotsIndexCatalog = resp
+            .json()
+            .await
+            .with_context(|| format!("解析 bot 索引目录失败：{endpoint}"))?;
+        if catalog.version != 1 {
+            bail!("不支持的 bot 索引目录版本：{}", catalog.version);
+        }
+        if catalog.indexes.is_empty() {
+            bail!("bot 索引目录不含任何索引：{endpoint}");
+        }
+        Ok(catalog)
     }
 
     async fn fetch_index_from(&self, endpoint: &str) -> Result<BotsIndex> {

--- a/crates/tiangong-bots/src/manifest.rs
+++ b/crates/tiangong-bots/src/manifest.rs
@@ -1,7 +1,7 @@
 //! bot 制品清单（`bots-index.json`）模型与平台标识。
 //!
 //! bot 与主程序独立发版，每个 bot 在阿里云 OSS 保存自己的索引对象。
-//! 主程序启动时合并所有可用索引，以渲染“可安装 bot 列表”。
+//! 主程序从目录文件发现这些对象并合并所有可用索引，以渲染“可安装 bot 列表”。
 
 use std::collections::BTreeMap;
 
@@ -9,12 +9,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::ConfigFieldSchema;
 
-/// 各 bot 的独立索引端点。
-pub const BOTS_INDEX_ENDPOINTS: &[&str] = &[
-    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/feishu.json",
-    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/weixin.json",
-    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/qq.json",
-];
+/// bot 索引目录端点。
+pub const BOTS_INDEX_CATALOG_ENDPOINT: &str =
+    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/catalog.json";
+
+/// bot 索引目录。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BotsIndexCatalog {
+    /// 目录格式版本。
+    pub version: u32,
+    /// 各 bot 独立索引的完整 URL。
+    pub indexes: Vec<String>,
+}
 
 /// bots-index.json 顶层结构。
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/tiangong-bots/src/manifest.rs
+++ b/crates/tiangong-bots/src/manifest.rs
@@ -1,9 +1,7 @@
 //! bot 制品清单（`bots-index.json`）模型与平台标识。
 //!
-//! bot 与主程序**独立发版**（tag 前缀 `bots-v*`，见 `.github/workflows/release-bots.yml`），
-//! 因此 GitHub 的 `releases/latest`（指向主程序 tag）无法用于解析 bot index。
-//! `bots-index.json` 以**阿里云 OSS 根目录为权威源**，主程序启动时拉取以渲染
-//! "可安装 bot 列表"。
+//! bot 与主程序独立发版，每个 bot 在阿里云 OSS 保存自己的索引对象。
+//! 主程序启动时合并所有可用索引，以渲染“可安装 bot 列表”。
 
 use std::collections::BTreeMap;
 
@@ -11,12 +9,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::ConfigFieldSchema;
 
-/// bots-index.json 端点。
-///
-/// 以 OSS 根目录为权威源（bot 独立发版，GitHub latest 机制不可用）。
-/// OSS 不可达时回退到 OSS 的 HTTPS 根路径（同一源，仅作为重试）。
-pub const BOTS_INDEX_ENDPOINTS: &[&str] =
-    &["https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index.json"];
+/// 各 bot 的独立索引端点。
+pub const BOTS_INDEX_ENDPOINTS: &[&str] = &[
+    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/feishu.json",
+    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/weixin.json",
+    "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/bots-index/qq.json",
+];
 
 /// bots-index.json 顶层结构。
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## 变更内容

- 飞书、微信、QQ 分别发布到独立 OSS 索引，不再并发读写同一个根索引。
- 主程序只固定一个远端目录地址，由目录发现并合并独立 Bot 索引；新增或下线 Bot 不再需要发布主程序。
- 增加独立目录发布流程，目录文件合并到主分支后自动上传 OSS。
- Intel Mac 构建环境由已下线的 `macos-13` 更新为 `macos-15-intel`。
- 重复 Bot ID 按目录顺序保留第一项，后续同名项不能覆盖官方 Bot。
- 补充第三方 Bot 在外部仓库开发、托管索引并申请加入官方目录的接入约定。

## 问题原因

首次同时推送三个 `v0.1.0` tag 后确认了两个问题：

1. 三条发布流程共享根索引，首次 404 会留下空文件，并发发布还存在最后写入覆盖前序结果的风险。
2. `macos-13` runner 已下线，三条 Intel Mac 构建永久排队，导致发布无法完成。

## 验证结果

- `cargo fmt --all -- --check`
- `cargo check -p tiangong-bots`
- `cargo clippy -p tiangong-bots --all-targets -- -D warnings`
- `cargo test -p tiangong-bots`：31 项通过
- 推送钩子的 changed-crates check、clippy、nextest 全部通过
- 三个 Bot 的修复后 GitHub Actions 发布全部成功
- 三个 Release 均包含 4 个平台制品、4 个校验文件和 1 个索引文件
- OSS 上三个独立索引均为 `0.1.0`，各包含 4 个平台
- 从 OSS 实际下载全部 12 个制品并逐一核对 SHA-256，全部一致
- 在 Apple Silicon 上实际执行三个当前平台制品的 `--describe`，均返回正确 `artifact_id`

## 发布说明

`publish-bots-catalog.yml` 是新增工作流，GitHub 只有在它进入默认分支后才允许手动触发。合并本 PR 时的 `push` 事件会自动把 `bots/index-catalog.json` 发布到 `bots-index/catalog.json`。
