### PR TITLE
chore(bots): 发布 0.2.1 修复版本

### DIFF
--- a/bots/feishu/Cargo.lock
+++ b/bots/feishu/Cargo.lock
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-bot-feishu"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/bots/feishu/Cargo.toml
+++ b/bots/feishu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-bot-feishu"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "天工飞书 bot 制品——WebSocket 长连接接收飞书消息并转发到天工"

--- a/bots/qq/Cargo.lock
+++ b/bots/qq/Cargo.lock
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-bot-qq"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/bots/qq/Cargo.toml
+++ b/bots/qq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-bot-qq"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "天工 QQ bot 制品——通过 QQ 开放平台 WebSocket 网关接收 QQ 消息并转发到天工"

--- a/bots/weixin/Cargo.lock
+++ b/bots/weixin/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-bot-weixin"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/bots/weixin/Cargo.toml
+++ b/bots/weixin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-bot-weixin"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "天工微信 bot 制品——基于腾讯 iLink 协议长轮询接收微信消息并转发到天工"

--- a/bots/weixin/src/ilink.rs
+++ b/bots/weixin/src/ilink.rs
@@ -26,7 +26,7 @@ const BOT_TYPE: u32 = 3;
 const ILINK_APP_ID: &str = "bot";
 const ILINK_APP_CLIENT_VERSION: &str = "132102";
 const CHANNEL_VERSION: &str = "2.4.6";
-const BOT_AGENT: &str = "Tiangong/0.2.0";
+const BOT_AGENT: &str = "Tiangong/0.2.1";
 
 fn build_common_headers() -> HeaderMap {
     let mut headers = HeaderMap::new();


### PR DESCRIPTION
## 变更

- 飞书、微信和 QQ Bot 版本统一升级为 0.2.1
- 同步微信 Bot 的客户端版本标识
- 为已合入的长任务等待修复准备独立发布

## 验证

- 三个 Bot 格式检查通过
- 三个 Bot 编译、测试和严格检查通过
- 三个 Bot 正式构建通过
- 三个 Bot 的 125 秒 Mock 长任务回归通过