### PR TITLE
ci(bots): 支持第三方 Bot 目录 PR 校验

### DIFF
--- a/.github/workflows/publish-bots-catalog.yml
+++ b/.github/workflows/publish-bots-catalog.yml
@@ -2,6 +2,10 @@ name: Publish Bots Catalog
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - "bots/index-catalog.json"
+      - ".github/workflows/publish-bots-catalog.yml"
   push:
     branches:
       - main
@@ -10,7 +14,7 @@ on:
       - ".github/workflows/publish-bots-catalog.yml"
 
 concurrency:
-  group: publish-bots-catalog
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -21,20 +25,76 @@ defaults:
     shell: bash
 
 jobs:
-  publish:
-    name: Publish catalog to Aliyun OSS
+  validate:
+    name: Validate bots catalog
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate catalog
+      - name: Validate catalog structure
         run: |
+          set -euo pipefail
           jq -e '
             .version == 1 and
             (.indexes | type == "array" and length > 0) and
-            all(.indexes[]; type == "string" and startswith("https://"))
+            all(.indexes[]; type == "string" and test("^https://[^[:space:]]+$")) and
+            ((.indexes | length) == (.indexes | unique | length))
           ' bots/index-catalog.json >/dev/null
+
+      - name: Validate referenced bot indexes
+        run: |
+          set -euo pipefail
+          validation_dir="$(mktemp -d)"
+          bot_ids_file="$validation_dir/bot-ids.txt"
+          : > "$bot_ids_file"
+
+          index_number=0
+          while IFS= read -r index_url; do
+            index_number=$((index_number + 1))
+            index_file="$validation_dir/index-$index_number.json"
+            echo "Validating $index_url"
+            curl --connect-timeout 10 --max-time 30 --retry 2 \
+              --max-filesize 1048576 --proto '=https' --proto-redir '=https' \
+              --location --fail --silent --show-error \
+              "$index_url" -o "$index_file"
+
+            jq -e '
+              .version == 1 and
+              (.bots | type == "array" and length > 0) and
+              all(.bots[];
+                (.id | type == "string" and test("^[a-z][a-z0-9]{0,63}$")) and
+                (.name | type == "string" and length > 0) and
+                (.version | type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?(\\+[0-9A-Za-z.-]+)?$")) and
+                (.platforms | type == "object" and length > 0) and
+                all(.platforms | to_entries[];
+                  (.key | test("^(darwin|linux|windows)-(aarch64|x86_64)$")) and
+                  (.value | type == "object") and
+                  (.value.url | type == "string" and test("^https://[^[:space:]]+$")) and
+                  (.value.checksum | type == "string" and test("^sha256:[0-9a-fA-F]{64}$"))
+                )
+              )
+            ' "$index_file" >/dev/null
+            jq -r '.bots[].id' "$index_file" >> "$bot_ids_file"
+          done < <(jq -r '.indexes[]' bots/index-catalog.json)
+
+          duplicate_bot_ids="$(sort "$bot_ids_file" | uniq -d)"
+          if [[ -n "$duplicate_bot_ids" ]]; then
+            echo "Duplicate bot IDs are not allowed:"
+            echo "$duplicate_bot_ids"
+            exit 1
+          fi
+
+  publish:
+    name: Publish catalog to Aliyun OSS
+    needs: validate
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install ossutil
         run: |

--- a/bots/README.md
+++ b/bots/README.md
@@ -63,8 +63,46 @@ bots/
 4. 在第三方自己的 HTTPS 地址发布独立 `bots-index.json`；索引中的 `id` 必须与 `--describe` 的 `artifact_id` 一致、全局唯一，并符合小写字母和数字组成、总长 1～64 位的规则。
 5. 向 `bots/index-catalog.json` 提交该索引地址。目录合并并发布后，天工会自动发现该 Bot；后续版本只需更新第三方自己的索引，不需要再次修改天工或发布主程序。
 
+### 独立索引示例
+
+第三方索引至少包含一个 Bot 和一个平台制品。平台键使用 `darwin-aarch64`、`darwin-x86_64`、`linux-aarch64`、`linux-x86_64`、`windows-aarch64` 或 `windows-x86_64`。
+
+```json
+{
+  "version": 1,
+  "bots": [
+    {
+      "id": "examplebot",
+      "name": "Example Bot",
+      "version": "0.1.0",
+      "description": "Example 平台连接器",
+      "config_schema": [],
+      "platforms": {
+        "linux-x86_64": {
+          "url": "https://example.com/releases/0.1.0/examplebot-linux-x86_64",
+          "checksum": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        }
+      },
+      "min_app_version": "0.12.3"
+    }
+  ]
+}
+```
+
+### 贡献到官方目录
+
+第三方只需要贡献索引地址，不需要把 Bot 源码或二进制提交到天工仓库：
+
+1. 在自己的仓库或网站发布 Bot、SHA-256 和独立索引，并确保索引可以通过公网 HTTPS 直接读取。
+2. Fork 天工仓库，在 `bots/index-catalog.json` 的 `indexes` 数组末尾添加自己的索引 URL，不修改或重排已有地址。
+3. 提交 PR，并在说明中提供 Bot 源码地址、许可证、支持平台、需要的外部权限及一次实际运行结果。
+4. `Publish Bots Catalog / Validate bots catalog` 会检查目录格式、索引可访问性、Bot ID 冲突、版本格式、HTTPS 制品地址和 SHA-256 格式。
+5. 审核通过并合并后，发布任务自动更新 OSS 上的 `bots-index/catalog.json`。以后发布新版本只更新第三方自己的索引，不再提交目录 PR。
+
+PR 校验任务不读取 OSS 密钥，也不会上传文件；只有主分支更新或维护者手工触发时才执行发布。
+
 官方目录中的第三方 Bot 需要经过代码与制品来源审核。允许用户自行添加未经审核索引源属于另一项安全边界更大的功能，不在当前发布流程内。
-多个索引声明相同 `id` 时按目录顺序保留第一项，后续同名项不会覆盖已有 Bot；官方索引应排在第三方索引之前。
+目录 CI 会拒绝重复的索引地址和 Bot ID，第三方不能使用已有官方 Bot 的 ID。
 
 ## 凭证注入约定
 


### PR DESCRIPTION
## 变更

- 在修改 Bot 根目录的 PR 中自动校验目录格式、HTTPS 地址和重复地址
- 拉取每个下级索引，校验 Bot ID、版本、平台制品地址和 SHA-256，并拒绝跨索引 ID 冲突
- PR 阶段不读取 OSS 密钥，只有主分支更新或手工触发才发布根目录
- 在 bots/README.md 补充第三方独立索引示例和官方目录贡献流程

## 验证

- actionlint 检查工作流通过
- 使用当前飞书、微信、QQ 三个线上索引完成真实校验
- 重复目录地址、非法 Bot ID、非 HTTPS 地址和错误 SHA-256 的反向校验均按预期失败
- 提交与推送钩子通过