### PR TITLE
feat(bots): 支持本地自有 Bot 接入

### DIFF
--- a/bots/README.md
+++ b/bots/README.md
@@ -9,6 +9,60 @@
 - 平台凭证可由 bot 的扫码流程自行保存；手工配置的凭证仍可由主程序通过环境变量注入。
 - 主程序负责：制品下载（SHA256 校验）→ spawn → 崩溃重启 → 日志捕获。
 
+## Bot 开发协议
+
+Bot 可以使用任意语言实现，但最终必须提供当前系统可直接运行的独立程序。
+
+### 配置描述
+
+程序收到 `--describe` 时必须在 stdout 只输出一个 JSON 对象并以成功状态退出。配置字段的 `env` 表示天工启动 Bot 时注入的环境变量名。
+
+```json
+{
+  "schema_version": 1,
+  "artifact_id": "examplebot",
+  "config_schema": [
+    {
+      "key": "api_token",
+      "label": "API Token",
+      "field_type": { "kind": "secret" },
+      "required": true,
+      "env": "EXAMPLE_BOT_API_TOKEN"
+    }
+  ]
+}
+```
+
+`artifact_id` 必须以小写英文字母开头，只包含小写英文字母和数字，总长 1～64 位。字段类型支持 `string`、`secret`、`boolean`、`barcode` 和带 `options` 的 `select`。
+
+### 正常运行
+
+程序不带参数启动时进入消息接收循环，并读取：
+
+- `TIANGONG_URL`：天工服务地址。
+- `TIANGONG_TOKEN`：访问令牌，请使用 `Authorization: Bearer <token>`。
+- `config_schema` 中各字段声明的环境变量。
+
+收到外部消息后，向 `${TIANGONG_URL}/api/v1/messages` 发送 JSON。请求至少提供 `channel_id`，并提供非空 `message` 或结构化 `content`；建议同时提供稳定的 `connector`、`sender_id` 和 `message_id`。
+
+```json
+{
+  "connector": "examplebot",
+  "channel_id": "external-channel-id",
+  "sender_id": "external-user-id",
+  "message_id": "external-message-id",
+  "message": "你好"
+}
+```
+
+Bot 应正确处理 `SIGTERM`/`SIGINT` 并退出。运行日志写 stdout 或 stderr；执行 `--describe` 和扫码命令时，stdout 只用于返回协议 JSON。
+
+### 可选扫码协议
+
+- `--provision-begin`：在 stdout 返回 `qr_url`、Unix 秒级 `expires_at`、秒级 `interval` 和 Bot 自用的 `state`。
+- `--provision-poll`：从 stdin 读取上一条扫码会话 JSON，在 stdout 返回 `pending`、`success`、`expired` 或带 `message` 的 `error`。
+- 扫码所得凭证由 Bot 自行保存，天工不读取凭证明文。
+
 ## 目录结构
 
 ```
@@ -24,7 +78,7 @@ bots/
     src/main.rs
 ```
 
-## 新增一个 bot
+## 在本仓库新增官方 Bot
 
 1. 在 `bots/` 下新建目录，Cargo.toml 声明 `[[bin]]` + 空 `[workspace]` 表（避免被主 workspace 收编）。
 2. 实现 `--describe` 输出配置 schema（单一真相来源），并可选实现 `--provision-begin`/`--provision-poll` 扫码配置。
@@ -101,8 +155,29 @@ bots/
 
 PR 校验任务不读取 OSS 密钥，也不会上传文件；只有主分支更新或维护者手工触发时才执行发布。
 
-官方目录中的第三方 Bot 需要经过代码与制品来源审核。允许用户自行添加未经审核索引源属于另一项安全边界更大的功能，不在当前发布流程内。
+官方目录中的第三方 Bot 需要经过代码与制品来源审核。用户自行填写未经审核的在线索引源属于另一项安全边界更大的功能，不在当前发布流程内；不需要加入官方目录时，可以使用下方的本地接入方式。
 目录 CI 会拒绝重复的索引地址和 Bot ID，第三方不能使用已有官方 Bot 的 ID。
+
+## 仅在本机添加自有 Bot
+
+本地接入不需要提交 PR、远端索引、`schema.json` 或 `version.json`。天工会直接执行本地程序的 `--describe` 获取配置字段，并且不会上传该程序或配置。
+
+1. 按上面的开发协议实现并构建 Bot，先在终端确认 `--describe` 能输出有效 JSON。
+2. 创建 `~/.tiangong/bots/<bot-id>/` 目录；`<bot-id>` 必须与 `--describe` 的 `artifact_id` 完全一致。
+3. 将 macOS 或 Linux 可执行文件放为 `~/.tiangong/bots/<bot-id>/bot` 并赋予执行权限；Windows 放为 `%USERPROFILE%\.tiangong\bots\<bot-id>\bot.exe`。
+4. 打开天工的“设置 → 移动端控制”并刷新，找到该 Bot 后点击配置。
+5. 天工读取 `--describe`、保存配置并启动 Bot。替换本地程序后再次打开配置，配置字段会重新读取。
+
+macOS 和 Linux 示例：
+
+```bash
+mkdir -p ~/.tiangong/bots/examplebot
+cp /path/to/examplebot ~/.tiangong/bots/examplebot/bot
+chmod 755 ~/.tiangong/bots/examplebot/bot
+~/.tiangong/bots/examplebot/bot --describe
+```
+
+本地接入没有线上自动更新；需要分发给其他用户时，再发布独立索引并按上方流程贡献到官方目录。本地 Bot 以当前用户权限作为独立进程运行，只应添加自己构建或确认可信的程序。
 
 ## 凭证注入约定
 

--- a/crates/tiangong-bots/src/runtime.rs
+++ b/crates/tiangong-bots/src/runtime.rs
@@ -401,11 +401,12 @@ struct DescribeOutput {
 /// 调用 `bot --describe` 获取 schema 并缓存到 `schema.json`。
 ///
 /// bot 二进制收到 `--describe` 参数后，输出 schema JSON 到 stdout 并退出。
-/// 主程序在 [`BotRuntime::install`] 成功后调用此函数缓存 schema。
+/// 用于没有远端清单和版本记录的本地 bot；其 `artifact_id` 必须与目录 ID 一致。
 pub async fn describe_and_cache(bot_id: &BotId) -> Result<Vec<ConfigFieldSchema>> {
     paths::ensure_executable_paths_safe(bot_id)?;
     let artifact_path = paths::bot_artifact_path(bot_id);
     let parsed = describe_artifact(&artifact_path).await?;
+    validate_local_description(&parsed, bot_id)?;
 
     let schema_path = paths::bot_schema_path(bot_id);
     let content =
@@ -413,6 +414,23 @@ pub async fn describe_and_cache(bot_id: &BotId) -> Result<Vec<ConfigFieldSchema>
     crate::store::atomic_write(&schema_path, &content)
         .with_context(|| format!("写入 schema 缓存失败：{}", schema_path.display()))?;
     Ok(parsed.config_schema)
+}
+
+fn validate_local_description(description: &DescribeOutput, bot_id: &BotId) -> Result<()> {
+    if description.schema_version != 1 {
+        bail!(
+            "bot --describe schema_version 不受支持：{}",
+            description.schema_version
+        );
+    }
+    if description.artifact_id != bot_id.as_str() {
+        bail!(
+            "本地 bot --describe artifact_id 与目录名不一致：期望 {}，实际 {}",
+            bot_id,
+            description.artifact_id
+        );
+    }
+    Ok(())
 }
 
 async fn describe_artifact(artifact_path: &Path) -> Result<DescribeOutput> {

--- a/frontend/src/components/bots/BotFormDialog.tsx
+++ b/frontend/src/components/bots/BotFormDialog.tsx
@@ -74,6 +74,8 @@ export function BotFormDialog({
   const { showSuccess, showError } = useToast();
 
   const [schema, setSchema] = useState<ConfigFieldSchema[]>([]);
+  const [schemaLoading, setSchemaLoading] = useState(true);
+  const [schemaError, setSchemaError] = useState<string | null>(null);
   const [id, setId] = useState(bot?.id ?? suggestedId ?? '');
   const [values, setValues] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
@@ -100,6 +102,8 @@ export function BotFormDialog({
   useEffect(() => {
     let cancelled = false;
     (async () => {
+      setSchemaLoading(true);
+      setSchemaError(null);
       try {
         const fields = await api.botConfigSchema(artifactId, bot?.id);
         if (cancelled) return;
@@ -118,6 +122,12 @@ export function BotFormDialog({
         if (!cancelled) setValues(initial);
       } catch (err) {
         console.error('加载 bot 配置 schema 失败:', err);
+        if (!cancelled) {
+          setSchema([]);
+          setSchemaError(String(err));
+        }
+      } finally {
+        if (!cancelled) setSchemaLoading(false);
       }
     })();
     return () => {
@@ -331,11 +341,33 @@ export function BotFormDialog({
                 value={id}
                 onChange={(e) => setId(e.target.value)}
                 placeholder="例如：feishu"
-                disabled={isEdit}
+                disabled={isEdit || !!suggestedId}
               />
-              {isEdit && (
-                <p className="text-xs text-muted-foreground">创建后不可修改</p>
+              {(isEdit || suggestedId) && (
+                <p className="text-xs text-muted-foreground">
+                  {isEdit ? '创建后不可修改' : '与本地安装目录一致'}
+                </p>
               )}
+            </div>
+          )}
+
+          {schemaLoading && (
+            <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              正在读取 Bot 配置
+            </div>
+          )}
+
+          {schemaError && (
+            <div
+              role="alert"
+              className="flex items-start gap-2 border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+            >
+              <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="min-w-0">
+                <div className="font-medium">无法读取 Bot 配置</div>
+                <div className="mt-0.5 break-words text-xs opacity-80">{schemaError}</div>
+              </div>
             </div>
           )}
 
@@ -462,7 +494,7 @@ export function BotFormDialog({
             {!scanMode && (
               <Button
                 onClick={() => void persistBot('manual')}
-                disabled={saving || (!isEdit && !id.trim())}
+                disabled={saving || schemaLoading || !!schemaError || (!isEdit && !id.trim())}
               >
                 {saving ? '保存中...' : isEdit ? '更新' : '创建'}
               </Button>

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2686,16 +2686,35 @@ pub async fn bot_config_schema(
     state: State<'_, TiangongApp>,
 ) -> Result<Vec<tiangong_bots::ConfigFieldSchema>, String> {
     let bot_id = bot_id.map(validate_bot_id).transpose()?;
-    // 1) 优先读已安装 bot 的缓存 schema（权威来源）。
+    let local_artifacts = state.bot_runtime.scan_local_artifacts();
+
+    // 1) 本地自有 bot 没有版本记录，每次打开配置时重新读取 --describe。
     if let Some(id) = &bot_id {
+        if local_artifacts
+            .iter()
+            .any(|local| local.id == id.as_str() && local.version.is_empty())
+        {
+            return tiangong_bots::describe_and_cache(id)
+                .await
+                .map_err(|err| format!("读取本地 Bot 配置失败：{err}"));
+        }
+        // 线上安装的 bot 优先使用安装时验证并缓存的 schema。
         if let Some(schema) = tiangong_bots::cached_schema(id) {
             return Ok(schema);
         }
     }
-    // 2) 扫描本地制品找匹配 artifact_id 的 schema。
-    for local in state.bot_runtime.scan_local_artifacts() {
+    // 2) 扫描本地制品；没有缓存时直接调用本地 bot --describe。
+    for local in local_artifacts {
         if local.artifact_id == artifact_id {
-            return Ok(local.config_schema);
+            let local_id = validate_bot_id(local.id)?;
+            if !local.version.is_empty() {
+                if let Some(schema) = tiangong_bots::cached_schema(&local_id) {
+                    return Ok(schema);
+                }
+            }
+            return tiangong_bots::describe_and_cache(&local_id)
+                .await
+                .map_err(|err| format!("读取本地 Bot 配置失败：{err}"));
         }
     }
     // 3) 回退到 bots-index.json 的预览 schema（安装前展示）。


### PR DESCRIPTION
## 变更

- 本地目录只有 Bot 可执行文件时，配置页自动执行 `--describe` 并缓存配置定义
- 校验描述协议版本及 `artifact_id` 与本地目录 ID 一致，失败时不写缓存
- 本地自有 Bot 每次打开配置时刷新描述，替换程序后无需手工维护缓存
- 固定已安装 Bot 的 ID，并在配置读取失败时展示错误、阻止保存
- 补充完整 Bot 开发协议、官方目录贡献流程和无需提交 PR 的本地接入说明

## 验证

- `cargo fmt --all -- --check`
- `cargo check -p tiangong-bots -p tiangong-app`
- `cargo clippy -p tiangong-bots -p tiangong-app --tests -- -D warnings`
- `cargo test -p tiangong-bots`：31 项通过
- `yarn build`
- 使用 OSS 上的飞书 v0.1.0 程序，仅放置可执行文件后成功读取并缓存 3 个配置字段
- 将同一程序放入错误 ID 目录时被拒绝，且未生成缓存