### PR TITLE
feat(bots): 优化 Bot 更新流程和操作按钮

### DIFF
--- a/crates/tiangong-bots/src/runtime.rs
+++ b/crates/tiangong-bots/src/runtime.rs
@@ -251,7 +251,7 @@ impl BotRuntime {
 
     /// 升级 bot 制品（停止运行中的 bot → 下载新版本 → 写 version）。
     ///
-    /// 升级后不自动重启——用户手动点启动。
+    /// 本层只负责停止和替换制品，是否恢复运行由调用方按升级前状态决定。
     pub async fn upgrade(
         &self,
         bot_id: &BotId,

--- a/frontend/src/components/bots/BotFormDialog.tsx
+++ b/frontend/src/components/bots/BotFormDialog.tsx
@@ -382,7 +382,13 @@ export function BotFormDialog({
                 </div>
                 <div className="flex shrink-0 items-center gap-1">
                   {scanMode && !provisionBusy && (
-                    <Button type="button" size="sm" variant="ghost" onClick={handleManualMode}>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 px-2 text-xs"
+                      onClick={handleManualMode}
+                    >
                       手动输入
                     </Button>
                   )}
@@ -390,6 +396,7 @@ export function BotFormDialog({
                     type="button"
                     size="sm"
                     variant={scanMode ? 'outline' : 'default'}
+                    className="h-7 gap-1 px-2 text-xs [&_svg]:size-3.5"
                     onClick={() =>
                       provisionState.kind === 'error' && provisionState.retryAction === 'save'
                         ? void persistBot('provision')
@@ -401,11 +408,11 @@ export function BotFormDialog({
                     disabled={provisionBusy}
                   >
                     {provisionBusy ? (
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="animate-spin" />
                     ) : qrSession || scanMode ? (
-                      <RefreshCw className="mr-2 h-4 w-4" />
+                      <RefreshCw />
                     ) : (
-                      <QrCode className="mr-2 h-4 w-4" />
+                      <QrCode />
                     )}
                     {provisionState.kind === 'starting'
                       ? '生成中...'
@@ -488,11 +495,19 @@ export function BotFormDialog({
             ))}
 
           <div className="flex justify-end gap-2 pt-2">
-            <Button variant="outline" onClick={onClose} disabled={saving}>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 px-3 text-xs"
+              onClick={onClose}
+              disabled={saving}
+            >
               取消
             </Button>
             {!scanMode && (
               <Button
+                size="sm"
+                className="h-7 px-3 text-xs"
                 onClick={() => void persistBot('manual')}
                 disabled={saving || schemaLoading || !!schemaError || (!isEdit && !id.trim())}
               >

--- a/frontend/src/components/bots/BotLogDialog.tsx
+++ b/frontend/src/components/bots/BotLogDialog.tsx
@@ -51,15 +51,16 @@ export function BotLogDialog({ botId, onClose }: Props) {
                 <span className="text-xs text-muted-foreground">仅显示最近内容</span>
               )}
               <Button
-                size="icon"
+                size="sm"
                 variant="ghost"
-                className="h-8 w-8"
+                className="h-7 gap-1 px-2 text-xs [&_svg]:size-3.5"
                 onClick={() => void load()}
                 disabled={loading}
                 title="刷新日志"
                 aria-label="刷新日志"
               >
                 <RefreshCw className={loading ? 'animate-spin' : ''} />
+                刷新
               </Button>
             </div>
           </div>
@@ -78,7 +79,12 @@ export function BotLogDialog({ botId, onClose }: Props) {
             <div className="flex min-h-64 flex-col items-center justify-center gap-3 px-6 text-center text-zinc-300">
               <AlertTriangle className="h-5 w-5 text-red-400" />
               <p className="max-w-xl break-words text-sm">{error}</p>
-              <Button size="sm" variant="secondary" onClick={() => void load()}>
+              <Button
+                size="sm"
+                variant="secondary"
+                className="h-7 px-2 text-xs"
+                onClick={() => void load()}
+              >
                 重新读取
               </Button>
             </div>

--- a/frontend/src/components/bots/BotPanel.tsx
+++ b/frontend/src/components/bots/BotPanel.tsx
@@ -37,6 +37,54 @@ interface BotEntry {
   configured: BotConfig | null;
 }
 
+interface ParsedVersion {
+  core: [bigint, bigint, bigint];
+  prerelease: string[] | null;
+}
+
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function parseVersion(version: string): ParsedVersion | null {
+  const match = SEMVER_PATTERN.exec(version);
+  if (!match) return null;
+  return {
+    core: [BigInt(match[1]), BigInt(match[2]), BigInt(match[3])],
+    prerelease: match[4]?.split('.') ?? null,
+  };
+}
+
+function isVersionNewer(remoteVersion: string, localVersion: string): boolean {
+  const remote = parseVersion(remoteVersion);
+  const local = parseVersion(localVersion);
+  if (!remote || !local) return remoteVersion !== localVersion;
+
+  for (let index = 0; index < remote.core.length; index += 1) {
+    if (remote.core[index] !== local.core[index]) {
+      return remote.core[index] > local.core[index];
+    }
+  }
+
+  if (!remote.prerelease) return local.prerelease !== null;
+  if (!local.prerelease) return false;
+
+  const count = Math.max(remote.prerelease.length, local.prerelease.length);
+  for (let index = 0; index < count; index += 1) {
+    const remotePart = remote.prerelease[index];
+    const localPart = local.prerelease[index];
+    if (remotePart === localPart) continue;
+    if (remotePart === undefined) return false;
+    if (localPart === undefined) return true;
+
+    const remoteNumeric = /^\d+$/.test(remotePart);
+    const localNumeric = /^\d+$/.test(localPart);
+    if (remoteNumeric && localNumeric) return BigInt(remotePart) > BigInt(localPart);
+    if (remoteNumeric !== localNumeric) return !remoteNumeric;
+    return remotePart > localPart;
+  }
+  return false;
+}
+
 /** Bot 列表面板——合并线上目录、本地制品和已保存配置。 */
 export function BotPanel() {
   const { showSuccess, showError } = useToast();
@@ -55,8 +103,7 @@ export function BotPanel() {
   const [logBotId, setLogBotId] = useState<string | null>(null);
   const [pushTargetBot, setPushTargetBot] = useState<{ id: string; name: string } | null>(null);
 
-  // 检查更新中状态。
-  const [checking, setChecking] = useState<Record<string, boolean>>({});
+  const [upgrading, setUpgrading] = useState<Record<string, boolean>>({});
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -182,23 +229,28 @@ export function BotPanel() {
     }
   };
 
-  const handleCheckUpdate = async (bot: BotConfig, name: string) => {
-    setChecking((prev) => ({ ...prev, [bot.id]: true }));
+  const handleUpgrade = async (
+    bot: BotConfig,
+    name: string,
+    localVersion: string,
+    manifest: BotManifest,
+  ) => {
+    if (
+      !confirm(
+        `“${name}”将从 ${localVersion} 更新到 ${manifest.version}。更新期间会停止 Bot，完成后恢复当前状态。`,
+      )
+    )
+      return;
+
+    setUpgrading((prev) => ({ ...prev, [bot.id]: true }));
     try {
-      const manifest = await api.botCheckUpdate(bot.artifact_id);
-      if (!manifest) {
-        showSuccess('已是最新', `“${name}”已是最新版本`);
-        return;
-      }
-      if (!confirm(`“${name}”发现新版本 ${manifest.version}，是否升级？升级会先停止 Bot。`))
-        return;
-      await api.botUpgrade(bot.id);
-      showSuccess('升级完成', `“${name}”已升级到 ${manifest.version}，请重新启动`);
-      load();
+      const result = await api.botUpgrade(bot.id);
+      showSuccess('更新完成', `“${name}”已更新到 ${manifest.version}。${result}`);
     } catch (err) {
-      showError('检查更新失败', String(err));
+      showError('更新失败', String(err));
     } finally {
-      setChecking((prev) => ({ ...prev, [bot.id]: false }));
+      await load();
+      setUpgrading((prev) => ({ ...prev, [bot.id]: false }));
     }
   };
 
@@ -272,15 +324,16 @@ export function BotPanel() {
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-medium">移动端控制</h3>
         <Button
-          size="icon"
+          size="sm"
           variant="outline"
-          className="h-9 w-9"
+          className="h-7 gap-1 px-2 text-xs [&_svg]:size-3.5"
           onClick={() => void load()}
           disabled={isLoading}
           title="刷新"
           aria-label="刷新 Bot 列表"
         >
-          <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+          <RefreshCw className={isLoading ? 'animate-spin' : ''} />
+          刷新
         </Button>
       </div>
 
@@ -309,6 +362,12 @@ export function BotPanel() {
                 const displayName = entry.local?.name || entry.manifest?.name || entry.id;
                 const version = entry.local?.version || entry.manifest?.version;
                 const isRunning = bot && healthMap[bot.id] === 'running';
+                const updateManifest =
+                  entry.local &&
+                  entry.manifest &&
+                  isVersionNewer(entry.manifest.version, entry.local.version)
+                    ? entry.manifest
+                    : null;
                 const description = entry.local
                   ? bot
                     ? `创建于 ${bot.created_at}`
@@ -337,9 +396,10 @@ export function BotPanel() {
                           <Button
                             size="sm"
                             variant="outline"
+                            className="h-7 gap-1 px-2 text-xs [&_svg]:size-3.5"
                             onClick={() => openConfigure(entry)}
                           >
-                            <SettingsIcon className="h-4 w-4" />
+                            <SettingsIcon />
                             配置
                           </Button>
                         )}
@@ -347,14 +407,14 @@ export function BotPanel() {
                           <Button
                             size="sm"
                             variant="outline"
-                            className="min-w-[88px]"
+                            className="h-7 min-w-[72px] gap-1 px-2 text-xs [&_svg]:size-3.5"
                             onClick={() => void handleInstall(entry.manifest!, bot.id, bot)}
                             disabled={installingBotId !== null}
                           >
                             {installingBotId === bot.id ? (
-                              <Loader2 className="h-4 w-4 animate-spin" />
+                              <Loader2 className="animate-spin" />
                             ) : (
-                              <Download className="h-4 w-4" />
+                              <Download />
                             )}
                             {installButtonLabel(bot.id)}
                           </Button>
@@ -363,86 +423,105 @@ export function BotPanel() {
                           <>
                             {isRunning ? (
                               <Button
-                                size="icon"
+                                size="sm"
                                 variant="ghost"
-                                className="h-5 w-5 rounded-none p-0 text-red-500 hover:bg-transparent hover:text-red-400"
+                                className="h-7 gap-1 px-2 text-xs text-red-500 hover:bg-red-500/10 hover:text-red-400 [&_svg]:size-3.5"
                                 onClick={() => handleStop(bot, displayName)}
                                 title="停止"
                                 aria-label={`停止 ${displayName} 并取消自动运行`}
                               >
-                                <Square className="!h-5 !w-5 fill-current" />
+                                <Square className="fill-current" />
+                                停止
                               </Button>
                             ) : (
                               <Button
-                                size="icon"
+                                size="sm"
                                 variant="ghost"
-                                className="h-5 w-5 rounded-none p-0 text-emerald-500 hover:bg-transparent hover:text-emerald-400"
+                                className="h-7 gap-1 px-2 text-xs text-emerald-500 hover:bg-emerald-500/10 hover:text-emerald-400 [&_svg]:size-3.5"
                                 onClick={() =>
                                   handleStart(bot, displayName, entry.local!.supports_mcp)
                                 }
                                 title="启动"
                                 aria-label={`启动 ${displayName} 并设为自动运行`}
                               >
-                                <Play className="!h-5 !w-5 fill-current" />
+                                <Play className="fill-current" />
+                                启动
+                              </Button>
+                            )}
+                            {updateManifest && (
+                              <Button
+                                size="sm"
+                                className="h-7 min-w-[68px] gap-1 px-2 text-xs [&_svg]:size-3.5"
+                                onClick={() =>
+                                  handleUpgrade(
+                                    bot,
+                                    displayName,
+                                    entry.local!.version,
+                                    updateManifest,
+                                  )
+                                }
+                                disabled={upgrading[bot.id]}
+                                title={`更新到 v${updateManifest.version}`}
+                                aria-label={`更新 ${displayName} 到 ${updateManifest.version}`}
+                              >
+                                {upgrading[bot.id] ? (
+                                  <Loader2 className="animate-spin" />
+                                ) : (
+                                  <ArrowUpCircle />
+                                )}
+                                {upgrading[bot.id] ? '更新中' : '更新'}
                               </Button>
                             )}
                             <Button
-                              size="icon"
+                              size="sm"
                               variant="ghost"
-                              className="h-9 w-9"
-                              onClick={() => handleCheckUpdate(bot, displayName)}
-                              disabled={checking[bot.id]}
-                              title="检查更新"
-                              aria-label={`检查 ${displayName} 更新`}
-                            >
-                              <ArrowUpCircle className={checking[bot.id] ? 'animate-spin' : ''} />
-                            </Button>
-                            <Button
-                              size="icon"
-                              variant="ghost"
-                              className="h-9 w-9"
+                              className="h-7 gap-1 px-2 text-xs [&_svg]:size-3.5"
                               onClick={() => setLogBotId(bot.id)}
                               title="查看日志"
                               aria-label={`查看 ${displayName} 日志`}
                             >
-                              <FileText className="h-4 w-4" />
+                              <FileText />
+                              日志
                             </Button>
                             {entry.local.supports_mcp && (
                               <Button
-                                size="icon"
+                                size="sm"
                                 variant="ghost"
-                                className="h-9 w-9"
+                                className="h-7 gap-1 px-2 text-xs [&_svg]:size-3.5"
                                 onClick={() =>
                                   setPushTargetBot({ id: bot.id, name: displayName })
                                 }
                                 title="管理推送授权"
                                 aria-label={`管理 ${displayName} 推送授权`}
                               >
-                                <MessageSquareText className="h-4 w-4" />
+                                <MessageSquareText />
+                                推送授权
                               </Button>
                             )}
                             <Button
-                              size="icon"
+                              size="sm"
                               variant="ghost"
-                              className="h-9 w-9"
+                              className="h-7 gap-1 px-2 text-xs [&_svg]:size-3.5"
                               onClick={() => openConfigure(entry)}
                               title="编辑配置"
                               aria-label={`编辑 ${displayName} 配置`}
                             >
-                              <SettingsIcon className="h-4 w-4" />
+                              <SettingsIcon />
+                              配置
                             </Button>
                           </>
                         )}
                         {bot && (
                           <Button
-                            size="icon"
+                            size="sm"
                             variant="ghost"
-                            className="h-9 w-9 hover:bg-destructive/20 hover:text-destructive"
+                            className="h-7 gap-1 px-2 text-xs hover:bg-destructive/20 hover:text-destructive [&_svg]:size-3.5"
                             onClick={() => handleRemove(bot, displayName)}
                             title="删除配置"
                             aria-label={`删除 ${displayName} 配置`}
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 />
+                            删除
                           </Button>
                         )}
                       </div>
@@ -479,14 +558,14 @@ export function BotPanel() {
                     <div className="col-span-2 flex justify-end sm:col-span-1">
                       <Button
                         size="sm"
-                        className="min-w-[88px]"
+                        className="h-7 min-w-[72px] gap-1 px-2 text-xs [&_svg]:size-3.5"
                         onClick={() => void handleInstall(manifest, manifest.id, null)}
                         disabled={installingBotId !== null}
                       >
                         {installingBotId === manifest.id ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
+                          <Loader2 className="animate-spin" />
                         ) : (
-                          <Download className="h-4 w-4" />
+                          <Download />
                         )}
                         {installButtonLabel(manifest.id)}
                       </Button>

--- a/frontend/src/components/bots/BotPushTargetsDialog.tsx
+++ b/frontend/src/components/bots/BotPushTargetsDialog.tsx
@@ -59,15 +59,16 @@ export function BotPushTargetsDialog({ botId, botName, onClose }: Props) {
           <div className="flex items-center justify-between gap-3">
             <DialogTitle className="truncate">{botName} 推送授权</DialogTitle>
             <Button
-              size="icon"
+              size="sm"
               variant="ghost"
-              className="h-8 w-8 shrink-0"
+              className="h-7 shrink-0 gap-1 px-2 text-xs [&_svg]:size-3.5"
               onClick={() => void load()}
               disabled={loading}
               title="刷新推送目标"
               aria-label="刷新推送目标"
             >
               <RefreshCw className={loading ? 'animate-spin' : ''} />
+              刷新
             </Button>
           </div>
         </DialogHeader>
@@ -118,9 +119,9 @@ export function BotPushTargetsDialog({ botId, botName, onClose }: Props) {
                       </div>
                     </div>
                     <Button
-                      size="icon"
+                      size="sm"
                       variant="ghost"
-                      className="h-9 w-9 text-muted-foreground hover:bg-destructive/15 hover:text-destructive"
+                      className="h-7 gap-1 px-2 text-xs text-muted-foreground hover:bg-destructive/15 hover:text-destructive [&_svg]:size-3.5"
                       onClick={() => void deleteTarget(target)}
                       disabled={isDeleting}
                       title="删除推送授权"
@@ -129,8 +130,9 @@ export function BotPushTargetsDialog({ botId, botName, onClose }: Props) {
                       {isDeleting ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
                       ) : (
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 />
                       )}
+                      {isDeleting ? '删除中' : '删除'}
                     </Button>
                   </div>
                 );

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3203,9 +3203,7 @@ pub async fn bot_check_update(
         .map_err(|e| e.to_string())
 }
 
-/// 升级 bot 制品（停止运行中的 bot → 下载新版本 → 写 version）。
-///
-/// 升级后需用户手动重新启动。
+/// 升级 bot 制品（记录原状态 → 停止 → 下载新版本 → 恢复原状态）。
 #[tauri::command]
 pub async fn bot_upgrade(
     bot_id: String,
@@ -3246,10 +3244,20 @@ pub async fn bot_upgrade(
             );
         }
     });
-    state
-        .bot_store
-        .set_enabled(&bot_id, false)
-        .map_err(|error| format!("升级前取消自动运行失败，未开始升级：{error}"))?;
+    let mcp_removed = unregister_bot_mcp(&bot_id, state.inner()).await?;
+    if let Err(error) = state.bot_store.set_enabled(&bot_id, false) {
+        let recovery = if mcp_removed {
+            ensure_bot_mcp_registered(&bot_id, state.inner())
+                .await
+                .map(|_| "已恢复 MCP 注册".to_string())
+                .unwrap_or_else(|restore_error| format!("恢复 MCP 注册失败：{restore_error}"))
+        } else {
+            "MCP 状态无需恢复".to_string()
+        };
+        return Err(format!(
+            "升级前取消自动运行失败，未开始升级：{error}；{recovery}"
+        ));
+    }
 
     let upgrade_result = state
         .bot_runtime
@@ -3290,12 +3298,65 @@ pub async fn bot_upgrade(
             recovery.push("自动运行状态仍为关闭".to_string());
         }
 
+        if state.bot_runtime.is_running(&bot_id).await {
+            match ensure_bot_mcp_registered(&bot_id, state.inner()).await {
+                Ok(Some(_)) => recovery.push("MCP 注册已恢复".to_string()),
+                Ok(None) => recovery.push("Bot 不需要 MCP 注册".to_string()),
+                Err(error) => recovery.push(format!("恢复 MCP 注册失败：{error}")),
+            }
+        } else if mcp_removed {
+            recovery.push("Bot 未恢复运行，MCP 保持注销".to_string());
+        }
+
         return Err(format!(
             "升级失败：{upgrade_error}；恢复结果：{}",
             recovery.join("；")
         ));
     }
-    Ok("升级完成，请重新启动 bot".to_string())
+
+    let mut restore_errors = Vec::new();
+    let mut restored_running = !was_running;
+    if was_running {
+        match state
+            .bot_runtime
+            .start(
+                &bot,
+                restart_env
+                    .as_ref()
+                    .expect("运行中的 bot 必须准备恢复环境变量"),
+            )
+            .await
+        {
+            Ok(()) => restored_running = true,
+            Err(error) => restore_errors.push(format!("恢复运行失败：{error}")),
+        }
+    }
+
+    if bot.enabled {
+        if let Err(error) = state.bot_store.set_enabled(&bot_id, true) {
+            restore_errors.push(format!("恢复自动运行状态失败：{error}"));
+        }
+    }
+
+    if was_running && restored_running {
+        match ensure_bot_mcp_registered(&bot_id, state.inner()).await {
+            Ok(_) => {}
+            Err(error) => restore_errors.push(format!("恢复 MCP 注册失败：{error}")),
+        }
+    }
+
+    if !restore_errors.is_empty() {
+        return Err(format!(
+            "升级已完成，但恢复原状态失败：{}",
+            restore_errors.join("；")
+        ));
+    }
+
+    if was_running {
+        Ok("升级完成，Bot 已恢复运行".to_string())
+    } else {
+        Ok("升级完成，Bot 保持停止".to_string())
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## 变更内容

- 进入移动端控制页后自动判断 Bot 是否存在新版本，仅在有更新时显示更新按钮
- 更新前停止 Bot 并注销对应 MCP，更新结束后按原状态恢复运行、自动运行和 MCP 注册
- 更新失败时恢复旧制品及原有状态，并明确展示恢复结果
- 缩小 Bot 管理页及相关弹窗的操作按钮，所有按钮显示中文动作名称

## 验证

- yarn build
- cargo fmt --all --check
- cargo check -p tiangong-app
- 推送前自动检查：cargo check、cargo clippy、cargo nextest、前端构建及前端测试
- 桌面和 430px 窄屏界面检查，无文字截断、重叠或横向溢出