### PR TITLE
fix(bots): 恢复线上 Bot 安装入口

### DIFF
--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -429,6 +429,11 @@ export interface BotLog {
   truncated: boolean;
 }
 
+export interface BotTransferProgress {
+  downloaded: number;
+  total: number;
+}
+
 export type ProvisionStatus =
   | { status: 'pending'; retry_after?: number }
   | { status: 'success' }
@@ -861,6 +866,9 @@ export const api = {
 
   botInstall: (artifactId: string, destBotId: string): Promise<string> =>
     invoke('bot_install', { artifactId, destBotId }),
+
+  onBotInstallProgress: (callback: (progress: BotTransferProgress) => void) =>
+    listen<BotTransferProgress>('bot_install_progress', (event) => callback(event.payload)),
 
   botStart: (id: string): Promise<string> =>
     invoke('bot_start', { id }),

--- a/frontend/src/components/bots/BotPanel.tsx
+++ b/frontend/src/components/bots/BotPanel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   api,
   type BotConfig,
   type BotHealth,
+  type BotManifest,
   type LocalArtifact,
 } from '../../api/tauri';
 import { Button } from '../ui/button';
@@ -11,31 +12,39 @@ import { Card, CardContent } from '../ui/card';
 import {
   ArrowUpCircle,
   Bot as BotIcon,
+  Download,
   FileText,
+  Loader2,
   Play,
   RefreshCw,
   Settings as SettingsIcon,
   Square,
   Trash2,
+  TriangleAlert,
 } from 'lucide-react';
 import { useToast } from '../Toast';
 import { BotFormDialog } from './BotFormDialog';
 import { BotLogDialog } from './BotLogDialog';
 
-/** 列表条目——本地制品 + 可选的已配置 BotConfig。 */
+/** 已安装或已配置的 Bot 条目。 */
 interface BotEntry {
-  /** 本地制品信息（来自扫描）。 */
-  local: LocalArtifact;
-  /** 已配置的 bot（来自 bots.json），null 表示未配置。 */
+  id: string;
+  artifactId: string;
+  local: LocalArtifact | null;
+  manifest: BotManifest | null;
   configured: BotConfig | null;
 }
 
-/** bot 列表面板——本地制品直接展示，按配置状态显示不同操作。 */
+/** Bot 列表面板——合并线上目录、本地制品和已保存配置。 */
 export function BotPanel() {
   const { showSuccess, showError } = useToast();
   const [entries, setEntries] = useState<BotEntry[]>([]);
+  const [available, setAvailable] = useState<BotManifest[]>([]);
   const [healthMap, setHealthMap] = useState<Record<string, BotHealth>>({});
   const [isLoading, setIsLoading] = useState(false);
+  const [onlineError, setOnlineError] = useState<string | null>(null);
+  const [installingBotId, setInstallingBotId] = useState<string | null>(null);
+  const [installProgress, setInstallProgress] = useState<number | null>(null);
 
   // 编辑/配置表单。
   // bot 非空 → 编辑已有配置；bot 为空 → 配置未配置的本地制品。
@@ -46,35 +55,66 @@ export function BotPanel() {
   // 检查更新中状态。
   const [checking, setChecking] = useState<Record<string, boolean>>({});
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setIsLoading(true);
     try {
-      const [local, bots] = await Promise.all([api.botScanLocal(), api.botList()]);
-      // 合并：本地制品 + 已注册但制品还在的 bot。
+      const [localResult, botsResult, onlineResult] = await Promise.allSettled([
+        api.botScanLocal(),
+        api.botList(),
+        api.botAvailable(),
+      ]);
+
+      const local = localResult.status === 'fulfilled' ? localResult.value : [];
+      const bots = botsResult.status === 'fulfilled' ? botsResult.value : [];
+      const manifests = onlineResult.status === 'fulfilled' ? onlineResult.value.bots : [];
+
+      if (localResult.status === 'rejected') {
+        console.error('扫描本地 Bot 失败:', localResult.reason);
+        showError('加载 Bot 失败', String(localResult.reason));
+      } else if (botsResult.status === 'rejected') {
+        console.error('加载 Bot 配置失败:', botsResult.reason);
+        showError('加载 Bot 失败', String(botsResult.reason));
+      }
+
+      if (onlineResult.status === 'rejected') {
+        console.error('加载线上 Bot 目录失败:', onlineResult.reason);
+        setOnlineError(String(onlineResult.reason));
+      } else {
+        setOnlineError(null);
+      }
+
       const botById = new Map(bots.map((b) => [b.id, b]));
+      const manifestById = new Map(manifests.map((manifest) => [manifest.id, manifest]));
       const merged: BotEntry[] = local.map((l) => ({
+        id: l.id,
+        artifactId: l.artifact_id,
         local: l,
+        manifest: manifestById.get(l.artifact_id) ?? null,
         configured: botById.get(l.id) ?? null,
       }));
-      // 已注册但本地扫描未覆盖的 bot（制品可能被删）也展示。
+
       const localIds = new Set(local.map((l) => l.id));
       for (const bot of bots) {
         if (!localIds.has(bot.id)) {
           merged.push({
-            local: {
-              id: bot.id,
-              name: bot.id,
-              artifact_id: bot.artifact_id,
-              version: '',
-              config_schema: [],
-            },
+            id: bot.id,
+            artifactId: bot.artifact_id,
+            local: null,
+            manifest: manifestById.get(bot.artifact_id) ?? null,
             configured: bot,
           });
         }
       }
+      merged.sort((left, right) => {
+        const leftName = left.local?.name || left.manifest?.name || left.id;
+        const rightName = right.local?.name || right.manifest?.name || right.id;
+        return leftName.localeCompare(rightName, 'zh-CN');
+      });
       setEntries(merged);
 
-      // 异步刷新已配置 bot 的健康状态。
+      const knownArtifactIds = new Set(merged.map((entry) => entry.artifactId));
+      setAvailable(manifests.filter((manifest) => !knownArtifactIds.has(manifest.id)));
+
       const health: Record<string, BotHealth> = {};
       await Promise.all(
         merged
@@ -90,11 +130,55 @@ export function BotPanel() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [showError]);
 
   useEffect(() => {
-    load();
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    void api
+      .onBotInstallProgress(({ downloaded, total }) => {
+        if (disposed) return;
+        setInstallProgress(total > 0 ? Math.min(100, Math.round((downloaded / total) * 100)) : null);
+      })
+      .then((stopListening) => {
+        if (disposed) stopListening();
+        else unlisten = stopListening;
+      })
+      .catch((err) => console.error('监听 Bot 安装进度失败:', err));
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
   }, []);
+
+  const handleInstall = async (
+    manifest: BotManifest,
+    destBotId: string,
+    configured: BotConfig | null,
+  ) => {
+    setInstallingBotId(destBotId);
+    setInstallProgress(null);
+    try {
+      await api.botInstall(manifest.id, destBotId);
+      const installed = (await api.botScanLocal()).find((item) => item.id === destBotId);
+      if (!installed) throw new Error('安装完成后未发现 Bot 程序');
+
+      showSuccess('安装完成', `“${manifest.name || destBotId}”已安装`);
+      await load();
+      setFormArtifact(installed);
+      setFormBot(configured);
+    } catch (err) {
+      showError('安装失败', String(err));
+    } finally {
+      setInstallingBotId(null);
+      setInstallProgress(null);
+    }
+  };
 
   const handleCheckUpdate = async (bot: BotConfig, name: string) => {
     setChecking((prev) => ({ ...prev, [bot.id]: true }));
@@ -148,8 +232,14 @@ export function BotPanel() {
   };
 
   const openConfigure = (entry: BotEntry) => {
+    if (!entry.local) return;
     setFormArtifact(entry.local);
     setFormBot(entry.configured);
+  };
+
+  const installButtonLabel = (botId: string) => {
+    if (installingBotId !== botId) return '安装';
+    return installProgress === null ? '安装中' : `${installProgress}%`;
   };
 
   const healthBadge = (id: string, configured: boolean) => {
@@ -166,125 +256,223 @@ export function BotPanel() {
     <div className="p-4 space-y-4">
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-medium">移动端控制</h3>
-        <Button size="sm" variant="outline" onClick={load}>
-          <RefreshCw className="w-4 h-4 mr-2" />
-          刷新
+        <Button
+          size="icon"
+          variant="outline"
+          className="h-9 w-9"
+          onClick={() => void load()}
+          disabled={isLoading}
+          title="刷新"
+          aria-label="刷新 Bot 列表"
+        >
+          <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
         </Button>
       </div>
 
-      {isLoading ? (
+      {onlineError && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+        >
+          <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+          <div className="min-w-0">
+            <div className="font-medium">线上 Bot 加载失败</div>
+            <div className="mt-0.5 break-words text-xs opacity-80">{onlineError}</div>
+          </div>
+        </div>
+      )}
+
+      {isLoading && entries.length === 0 && available.length === 0 ? (
         <div className="text-center text-muted-foreground py-8">加载中...</div>
-      ) : entries.length === 0 ? (
-        <Card>
-          <CardContent className="text-sm text-muted-foreground py-3">
-            暂无 bot 制品。请将 bot 二进制放入 ~/.tiangong/bots/&lt;名称&gt;/ 目录。
-          </CardContent>
-        </Card>
       ) : (
-        <div className="space-y-2">
-          {entries.map((entry) => {
-            const bot = entry.configured;
-            const displayName = entry.local.name || entry.local.id;
-            const isRunning = bot && healthMap[bot.id] === 'running';
-            return (
-              <Card key={entry.local.id}>
-                <CardContent className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto]">
-                  <BotIcon className="w-5 h-5 text-muted-foreground shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-medium truncate">{displayName}</span>
-                      <Badge variant="outline">{entry.local.artifact_id}</Badge>
-                      {entry.local.version && (
-                        <span className="text-xs text-muted-foreground">v{entry.local.version}</span>
-                      )}
-                      {healthBadge(bot?.id ?? entry.local.id, !!bot)}
-                    </div>
-                    <div className="text-xs text-muted-foreground mt-0.5">
-                      {bot ? `创建于 ${bot.created_at}` : '本地制品，尚未配置'}
-                    </div>
-                  </div>
-                  <div className="col-span-2 flex shrink-0 items-center justify-end gap-1 sm:col-span-1">
-                    {/* 未配置 → 配置按钮 */}
-                    {!bot && (
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => openConfigure(entry)}
-                        title="配置"
-                      >
-                        <SettingsIcon className="w-4 h-4 mr-1" />
-                        配置
-                      </Button>
-                    )}
-                    {/* 已配置 → 启停 + 检查更新 + 配置 + 删除 */}
-                    {bot && (
-                      <>
-                        {isRunning ? (
+        <div className="space-y-5">
+          {entries.length > 0 && (
+            <section className="space-y-2">
+              <h4 className="text-sm font-medium">已安装</h4>
+              {entries.map((entry) => {
+                const bot = entry.configured;
+                const displayName = entry.local?.name || entry.manifest?.name || entry.id;
+                const version = entry.local?.version || entry.manifest?.version;
+                const isRunning = bot && healthMap[bot.id] === 'running';
+                const description = entry.local
+                  ? bot
+                    ? `创建于 ${bot.created_at}`
+                    : entry.manifest?.description || '尚未配置'
+                  : entry.manifest?.description || '本地程序缺失';
+
+                return (
+                  <Card key={entry.id}>
+                    <CardContent className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto]">
+                      <BotIcon className="h-5 w-5 shrink-0 text-muted-foreground" />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="truncate font-medium">{displayName}</span>
+                          <Badge variant="outline">{entry.artifactId}</Badge>
+                          {version && (
+                            <span className="text-xs text-muted-foreground">v{version}</span>
+                          )}
+                          {healthBadge(bot?.id ?? entry.id, !!bot)}
+                        </div>
+                        <div className="mt-0.5 truncate text-xs text-muted-foreground" title={description}>
+                          {description}
+                        </div>
+                      </div>
+                      <div className="col-span-2 flex shrink-0 items-center justify-end gap-1 sm:col-span-1">
+                        {!bot && entry.local && (
                           <Button
-                            size="icon"
-                            variant="ghost"
-                            className="h-5 w-5 rounded-none p-0 text-red-500 hover:bg-transparent hover:text-red-400"
-                            onClick={() => handleStop(bot, displayName)}
-                            title="停止"
-                            aria-label={`停止 ${displayName} 并取消自动运行`}
+                            size="sm"
+                            variant="outline"
+                            onClick={() => openConfigure(entry)}
                           >
-                            <Square className="!h-5 !w-5 fill-current" />
-                          </Button>
-                        ) : (
-                          <Button
-                            size="icon"
-                            variant="ghost"
-                            className="h-5 w-5 rounded-none p-0 text-emerald-500 hover:bg-transparent hover:text-emerald-400"
-                            onClick={() => handleStart(bot, displayName)}
-                            title="启动"
-                            aria-label={`启动 ${displayName} 并设为自动运行`}
-                          >
-                            <Play className="!h-5 !w-5 fill-current" />
+                            <SettingsIcon className="h-4 w-4" />
+                            配置
                           </Button>
                         )}
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => handleCheckUpdate(bot, displayName)}
-                          disabled={checking[bot.id]}
-                          title="检查更新"
+                        {bot && !entry.local && entry.manifest && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="min-w-[88px]"
+                            onClick={() => void handleInstall(entry.manifest!, bot.id, bot)}
+                            disabled={installingBotId !== null}
+                          >
+                            {installingBotId === bot.id ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <Download className="h-4 w-4" />
+                            )}
+                            {installButtonLabel(bot.id)}
+                          </Button>
+                        )}
+                        {bot && entry.local && (
+                          <>
+                            {isRunning ? (
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-5 w-5 rounded-none p-0 text-red-500 hover:bg-transparent hover:text-red-400"
+                                onClick={() => handleStop(bot, displayName)}
+                                title="停止"
+                                aria-label={`停止 ${displayName} 并取消自动运行`}
+                              >
+                                <Square className="!h-5 !w-5 fill-current" />
+                              </Button>
+                            ) : (
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-5 w-5 rounded-none p-0 text-emerald-500 hover:bg-transparent hover:text-emerald-400"
+                                onClick={() => handleStart(bot, displayName)}
+                                title="启动"
+                                aria-label={`启动 ${displayName} 并设为自动运行`}
+                              >
+                                <Play className="!h-5 !w-5 fill-current" />
+                              </Button>
+                            )}
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-9 w-9"
+                              onClick={() => handleCheckUpdate(bot, displayName)}
+                              disabled={checking[bot.id]}
+                              title="检查更新"
+                              aria-label={`检查 ${displayName} 更新`}
+                            >
+                              <ArrowUpCircle className={checking[bot.id] ? 'animate-spin' : ''} />
+                            </Button>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-9 w-9"
+                              onClick={() => setLogBotId(bot.id)}
+                              title="查看日志"
+                              aria-label={`查看 ${displayName} 日志`}
+                            >
+                              <FileText className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-9 w-9"
+                              onClick={() => openConfigure(entry)}
+                              title="编辑配置"
+                              aria-label={`编辑 ${displayName} 配置`}
+                            >
+                              <SettingsIcon className="h-4 w-4" />
+                            </Button>
+                          </>
+                        )}
+                        {bot && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="h-9 w-9 hover:bg-destructive/20 hover:text-destructive"
+                            onClick={() => handleRemove(bot, displayName)}
+                            title="删除配置"
+                            aria-label={`删除 ${displayName} 配置`}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </section>
+          )}
+
+          {available.length > 0 && (
+            <section className="space-y-2">
+              <h4 className="text-sm font-medium">可安装</h4>
+              {available.map((manifest) => (
+                <Card key={manifest.id}>
+                  <CardContent className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto]">
+                    <BotIcon className="h-5 w-5 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="truncate font-medium">{manifest.name || manifest.id}</span>
+                        <Badge variant="outline">{manifest.id}</Badge>
+                        <span className="text-xs text-muted-foreground">v{manifest.version}</span>
+                        <Badge variant="secondary">未安装</Badge>
+                      </div>
+                      {manifest.description && (
+                        <div
+                          className="mt-0.5 truncate text-xs text-muted-foreground"
+                          title={manifest.description}
                         >
-                          <ArrowUpCircle className="w-4 h-4" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => setLogBotId(bot.id)}
-                          title="查看日志"
-                          aria-label={`查看 ${displayName} 日志`}
-                        >
-                          <FileText className="w-4 h-4" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => openConfigure(entry)}
-                          title="编辑配置"
-                        >
-                          <SettingsIcon className="w-4 h-4" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="hover:bg-destructive/20 hover:text-destructive"
-                          onClick={() => handleRemove(bot, displayName)}
-                          title="删除配置"
-                          aria-label={`删除 ${displayName} 配置`}
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </Button>
-                      </>
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
+                          {manifest.description}
+                        </div>
+                      )}
+                    </div>
+                    <div className="col-span-2 flex justify-end sm:col-span-1">
+                      <Button
+                        size="sm"
+                        className="min-w-[88px]"
+                        onClick={() => void handleInstall(manifest, manifest.id, null)}
+                        disabled={installingBotId !== null}
+                      >
+                        {installingBotId === manifest.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Download className="h-4 w-4" />
+                        )}
+                        {installButtonLabel(manifest.id)}
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </section>
+          )}
+
+          {entries.length === 0 && available.length === 0 && (
+            <Card>
+              <CardContent className="py-3 text-sm text-muted-foreground">
+                {onlineError ? '暂无已安装 Bot' : '暂无可用 Bot'}
+              </CardContent>
+            </Card>
+          )}
         </div>
       )}
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2762,21 +2762,16 @@ pub async fn bot_provision_poll(
 
 /// 拉取远端 bots-index.json（可安装的 bot 列表）。
 ///
-/// 线上不可达时返回空列表（不报错），调用方应回退到本地扫描。
+/// 线上不可达时返回明确错误；前端仍会独立加载并展示本地制品。
 #[tauri::command]
 pub async fn bot_available(
     state: State<'_, TiangongApp>,
 ) -> Result<tiangong_bots::BotsIndex, String> {
-    match state.bot_runtime.fetch_index().await {
-        Ok(index) => Ok(index),
-        Err(err) => {
-            tracing::warn!("拉取 bots-index 失败，返回空列表：{err}");
-            Ok(tiangong_bots::BotsIndex {
-                version: 1,
-                bots: vec![],
-            })
-        }
-    }
+    state
+        .bot_runtime
+        .fetch_index()
+        .await
+        .map_err(|err| format!("加载线上 Bot 目录失败：{err}"))
 }
 
 /// 扫描本地已安装的制品（`~/.tiangong/bots/*/`）。


### PR DESCRIPTION
## 变更内容

- 移动端控制页面并行加载线上目录、本地程序和已保存配置。
- 展示飞书、QQ、微信等未安装 Bot 的名称、说明、版本和安装入口。
- 下载时展示安装进度，安装完成后自动进入配置。
- 已有配置但程序缺失时支持重新安装，保留原配置。
- 线上目录不可达时明确提示，并继续保留本地 Bot 管理和刷新重试。

## 验证

- `yarn build`
- `yarn test`（109 项通过）
- `cargo fmt --all -- --check`
- `cargo check -p tiangong-app`
- `cargo clippy -p tiangong-bots -p tiangong-app --tests -- -D warnings`
- `cargo test -p tiangong-bots`（31 项通过）
- 推送前受影响代码检查、严格检查、完整测试和前端构建全部通过。
- 使用线上 OSS 根目录及三个独立索引验证飞书、QQ、微信均可展示。
- 使用 Playwright 验证桌面与窄屏布局、20% 下载进度、安装后自动配置、线上失败时本地条目保留及恢复刷新。