### PR TITLE
fix(bots): 取消天工消息转发 120 秒超时

### DIFF
--- a/bots/feishu/src/main.rs
+++ b/bots/feishu/src/main.rs
@@ -27,11 +27,16 @@ mod mcp;
 mod provision;
 mod schema;
 mod target_store;
+#[cfg(test)]
+#[path = "../../test_support.rs"]
+mod test_support;
 
 // ── 数据结构 ──────────────────────────────────────────────────
 
 struct BotState {
     http: reqwest::Client,
+    /// 天工任务允许长时间执行，不设置请求总时限。
+    tiangong_http: reqwest::Client,
     app_id: String,
     app_secret: String,
     access_token: RwLock<Option<String>>,
@@ -393,6 +398,7 @@ async fn main() -> Result<()> {
         http: reqwest::Client::builder()
             .timeout(Duration::from_secs(120))
             .build()?,
+        tiangong_http: reqwest::Client::builder().build()?,
         app_id,
         app_secret,
         access_token: RwLock::new(None),
@@ -921,7 +927,7 @@ async fn forward_to_tiangong(
         media,
     };
 
-    let mut req = state.http.post(&url);
+    let mut req = state.tiangong_http.post(&url);
     if let Some(ref token) = state.tiangong_token {
         req = req.bearer_auth(token);
     }
@@ -1381,6 +1387,8 @@ fn mime_extension(mime: &str) -> &'static str {
 mod tests {
     use super::*;
 
+    const LONG_MOCK_DELAY: Duration = Duration::from_secs(125);
+
     fn request_from(parsed: ParsedMessage) -> ConnectorRequest {
         ConnectorRequest {
             connector: "feishu-bot".to_string(),
@@ -1482,6 +1490,7 @@ mod tests {
     fn bot_state_for_test() -> Arc<BotState> {
         Arc::new(BotState {
             http: reqwest::Client::new(),
+            tiangong_http: reqwest::Client::new(),
             app_id: String::new(),
             app_secret: String::new(),
             access_token: RwLock::new(None),
@@ -1489,6 +1498,53 @@ mod tests {
             tiangong_token: None,
             recent_messages: Mutex::new(RecentMessages::default()),
         })
+    }
+
+    #[tokio::test]
+    #[ignore = "长时回归测试会等待 125 秒"]
+    async fn forward_to_tiangong_waits_beyond_120_seconds() {
+        let body = serde_json::json!({
+            "session_id": "mock-session",
+            "connector": "feishu-bot",
+            "channel_id": "mock-channel",
+            "message": "mock-ok",
+            "content": { "type": "text", "text": "mock-ok" },
+            "attachments": []
+        })
+        .to_string();
+        let (tiangong_url, server) =
+            test_support::spawn_delayed_json_response(LONG_MOCK_DELAY, body).await;
+        let state = Arc::new(BotState {
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(120))
+                .build()
+                .unwrap(),
+            tiangong_http: reqwest::Client::builder().build().unwrap(),
+            app_id: String::new(),
+            app_secret: String::new(),
+            access_token: RwLock::new(None),
+            tiangong_url,
+            tiangong_token: None,
+            recent_messages: Mutex::new(RecentMessages::default()),
+        });
+
+        let started = std::time::Instant::now();
+        let reply = forward_to_tiangong(
+            &state,
+            "mock-channel",
+            "mock-sender",
+            &Some("mock-message".to_string()),
+            ApiMessageContent::Text {
+                text: "mock-request".to_string(),
+            },
+            Vec::new(),
+        )
+        .await
+        .expect("天工长任务响应不应在 120 秒时超时");
+
+        assert!(started.elapsed() >= LONG_MOCK_DELAY);
+        assert_eq!(reply.text, "mock-ok");
+        server.await.expect("长时 Mock 服务异常退出");
     }
 
     fn image_content(url: &str) -> ApiMessageContent {

--- a/bots/feishu/src/mcp.rs
+++ b/bots/feishu/src/mcp.rs
@@ -262,6 +262,7 @@ pub async fn serve() -> Result<()> {
         http: reqwest::Client::builder()
             .timeout(Duration::from_secs(20))
             .build()?,
+        tiangong_http: reqwest::Client::new(),
         app_id: credentials.app_id,
         app_secret: credentials.app_secret,
         access_token: tokio::sync::RwLock::new(None),

--- a/bots/qq/src/main.rs
+++ b/bots/qq/src/main.rs
@@ -31,6 +31,9 @@ mod mcp;
 mod provision;
 mod schema;
 mod target_store;
+#[cfg(test)]
+#[path = "../../test_support.rs"]
+mod test_support;
 mod token;
 
 use gateway::{DispatchEvent, GatewayRunner, INTENT_GROUP_AND_C2C_EVENT};
@@ -44,6 +47,8 @@ const OPENAPI_BASE: &str = "https://api.sgroup.qq.com";
 
 struct BotState {
     http: Client,
+    /// 天工任务允许长时间执行，不设置请求总时限。
+    tiangong_http: Client,
     token: AccessTokenCache,
     /// 天工 server 地址，如 http://127.0.0.1:8080
     tiangong_url: String,
@@ -364,6 +369,9 @@ async fn main() -> Result<()> {
 
     let state = Arc::new(BotState {
         http: http.clone(),
+        tiangong_http: Client::builder()
+            .build()
+            .context("构建天工 HTTP 客户端失败")?,
         token,
         tiangong_url,
         tiangong_token,
@@ -615,7 +623,7 @@ async fn forward_to_tiangong(
         media: parsed.media,
     };
 
-    let mut builder = state.http.post(url);
+    let mut builder = state.tiangong_http.post(url);
     if let Some(token) = &state.tiangong_token {
         builder = builder.bearer_auth(token);
     }
@@ -1052,6 +1060,54 @@ fn truncate_str(value: &str, max_chars: usize) -> String {
 mod tests {
     use super::*;
 
+    const LONG_MOCK_DELAY: Duration = Duration::from_secs(125);
+
+    #[tokio::test]
+    #[ignore = "长时回归测试会等待 125 秒"]
+    async fn forward_to_tiangong_waits_beyond_120_seconds() {
+        let body = serde_json::json!({
+            "session_id": "mock-session",
+            "message": "mock-ok",
+            "content": { "type": "text", "text": "mock-ok" },
+            "attachments": []
+        })
+        .to_string();
+        let (tiangong_url, server) =
+            test_support::spawn_delayed_json_response(LONG_MOCK_DELAY, body).await;
+        let http = Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+            .unwrap();
+        let state = BotState {
+            http: http.clone(),
+            tiangong_http: Client::builder().build().unwrap(),
+            token: AccessTokenCache::new(http, String::new(), String::new()),
+            tiangong_url,
+            tiangong_token: None,
+            recent_messages: Mutex::new(RecentMessages::default()),
+        };
+
+        let started = std::time::Instant::now();
+        let reply = forward_to_tiangong(
+            &state,
+            "mock-channel",
+            "mock-sender",
+            "mock-message",
+            ParsedMessage {
+                content: ApiMessageContent::Text {
+                    text: "mock-request".to_string(),
+                },
+                media: Vec::new(),
+            },
+        )
+        .await
+        .expect("天工长任务响应不应在 120 秒时超时");
+
+        assert!(started.elapsed() >= LONG_MOCK_DELAY);
+        assert_eq!(reply.text, "mock-ok");
+        server.await.expect("长时 Mock 服务异常退出");
+    }
+
     #[test]
     fn recent_messages_deduplicates_and_releases() {
         let mut messages = RecentMessages::default();
@@ -1204,6 +1260,7 @@ mod tests {
     fn bot_state_for_test() -> BotState {
         BotState {
             http: Client::new(),
+            tiangong_http: Client::new(),
             // 测试只覆盖文本/空附件路径，不会触发 token 刷新，故用空凭证
             token: AccessTokenCache::new(Client::new(), String::new(), String::new()),
             tiangong_url: String::new(),

--- a/bots/qq/src/mcp.rs
+++ b/bots/qq/src/mcp.rs
@@ -257,6 +257,7 @@ pub async fn serve() -> Result<()> {
     let token = AccessTokenCache::new(http.clone(), credentials.app_id, credentials.app_secret);
     let state = Arc::new(BotState {
         http,
+        tiangong_http: reqwest::Client::new(),
         token,
         tiangong_url: String::new(),
         tiangong_token: None,

--- a/bots/test_support.rs
+++ b/bots/test_support.rs
@@ -1,0 +1,32 @@
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::task::JoinHandle;
+
+pub async fn spawn_delayed_json_response(
+    delay: Duration,
+    body: String,
+) -> (String, JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("绑定长时 Mock 服务失败");
+    let address = listener.local_addr().expect("读取长时 Mock 地址失败");
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("接收 Mock 请求失败");
+        let mut request = [0_u8; 8192];
+        let size = stream.read(&mut request).await.expect("读取 Mock 请求失败");
+        assert!(size > 0, "Mock 服务必须收到请求后再开始等待");
+
+        tokio::time::sleep(delay).await;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("写入 Mock 响应失败");
+    });
+    (format!("http://{address}"), server)
+}

--- a/bots/weixin/src/main.rs
+++ b/bots/weixin/src/main.rs
@@ -22,12 +22,17 @@ mod mcp;
 mod provision;
 mod schema;
 mod target_store;
+#[cfg(test)]
+#[path = "../../test_support.rs"]
+mod test_support;
 
 const POLL_ERROR_BACKOFF: Duration = Duration::from_secs(5);
 const RECENT_MESSAGE_LIMIT: usize = 1024;
 
 struct BotState {
     http: Client,
+    /// 天工任务允许长时间执行，不设置请求总时限。
+    tiangong_http: Client,
     bot_token: String,
     api_base_url: String,
     tiangong_url: String,
@@ -275,6 +280,9 @@ async fn main() -> Result<()> {
             .timeout(Duration::from_secs(120))
             .build()
             .context("构建 HTTP 客户端失败")?,
+        tiangong_http: Client::builder()
+            .build()
+            .context("构建天工 HTTP 客户端失败")?,
         bot_token: credentials.bot_token,
         api_base_url: credentials
             .base_url
@@ -624,7 +632,7 @@ async fn forward_to_tiangong(
         media,
     };
 
-    let mut builder = state.http.post(url);
+    let mut builder = state.tiangong_http.post(url);
     if let Some(token) = &state.tiangong_token {
         builder = builder.bearer_auth(token);
     }
@@ -672,6 +680,53 @@ fn reply_from_connector_response(body: ConnectorResponse) -> BotReply {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const LONG_MOCK_DELAY: Duration = Duration::from_secs(125);
+
+    #[tokio::test]
+    #[ignore = "长时回归测试会等待 125 秒"]
+    async fn forward_to_tiangong_waits_beyond_120_seconds() {
+        let body = serde_json::json!({
+            "session_id": "mock-session",
+            "message": "mock-ok",
+            "content": { "type": "text", "text": "mock-ok" },
+            "attachments": []
+        })
+        .to_string();
+        let (tiangong_url, server) =
+            test_support::spawn_delayed_json_response(LONG_MOCK_DELAY, body).await;
+        let state = BotState {
+            http: Client::builder()
+                .timeout(Duration::from_secs(120))
+                .build()
+                .unwrap(),
+            tiangong_http: Client::builder().build().unwrap(),
+            bot_token: String::new(),
+            api_base_url: String::new(),
+            tiangong_url,
+            tiangong_token: None,
+            cursor: RwLock::new(String::new()),
+            recent_messages: Mutex::new(RecentMessages::default()),
+        };
+
+        let started = std::time::Instant::now();
+        let reply = forward_to_tiangong(
+            &state,
+            "mock-channel",
+            "mock-sender",
+            Some("mock-message"),
+            ApiMessageContent::Text {
+                text: "mock-request".to_string(),
+            },
+            Vec::new(),
+        )
+        .await
+        .expect("天工长任务响应不应在 120 秒时超时");
+
+        assert!(started.elapsed() >= LONG_MOCK_DELAY);
+        assert_eq!(reply.text, "mock-ok");
+        server.await.expect("长时 Mock 服务异常退出");
+    }
 
     #[test]
     fn recent_messages_can_retry_failed_message() {

--- a/bots/weixin/src/mcp.rs
+++ b/bots/weixin/src/mcp.rs
@@ -248,6 +248,7 @@ pub async fn serve() -> Result<()> {
             .timeout(Duration::from_secs(120))
             .build()
             .context("构建微信 MCP HTTP 客户端失败")?,
+        tiangong_http: reqwest::Client::new(),
         bot_token: credentials.bot_token,
         api_base_url: credentials
             .base_url


### PR DESCRIPTION
## 变更

- 飞书、微信和 QQ Bot 调用天工时改用不设总等待上限的独立客户端
- 平台接口、扫码、上传和 MCP 的原有超时保持不变
- 增加三端共用的 125 秒长时 Mock 回归测试

## 验证

- 三个 Bot 格式检查通过
- 现有测试通过：飞书 12 项、微信 15 项、QQ 30 项
- 三个 Bot 严格检查通过
- 三个 Bot 正式构建通过
- 三项 125 秒长时 Mock 测试均在 125.01 秒成功返回