### PR TITLE
fix(frontend): #264 修复流式输出重复与额外空行

### DIFF
--- a/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
+++ b/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
@@ -1,4 +1,4 @@
-import { act, type ReactNode } from 'react';
+import { act, StrictMode, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -6,23 +6,49 @@ import type { Session } from '@/api/tauri';
 
 const mocks = vi.hoisted(() => {
   const eventHandlers = new Map<string, Set<(event: { payload: unknown }) => void>>();
+  const streamEventHandlers = new Set<(event: unknown) => void>();
   const unlisteners: ReturnType<typeof vi.fn>[] = [];
+  // 注册是否立即完成。默认 true：注册 Promise 同步 resolve，保持现有用例行为。
+  // StrictMode 竞态用例临时置为 false，让注册延迟完成，模拟"清理早于注册完成"。
+  let deferRegistrations = false;
+  // 待 resolve 的注册 Promise：defer 模式下调用方 hold 住 resolve，按需放行。
+  type Pending = { resolve: (un: ReturnType<typeof vi.fn>) => void; unlisten: ReturnType<typeof vi.fn> };
+  const pending: Pending[] = [];
   const makeUnlistener = () => {
     const unlisten = vi.fn();
     unlisteners.push(unlisten);
     return unlisten;
   };
+  // 返回注册 Promise。immediate 模式下立即 resolve；defer 模式下入队 pending。
+  const makeRegistration = () => {
+    const unlisten = makeUnlistener();
+    if (!deferRegistrations) {
+      return Promise.resolve(unlisten);
+    }
+    let resolveFn!: (un: ReturnType<typeof vi.fn>) => void;
+    const promise = new Promise<ReturnType<typeof vi.fn>>((resolve) => {
+      resolveFn = resolve;
+    });
+    pending.push({ resolve: resolveFn, unlisten });
+    return promise;
+  };
   const appWindow = {
     scaleFactor: vi.fn(() => Promise.resolve(1)),
     innerSize: vi.fn(() => Promise.resolve({ width: 1200, height: 800 })),
     setSize: vi.fn(() => Promise.resolve()),
-    onResized: vi.fn(() => Promise.resolve(makeUnlistener())),
+    onResized: vi.fn(() => makeRegistration()),
   };
   const api = {
     getSessions: vi.fn(),
     getReasoningEffort: vi.fn(() => Promise.resolve('medium')),
     getWorkspaceDir: vi.fn(() => Promise.resolve('/workspace')),
-    onStreamEvent: vi.fn(() => Promise.resolve(makeUnlistener())),
+    onStreamEvent: vi.fn((callback: (event: unknown) => void) => {
+      streamEventHandlers.add(callback);
+      return makeRegistration().then((unlisten) => {
+        unlisten.mockImplementation(() => streamEventHandlers.delete(callback));
+        return unlisten;
+      });
+    }),
     browserHide: vi.fn(() => Promise.resolve()),
   };
   const listen = vi.fn((eventName: string, handler: (event: { payload: unknown }) => void) => {
@@ -32,11 +58,12 @@ const mocks = vi.hoisted(() => {
       eventHandlers.set(eventName, handlers);
     }
     handlers.add(handler);
-    const unlisten = vi.fn(() => handlers!.delete(handler));
-    unlisteners.push(unlisten);
-    return Promise.resolve(unlisten);
+    return makeRegistration().then((unlisten) => {
+      unlisten.mockImplementation(() => handlers!.delete(handler));
+      return unlisten;
+    });
   });
-  return { api, appWindow, eventHandlers, listen, makeUnlistener, unlisteners };
+  return { api, appWindow, eventHandlers, listen, makeUnlistener, unlisteners, pending, streamEventHandlers, setDefer: (v: boolean) => { deferRegistrations = v; } };
 });
 
 vi.mock('@/api/tauri', async (importOriginal) => {
@@ -129,6 +156,8 @@ describe('MainApp sessions_updated scheduling contract', () => {
     vi.useFakeTimers();
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     mocks.eventHandlers.clear();
+    mocks.streamEventHandlers.clear();
+    mocks.pending.length = 0;
     mocks.unlisteners.length = 0;
     mocks.listen.mockClear();
     mocks.appWindow.onResized.mockClear();
@@ -258,5 +287,155 @@ describe('MainApp sessions_updated scheduling contract', () => {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
     expect(mocks.eventHandlers.get('sessions_updated')?.size ?? 0).toBe(0);
+  });
+});
+
+describe('MainApp StrictMode 异步监听注册竞态', () => {
+  // 事件名清单：每类都应只保留一个有效监听器。
+  const LISTENED_EVENTS = [
+    'sessions_updated',
+    'desktop_notification_open_session',
+    'browser:open',
+    'terminal:tab_updated',
+  ] as const;
+
+  function emitStreamDelta(messageId: string, text: string) {
+    for (const handler of mocks.streamEventHandlers) {
+      handler({ session_id: 'a', event: { type: 'delta', message_id: messageId, content: text } });
+    }
+  }
+
+  function emitStreamReasoning(messageId: string, text: string) {
+    for (const handler of mocks.streamEventHandlers) {
+      handler({ session_id: 'a', event: { type: 'reasoning', message_id: messageId, content: text } });
+    }
+  }
+
+  async function mountMainAppStrict() {
+    mocks.setDefer(true);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <StrictMode>
+          <MainApp />
+        </StrictMode>,
+      );
+      await flushMicrotasks();
+    });
+  }
+
+  async function resolveAllPending() {
+    await act(async () => {
+      for (let i = 0; i < 40; i += 1) {
+        if (mocks.pending.length === 0) {
+          await flushMicrotasks();
+          if (mocks.pending.length === 0) break;
+        }
+        while (mocks.pending.length > 0) {
+          const entry = mocks.pending.pop()!;
+          entry.resolve(entry.unlisten);
+        }
+        await flushMicrotasks();
+      }
+    });
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mocks.eventHandlers.clear();
+    mocks.streamEventHandlers.clear();
+    mocks.pending.length = 0;
+    mocks.unlisteners.length = 0;
+    mocks.setDefer(false);
+    mocks.listen.mockClear();
+    mocks.appWindow.onResized.mockClear();
+    mocks.api.onStreamEvent.mockClear();
+    mocks.api.getWorkspaceDir.mockClear();
+    mocks.api.getReasoningEffort.mockClear();
+    mocks.api.getReasoningEffort.mockResolvedValue('medium');
+    getSessionsMock.mockReset();
+    getSessionsMock.mockResolvedValue([session('a', 1)]);
+    useStore.setState({
+      ...initialState,
+      sessions: [session('a', 1)],
+      activeSessionId: 'a',
+      isNewConversation: false,
+    }, true);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root!.unmount());
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    mocks.setDefer(false);
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('StrictMode 挂载→清理→再挂载后，每类事件最终只剩一个有效监听器', async () => {
+    await mountMainAppStrict();
+    // defer 模式下注册串行进行：每轮 effect 卡在首个 await（onStreamEvent）。
+    // StrictMode 挂载→清理→再挂载会跑两轮 effect，故至少有 2 个未 resolve 的注册。
+    // 此时第一轮 effect 已被清理，但注册尚未完成；resolve 后第一轮应在 guard 处放弃。
+    expect(mocks.pending.length).toBeGreaterThanOrEqual(2);
+
+    await resolveAllPending();
+
+    // stream_event（onStreamEvent）+ 4 个 listen 事件，每类恰好一个 handler。
+    // 第一轮的孤儿监听已被 guard 放弃时取消，不会重复消费。
+    expect(mocks.streamEventHandlers.size).toBe(1);
+    for (const eventName of LISTENED_EVENTS) {
+      expect(mocks.eventHandlers.get(eventName)?.size ?? 0).toBe(1);
+    }
+  });
+
+  it('一个后端流事件只被消费一次，正文与 reasoning 各追加一次', async () => {
+    await mountMainAppStrict();
+    await resolveAllPending();
+
+    const messageId = 'msg-1';
+    // 发送一次正文增量，flush 后应只追加一次。
+    act(() => emitStreamDelta(messageId, 'hello'));
+    await advance(16);
+    let message = useStore.getState().messages.find((item) => item.id === messageId);
+    expect(message?.content).toEqual([{ type: 'text', text: 'hello' }]);
+
+    // 再发一次 reasoning 增量，只追加一次。
+    act(() => emitStreamReasoning(messageId, 'thinking'));
+    await advance(16);
+    message = useStore.getState().messages.find((item) => item.id === messageId);
+    expect(message?.reasoning_content).toBe('thinking');
+  });
+
+  it('卸载后所有迟到的 unlisten 都被调用，且再发事件不改变状态', async () => {
+    await mountMainAppStrict();
+    await resolveAllPending();
+    const registeredUnlisteners = [...mocks.unlisteners];
+
+    await act(async () => root!.unmount());
+    root = null;
+
+    // 卸载后再发送事件，store 状态不应变化（无遗留监听）。
+    const before = useStore.getState().messages.length;
+    act(() => emitStreamDelta('late-msg', 'late'));
+    await advance(16);
+    expect(useStore.getState().messages.length).toBe(before);
+
+    // 第一轮的迟到 unlisten 在 guard 放弃时被立即调用；第二轮在 cleanup 中释放。
+    // 每个注册产生的 unlisten 至少被调用一次。
+    for (const unlisten of registeredUnlisteners) {
+      expect(unlisten).toHaveBeenCalled();
+    }
+    expect(mocks.streamEventHandlers.size).toBe(0);
+    for (const eventName of LISTENED_EVENTS) {
+      expect(mocks.eventHandlers.get(eventName)?.size ?? 0).toBe(0);
+    }
   });
 });

--- a/frontend/src/components/message/StreamingMessage.tsx
+++ b/frontend/src/components/message/StreamingMessage.tsx
@@ -1,14 +1,51 @@
+import { useEffect, useRef, useState } from "react";
 import { MdPreview } from "md-editor-rt";
 import { useResolvedTheme } from "@/hooks/useTheme";
 import { ThinkingBlock } from "../ThinkingBlock";
 import { resolveMarkdownImages } from "./utils";
 
+/**
+ * 流式期间 Markdown 预览的刷新间隔（毫秒）。
+ *
+ * 流事件仍以约 16ms 写入状态，但直接把不断增长的半成品 Markdown 交给 MdPreview，
+ * 会因反复解析未闭合的代码块/列表/表格等结构，产生临时块级排版异常（表现为换行间隔过大）。
+ * 降低预览刷新频率可显著减少半成品解析次数，同时保留流式观感。
+ */
+const MD_PREVIEW_THROTTLE_MS = 80;
+
 export function StreamingMessage({ content, reasoningContent }: { content: string; reasoningContent: string }) {
   const resolvedTheme = useResolvedTheme();
+  // 传给 MdPreview 的内容降频更新：latestRef 始终持有最新文本，renderedContent 每
+  // MD_PREVIEW_THROTTLE_MS 至多更新一次。这是节流（非防抖）——content 持续高频变化时，
+  // 定时器不会被反复重置，到点即 flush；组件卸载时清理定时器。
+  const latestRef = useRef(content);
+  const [renderedContent, setRenderedContent] = useState(content);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    latestRef.current = content;
+    // 已有定时器在等待：由它统一 flush，避免每次都重置导致末尾内容迟迟不刷新。
+    if (timerRef.current !== null) return;
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      setRenderedContent(latestRef.current);
+    }, MD_PREVIEW_THROTTLE_MS);
+  }, [content]);
+
+  // 仅在组件卸载时清理定时器；content 变化时不清理（否则退化为防抖）。
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
   return (
     <div>
       {reasoningContent && <ThinkingBlock content={reasoningContent} isActive defaultExpanded />}
-      <MdPreview modelValue={resolveMarkdownImages(content)} theme={resolvedTheme} previewTheme="github" />
+      <MdPreview modelValue={resolveMarkdownImages(renderedContent)} theme={resolvedTheme} previewTheme="github" />
       {content.length > 0 && <span className="inline-block w-1.5 h-4 bg-primary ml-0.5 animate-pulse" />}
     </div>
   );

--- a/frontend/src/components/message/StreamingMessage.tsx
+++ b/frontend/src/components/message/StreamingMessage.tsx
@@ -1,51 +1,16 @@
-import { useEffect, useRef, useState } from "react";
 import { MdPreview } from "md-editor-rt";
 import { useResolvedTheme } from "@/hooks/useTheme";
 import { ThinkingBlock } from "../ThinkingBlock";
 import { resolveMarkdownImages } from "./utils";
 
-/**
- * 流式期间 Markdown 预览的刷新间隔（毫秒）。
- *
- * 流事件仍以约 16ms 写入状态，但直接把不断增长的半成品 Markdown 交给 MdPreview，
- * 会因反复解析未闭合的代码块/列表/表格等结构，产生临时块级排版异常（表现为换行间隔过大）。
- * 降低预览刷新频率可显著减少半成品解析次数，同时保留流式观感。
- */
-const MD_PREVIEW_THROTTLE_MS = 80;
-
 export function StreamingMessage({ content, reasoningContent }: { content: string; reasoningContent: string }) {
   const resolvedTheme = useResolvedTheme();
-  // 传给 MdPreview 的内容降频更新：latestRef 始终持有最新文本，renderedContent 每
-  // MD_PREVIEW_THROTTLE_MS 至多更新一次。这是节流（非防抖）——content 持续高频变化时，
-  // 定时器不会被反复重置，到点即 flush；组件卸载时清理定时器。
-  const latestRef = useRef(content);
-  const [renderedContent, setRenderedContent] = useState(content);
-  const timerRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    latestRef.current = content;
-    // 已有定时器在等待：由它统一 flush，避免每次都重置导致末尾内容迟迟不刷新。
-    if (timerRef.current !== null) return;
-    timerRef.current = window.setTimeout(() => {
-      timerRef.current = null;
-      setRenderedContent(latestRef.current);
-    }, MD_PREVIEW_THROTTLE_MS);
-  }, [content]);
-
-  // 仅在组件卸载时清理定时器；content 变化时不清理（否则退化为防抖）。
-  useEffect(() => {
-    return () => {
-      if (timerRef.current !== null) {
-        window.clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
-    };
-  }, []);
-
   return (
-    <div>
+    // ReAct 过程消息的父容器使用 pre-wrap 展示完成态纯文本。流式 Markdown 必须覆盖该
+    // 可继承样式，否则预览生成的标签间格式换行也会显示，形成额外空行。
+    <div className="whitespace-normal">
       {reasoningContent && <ThinkingBlock content={reasoningContent} isActive defaultExpanded />}
-      <MdPreview modelValue={resolveMarkdownImages(renderedContent)} theme={resolvedTheme} previewTheme="github" />
+      <MdPreview modelValue={resolveMarkdownImages(content)} theme={resolvedTheme} previewTheme="github" />
       {content.length > 0 && <span className="inline-block w-1.5 h-4 bg-primary ml-0.5 animate-pulse" />}
     </div>
   );

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -119,7 +119,6 @@ export function MainApp() {
   const workspaceOpenRequestIdRef = useRef(0);
   const chatPanelWidthRef = useRef(MIN_CHAT_WIDTH);
   const isDraggingRef = useRef(false);
-  const unlistenRef = useRef<UnlistenFn | null>(null);
   const streamEventQueueRef = useRef<SessionStreamEvent[]>([]);
   const streamEventTimerRef = useRef<number | null>(null);
   // sessions_updated 在一次 done 后会被连续 emit 多次（done/标题生成/Core 退役），
@@ -343,10 +342,29 @@ export function MainApp() {
       streamEventTimerRef.current = window.setTimeout(flushStreamEvents, 16);
     };
 
-    const setupListener = async () => {
-      const unlistenStream = await api.onStreamEvent(scheduleStreamEvent);
+    // 本轮 effect 的生命周期标记与取消函数集合。
+    // 关键：不使用跨 effect 的单值引用（会被旧异步流程覆盖，导致第一轮监听器成为孤儿）。
+    // 每个 await 注册完成后立即交给 track 收纳；guard 在每个 await 点之后检查 disposed，
+    // 已清理则立即取消并中止后续注册，避免 StrictMode 挂载→清理→再挂载时第一轮监听器残留。
+    let disposed = false;
+    const cleanups: UnlistenFn[] = [];
+    const track = (un: UnlistenFn) => {
+      if (disposed) {
+        un();
+        return;
+      }
+      cleanups.push(un);
+    };
+    const guard = () => {
+      if (disposed) throw new DOMException('Aborted', 'AbortError');
+    };
 
-      const { listen } = await import('@tauri-apps/api/event');
+    const setupListener = async () => {
+      try {
+        track(await api.onStreamEvent(scheduleStreamEvent));
+        guard();
+
+        const { listen } = await import('@tauri-apps/api/event');
       // 尾沿去抖 + in-flight 串行化 + dirty rerun。
       // - 每次事件都重置 120ms 计时器，等事件静默后再刷新；
       // - 刷新进行中来的事件标记 dirty，settle 后 rerun 一次，避免并发读取。
@@ -377,24 +395,27 @@ export function MainApp() {
           runProtectiveRefresh();
         }, 120);
       };
-      const unlistenSessions = await listen('sessions_updated', () => {
+      track(await listen('sessions_updated', () => {
         scheduleSessionsRefresh();
-      });
-      const unlistenOpenSession = await listen<string>('desktop_notification_open_session', (event) => {
+      }));
+      guard();
+      track(await listen<string>('desktop_notification_open_session', (event) => {
         const sessionId = event.payload;
         if (sessionId) {
           useStore.getState().switchSession(sessionId).catch(console.error);
         }
-      });
+      }));
+      guard();
 
-      const unlistenBrowserOpen = await listen<{ session_id: string; url: string }>('browser:open', async (event) => {
+      track(await listen<{ session_id: string; url: string }>('browser:open', async (event) => {
         const { session_id } = event.payload;
         if (!session_id || useStore.getState().activeSessionId !== session_id) return;
         await openWorkspacePanel('browser');
         await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
         // browser:open 已在后端完成导航，前端不再重复 navigate
-      });
-      const unlistenTerminalTabUpdated = await listen<{
+      }));
+      guard();
+      track(await listen<{
         session_id: string;
         active_tab_id?: string | null;
         source?: string | null;
@@ -425,9 +446,10 @@ export function MainApp() {
         if (showWorkspacePanelRef.current && workspaceTabKindRef.current === 'terminal' && active_tab_id) {
           await openWorkspacePanel('terminal', active_tab_id);
         }
-      });
+      }));
+      guard();
 
-      const unlistenResize = await getCurrentWindow().onResized(async () => {
+      track(await getCurrentWindow().onResized(async () => {
         if (programmaticResizeRef.current) return;
 
         const appWindow = getCurrentWindow();
@@ -452,16 +474,13 @@ export function MainApp() {
         ) {
           setSidebarOpenByLayout(true);
         }
-      });
-
-      unlistenRef.current = () => {
-        unlistenStream();
-        unlistenSessions();
-        unlistenOpenSession();
-        unlistenBrowserOpen();
-        unlistenTerminalTabUpdated();
-        unlistenResize();
-      };
+      }));
+      } catch (error) {
+        // effect 已被清理（guard 抛 AbortError），释放本轮已收纳的监听。
+        if ((error as DOMException)?.name !== 'AbortError') {
+          throw error;
+        }
+      }
     };
 
     setupListener();
@@ -493,6 +512,13 @@ export function MainApp() {
     window.addEventListener('tiangong:open-browser', onOpenBrowser);
 
     return () => {
+      // 先标记本轮 disposed，使尚未完成的异步注册流程在后续 guard 处自行放弃；
+      // 再释放本轮已收纳的监听，避免遗留孤儿监听导致事件被重复消费。
+      disposed = true;
+      while (cleanups.length > 0) {
+        const un = cleanups.pop();
+        un?.();
+      }
       if (streamEventTimerRef.current !== null) {
         window.clearTimeout(streamEventTimerRef.current);
         streamEventTimerRef.current = null;
@@ -503,7 +529,6 @@ export function MainApp() {
         sessionsRefreshTimerRef.current = null;
       }
       window.removeEventListener('tiangong:open-browser', onOpenBrowser);
-      unlistenRef.current?.();
     };
   }, [
     setSidebarOpenByLayout,


### PR DESCRIPTION
## 变更内容

- 修复开发模式下异步监听重复注册，避免同一流式片段被重复消费。
- 修复过程消息继承纯文本换行规则后，Markdown 排版内部换行被显示成额外空行的问题。
- 移除未解决根因的预览降频处理，恢复内容实时更新。

## 验证结果

- yarn build 通过。
- yarn test 通过，共 112 项。
- 提交与推送前的项目检查全部通过。

Fixes #264