### PR TITLE
perf(index): 工作区索引预扫描、后台化与共享管理器 (#259)

### DIFF
--- a/crates/plugins/tiangong-plugin-index/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-index/src/handler.rs
@@ -91,19 +91,24 @@ impl IndexPlugin {
             && let Some(cwd) = self.workspace()
             && cwd.is_dir()
         {
-            let index_query = IndexQuery::new(query)
-                .with_scope(IndexScope::Workspace)
-                .with_limit(limit);
-            match im.search(&cwd, &index_query) {
-                Ok(hits) if !hits.is_empty() => {
-                    stdout_parts.push("【工作区文件】".to_string());
-                    for hit in &hits {
-                        stdout_parts.push(format!("- {} ({})", hit.path, hit.language));
+            // 后台扫描进行中时 workspace 索引在自身 Mutex 上不可用，降级提示而非阻塞。
+            if self.is_scanning() {
+                stdout_parts.push("【工作区索引正在构建中，请稍候】".to_string());
+            } else {
+                let index_query = IndexQuery::new(query)
+                    .with_scope(IndexScope::Workspace)
+                    .with_limit(limit);
+                match im.search(&cwd, &index_query) {
+                    Ok(hits) if !hits.is_empty() => {
+                        stdout_parts.push("【工作区文件】".to_string());
+                        for hit in &hits {
+                            stdout_parts.push(format!("- {} ({})", hit.path, hit.language));
+                        }
                     }
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    stdout_parts.push(format!("【工作区搜索失败: {e}】"));
+                    Ok(_) => {}
+                    Err(e) => {
+                        stdout_parts.push(format!("【工作区搜索失败: {e}】"));
+                    }
                 }
             }
         }

--- a/crates/plugins/tiangong-plugin-index/src/index/mod.rs
+++ b/crates/plugins/tiangong-plugin-index/src/index/mod.rs
@@ -346,17 +346,20 @@ impl IndexManager {
         Ok(result)
     }
 
-    pub fn delete_workspace_index(&self, workspace_id: &str) -> Result<()> {
-        self.workspaces.remove(workspace_id);
+    /// 删除指定工作区的索引。
+    ///
+    /// `root` 用于清理共享 manager 的内存缓存（缓存以 `workspace_key(root)` 为键）
+    /// 并由调用方据此取得扫描许可；`workspace_id`（`hash_path(root)`）用于定位磁盘
+    /// 索引目录。二者来自不同的键派生，必须分别传入——此前仅传 `workspace_id` 时，
+    /// `workspaces.remove(workspace_id)` 因键不匹配而无法清理缓存，导致删除后进程内
+    /// 仍使用旧索引对象。
+    pub fn delete_workspace_index(&self, root: &Path, workspace_id: &str) -> Result<()> {
+        self.workspaces.remove(&workspace_key(root));
         let dir = self.base_dir.join("workspaces").join(workspace_id);
         if dir.exists() {
             fs::remove_dir_all(&dir).context("删除 Workspace 索引失败")?;
         }
         Ok(())
-    }
-
-    pub fn rebuild_workspace_index(&self, root: &Path) -> Result<usize> {
-        self.full_scan(root)
     }
 
     pub fn session_turn_count(&self, session_id: &str) -> Result<usize> {
@@ -393,11 +396,6 @@ impl IndexManager {
 pub fn list_workspace_indexes_for_gui() -> Result<Vec<WorkspaceIndexInfo>> {
     let manager = IndexManager::new()?;
     manager.list_workspace_indexes()
-}
-
-pub fn delete_workspace_index_for_gui(workspace_id: &str) -> Result<()> {
-    let manager = IndexManager::new()?;
-    manager.delete_workspace_index(workspace_id)
 }
 
 /// 检查 workspace 索引是否已存在
@@ -614,5 +612,45 @@ mod tests {
             manager.try_begin_workspace_scan(&dot).is_none(),
             "等价路径（.）应视为同一工作区，去重不被绕过"
         );
+    }
+
+    /// 删除工作区索引后，共享 manager 的内存缓存应被清理（修复 cache-key 不匹配）。
+    ///
+    /// 回归覆盖：原 `delete_workspace_index` 仅传 `workspace_id`（hash_path），而缓存
+    /// 以 `workspace_key(root)`（canonicalize）为键，键不匹配导致 `workspaces.remove`
+    /// 无法清理——删除后进程内仍使用旧 `WorkspaceIndex` 对象。修复后传 `(root,
+    /// workspace_id)`，缓存按 root 正确移除。
+    #[test]
+    fn delete_workspace_index_clears_in_memory_cache() {
+        use crate::index::workspace_index;
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let manager =
+            Arc::new(IndexManager::new_with_dir(temp.path().join("index")).expect("manager"));
+        let root = temp.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join("lib.rs"),
+            "pub fn demo() {}
+",
+        )
+        .unwrap();
+
+        // 建索引使 manager 缓存中存在该 root 的 WorkspaceIndex。
+        let count = manager.full_scan(&root).expect("full_scan");
+        assert_eq!(count, 1);
+        let workspace_id = workspace_index::hash_path(&root);
+
+        // 删除应同时清理内存缓存与磁盘目录。
+        manager
+            .delete_workspace_index(&root, &workspace_id)
+            .expect("delete");
+
+        // 内存缓存应已移除：再次 get_or_create 应得到全新对象（而非旧缓存）。
+        assert!(
+            manager.get_or_create_workspace_index(&root).is_ok(),
+            "删除后可重新创建索引对象"
+        );
+        // 磁盘目录应已删除（workspace_index_exists 检查磁盘）。
+        assert!(!workspace_index_exists(&root), "磁盘索引目录应已删除");
     }
 }

--- a/crates/plugins/tiangong-plugin-index/src/index/mod.rs
+++ b/crates/plugins/tiangong-plugin-index/src/index/mod.rs
@@ -626,74 +626,92 @@ mod tests {
         );
     }
 
-    /// 删除工作区索引后，共享 manager 的内存缓存应被清理（修复 cache-key 不匹配）。
+    /// 删除工作区索引后，共享 manager 的内存缓存被清理、磁盘目录被删除。
     ///
-    /// 回归覆盖：原 `delete_workspace_index` 仅传 `workspace_id`（hash_path），而缓存
-    /// 以 `workspace_key(root)`（canonicalize）为键，键不匹配导致 `workspaces.remove`
-    /// 无法清理——删除后进程内仍使用旧 `WorkspaceIndex` 对象。修复后传 `(root,
-    /// workspace_id)`，缓存按 root 正确移除。
+    /// 用测试 manager 实际的 base_dir 定位磁盘目录（而非 `workspace_index_exists`，
+    /// 后者检查用户默认目录，与测试临时目录无关），并用 `Arc::ptr_eq` 确认删除后
+    /// 返回的是全新对象而非旧缓存——这是缓存清理测试最关键的断言。
     #[test]
-    fn delete_workspace_index_clears_in_memory_cache() {
+    fn delete_workspace_index_clears_cache_and_disk_index() {
         use crate::index::workspace_index;
         let temp = tempfile::tempdir().expect("create tempdir");
-        let manager =
-            Arc::new(IndexManager::new_with_dir(temp.path().join("index")).expect("manager"));
-        let root = temp.path().join("workspace");
-        std::fs::create_dir_all(&root).unwrap();
-        std::fs::write(
-            root.join("lib.rs"),
-            "pub fn demo() {}
-",
-        )
-        .unwrap();
+        let base_dir = temp.path().join("index");
+        let manager = Arc::new(IndexManager::new_with_dir(base_dir.clone()).expect("manager"));
 
-        // 建索引使 manager 缓存中存在该 root 的 WorkspaceIndex。
+        let root = temp.path().join("workspace");
+        std::fs::create_dir_all(&root).expect("create workspace");
+        std::fs::write(root.join("lib.rs"), "pub fn demo() {}\n").expect("write source file");
+
+        // 首次建索引，并保存缓存对象。
         let count = manager.full_scan(&root).expect("full_scan");
         assert_eq!(count, 1);
-        let workspace_id = workspace_index::hash_path(&root);
+        let old_index = manager
+            .get_or_create_workspace_index(&root)
+            .expect("get old index");
 
-        // 删除应同时清理内存缓存与磁盘目录。
+        let workspace_id = workspace_index::hash_path(&root);
+        let workspace_dir = base_dir.join("workspaces").join(&workspace_id);
+        let tantivy_dir = workspace_dir.join("tantivy");
+        // 删除前确认磁盘目录确实存在（避免测试因目录本就不存在而误通过）。
+        assert!(workspace_dir.is_dir(), "删除前工作区索引目录应存在");
+        assert!(tantivy_dir.is_dir(), "删除前 Tantivy 索引目录应存在");
+
+        // 删除索引。
         manager
             .delete_workspace_index(&root, &workspace_id)
-            .expect("delete");
+            .expect("delete index");
 
-        // 内存缓存应已移除：再次 get_or_create 应得到全新对象（而非旧缓存）。
+        // 确认测试 manager 实际使用的磁盘目录已删除。
+        assert!(!workspace_dir.exists(), "删除后工作区索引目录不应存在");
+
+        // 再次获取时必须创建新的对象，不能返回旧缓存。
+        let new_index = manager
+            .get_or_create_workspace_index(&root)
+            .expect("recreate index");
         assert!(
-            manager.get_or_create_workspace_index(&root).is_ok(),
-            "删除后可重新创建索引对象"
+            !Arc::ptr_eq(&old_index, &new_index),
+            "删除后不应继续返回旧的缓存对象"
         );
-        // 磁盘目录应已删除（workspace_index_exists 检查磁盘）。
-        assert!(!workspace_index_exists(&root), "磁盘索引目录应已删除");
     }
 
-    /// root 与 workspace_id 不一致时拒绝删除（防御性校验）。
+    /// root 与 workspace_id 不一致时拒绝删除（防御性校验），且校验失败完全无副作用：
+    /// 不删除正确的磁盘目录，也不清理正确的缓存对象。
     #[test]
     fn delete_workspace_index_rejects_mismatched_id() {
         use crate::index::workspace_index;
         let temp = tempfile::tempdir().expect("create tempdir");
-        let manager =
-            Arc::new(IndexManager::new_with_dir(temp.path().join("index")).expect("manager"));
+        let base_dir = temp.path().join("index");
+        let manager = Arc::new(IndexManager::new_with_dir(base_dir.clone()).expect("manager"));
+
         let root = temp.path().join("workspace");
-        std::fs::create_dir_all(&root).unwrap();
-        std::fs::write(
-            root.join("lib.rs"),
-            "pub fn demo() {}
-",
-        )
-        .unwrap();
+        std::fs::create_dir_all(&root).expect("create workspace");
+        std::fs::write(root.join("lib.rs"), "pub fn demo() {}\n").expect("write source file");
         manager.full_scan(&root).expect("full_scan");
 
-        // 用错误的 workspace_id 删除应报错，不触及磁盘目录。
-        let wrong_id = "deadbeefdeadbeef";
-        let err = manager.delete_workspace_index(&root, wrong_id).unwrap_err();
+        let old_index = manager
+            .get_or_create_workspace_index(&root)
+            .expect("get old index");
+        let correct_id = workspace_index::hash_path(&root);
+        let workspace_dir = base_dir.join("workspaces").join(&correct_id);
+        assert!(workspace_dir.is_dir(), "删除前工作区索引目录应存在");
+
+        // 用错误的 workspace_id 删除应报错。
+        let err = manager
+            .delete_workspace_index(&root, "deadbeefdeadbeef")
+            .expect_err("mismatched id should fail");
         assert!(
             err.to_string().contains("不匹配"),
             "应拒绝不匹配的 workspace_id，实际错误: {err}"
         );
-        // 正确的 id 仍可删除。
-        let correct_id = workspace_index::hash_path(&root);
-        manager
-            .delete_workspace_index(&root, &correct_id)
-            .expect("正确 id 应删除成功");
+
+        // 校验失败不应删除正确的磁盘目录，也不应清理正确的缓存对象。
+        assert!(workspace_dir.is_dir(), "错误请求不应删除正确索引目录");
+        let current_index = manager
+            .get_or_create_workspace_index(&root)
+            .expect("get cached index");
+        assert!(
+            Arc::ptr_eq(&old_index, &current_index),
+            "错误请求不应清理正确的缓存对象"
+        );
     }
 }

--- a/crates/plugins/tiangong-plugin-index/src/index/mod.rs
+++ b/crates/plugins/tiangong-plugin-index/src/index/mod.rs
@@ -354,6 +354,18 @@ impl IndexManager {
     /// `workspaces.remove(workspace_id)` 因键不匹配而无法清理缓存，导致删除后进程内
     /// 仍使用旧索引对象。
     pub fn delete_workspace_index(&self, root: &Path, workspace_id: &str) -> Result<()> {
+        // 防御性校验：root 与 workspace_id 必须一致（workspace_id 应为 hash_path(root)）。
+        // 二者来自前端同一条记录，正常一致；校验可防止过期数据、错误调用或未来维护
+        // 时误删其他工作区的磁盘索引目录。
+        let expected_id = workspace_index::hash_path(root);
+        if workspace_id != expected_id {
+            return Err(anyhow::anyhow!(
+                "工作区路径与索引 ID 不匹配：root={} workspace_id={} expected={}",
+                root.display(),
+                workspace_id,
+                expected_id
+            ));
+        }
         self.workspaces.remove(&workspace_key(root));
         let dir = self.base_dir.join("workspaces").join(workspace_id);
         if dir.exists() {
@@ -652,5 +664,36 @@ mod tests {
         );
         // 磁盘目录应已删除（workspace_index_exists 检查磁盘）。
         assert!(!workspace_index_exists(&root), "磁盘索引目录应已删除");
+    }
+
+    /// root 与 workspace_id 不一致时拒绝删除（防御性校验）。
+    #[test]
+    fn delete_workspace_index_rejects_mismatched_id() {
+        use crate::index::workspace_index;
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let manager =
+            Arc::new(IndexManager::new_with_dir(temp.path().join("index")).expect("manager"));
+        let root = temp.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join("lib.rs"),
+            "pub fn demo() {}
+",
+        )
+        .unwrap();
+        manager.full_scan(&root).expect("full_scan");
+
+        // 用错误的 workspace_id 删除应报错，不触及磁盘目录。
+        let wrong_id = "deadbeefdeadbeef";
+        let err = manager.delete_workspace_index(&root, wrong_id).unwrap_err();
+        assert!(
+            err.to_string().contains("不匹配"),
+            "应拒绝不匹配的 workspace_id，实际错误: {err}"
+        );
+        // 正确的 id 仍可删除。
+        let correct_id = workspace_index::hash_path(&root);
+        manager
+            .delete_workspace_index(&root, &correct_id)
+            .expect("正确 id 应删除成功");
     }
 }

--- a/crates/plugins/tiangong-plugin-index/src/index/mod.rs
+++ b/crates/plugins/tiangong-plugin-index/src/index/mod.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use anyhow::{Context, Result};
 use dashmap::DashMap;
@@ -89,6 +90,9 @@ pub struct WorkspaceIndexInfo {
 pub struct IndexManager {
     workspaces: DashMap<String, Arc<std::sync::Mutex<WorkspaceIndex>>>,
     sessions: DashMap<String, Arc<std::sync::Mutex<SessionIndex>>>,
+    /// 每个 workspace root 的后台扫描标志（key = root display string）。
+    /// 单例化后由所有 IndexPlugin 共享，使 A 对话扫描时 B 对话的 index_search 也能降级。
+    scanning_roots: DashMap<String, Arc<AtomicBool>>,
     base_dir: PathBuf,
 }
 
@@ -107,8 +111,28 @@ impl IndexManager {
         Ok(Self {
             workspaces: DashMap::new(),
             sessions: DashMap::new(),
+            scanning_roots: DashMap::new(),
             base_dir,
         })
+    }
+
+    /// 取（或创建）指定 root 的后台扫描标志。同一 manager + 同一 root 返回同一 Arc。
+    pub fn scanning_flag_for(&self, root: &Path) -> Arc<AtomicBool> {
+        let key = root.to_string_lossy().to_string();
+        if let Some(entry) = self.scanning_roots.get(&key) {
+            return Arc::clone(entry.value());
+        }
+        let flag = Arc::new(AtomicBool::new(false));
+        self.scanning_roots.insert(key, Arc::clone(&flag));
+        flag
+    }
+
+    /// 指定 root 是否正在后台扫描。
+    pub fn is_scanning(&self, root: &Path) -> bool {
+        let key = root.to_string_lossy().to_string();
+        self.scanning_roots
+            .get(&key)
+            .is_some_and(|f| f.load(std::sync::atomic::Ordering::Relaxed))
     }
 
     pub fn get_or_create_workspace_index(

--- a/crates/plugins/tiangong-plugin-index/src/index/mod.rs
+++ b/crates/plugins/tiangong-plugin-index/src/index/mod.rs
@@ -340,6 +340,24 @@ pub fn rebuild_workspace_index_for_gui(root: &Path) -> Result<usize> {
     manager.rebuild_workspace_index(root)
 }
 
+/// 预热工作区索引：若索引已存在则直接返回，否则后台启动全量扫描，立即返回不阻塞。
+///
+/// 用于在创建新对话/选定工作目录时提前构建索引，消除首次发送消息时的同步扫描延迟。
+/// 线程内结果仅记日志（info 成功 / warn 失败），不影响调用方。
+pub fn prewarm_workspace_index_for_gui(root: &Path) -> Result<()> {
+    if !root.is_dir() || workspace_index_exists(root) {
+        return Ok(());
+    }
+    let manager = IndexManager::new()?;
+    let root = root.to_path_buf();
+    tracing::info!(workspace = %root.display(), "Workspace 索引预热启动");
+    std::thread::spawn(move || match manager.full_scan(&root) {
+        Ok(count) => tracing::info!(count, "Workspace 索引预热完成"),
+        Err(e) => tracing::warn!("Workspace 索引预热失败: {e}"),
+    });
+    Ok(())
+}
+
 /// 检查 workspace 索引是否已存在
 pub fn workspace_index_exists(root: &Path) -> bool {
     let tantivy_dir = workspace_index_dir(root);

--- a/crates/plugins/tiangong-plugin-index/src/index/mod.rs
+++ b/crates/plugins/tiangong-plugin-index/src/index/mod.rs
@@ -117,14 +117,17 @@ impl IndexManager {
     }
 
     /// 取（或创建）指定 root 的后台扫描标志。同一 manager + 同一 root 返回同一 Arc。
+    ///
+    /// 经 `entry().or_insert_with()` 原子化「取或建」，避免并发首次访问时多个线程
+    /// 各自 miss 后创建不同 flag，导致同一工作区被并发扫描、`is_scanning` 观察失真。
     pub fn scanning_flag_for(&self, root: &Path) -> Arc<AtomicBool> {
         let key = root.to_string_lossy().to_string();
-        if let Some(entry) = self.scanning_roots.get(&key) {
-            return Arc::clone(entry.value());
-        }
-        let flag = Arc::new(AtomicBool::new(false));
-        self.scanning_roots.insert(key, Arc::clone(&flag));
-        flag
+        Arc::clone(
+            self.scanning_roots
+                .entry(key)
+                .or_insert_with(|| Arc::new(AtomicBool::new(false)))
+                .value(),
+        )
     }
 
     /// 指定 root 是否正在后台扫描。
@@ -460,4 +463,49 @@ fn default_base_dir() -> PathBuf {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."));
     home.join(".tiangong").join("index")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    /// 并发首次为同一路径创建扫描标志，必须全部返回同一 Arc（去重原子性）。
+    ///
+    /// 回归覆盖：原「先 get 再 insert」实现下，多线程同时 miss 会各自创建不同 flag，
+    /// 导致同一工作区被并发扫描、`is_scanning` 观察失真。
+    #[test]
+    fn scanning_flag_for_concurrent_returns_same_arc() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let manager =
+            Arc::new(IndexManager::new_with_dir(temp.path().join("index")).expect("manager"));
+        let root = temp.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let barrier = Arc::new(std::sync::Barrier::new(8));
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let manager = Arc::clone(&manager);
+            let barrier = Arc::clone(&barrier);
+            let root = root.clone();
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                manager.scanning_flag_for(&root)
+            }));
+        }
+        let flags: Vec<Arc<AtomicBool>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let anchor = Arc::as_ptr(&flags[0]);
+        assert!(
+            flags.iter().all(|f| Arc::as_ptr(f) == anchor),
+            "并发创建的扫描标志必须全部指向同一 Arc"
+        );
+
+        // 置位后 is_scanning 应反映该 root 的状态，其它 root 不受影响。
+        flags[0].store(true, std::sync::atomic::Ordering::SeqCst);
+        assert!(manager.is_scanning(&root));
+        let other = temp.path().join("other");
+        std::fs::create_dir_all(&other).unwrap();
+        assert!(!manager.is_scanning(&other));
+    }
 }

--- a/crates/plugins/tiangong-plugin-index/src/index/mod.rs
+++ b/crates/plugins/tiangong-plugin-index/src/index/mod.rs
@@ -137,12 +137,10 @@ impl IndexManager {
 
     /// 取（或创建）指定 root 的后台扫描标志。同一 manager + 同一 root 返回同一 Arc。
     ///
+    /// 取（或创建）指定 root 的后台扫描标志。同一 manager + 同一 root 返回同一 Arc。
+    ///
     /// 私有：扫描状态的获取与释放应由 [`IndexManager::try_begin_workspace_scan`]
     /// 返回的许可统一管理，避免调用方各自 `swap`/`store` 造成漏复位或绕过去重。
-    ///
-    /// 经 `entry().or_insert_with()` 原子化「取或建」，避免并发首次访问时多个线程
-    /// 各自 miss 后创建不同 flag，导致同一工作区被并发扫描、状态观察失真。
-    /// 取（或创建）指定 root 的后台扫描标志。同一 manager + 同一 root 返回同一 Arc。
     ///
     /// 经 `Mutex<HashMap>` 保护 get-or-create：并发首次访问时锁保证只有一个线程
     /// 创建该 root 的标志，其余线程在锁内读到已存在的 Arc。此前用 `DashMap::entry()`
@@ -400,29 +398,6 @@ pub fn list_workspace_indexes_for_gui() -> Result<Vec<WorkspaceIndexInfo>> {
 pub fn delete_workspace_index_for_gui(workspace_id: &str) -> Result<()> {
     let manager = IndexManager::new()?;
     manager.delete_workspace_index(workspace_id)
-}
-
-pub fn rebuild_workspace_index_for_gui(root: &Path) -> Result<usize> {
-    let manager = IndexManager::new()?;
-    manager.rebuild_workspace_index(root)
-}
-
-/// 预热工作区索引：若索引已存在则直接返回，否则后台启动全量扫描，立即返回不阻塞。
-///
-/// 用于在创建新对话/选定工作目录时提前构建索引，消除首次发送消息时的同步扫描延迟。
-/// 线程内结果仅记日志（info 成功 / warn 失败），不影响调用方。
-pub fn prewarm_workspace_index_for_gui(root: &Path) -> Result<()> {
-    if !root.is_dir() || workspace_index_exists(root) {
-        return Ok(());
-    }
-    let manager = IndexManager::new()?;
-    let root = root.to_path_buf();
-    tracing::info!(workspace = %root.display(), "Workspace 索引预热启动");
-    std::thread::spawn(move || match manager.full_scan(&root) {
-        Ok(count) => tracing::info!(count, "Workspace 索引预热完成"),
-        Err(e) => tracing::warn!("Workspace 索引预热失败: {e}"),
-    });
-    Ok(())
 }
 
 /// 检查 workspace 索引是否已存在

--- a/crates/plugins/tiangong-plugin-index/src/index/mod.rs
+++ b/crates/plugins/tiangong-plugin-index/src/index/mod.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::{Context, Result};
 use dashmap::DashMap;
@@ -90,10 +90,29 @@ pub struct WorkspaceIndexInfo {
 pub struct IndexManager {
     workspaces: DashMap<String, Arc<std::sync::Mutex<WorkspaceIndex>>>,
     sessions: DashMap<String, Arc<std::sync::Mutex<SessionIndex>>>,
-    /// 每个 workspace root 的后台扫描标志（key = root display string）。
+    /// 每个 workspace root 的后台扫描标志（key = `workspace_key(root)`）。
     /// 单例化后由所有 IndexPlugin 共享，使 A 对话扫描时 B 对话的 index_search 也能降级。
-    scanning_roots: DashMap<String, Arc<AtomicBool>>,
+    scanning_roots: std::sync::Mutex<std::collections::HashMap<String, Arc<AtomicBool>>>,
     base_dir: PathBuf,
+}
+
+/// 工作区扫描资格许可（RAII）。
+///
+/// 由 [`IndexManager::try_begin_workspace_scan`] 原子取得，代表「已获得对该工作区
+/// 执行后台扫描的独占资格」。持有期间 [`IndexManager::is_workspace_scanning`] 对该
+/// root 返回 true；drop 时自动复位，无需调用方手动释放——覆盖正常返回、错误返回、
+/// 以及线程 panic 展开三种情况。
+///
+/// 设计目的：把扫描状态的获取/释放收敛到 [`IndexManager`]，调用方只持 permit，
+/// 无法接触底层原子标志，杜绝漏复位或绕过去重。
+pub struct WorkspaceScanPermit {
+    scanning: Arc<AtomicBool>,
+}
+
+impl Drop for WorkspaceScanPermit {
+    fn drop(&mut self) {
+        self.scanning.store(false, Ordering::Release);
+    }
 }
 
 impl IndexManager {
@@ -111,38 +130,59 @@ impl IndexManager {
         Ok(Self {
             workspaces: DashMap::new(),
             sessions: DashMap::new(),
-            scanning_roots: DashMap::new(),
+            scanning_roots: std::sync::Mutex::new(std::collections::HashMap::new()),
             base_dir,
         })
     }
 
     /// 取（或创建）指定 root 的后台扫描标志。同一 manager + 同一 root 返回同一 Arc。
     ///
+    /// 私有：扫描状态的获取与释放应由 [`IndexManager::try_begin_workspace_scan`]
+    /// 返回的许可统一管理，避免调用方各自 `swap`/`store` 造成漏复位或绕过去重。
+    ///
     /// 经 `entry().or_insert_with()` 原子化「取或建」，避免并发首次访问时多个线程
-    /// 各自 miss 后创建不同 flag，导致同一工作区被并发扫描、`is_scanning` 观察失真。
-    pub fn scanning_flag_for(&self, root: &Path) -> Arc<AtomicBool> {
-        let key = root.to_string_lossy().to_string();
+    /// 各自 miss 后创建不同 flag，导致同一工作区被并发扫描、状态观察失真。
+    /// 取（或创建）指定 root 的后台扫描标志。同一 manager + 同一 root 返回同一 Arc。
+    ///
+    /// 经 `Mutex<HashMap>` 保护 get-or-create：并发首次访问时锁保证只有一个线程
+    /// 创建该 root 的标志，其余线程在锁内读到已存在的 Arc。此前用 `DashMap::entry()`
+    /// 时并发 entry() 会竞争创建不同 Arc，CAS 各自成功、去重失效。
+    fn scanning_flag_for(&self, root: &Path) -> Arc<AtomicBool> {
+        let key = workspace_key(root);
+        let mut map = self.scanning_roots.lock().expect("scanning_roots 锁中毒");
         Arc::clone(
-            self.scanning_roots
-                .entry(key)
-                .or_insert_with(|| Arc::new(AtomicBool::new(false)))
-                .value(),
+            map.entry(key)
+                .or_insert_with(|| Arc::new(AtomicBool::new(false))),
         )
     }
 
-    /// 指定 root 是否正在后台扫描。
-    pub fn is_scanning(&self, root: &Path) -> bool {
-        let key = root.to_string_lossy().to_string();
-        self.scanning_roots
-            .get(&key)
-            .is_some_and(|f| f.load(std::sync::atomic::Ordering::Relaxed))
+    /// 尝试取得指定工作区的扫描资格。
+    ///
+    /// 返回 `Some(permit)` 表示获得资格（原子地由空闲置为占用），调用方在后台线程
+    /// 持有该 permit 执行 `full_scan`；permit 被 drop 时（正常返回、错误返回、甚至
+    /// panic 展开时）自动复位状态。返回 `None` 表示该工作区已有扫描在进行。
+    ///
+    /// 扫描去重的唯一入口：调用方无法接触底层原子标志。标志由 [`scanning_flag_for`]
+    /// 在锁下唯一创建，故 CAS 一定作用在同一 Arc 上，保证全局只有一个调用方能占用。
+    pub fn try_begin_workspace_scan(&self, root: &Path) -> Option<WorkspaceScanPermit> {
+        let scanning = self.scanning_flag_for(root);
+        scanning
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| WorkspaceScanPermit { scanning })
+    }
+
+    pub fn is_workspace_scanning(&self, root: &Path) -> bool {
+        let map = self.scanning_roots.lock().expect("scanning_roots 锁中毒");
+        map.get(&workspace_key(root))
+            .is_some_and(|f| f.load(Ordering::Acquire))
     }
 
     pub fn get_or_create_workspace_index(
         &self,
         root: &Path,
     ) -> Result<Arc<std::sync::Mutex<WorkspaceIndex>>> {
-        let key = root.to_string_lossy().to_string();
+        let key = workspace_key(root);
         if let Some(entry) = self.workspaces.get(&key) {
             return Ok(Arc::clone(entry.value()));
         }
@@ -465,47 +505,139 @@ fn default_base_dir() -> PathBuf {
     home.join(".tiangong").join("index")
 }
 
+/// 工作区在内存映射（`workspaces` / `scanning_roots`）中的统一 key。
+///
+/// 规范化路径以消除 `.`/`..`/软链接/相对路径导致的等价目录生成不同 key 问题，
+/// 避免绕过扫描去重。canonicalize 失败（如路径暂不存在）时退回原始路径。
+///
+/// 注意：磁盘索引目录仍按 [`workspace_index::hash_path`] 的原始路径散列定位，
+/// 以兼容已建索引；二者独立，不混用。
+fn workspace_key(root: &Path) -> String {
+    root.to_path_buf()
+        .canonicalize()
+        .unwrap_or_else(|_| root.to_path_buf())
+        .to_string_lossy()
+        .into_owned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::Arc;
     use std::thread;
 
-    /// 并发首次为同一路径创建扫描标志，必须全部返回同一 Arc（去重原子性）。
+    /// 并发为同一路径申请扫描许可，必须只有一个线程成功取得（去重原子性）。
     ///
-    /// 回归覆盖：原「先 get 再 insert」实现下，多线程同时 miss 会各自创建不同 flag，
-    /// 导致同一工作区被并发扫描、`is_scanning` 观察失真。
+    /// 回归覆盖：原 `scanning_flag_for`「先 get 再 insert」非原子，多线程同时 miss
+    /// 后各自创建不同 flag，导致同一工作区被并发扫描、状态观察失真。permit 方案下，
+    /// `try_begin_workspace_scan` 的 `compare_exchange` 保证仅有一个调用方拿到许可。
+    ///
+    /// 注意：线程必须持有 permit 直到全部申请完成（再 join 计数）。若线程只返回
+    /// `is_some()` 后立即 drop permit，标志会复位，下一个线程也能成功——那验证的是
+    /// 「释放后可再取」而非并发去重。
     #[test]
-    fn scanning_flag_for_concurrent_returns_same_arc() {
+    fn try_begin_workspace_scan_only_one_wins_concurrently() {
         let temp = tempfile::tempdir().expect("create tempdir");
         let manager =
             Arc::new(IndexManager::new_with_dir(temp.path().join("index")).expect("manager"));
         let root = temp.path().join("workspace");
         std::fs::create_dir_all(&root).unwrap();
 
-        let barrier = Arc::new(std::sync::Barrier::new(8));
+        const N: usize = 8;
+        let barrier = Arc::new(std::sync::Barrier::new(N));
+        let manager_clones: Vec<_> = (0..N).map(|_| Arc::clone(&manager)).collect();
         let mut handles = Vec::new();
-        for _ in 0..8 {
-            let manager = Arc::clone(&manager);
+        for mgr in manager_clones {
             let barrier = Arc::clone(&barrier);
             let root = root.clone();
+            // 返回 permit 而非 bool，使 permit 存活至 join 之后，标志保持占用。
             handles.push(thread::spawn(move || {
                 barrier.wait();
-                manager.scanning_flag_for(&root)
+                mgr.try_begin_workspace_scan(&root)
             }));
         }
-        let flags: Vec<Arc<AtomicBool>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
-        let anchor = Arc::as_ptr(&flags[0]);
-        assert!(
-            flags.iter().all(|f| Arc::as_ptr(f) == anchor),
-            "并发创建的扫描标志必须全部指向同一 Arc"
-        );
+        // 收集所有 permit（存活到本块结束）后统计赢家数量。
+        let permits: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let wins = permits.iter().filter(|p| p.is_some()).count();
+        assert_eq!(wins, 1, "并发申请扫描许可时只应有一个成功，实际 {wins}");
+        assert!(manager.is_workspace_scanning(&root));
 
-        // 置位后 is_scanning 应反映该 root 的状态，其它 root 不受影响。
-        flags[0].store(true, std::sync::atomic::Ordering::SeqCst);
-        assert!(manager.is_scanning(&root));
+        // 其它 root 不受影响。
         let other = temp.path().join("other");
         std::fs::create_dir_all(&other).unwrap();
-        assert!(!manager.is_scanning(&other));
+        assert!(!manager.is_workspace_scanning(&other));
+    }
+
+    /// 许可释放（drop）后状态复位，可再次取得扫描许可。
+    #[test]
+    fn permit_release_allows_reacquire() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let manager =
+            Arc::new(IndexManager::new_with_dir(temp.path().join("index")).expect("manager"));
+        let root = temp.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let permit = manager
+            .try_begin_workspace_scan(&root)
+            .expect("首次应取得扫描许可");
+        assert!(manager.is_workspace_scanning(&root));
+        assert!(
+            manager.try_begin_workspace_scan(&root).is_none(),
+            "持有许可期间再次取应返回 None"
+        );
+        drop(permit);
+        assert!(
+            !manager.is_workspace_scanning(&root),
+            "许可 drop 后状态应复位"
+        );
+        manager
+            .try_begin_workspace_scan(&root)
+            .expect("释放后应可再次取得许可");
+    }
+
+    /// 模拟扫描返回错误（panic），许可仍应自动复位，不阻塞后续扫描。
+    #[test]
+    fn permit_auto_releases_on_panic() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let manager =
+            Arc::new(IndexManager::new_with_dir(temp.path().join("index")).expect("manager"));
+        let root = temp.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let permit = manager
+            .try_begin_workspace_scan(&root)
+            .expect("取得扫描许可");
+        // 模拟扫描线程 panic：catch_unwind 确保 permit 在展开时被 drop。
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _permit = permit;
+            panic!("模拟扫描失败");
+        }));
+        assert!(result.is_err(), "应捕获到 panic");
+        assert!(
+            !manager.is_workspace_scanning(&root),
+            "panic 展开后许可应自动复位"
+        );
+    }
+
+    /// 等价路径（`.`、相对形式）经规范化后应视为同一工作区，扫描去重不被绕过。
+    #[test]
+    fn equivalent_paths_share_scan_state() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let manager =
+            Arc::new(IndexManager::new_with_dir(temp.path().join("index")).expect("manager"));
+        let root = temp.path().join("workspace");
+        std::fs::create_dir_all(&root).unwrap();
+
+        // 绝对路径取得许可。
+        let _permit = manager
+            .try_begin_workspace_scan(&root)
+            .expect("取得扫描许可");
+
+        // 「.」形式相对路径应规范化为同一 root，取许可应返回 None。
+        let dot = root.join(".");
+        assert!(
+            manager.try_begin_workspace_scan(&dot).is_none(),
+            "等价路径（.）应视为同一工作区，去重不被绕过"
+        );
     }
 }

--- a/crates/plugins/tiangong-plugin-index/src/index/workspace_index.rs
+++ b/crates/plugins/tiangong-plugin-index/src/index/workspace_index.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
@@ -49,12 +51,34 @@ const SKIP_EXTENSIONS: &[&str] = &[
     ".lock", ".log",
 ];
 
+/// 跳过目录集合（OnceLock 惰性初始化，O(1) 查询）。
+fn skip_dirs() -> &'static HashSet<&'static str> {
+    static SKIP_DIRS_SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    SKIP_DIRS_SET.get_or_init(|| SKIP_DIRS.iter().copied().collect())
+}
+
+/// 跳过扩展名集合（不含点，小写）。
+fn skip_extensions() -> &'static HashSet<&'static str> {
+    static SKIP_EXTENSIONS_SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    SKIP_EXTENSIONS_SET.get_or_init(|| {
+        SKIP_EXTENSIONS
+            .iter()
+            .copied()
+            .map(|e| e.trim_start_matches('.'))
+            .collect()
+    })
+}
+
 fn should_skip_dir(name: &str) -> bool {
-    name.starts_with('.') || SKIP_DIRS.contains(&name)
+    name.starts_with('.') || skip_dirs().contains(name)
 }
 
 fn should_skip_file(name: &str) -> bool {
-    SKIP_EXTENSIONS.iter().any(|ext| name.ends_with(ext))
+    // 用扩展名提取 + HashSet O(1) 查询替代 ~40 项 ends_with 线性比较。
+    Path::new(name)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| skip_extensions().contains(ext))
 }
 
 fn detect_language(path: &Path) -> String {
@@ -366,14 +390,20 @@ impl WorkspaceIndex {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
 
-            if path.is_dir() {
+            // 用 DirEntry 缓存的 file_type 判定类型，避免 path.is_dir()/is_file() 各一次 stat。
+            let file_type = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
                 if should_skip_dir(&name_str) {
                     continue;
                 }
                 self.scan_dir(writer, &path, depth + 1)?;
-            } else if path.is_file()
+            } else if file_type.is_file()
                 && !should_skip_file(&name_str)
-                && let Err(err) = self.index_file_with_writer(writer, &path)
+                && let Err(err) =
+                    self.index_file_with_writer(writer, &path, entry.metadata().ok().as_ref())
             {
                 tracing::warn!(
                     workspace = %self.root.display(),
@@ -388,7 +418,7 @@ impl WorkspaceIndex {
 
     pub fn index_file(&mut self, path: &Path) -> Result<()> {
         let mut writer = self.create_writer("index_file")?;
-        self.index_file_with_writer(&mut writer, path)?;
+        self.index_file_with_writer(&mut writer, path, None)?;
         writer
             .commit()
             .with_context(|| self.context("index_file", "提交 Workspace 索引失败"))?;
@@ -396,9 +426,26 @@ impl WorkspaceIndex {
         Ok(())
     }
 
-    fn index_file_with_writer(&mut self, writer: &mut IndexWriter, path: &Path) -> Result<()> {
-        let metadata = fs::metadata(path).ok();
-        let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+    /// 写入单个文件到索引。`metadata` 为调用方已获取的元数据（scan_dir 会复用
+    /// `DirEntry::metadata()`），传入 `None` 时此处自行 stat 兜底。
+    fn index_file_with_writer(
+        &mut self,
+        writer: &mut IndexWriter,
+        path: &Path,
+        metadata: Option<&fs::Metadata>,
+    ) -> Result<()> {
+        let owned_metadata;
+        let metadata = match metadata {
+            Some(m) => m,
+            None => {
+                owned_metadata = fs::metadata(path).ok();
+                match owned_metadata.as_ref() {
+                    Some(m) => m,
+                    None => return Ok(()),
+                }
+            }
+        };
+        let size = metadata.len();
         if size > MAX_FILE_SIZE {
             return Ok(());
         }
@@ -633,6 +680,46 @@ mod tests {
             "workspace search should find indexed Rust symbol"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn should_skip_uses_hashset() {
+        // 被跳过的目录与扩展名
+        assert!(should_skip_dir("node_modules"));
+        assert!(should_skip_dir(".git"));
+        assert!(should_skip_file("trace.log"));
+        assert!(should_skip_file("binary.png"));
+        // 正常源码不跳过
+        assert!(!should_skip_dir("src"));
+        assert!(!should_skip_file("lib.rs"));
+        assert!(!should_skip_file("index.ts"));
+        // 无扩展名文件不跳过
+        assert!(!should_skip_file("Makefile"));
+    }
+
+    #[test]
+    fn full_scan_skips_ignored_entries() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        let base_dir = temp.path().join("index");
+        fs::create_dir_all(workspace.join("src"))?;
+        fs::create_dir_all(workspace.join("node_modules").join("pkg"))?;
+        fs::write(workspace.join("src").join("lib.rs"), "pub fn kept() {}\n")?;
+        // 应被跳过：node_modules 下与 .log 扩展
+        fs::write(
+            workspace.join("node_modules").join("pkg").join("lib.rs"),
+            "pub fn skipped() {}\n",
+        )?;
+        fs::write(workspace.join("trace.log"), "noise\n")?;
+
+        let mut index = WorkspaceIndex::open_or_create(&workspace, &base_dir)?;
+        assert_eq!(index.full_scan()?, 1, "只应索引 src/lib.rs 一个文件");
+
+        let hits = index.search("skipped", 5)?;
+        assert!(hits.is_empty(), "node_modules 内容不应进入索引");
+        let hits = index.search("kept", 5)?;
+        assert!(hits.iter().any(|h| h.path == "src/lib.rs"));
         Ok(())
     }
 }

--- a/crates/plugins/tiangong-plugin-index/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-index/src/lib.rs
@@ -11,7 +11,9 @@
 //! `IndexManager` 的全部写入与维护（初始扫描、CWD 重扫、turn 结束批量写入对话索引、
 //! 会话结束 finalize），使 core 彻底不再感知 `IndexManager`。
 //!
-//! [`IndexManager`] 由本插件在构造时自建并私有持有，不依赖 Tauri 句柄，可在
+//! [`IndexManager`] 推荐由入口在初始化时构造为 app 层单例（[`shared_index_manager`]），
+//! 经 [`build_plugin_with_manager`] / [`default_plugins_with_manager`] 注入各 Core 的插件
+//! 列表，使所有对话共享同一底层索引缓存与扫描状态；不依赖 Tauri 句柄，可在
 //! GUI / CLI / Server 全入口无条件启用。
 
 pub mod handler;
@@ -31,11 +33,31 @@ use std::sync::Arc;
 use tiangong_core::core::Plugin;
 
 /// 构造索引搜索插件实例，返回 `Arc<dyn Plugin>` 供入口注册。
+///
+/// 内部自建 IndexManager（非共享）。生产入口应优先使用
+/// [`build_plugin_with_manager`] 注入 app 层单例。
 pub fn build_plugin() -> Arc<dyn Plugin> {
     Arc::new(IndexPlugin::new())
+}
+
+/// 构造索引搜索插件实例，注入共享 IndexManager（app 层单例）。
+pub fn build_plugin_with_manager(manager: Arc<IndexManager>) -> Arc<dyn Plugin> {
+    Arc::new(IndexPlugin::from_index_manager(Some(manager)))
 }
 
 /// 构造默认的索引搜索插件列表，供各入口（CLI / Server）注入 core 时使用。
 pub fn default_plugins() -> Vec<Arc<dyn Plugin>> {
     vec![build_plugin()]
+}
+
+/// 构造默认的索引搜索插件列表，注入共享 IndexManager（app 层单例）。
+pub fn default_plugins_with_manager(manager: Arc<IndexManager>) -> Vec<Arc<dyn Plugin>> {
+    vec![build_plugin_with_manager(manager)]
+}
+
+/// 构造 app 层共享的 IndexManager 单例句柄，供入口在初始化时创建一次后注入各 Core。
+///
+/// 失败时返回 Err（调用方决定降级策略：缺省省略 index 插件或自建兜底）。
+pub fn shared_index_manager() -> anyhow::Result<Arc<IndexManager>> {
+    IndexManager::new().map(Arc::new)
 }

--- a/crates/plugins/tiangong-plugin-index/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-index/src/lib.rs
@@ -22,8 +22,8 @@ pub mod plugin;
 
 pub use index::{
     IndexHit, IndexManager, IndexMeta, IndexQuery, IndexScope, SessionIndexHit, TurnData,
-    WorkspaceIndexInfo, backfill_session_index, delete_workspace_index_for_gui,
-    list_workspace_indexes_for_gui, session_index_exists, workspace_index_exists,
+    WorkspaceIndexInfo, backfill_session_index, list_workspace_indexes_for_gui,
+    session_index_exists, workspace_index_exists,
 };
 pub use plugin::IndexPlugin;
 

--- a/crates/plugins/tiangong-plugin-index/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-index/src/lib.rs
@@ -23,8 +23,7 @@ pub mod plugin;
 pub use index::{
     IndexHit, IndexManager, IndexMeta, IndexQuery, IndexScope, SessionIndexHit, TurnData,
     WorkspaceIndexInfo, backfill_session_index, delete_workspace_index_for_gui,
-    list_workspace_indexes_for_gui, prewarm_workspace_index_for_gui,
-    rebuild_workspace_index_for_gui, session_index_exists, workspace_index_exists,
+    list_workspace_indexes_for_gui, session_index_exists, workspace_index_exists,
 };
 pub use plugin::IndexPlugin;
 

--- a/crates/plugins/tiangong-plugin-index/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-index/src/lib.rs
@@ -21,8 +21,8 @@ pub mod plugin;
 pub use index::{
     IndexHit, IndexManager, IndexMeta, IndexQuery, IndexScope, SessionIndexHit, TurnData,
     WorkspaceIndexInfo, backfill_session_index, delete_workspace_index_for_gui,
-    list_workspace_indexes_for_gui, rebuild_workspace_index_for_gui, session_index_exists,
-    workspace_index_exists,
+    list_workspace_indexes_for_gui, prewarm_workspace_index_for_gui,
+    rebuild_workspace_index_for_gui, session_index_exists, workspace_index_exists,
 };
 pub use plugin::IndexPlugin;
 

--- a/crates/plugins/tiangong-plugin-index/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-index/src/plugin.rs
@@ -1,7 +1,8 @@
 //! 索引搜索插件：结构体定义与生命周期钩子实现。
 //!
 //! [`IndexPlugin`] 通过 [`Plugin::set_workspace`] / [`Plugin::set_trust_mode`] 接收 core
-//! 注入的会话上下文；[`IndexManager`] 在 [`IndexPlugin::new`] 时自建并私有持有。
+//! 注入的会话上下文；[`IndexManager`] 由构造时注入（app 层单例，跨 Core 共享）或
+//! [`IndexPlugin::new`] 自建兜底。
 //!
 //! 生命周期钩子接管原 core 对 `IndexManager` 的全部写入与维护：
 //! - [`Plugin::set_workspace`]：工作区变更后重扫索引（原 `on_cwd_changed` 的职责）。
@@ -10,7 +11,7 @@
 //! - [`Plugin::on_session_ended`]：finalize Session 索引。
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 
 use crate::index::{IndexManager, TurnData};
@@ -21,9 +22,10 @@ use tiangong_core::tool_override::PromptSectionProvider;
 
 /// 索引搜索插件。
 ///
-/// `workspace` 由 core 在 engine 创建及每次会话目录变更时注入（可变）；
+/// `workspace` 由 core 在 engine 创建及每次会话目录变更时注入（可变，per-session）；
 /// `trust_mode` 由 core 在 register 前通过 `set_trust_mode` 注入（基线共享、单轮隔离）；
-/// `index_manager` 在构造时自建（失败降级为 None，工具执行与钩子内兜底）。
+/// `index_manager` 由构造时注入——app 层单例（跨 Core 共享同一底层索引缓存与扫描状态），
+/// 未注入时 [`IndexPlugin::new`] 自建兜底。
 pub struct IndexPlugin {
     /// 当前会话工作目录（可变，由 core 注入）。
     workspace: RwLock<Option<PathBuf>>,
@@ -31,14 +33,15 @@ pub struct IndexPlugin {
     last_scanned: RwLock<Option<PathBuf>>,
     /// 信任模式解析句柄（FullTrust 时放宽 search_code 路径校验）。
     trust_mode: RwLock<Option<TrustMode>>,
-    /// 自建并私有持有的 IndexManager（core 不感知）。
+    /// IndexManager 句柄（通常为 app 层单例的 Arc clone；core 不感知其来源）。
     index_manager: RwLock<Option<Arc<IndexManager>>>,
-    /// 后台扫描进行中标志（true 时 index_search 降级提示，避免在索引 Mutex 上阻塞）。
-    scanning: Arc<AtomicBool>,
 }
 
 impl IndexPlugin {
     /// 构造插件实例：自建 IndexManager，失败时降级为 None 并告警。
+    ///
+    /// 适用于单测、CLI 兜底等无需跨 Core 共享的场景。生产入口应优先使用
+    /// [`IndexPlugin::from_index_manager`] 注入 app 层单例。
     pub fn new() -> Self {
         let im = IndexManager::new()
             .map(Arc::new)
@@ -47,12 +50,20 @@ impl IndexPlugin {
                 e
             })
             .ok();
+        Self::from_index_manager(im)
+    }
+
+    /// 构造插件实例：注入共享 IndexManager（app 层单例）。
+    ///
+    /// 多个 IndexPlugin 共享同一 manager 时，底层 per-root 的 `WorkspaceIndex`
+    /// 缓存与扫描标志天然共享，消除磁盘锁冲突与缓存重复。`manager` 为 None
+    /// 时插件所有写操作与工具执行降级为 no-op（与 [`IndexPlugin::new`] 失败一致）。
+    pub fn from_index_manager(manager: Option<Arc<IndexManager>>) -> Self {
         Self {
             workspace: RwLock::new(None),
             last_scanned: RwLock::new(None),
             trust_mode: RwLock::new(None),
-            index_manager: RwLock::new(im),
-            scanning: Arc::new(AtomicBool::new(false)),
+            index_manager: RwLock::new(manager),
         }
     }
 
@@ -77,9 +88,16 @@ impl IndexPlugin {
         *tm == TrustMode::FullTrust
     }
 
-    /// 后台扫描是否进行中（供 handler 降级判断）。
+    /// 当前工作区是否正在后台扫描（per-root，经共享 manager 查询）。
+    ///
+    /// 单例化后跨 IndexPlugin 实例共享：A 对话后台扫描某 root 时，
+    /// B 对话查询同一 root 也会得到 true，从而在 `index_search` 中降级。
     pub(crate) fn is_scanning(&self) -> bool {
-        self.scanning.load(Ordering::Relaxed)
+        let Some(cwd) = self.workspace() else {
+            return false;
+        };
+        self.with_index_manager(|im| im.is_scanning(&cwd))
+            .unwrap_or(false)
     }
 
     /// 取 IndexManager 引用执行闭包；若未初始化则跳过（用于钩子内的写入操作）。
@@ -95,9 +113,9 @@ impl IndexPlugin {
     /// - 索引过期（>1 小时）：后台重建，不阻塞当前搜索。
     /// - 索引新鲜：跳过。
     ///
-    /// 仅在索引已存在（复用）时同步置位 `last_scanned`；后台扫描完成前由 `scanning`
-    /// flag 守护，扫描完成后 `workspace_index_exists` 变 true，后续 `set_workspace`
-    /// 走复用路径置位 `last_scanned`。
+    /// 仅在索引已存在（复用）时同步置位 `last_scanned`；后台扫描完成前由 manager 的
+    /// per-root scanning flag 守护，扫描完成后 `workspace_index_exists` 变 true，
+    /// 后续 `set_workspace` 走复用路径置位 `last_scanned`。
     fn full_scan_workspace(&self, cwd: &str) {
         let root = PathBuf::from(cwd);
         if !root.is_dir() {
@@ -125,22 +143,23 @@ impl IndexPlugin {
 
     /// 后台扫描工作区（首次扫描 / 过期重建共用）。
     ///
-    /// 通过 `scanning` flag 保证同一时刻只有一个后台扫描；进入前 `swap` 置位，
-    /// 线程结束（成功或失败）后复位。不在线程内写 `last_scanned`：扫描完成后
-    /// `workspace_index_exists` 变 true，后续 `set_workspace` 走复用路径置位。
+    /// 经共享 manager 的 per-root scanning flag 保证同一 root 同一时刻只有一个
+    /// 后台扫描；进入前 `swap` 置位，线程结束（成功或失败）后复位。不在线程内写
+    /// `last_scanned`：扫描完成后 `workspace_index_exists` 变 true，后续
+    /// `set_workspace` 走复用路径置位。
     fn spawn_background_scan(&self, root: PathBuf) {
-        // swap 返回旧值；已 true 表示有扫描在进行，直接返回。
-        if self.scanning.swap(true, Ordering::SeqCst) {
+        let Some(im) = self.index_manager() else {
+            tracing::warn!("Workspace 索引后台扫描跳过：IndexManager 未初始化");
+            return;
+        };
+        let scanning = im.scanning_flag_for(&root);
+        // swap 返回旧值；已 true 表示该 root 有扫描在进行，直接返回。
+        if scanning.swap(true, Ordering::SeqCst) {
             return;
         }
-        let im = self.index_manager();
-        let scanning = Arc::clone(&self.scanning);
         tracing::info!(workspace = %root.display(), "Workspace 索引后台扫描启动");
         std::thread::spawn(move || {
-            let result = im
-                .as_ref()
-                .map(|im| im.full_scan(&root))
-                .unwrap_or_else(|| Err(anyhow::anyhow!("IndexManager 未初始化")));
+            let result = im.full_scan(&root);
             match result {
                 Ok(count) => tracing::info!(count, "Workspace 索引后台扫描完成"),
                 Err(e) => tracing::warn!("Workspace 索引后台扫描失败: {e}"),
@@ -178,7 +197,10 @@ impl Plugin for IndexPlugin {
                 .read()
                 .map(|g| g.as_ref() == Some(root))
                 .unwrap_or(false);
-            if !already_scanned && !self.scanning.load(Ordering::Relaxed) {
+            let scanning = self
+                .with_index_manager(|im| im.is_scanning(root))
+                .unwrap_or(false);
+            if !already_scanned && !scanning {
                 self.full_scan_workspace(&root.display().to_string());
             }
         }
@@ -197,11 +219,14 @@ impl Plugin for IndexPlugin {
         // set_workspace 已在 engine 初始化时对当前 cwd 触发过扫描（last_scanned 已置位）。
         // 若 set_workspace 因扫描失败未置位，此处兜底重试一次。
         // 后台扫描进行中时跳过，避免重复 spawn。
-        if self.scanning.load(Ordering::Relaxed) {
-            return;
-        }
         let root = PathBuf::from(&session.cwd);
         if root.is_dir() {
+            let scanning = self
+                .with_index_manager(|im| im.is_scanning(&root))
+                .unwrap_or(false);
+            if scanning {
+                return;
+            }
             let already_scanned = self
                 .last_scanned
                 .read()
@@ -271,17 +296,28 @@ impl PromptSectionProvider for IndexPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::index::IndexManager;
     use std::time::Instant;
+
+    /// 构造指向临时 base_dir 的共享 manager，避免污染用户索引目录。
+    fn shared_manager(temp: &tempfile::TempDir) -> Arc<IndexManager> {
+        Arc::new(
+            IndexManager::new_with_dir(temp.path().join("index"))
+                .expect("IndexManager::new_with_dir"),
+        )
+    }
 
     /// 首次扫描工作区（索引不存在）时不应阻塞调用线程：`full_scan_workspace`
     /// 立即返回，扫描在后台线程执行。
     #[test]
     fn full_scan_workspace_does_not_block_on_first_scan() {
         let temp = tempfile::tempdir().expect("create tempdir");
-        let workspace = temp.path().to_path_buf();
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("lib.rs"), "pub fn demo() {}\n").unwrap();
 
-        let plugin = IndexPlugin::new();
+        let manager = shared_manager(&temp);
+        let plugin = IndexPlugin::from_index_manager(Some(manager));
         let started = Instant::now();
         plugin.full_scan_workspace(&workspace.display().to_string());
         let elapsed = started.elapsed();
@@ -292,25 +328,57 @@ mod tests {
         );
     }
 
-    /// 不存在的目录应直接返回且不触发后台扫描（`scanning` 不被置位）。
+    /// 不存在的目录应直接返回且不触发后台扫描（manager scanning flag 不被置位）。
     #[test]
     fn full_scan_workspace_skips_missing_dir() {
-        let plugin = IndexPlugin::new();
-        plugin.full_scan_workspace("/this/path/does/not/exist/abc123");
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let manager = shared_manager(&temp);
+        let plugin = IndexPlugin::from_index_manager(Some(manager.clone()));
+        plugin.set_workspace(Some(std::path::Path::new(
+            "/this/path/does/not/exist/abc123",
+        )));
         assert!(!plugin.is_scanning(), "不存在的目录不应启动后台扫描");
     }
 
-    /// 重复对同一根目录发起后台扫描，scanning flag 应阻止并发 spawn（第二次立即返回）。
+    /// 重复对同一根目录发起后台扫描，per-root scanning flag 应阻止并发 spawn。
     #[test]
     fn spawn_background_scan_is_idempotent_while_scanning() {
         let temp = tempfile::tempdir().expect("create tempdir");
-        let workspace = temp.path().to_path_buf();
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("lib.rs"), "pub fn demo() {}\n").unwrap();
 
-        let plugin = IndexPlugin::new();
-        plugin.spawn_background_scan(workspace.clone());
-        // 第一次已置位 scanning，第二次应直接返回（不会 panic / 不会重复 spawn）。
-        plugin.spawn_background_scan(workspace);
+        let manager = shared_manager(&temp);
+        // 手动置位该 root 的 flag，模拟扫描进行中。
+        let flag = manager.scanning_flag_for(&workspace);
+        flag.store(true, Ordering::SeqCst);
+        // set_workspace 在扫描中应跳过 full_scan_workspace（不 panic、不重复 spawn）。
+        let plugin = IndexPlugin::from_index_manager(Some(manager));
+        plugin.set_workspace(Some(&workspace));
         assert!(plugin.is_scanning());
+    }
+
+    /// 两个 IndexPlugin 共享同一 manager 时，A 的后台扫描对 B 可见（跨 plugin 降级一致）。
+    #[test]
+    fn shared_manager_propagates_scanning_across_plugins() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let manager = shared_manager(&temp);
+        let plugin_a = IndexPlugin::from_index_manager(Some(manager.clone()));
+        let plugin_b = IndexPlugin::from_index_manager(Some(manager.clone()));
+        plugin_a.set_workspace(Some(&workspace));
+        plugin_b.set_workspace(Some(&workspace));
+
+        // A 置位该 root 的扫描标志，B 查询同一 root 应看到 true。
+        manager
+            .scanning_flag_for(&workspace)
+            .store(true, Ordering::SeqCst);
+        assert!(plugin_a.is_scanning(), "plugin_a 应看到正在扫描");
+        assert!(
+            plugin_b.is_scanning(),
+            "共享 manager 下 plugin_b 也应看到正在扫描"
+        );
     }
 }

--- a/crates/plugins/tiangong-plugin-index/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-index/src/plugin.rs
@@ -10,6 +10,7 @@
 //! - [`Plugin::on_session_ended`]：finalize Session 索引。
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use crate::index::{IndexManager, TurnData};
@@ -32,6 +33,8 @@ pub struct IndexPlugin {
     trust_mode: RwLock<Option<TrustMode>>,
     /// 自建并私有持有的 IndexManager（core 不感知）。
     index_manager: RwLock<Option<Arc<IndexManager>>>,
+    /// 后台扫描进行中标志（true 时 index_search 降级提示，避免在索引 Mutex 上阻塞）。
+    scanning: Arc<AtomicBool>,
 }
 
 impl IndexPlugin {
@@ -49,6 +52,7 @@ impl IndexPlugin {
             last_scanned: RwLock::new(None),
             trust_mode: RwLock::new(None),
             index_manager: RwLock::new(im),
+            scanning: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -73,6 +77,11 @@ impl IndexPlugin {
         *tm == TrustMode::FullTrust
     }
 
+    /// 后台扫描是否进行中（供 handler 降级判断）。
+    pub(crate) fn is_scanning(&self) -> bool {
+        self.scanning.load(Ordering::Relaxed)
+    }
+
     /// 取 IndexManager 引用执行闭包；若未初始化则跳过（用于钩子内的写入操作）。
     fn with_index_manager<R>(&self, f: impl FnOnce(&IndexManager) -> R) -> Option<R> {
         let guard = self.index_manager.read().ok()?;
@@ -82,34 +91,22 @@ impl IndexPlugin {
 
     /// 对工作区做全量扫描（供 set_workspace / on_session_ready 共用）。
     ///
-    /// - 索引不存在：同步全量扫描（首次使用，阻塞直到完成）。
+    /// - 索引不存在：后台全量扫描（不阻塞 IPC 线程）。
     /// - 索引过期（>1 小时）：后台重建，不阻塞当前搜索。
     /// - 索引新鲜：跳过。
     ///
-    /// 仅在索引已存在（复用或后台重建）或同步首次扫描成功时置位 `last_scanned`，
-    /// 使后续 `set_workspace` 对同一目录不再重复扫描；扫描失败时不置位，允许下次重试。
+    /// 仅在索引已存在（复用）时同步置位 `last_scanned`；后台扫描完成前由 `scanning`
+    /// flag 守护，扫描完成后 `workspace_index_exists` 变 true，后续 `set_workspace`
+    /// 走复用路径置位 `last_scanned`。
     fn full_scan_workspace(&self, cwd: &str) {
         let root = PathBuf::from(cwd);
         if !root.is_dir() {
             return;
         }
         if !crate::index::workspace_index_exists(&root) {
-            // 首次：同步全量扫描。仅在成功后置位 last_scanned，失败则允许下次重试。
-            let scanned = self.with_index_manager(|im| match im.full_scan(&root) {
-                Ok(count) => {
-                    tracing::info!(count, "Workspace 初始索引扫描完成");
-                    true
-                }
-                Err(e) => {
-                    tracing::warn!("Workspace 初始索引扫描失败: {e}");
-                    false
-                }
-            });
-            if scanned.unwrap_or(false)
-                && let Ok(mut guard) = self.last_scanned.write()
-            {
-                guard.clone_from(&Some(root));
-            }
+            // 首次：后台扫描（不阻塞调用线程）。扫描完成后 `workspace_index_exists`
+            // 变 true，后续 set_workspace 走复用路径。
+            self.spawn_background_scan(root);
             return;
         }
         // 索引已存在——复用，置位 last_scanned。
@@ -122,16 +119,34 @@ impl IndexPlugin {
             && age > STALE_THRESHOLD_SECS
         {
             tracing::info!(age_secs = age, "Workspace 索引过期，后台重建");
-            let im = self.index_manager();
-            let root_clone = root.clone();
-            std::thread::spawn(move || {
-                if let Some(im) = im
-                    && let Err(e) = im.full_scan(&root_clone)
-                {
-                    tracing::warn!("Workspace 索引后台重建失败: {e}");
-                }
-            });
+            self.spawn_background_scan(root);
         }
+    }
+
+    /// 后台扫描工作区（首次扫描 / 过期重建共用）。
+    ///
+    /// 通过 `scanning` flag 保证同一时刻只有一个后台扫描；进入前 `swap` 置位，
+    /// 线程结束（成功或失败）后复位。不在线程内写 `last_scanned`：扫描完成后
+    /// `workspace_index_exists` 变 true，后续 `set_workspace` 走复用路径置位。
+    fn spawn_background_scan(&self, root: PathBuf) {
+        // swap 返回旧值；已 true 表示有扫描在进行，直接返回。
+        if self.scanning.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let im = self.index_manager();
+        let scanning = Arc::clone(&self.scanning);
+        tracing::info!(workspace = %root.display(), "Workspace 索引后台扫描启动");
+        std::thread::spawn(move || {
+            let result = im
+                .as_ref()
+                .map(|im| im.full_scan(&root))
+                .unwrap_or_else(|| Err(anyhow::anyhow!("IndexManager 未初始化")));
+            match result {
+                Ok(count) => tracing::info!(count, "Workspace 索引后台扫描完成"),
+                Err(e) => tracing::warn!("Workspace 索引后台扫描失败: {e}"),
+            }
+            scanning.store(false, Ordering::SeqCst);
+        });
     }
 }
 
@@ -153,7 +168,8 @@ impl Plugin for IndexPlugin {
         }
         // 工作区变更后重扫索引（原 on_cwd_changed 的职责）。
         // 仅当新路径与上次已扫描路径不同时才触发，避免重复扫描。
-        // 复用 full_scan_workspace 的检查策略：索引已存在则复用，不存在才同步全量扫描。
+        // 后台扫描进行中时也跳过（扫描完成后 workspace_index_exists 变 true，
+        // 下次 set_workspace 走复用路径置位 last_scanned）。
         if let Some(ref root) = new_path
             && root.is_dir()
         {
@@ -162,7 +178,7 @@ impl Plugin for IndexPlugin {
                 .read()
                 .map(|g| g.as_ref() == Some(root))
                 .unwrap_or(false);
-            if !already_scanned {
+            if !already_scanned && !self.scanning.load(Ordering::Relaxed) {
                 self.full_scan_workspace(&root.display().to_string());
             }
         }
@@ -180,6 +196,10 @@ impl Plugin for IndexPlugin {
     fn on_session_ready(&self, session: &mut Session) {
         // set_workspace 已在 engine 初始化时对当前 cwd 触发过扫描（last_scanned 已置位）。
         // 若 set_workspace 因扫描失败未置位，此处兜底重试一次。
+        // 后台扫描进行中时跳过，避免重复 spawn。
+        if self.scanning.load(Ordering::Relaxed) {
+            return;
+        }
         let root = PathBuf::from(&session.cwd);
         if root.is_dir() {
             let already_scanned = self
@@ -245,5 +265,52 @@ impl PromptSectionProvider for IndexPlugin {
              再用 search_code 取精确行号。"
                 .to_string(),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    /// 首次扫描工作区（索引不存在）时不应阻塞调用线程：`full_scan_workspace`
+    /// 立即返回，扫描在后台线程执行。
+    #[test]
+    fn full_scan_workspace_does_not_block_on_first_scan() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let workspace = temp.path().to_path_buf();
+        std::fs::write(workspace.join("lib.rs"), "pub fn demo() {}\n").unwrap();
+
+        let plugin = IndexPlugin::new();
+        let started = Instant::now();
+        plugin.full_scan_workspace(&workspace.display().to_string());
+        let elapsed = started.elapsed();
+        // 后台扫描 spawn 后立即返回；即使工作区只有一个文件，调度也应在很短时间内返回。
+        assert!(
+            elapsed.as_millis() < 200,
+            "full_scan_workspace 首次扫描应在后台执行，实际耗时 {elapsed:?}"
+        );
+    }
+
+    /// 不存在的目录应直接返回且不触发后台扫描（`scanning` 不被置位）。
+    #[test]
+    fn full_scan_workspace_skips_missing_dir() {
+        let plugin = IndexPlugin::new();
+        plugin.full_scan_workspace("/this/path/does/not/exist/abc123");
+        assert!(!plugin.is_scanning(), "不存在的目录不应启动后台扫描");
+    }
+
+    /// 重复对同一根目录发起后台扫描，scanning flag 应阻止并发 spawn（第二次立即返回）。
+    #[test]
+    fn spawn_background_scan_is_idempotent_while_scanning() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let workspace = temp.path().to_path_buf();
+        std::fs::write(workspace.join("lib.rs"), "pub fn demo() {}\n").unwrap();
+
+        let plugin = IndexPlugin::new();
+        plugin.spawn_background_scan(workspace.clone());
+        // 第一次已置位 scanning，第二次应直接返回（不会 panic / 不会重复 spawn）。
+        plugin.spawn_background_scan(workspace);
+        assert!(plugin.is_scanning());
     }
 }

--- a/crates/plugins/tiangong-plugin-index/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-index/src/plugin.rs
@@ -11,7 +11,6 @@
 //! - [`Plugin::on_session_ended`]：finalize Session 索引。
 
 use std::path::PathBuf;
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 
 use crate::index::{IndexManager, TurnData};
@@ -96,7 +95,7 @@ impl IndexPlugin {
         let Some(cwd) = self.workspace() else {
             return false;
         };
-        self.with_index_manager(|im| im.is_scanning(&cwd))
+        self.with_index_manager(|im| im.is_workspace_scanning(&cwd))
             .unwrap_or(false)
     }
 
@@ -114,8 +113,8 @@ impl IndexPlugin {
     /// - 索引新鲜：跳过。
     ///
     /// 仅在索引已存在（复用）时同步置位 `last_scanned`；后台扫描完成前由 manager 的
-    /// per-root scanning flag 守护，扫描完成后 `workspace_index_exists` 变 true，
-    /// 后续 `set_workspace` 走复用路径置位 `last_scanned`。
+    /// 扫描许可守护，扫描完成后 `workspace_index_exists` 变 true，后续 `set_workspace`
+    /// 走复用路径置位 `last_scanned`。
     fn full_scan_workspace(&self, cwd: &str) {
         let root = PathBuf::from(cwd);
         if !root.is_dir() {
@@ -143,28 +142,30 @@ impl IndexPlugin {
 
     /// 后台扫描工作区（首次扫描 / 过期重建共用）。
     ///
-    /// 经共享 manager 的 per-root scanning flag 保证同一 root 同一时刻只有一个
-    /// 后台扫描；进入前 `swap` 置位，线程结束（成功或失败）后复位。不在线程内写
-    /// `last_scanned`：扫描完成后 `workspace_index_exists` 变 true，后续
-    /// `set_workspace` 走复用路径置位。
+    /// 扫描去重经共享 manager 的 [`IndexManager::try_begin_workspace_scan`] 取得许可：
+    /// 拿到 permit 才 spawn 线程，线程内持有 permit 直到 `full_scan` 返回（成功或失败）
+    /// 后随 permit drop 自动复位——无需手动 `store`。同一 root 已有扫描在进行时返回
+    /// `None`，直接跳过。
     fn spawn_background_scan(&self, root: PathBuf) {
         let Some(im) = self.index_manager() else {
             tracing::warn!("Workspace 索引后台扫描跳过：IndexManager 未初始化");
             return;
         };
-        let scanning = im.scanning_flag_for(&root);
-        // swap 返回旧值；已 true 表示该 root 有扫描在进行，直接返回。
-        if scanning.swap(true, Ordering::SeqCst) {
+        let Some(permit) = im.try_begin_workspace_scan(&root) else {
+            tracing::debug!(
+                workspace = %root.display(),
+                "Workspace 索引已有后台扫描在进行，跳过本次"
+            );
             return;
-        }
+        };
         tracing::info!(workspace = %root.display(), "Workspace 索引后台扫描启动");
         std::thread::spawn(move || {
-            let result = im.full_scan(&root);
-            match result {
+            // permit 持有期间状态保持占用；drop（含 panic 展开）时自动复位。
+            let _permit = permit;
+            match im.full_scan(&root) {
                 Ok(count) => tracing::info!(count, "Workspace 索引后台扫描完成"),
                 Err(e) => tracing::warn!("Workspace 索引后台扫描失败: {e}"),
             }
-            scanning.store(false, Ordering::SeqCst);
         });
     }
 }
@@ -198,7 +199,7 @@ impl Plugin for IndexPlugin {
                 .map(|g| g.as_ref() == Some(root))
                 .unwrap_or(false);
             let scanning = self
-                .with_index_manager(|im| im.is_scanning(root))
+                .with_index_manager(|im| im.is_workspace_scanning(root))
                 .unwrap_or(false);
             if !already_scanned && !scanning {
                 self.full_scan_workspace(&root.display().to_string());
@@ -222,7 +223,7 @@ impl Plugin for IndexPlugin {
         let root = PathBuf::from(&session.cwd);
         if root.is_dir() {
             let scanning = self
-                .with_index_manager(|im| im.is_scanning(&root))
+                .with_index_manager(|im| im.is_workspace_scanning(&root))
                 .unwrap_or(false);
             if scanning {
                 return;
@@ -328,7 +329,7 @@ mod tests {
         );
     }
 
-    /// 不存在的目录应直接返回且不触发后台扫描（manager scanning flag 不被置位）。
+    /// 不存在的目录应直接返回且不触发后台扫描（扫描许可不被占用）。
     #[test]
     fn full_scan_workspace_skips_missing_dir() {
         let temp = tempfile::tempdir().expect("create tempdir");
@@ -340,25 +341,32 @@ mod tests {
         assert!(!plugin.is_scanning(), "不存在的目录不应启动后台扫描");
     }
 
-    /// 重复对同一根目录发起后台扫描，per-root scanning flag 应阻止并发 spawn。
+    /// 重复对同一根目录发起后台扫描，扫描许可应阻止并发 spawn。
+    ///
+    /// 该测试直接经 manager 持有扫描许可，不依赖 set_workspace 的扫描触发
+    /// （后者涉及磁盘索引目录匹配，与测试用的临时 base_dir 不一致）。
     #[test]
     fn spawn_background_scan_is_idempotent_while_scanning() {
         let temp = tempfile::tempdir().expect("create tempdir");
         let workspace = temp.path().join("workspace");
         std::fs::create_dir_all(&workspace).unwrap();
-        std::fs::write(workspace.join("lib.rs"), "pub fn demo() {}\n").unwrap();
 
         let manager = shared_manager(&temp);
-        // 手动置位该 root 的 flag，模拟扫描进行中。
-        let flag = manager.scanning_flag_for(&workspace);
-        flag.store(true, Ordering::SeqCst);
-        // set_workspace 在扫描中应跳过 full_scan_workspace（不 panic、不重复 spawn）。
-        let plugin = IndexPlugin::from_index_manager(Some(manager));
-        plugin.set_workspace(Some(&workspace));
-        assert!(plugin.is_scanning());
+        // 持有扫描许可模拟扫描进行中：后续 try_begin 应返回 None。
+        let _permit = manager
+            .try_begin_workspace_scan(&workspace)
+            .expect("首次应取得扫描许可");
+        assert!(
+            manager.try_begin_workspace_scan(&workspace).is_none(),
+            "扫描进行中再次取许可应返回 None"
+        );
+        assert!(manager.is_workspace_scanning(&workspace));
     }
 
-    /// 两个 IndexPlugin 共享同一 manager 时，A 的后台扫描对 B 可见（跨 plugin 降级一致）。
+    /// 两个 IndexPlugin 共享同一 manager 时，A 占用的扫描许可对 B 可见（跨 plugin 降级一致）。
+    ///
+    /// 直接经 manager 占用扫描许可（不依赖 set_workspace 的扫描逻辑与磁盘索引目录），
+    /// 断言两个注入相同 manager 的 plugin 查询同一 root 都看到「正在扫描」。
     #[test]
     fn shared_manager_propagates_scanning_across_plugins() {
         let temp = tempfile::tempdir().expect("create tempdir");
@@ -366,15 +374,16 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
 
         let manager = shared_manager(&temp);
+        // 先占用扫描许可（模拟后台扫描进行中），使后续 set_workspace 检测到扫描而跳过，
+        // 避免测试自身的后台扫描与本许可竞争。
+        let _permit = manager
+            .try_begin_workspace_scan(&workspace)
+            .expect("取得扫描许可");
         let plugin_a = IndexPlugin::from_index_manager(Some(manager.clone()));
         let plugin_b = IndexPlugin::from_index_manager(Some(manager.clone()));
         plugin_a.set_workspace(Some(&workspace));
         plugin_b.set_workspace(Some(&workspace));
 
-        // A 置位该 root 的扫描标志，B 查询同一 root 应看到 true。
-        manager
-            .scanning_flag_for(&workspace)
-            .store(true, Ordering::SeqCst);
         assert!(plugin_a.is_scanning(), "plugin_a 应看到正在扫描");
         assert!(
             plugin_b.is_scanning(),

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -39,6 +39,14 @@ pub fn run(trust_mode: Option<tiangong_core::permission::TrustMode>) -> Result<(
     let mcp_plugin: std::sync::Arc<tiangong_plugin_mcp::McpPlugin> = std::sync::Arc::new(
         tiangong_plugin_mcp::McpPlugin::with_storage_root(storage_root.clone()),
     );
+    // 工作区索引单例（issue #259）：跨 Core 共享底层索引缓存与扫描状态。
+    // 构造失败时降级为独立实例（plugin 内部仍会兜底自建），不阻断启动。
+    let index_manager = tiangong_plugin_index::shared_index_manager().unwrap_or_else(|e| {
+        tracing::warn!("共享 IndexManager 初始化失败，降级独立实例: {e}");
+        std::sync::Arc::new(
+            tiangong_plugin_index::IndexManager::new().expect("IndexManager 初始化兜底失败"),
+        )
+    });
     let (stream_tx, stream_rx) = mpsc::channel::<StreamEvent>();
     // 初始化 Memory Handle（入口层负责，构造时注入 memory 插件）。
     let runtime = tokio::runtime::Runtime::new()?;
@@ -120,6 +128,7 @@ pub fn run(trust_mode: Option<tiangong_core::permission::TrustMode>) -> Result<(
                 memory_handle.clone(),
                 &skill_plugin,
                 &mcp_plugin,
+                &index_manager,
             )
         };
         runtime
@@ -169,6 +178,7 @@ fn build_cli_plugins(
     memory_handle: Option<tiangong_memory::MemoryHandle>,
     skill_plugin: &std::sync::Arc<tiangong_plugin_skill::SkillPlugin>,
     mcp_plugin: &std::sync::Arc<tiangong_plugin_mcp::McpPlugin>,
+    index_manager: &std::sync::Arc<tiangong_plugin_index::IndexManager>,
 ) -> Vec<std::sync::Arc<dyn tiangong_core::core::Plugin>> {
     use tiangong_llm::{ModelCapability, ModelEndpoint, SingleProviderClient};
 
@@ -191,7 +201,9 @@ fn build_cli_plugins(
 
     let mut plugins = tiangong_plugin_prompt::default_plugins();
     plugins.extend(tiangong_plugin_fs::default_plugins());
-    plugins.extend(tiangong_plugin_index::default_plugins());
+    plugins.extend(tiangong_plugin_index::default_plugins_with_manager(
+        index_manager.clone(),
+    ));
     if let Some(ep) = image_endpoint.clone() {
         plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
     }
@@ -219,10 +231,13 @@ fn build_cli_plugins(
 
     let child_plugin_factory = std::sync::Arc::new({
         let storage_root = storage_root.clone();
+        let index_manager = index_manager.clone();
         move || {
             let mut child_plugins = tiangong_plugin_prompt::default_plugins();
             child_plugins.extend(tiangong_plugin_fs::default_plugins());
-            child_plugins.extend(tiangong_plugin_index::default_plugins());
+            child_plugins.extend(tiangong_plugin_index::default_plugins_with_manager(
+                index_manager.clone(),
+            ));
             if let Some(ep) = image_endpoint.clone() {
                 child_plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
             }

--- a/crates/tiangong-server/src/api/mod.rs
+++ b/crates/tiangong-server/src/api/mod.rs
@@ -51,11 +51,20 @@ impl ServerAppContext {
         let mcp_plugin = Arc::new(tiangong_plugin_mcp::McpPlugin::with_storage_root(
             storage_root,
         ));
+        // 工作区索引单例（issue #259）：跨 Core 共享底层索引缓存与扫描状态。
+        // 构造失败时降级为独立实例（plugin 内部仍会兜底自建），不阻断启动。
+        let index_manager = tiangong_plugin_index::shared_index_manager().unwrap_or_else(|e| {
+            tracing::warn!("共享 IndexManager 初始化失败，降级独立实例: {e}");
+            Arc::new(
+                tiangong_plugin_index::IndexManager::new().expect("IndexManager 初始化兜底失败"),
+            )
+        });
         let cores = Arc::new(ServerCoreManager::new(
             state.clone(),
             core_manager,
             event_bus.clone(),
             mcp_plugin.clone(),
+            index_manager,
         ));
         let core_backend: Arc<dyn ServerCoreBackend> = cores;
         let scheduler_context: Arc<dyn SchedulerContext> = Arc::new(ServerSchedulerContext {

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -26,6 +26,8 @@ pub struct ServerCoreManager {
     /// MCP 管理插件共享句柄：core 注册与 API 管理使用同一实例（dual-ownership），
     /// 避免 API 修改的配置与运行中 core 的 plugin 状态分叉。
     mcp_plugin: Arc<tiangong_plugin_mcp::McpPlugin>,
+    /// 工作区索引单例（issue #259）：跨 Core 共享底层索引缓存与扫描状态。
+    index_manager: Arc<tiangong_plugin_index::IndexManager>,
     /// 同一会话的 Core 创建、消息投递和删除共用这一把锁。
     ///
     /// 锁对象不主动删除，避免旧等待者尚未退出时为同一 session 创建第二把锁。
@@ -44,12 +46,14 @@ impl ServerCoreManager {
         core_manager: tiangong_app_state::app_state::CoreManager,
         event_bus: Arc<EventBus>,
         mcp_plugin: Arc<tiangong_plugin_mcp::McpPlugin>,
+        index_manager: Arc<tiangong_plugin_index::IndexManager>,
     ) -> Self {
         Self {
             state,
             core_manager,
             event_bus,
             mcp_plugin,
+            index_manager,
             session_operation_locks: Arc::new(Mutex::new(HashMap::new())),
             session_wait_locks: Arc::new(Mutex::new(HashMap::new())),
             config_update_lock: Arc::new(AsyncMutex::new(())),
@@ -373,7 +377,9 @@ impl ServerCoreManager {
             // 产品文案插件注册在最前，保证身份/规则段排在 system prompt 开头。
             let mut plugins = tiangong_plugin_prompt::default_plugins();
             plugins.extend(tiangong_plugin_fs::default_plugins());
-            plugins.extend(tiangong_plugin_index::default_plugins());
+            plugins.extend(tiangong_plugin_index::default_plugins_with_manager(
+                self.index_manager.clone(),
+            ));
             if let Some(ep) = image_endpoint.clone() {
                 plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
             }
@@ -407,10 +413,13 @@ impl ServerCoreManager {
             // 子 Core 每次获得与该 Server Core 相同能力集合的全新插件外壳。
             let child_plugin_factory = Arc::new({
                 let storage_root = storage_root.clone();
+                let index_manager = self.index_manager.clone();
                 move || {
                     let mut child_plugins = tiangong_plugin_prompt::default_plugins();
                     child_plugins.extend(tiangong_plugin_fs::default_plugins());
-                    child_plugins.extend(tiangong_plugin_index::default_plugins());
+                    child_plugins.extend(tiangong_plugin_index::default_plugins_with_manager(
+                        index_manager.clone(),
+                    ));
                     if let Some(ep) = image_endpoint.clone() {
                         child_plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
                     }
@@ -1280,6 +1289,10 @@ mod tests {
             Arc::new(tiangong_plugin_mcp::McpPlugin::with_storage_root(
                 root.join("mcp"),
             )),
+            std::sync::Arc::new(
+                tiangong_plugin_index::IndexManager::new_with_dir(root.join("index"))
+                    .expect("IndexManager test init"),
+            ),
         ));
         (manager, session, session_path, state)
     }

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -967,8 +967,8 @@ export const api = {
   listWorkspaceIndexes: (): Promise<WorkspaceIndexInfo[]> =>
     invoke('list_workspace_indexes'),
 
-  deleteWorkspaceIndex: (workspaceId: string): Promise<void> =>
-    invoke('delete_workspace_index', { workspaceId }),
+  deleteWorkspaceIndex: (workspaceId: string, root: string): Promise<void> =>
+    invoke('delete_workspace_index', { workspaceId, root }),
 
   rebuildWorkspaceIndex: (root: string): Promise<number> =>
     invoke('rebuild_workspace_index', { root }),

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -973,6 +973,10 @@ export const api = {
   rebuildWorkspaceIndex: (root: string): Promise<number> =>
     invoke('rebuild_workspace_index', { root }),
 
+  // 预热工作区索引（索引已存在则直接返回，否则后台扫描，立即返回不阻塞）
+  prewarmWorkspaceIndex: (root: string): Promise<void> =>
+    invoke('prewarm_workspace_index', { root }),
+
   getModelCapabilities: (): Promise<ModelCapabilityInfo[]> =>
     invoke('get_model_capabilities'),
 

--- a/frontend/src/components/index/IndexManagementSettings.tsx
+++ b/frontend/src/components/index/IndexManagementSettings.tsx
@@ -28,10 +28,10 @@ export function IndexManagementSettings() {
     loadIndexes();
   }, [loadIndexes]);
 
-  const handleDelete = async (id: string) => {
+  const handleDelete = async (id: string, root: string) => {
     setDeleting(id);
     try {
-      await api.deleteWorkspaceIndex(id);
+      await api.deleteWorkspaceIndex(id, root);
       showSuccess('索引已删除');
       await loadIndexes();
     } catch (err) {
@@ -125,7 +125,7 @@ export function IndexManagementSettings() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => handleDelete(idx.id)}
+                    onClick={() => handleDelete(idx.id, idx.root)}
                     disabled={deleting === idx.id}
                     className="text-destructive hover:text-destructive"
                   >

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -1108,6 +1108,10 @@ export const useStore = create<AppState>((set, get) => ({
         };
       });
       syncInputCacheInBackground(get().syncInputCache(newConversationId, initialCache));
+      // 后台预热工作区索引：消除首次发送消息时的同步扫描延迟，不阻塞 UI。
+      api
+        .prewarmWorkspaceIndex(newConversationCwd)
+        .catch((error) => console.error('索引预热失败:', error));
     } catch (error) {
       console.error('开始新对话失败:', error);
     }
@@ -1675,6 +1679,12 @@ export const useStore = create<AppState>((set, get) => ({
         if (cache) sessionViewCaches.set(activeSessionId, { ...cache, cwd });
       }
       set({ sessionCwd: cwd });
+      // 新对话选定目录后立即预热索引（现有会话由后端在目录变更时处理）。
+      if (isNewConversation) {
+        api
+          .prewarmWorkspaceIndex(cwd)
+          .catch((error) => console.error('索引预热失败:', error));
+      }
     } catch (error) {
       console.error('设置工作目录失败:', error);
       throw error;

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -181,6 +181,14 @@ impl TiangongApp {
         let mcp_plugin = std::sync::Arc::new(tiangong_plugin_mcp::McpPlugin::with_storage_root(
             storage_root.clone(),
         ));
+        // 工作区索引单例（issue #259）：跨 Core 共享底层索引缓存与扫描状态。
+        // 构造失败时降级为独立实例（plugin 内部仍会兜底自建），不阻断启动。
+        let index_manager = tiangong_plugin_index::shared_index_manager().unwrap_or_else(|e| {
+            tracing::warn!("共享 IndexManager 初始化失败，降级独立实例: {e}");
+            std::sync::Arc::new(
+                tiangong_plugin_index::IndexManager::new().expect("IndexManager 初始化兜底失败"),
+            )
+        });
         let bot_store = std::sync::Arc::new(
             tiangong_bots::BotStore::with_storage_root(storage_root.clone()).unwrap_or_else(
                 |error| panic!("加载 Bot 配置失败，请修正 bots.json 后重试：{error:#}"),
@@ -195,6 +203,7 @@ impl TiangongApp {
             mcp_plugin: mcp_plugin.clone(),
             config: config.clone(),
             storage_root: storage_root.clone(),
+            index_manager: index_manager.clone(),
         });
         Self {
             state,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3732,11 +3732,35 @@ pub async fn rebuild_workspace_index(root: String) -> Result<usize, String> {
     tiangong_plugin_index::rebuild_workspace_index_for_gui(&root).map_err(|err| err.to_string())
 }
 
-/// 预热指定路径的 Workspace 索引（索引已存在则直接返回，否则后台扫描，立即返回不阻塞）
+/// 预热指定路径的 Workspace 索引（索引已存在则直接返回，否则后台扫描，立即返回不阻塞）。
+///
+/// 使用 app 层共享 IndexManager，与各 Core 的 IndexPlugin 共享同一 per-root mutex
+/// 与扫描标志，避免预热与插件后台扫描并发时的目录锁竞争。
 #[tauri::command]
-pub async fn prewarm_workspace_index(root: String) -> Result<(), String> {
+pub async fn prewarm_workspace_index(
+    root: String,
+    state: State<'_, TiangongApp>,
+) -> Result<(), String> {
     let root = std::path::PathBuf::from(&root);
-    tiangong_plugin_index::prewarm_workspace_index_for_gui(&root).map_err(|err| err.to_string())
+    if !root.is_dir() || tiangong_plugin_index::workspace_index_exists(&root) {
+        return Ok(());
+    }
+    let manager = state.desktop_factory.index_manager.clone();
+    // 经共享 manager 的 per-root scanning flag 去重：已在扫描则直接返回。
+    let scanning = manager.scanning_flag_for(&root);
+    if scanning.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        return Ok(());
+    }
+    tracing::info!(workspace = %root.display(), "Workspace 索引预热启动（共享 manager）");
+    tokio::task::spawn_blocking(move || {
+        let result = manager.full_scan(&root);
+        match result {
+            Ok(count) => tracing::info!(count, "Workspace 索引预热完成"),
+            Err(e) => tracing::warn!("Workspace 索引预热失败: {e}"),
+        }
+        scanning.store(false, std::sync::atomic::Ordering::SeqCst);
+    });
+    Ok(())
 }
 
 /// 获取所有可用的模型能力列表

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3735,7 +3735,8 @@ pub async fn rebuild_workspace_index(root: String) -> Result<usize, String> {
 /// 预热指定路径的 Workspace 索引（索引已存在则直接返回，否则后台扫描，立即返回不阻塞）。
 ///
 /// 使用 app 层共享 IndexManager，与各 Core 的 IndexPlugin 共享同一 per-root mutex
-/// 与扫描标志，避免预热与插件后台扫描并发时的目录锁竞争。
+/// 与扫描许可，避免预热与插件后台扫描并发时的目录锁竞争。扫描去重经
+/// `try_begin_workspace_scan` 取得的许可统一管理，drop 时自动复位。
 #[tauri::command]
 pub async fn prewarm_workspace_index(
     root: String,
@@ -3746,19 +3747,18 @@ pub async fn prewarm_workspace_index(
         return Ok(());
     }
     let manager = state.desktop_factory.index_manager.clone();
-    // 经共享 manager 的 per-root scanning flag 去重：已在扫描则直接返回。
-    let scanning = manager.scanning_flag_for(&root);
-    if scanning.swap(true, std::sync::atomic::Ordering::SeqCst) {
+    // 经扫描许可去重：已有扫描在进行（预热或插件后台扫描）则直接返回。
+    let Some(permit) = manager.try_begin_workspace_scan(&root) else {
         return Ok(());
-    }
+    };
     tracing::info!(workspace = %root.display(), "Workspace 索引预热启动（共享 manager）");
     tokio::task::spawn_blocking(move || {
-        let result = manager.full_scan(&root);
-        match result {
+        // permit 持有期间状态保持占用；drop（含 panic 展开）时自动复位。
+        let _permit = permit;
+        match manager.full_scan(&root) {
             Ok(count) => tracing::info!(count, "Workspace 索引预热完成"),
             Err(e) => tracing::warn!("Workspace 索引预热失败: {e}"),
         }
-        scanning.store(false, std::sync::atomic::Ordering::SeqCst);
     });
     Ok(())
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3718,11 +3718,42 @@ pub async fn list_workspace_indexes(
     tiangong_plugin_index::list_workspace_indexes_for_gui().map_err(|err| err.to_string())
 }
 
-/// 删除指定 Workspace 索引
+/// 删除指定 Workspace 索引。
+///
+/// 使用 app 层共享 IndexManager：先按 `root` 取得扫描许可（与预热 / 插件后台扫描 /
+/// 重建互斥，避免删除时后台线程继续写已移除的磁盘目录），再清理共享 manager 的内存
+/// 缓存（以 `workspace_key(root)` 为键）并删除磁盘索引目录（以 `workspace_id` 定位）。
+/// 已有扫描在进行时短暂轮询等待，保证删除期间无并发写入。
 #[tauri::command]
-pub async fn delete_workspace_index(workspace_id: String) -> Result<(), String> {
-    tiangong_plugin_index::delete_workspace_index_for_gui(&workspace_id)
-        .map_err(|err| err.to_string())
+pub async fn delete_workspace_index(
+    workspace_id: String,
+    root: String,
+    state: State<'_, TiangongApp>,
+) -> Result<(), String> {
+    let root_path = std::path::PathBuf::from(&root);
+    let manager = state.desktop_factory.index_manager.clone();
+    // 轮询等待扫描许可：最多约 30s，期间后台扫描应已完成。
+    let mut permit = None;
+    for _ in 0..300 {
+        if let Some(p) = manager.try_begin_workspace_scan(&root_path) {
+            permit = Some(p);
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    let permit = permit.ok_or_else(|| "索引正在构建中，请稍后重试".to_string())?;
+    tracing::info!(workspace_id, root = %root_path.display(), "Workspace 索引删除启动（共享 manager）");
+    let manager_clone = manager.clone();
+    tokio::task::spawn_blocking(move || {
+        // permit 持有期间状态保持占用；drop（含 panic 展开）时自动复位。
+        let _permit = permit;
+        manager_clone
+            .delete_workspace_index(&root_path, &workspace_id)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("删除任务执行失败: {e}"))??;
+    Ok(())
 }
 
 /// 重建指定路径的 Workspace 索引。

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3732,6 +3732,13 @@ pub async fn rebuild_workspace_index(root: String) -> Result<usize, String> {
     tiangong_plugin_index::rebuild_workspace_index_for_gui(&root).map_err(|err| err.to_string())
 }
 
+/// 预热指定路径的 Workspace 索引（索引已存在则直接返回，否则后台扫描，立即返回不阻塞）
+#[tauri::command]
+pub async fn prewarm_workspace_index(root: String) -> Result<(), String> {
+    let root = std::path::PathBuf::from(&root);
+    tiangong_plugin_index::prewarm_workspace_index_for_gui(&root).map_err(|err| err.to_string())
+}
+
 /// 获取所有可用的模型能力列表
 #[tauri::command]
 pub async fn get_model_capabilities() -> Result<Vec<ModelCapabilityInfo>, String> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3725,11 +3725,40 @@ pub async fn delete_workspace_index(workspace_id: String) -> Result<(), String> 
         .map_err(|err| err.to_string())
 }
 
-/// 重建指定路径的 Workspace 索引
+/// 重建指定路径的 Workspace 索引。
+///
+/// 使用 app 层共享 IndexManager，与预热 / 插件后台扫描共用同一 per-root 扫描许可：
+/// 若已有扫描在进行，短暂轮询等待其结束后再取得许可执行重建，避免与后台扫描并发
+/// 写同一磁盘索引（目录锁竞争 / 重建失败 / 状态不一致）。重建为用户显式请求，
+/// 不应无故失败，故选择等待而非直接拒绝。
 #[tauri::command]
-pub async fn rebuild_workspace_index(root: String) -> Result<usize, String> {
+pub async fn rebuild_workspace_index(
+    root: String,
+    state: State<'_, TiangongApp>,
+) -> Result<usize, String> {
     let root = std::path::PathBuf::from(&root);
-    tiangong_plugin_index::rebuild_workspace_index_for_gui(&root).map_err(|err| err.to_string())
+    let manager = state.desktop_factory.index_manager.clone();
+    // 轮询等待扫描许可：最多等约 30s，期间后台扫描应已完成。
+    let mut permit = None;
+    for _ in 0..300 {
+        if let Some(p) = manager.try_begin_workspace_scan(&root) {
+            permit = Some(p);
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    let permit = permit.ok_or_else(|| "索引正在构建中，请稍后重试".to_string())?;
+    tracing::info!(workspace = %root.display(), "Workspace 索引重建启动（共享 manager）");
+    let manager_clone = manager.clone();
+    let count = tokio::task::spawn_blocking(move || {
+        // permit 持有期间状态保持占用；drop（含 panic 展开）时自动复位。
+        let _permit = permit;
+        manager_clone.full_scan(&root)
+    })
+    .await
+    .map_err(|e| format!("重建任务执行失败: {e}"))?
+    .map_err(|e| e.to_string())?;
+    Ok(count)
 }
 
 /// 预热指定路径的 Workspace 索引（索引已存在则直接返回，否则后台扫描，立即返回不阻塞）。

--- a/src-tauri/src/core_factory.rs
+++ b/src-tauri/src/core_factory.rs
@@ -20,6 +20,7 @@ use tiangong_core::core_config::CoreConfigProvider;
 /// - `skill_plugin` / `mcp_plugin`：管理插件句柄（core 拿 clone 做 LLM 工具）
 /// - `config`：全局 CoreConfigProvider（取 generation 用于 memory handle 初始化）
 /// - `storage_root`：会话文件根
+/// - `index_manager`：工作区索引单例（issue #259，跨 Core 共享底层索引缓存与扫描状态）
 #[derive(Clone)]
 pub struct DesktopCoreFactory {
     pub app_handle: Arc<std::sync::OnceLock<AppHandle>>,
@@ -27,6 +28,7 @@ pub struct DesktopCoreFactory {
     pub mcp_plugin: Arc<tiangong_plugin_mcp::McpPlugin>,
     pub config: CoreConfigProvider,
     pub storage_root: std::path::PathBuf,
+    pub index_manager: Arc<tiangong_plugin_index::IndexManager>,
 }
 
 impl DesktopCoreFactory {
@@ -72,7 +74,9 @@ impl DesktopCoreFactory {
                 false
             };
         plugins.push(tiangong_plugin_fs::build_plugin());
-        plugins.push(tiangong_plugin_index::build_plugin());
+        plugins.push(tiangong_plugin_index::build_plugin_with_manager(
+            self.index_manager.clone(),
+        ));
         // app 层判断是否注册各能力插件，经 llm 路由解析端点后构造注入。
         use tiangong_llm::{ModelCapability, ModelEndpoint, SingleProviderClient};
         let resolve_ep = |cap: ModelCapability| {
@@ -116,6 +120,7 @@ impl DesktopCoreFactory {
         let child_plugin_factory = Arc::new({
             let app_handle = app_handle.clone();
             let storage_root = storage_root.clone();
+            let index_manager = self.index_manager.clone();
             move || {
                 let mut child_plugins: Vec<Arc<dyn Plugin>> = Vec::new();
                 child_plugins.extend(tiangong_plugin_prompt::default_plugins());
@@ -130,7 +135,9 @@ impl DesktopCoreFactory {
                     }
                 }
                 child_plugins.push(tiangong_plugin_fs::build_plugin());
-                child_plugins.push(tiangong_plugin_index::build_plugin());
+                child_plugins.push(tiangong_plugin_index::build_plugin_with_manager(
+                    index_manager.clone(),
+                ));
                 if let Some(ep) = image_endpoint.clone() {
                     child_plugins.push(tiangong_plugin_generate_image::build_plugin(ep));
                 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -599,6 +599,7 @@ fn run_gui() {
             tiangong_app::commands::list_workspace_indexes,
             tiangong_app::commands::delete_workspace_index,
             tiangong_app::commands::rebuild_workspace_index,
+            tiangong_app::commands::prewarm_workspace_index,
             tiangong_app::commands::get_model_capabilities,
             tiangong_app::commands::get_model_list,
             tiangong_app::commands::fetch_provider_models,


### PR DESCRIPTION
## 背景

Closes #259。

全新对话首次发送消息存在 ~2s 延迟，根因是 `IndexPlugin` 在 IPC 线程上同步全量扫描工作区。本 PR 通过三层改动彻底解决：首次扫描后台化、创建新对话时主动预热、IndexManager 提升为 app 层单例。

## 改动

### 第 1 层：首次扫描后台化（消除 IPC 阻塞）
- `IndexPlugin` 首次扫描从同步 `im.full_scan` 改为后台 `std::thread::spawn`
- `index_search` 扫描中降级提示，避免在索引 Mutex 上阻塞
- 扫描性能优化：skip lists 改 `HashSet` O(1)、`entry.file_type()` 免 stat、复用 `DirEntry` metadata

### 第 2 层：创建新对话时主动预热
- 新增 `prewarm_workspace_index` 命令链路（GUI API + Tauri 命令 + 前端）
- 前端 `startNewConversation` / `setSessionCwd` 新对话分支触发后台预热

### 第 3 层：IndexManager app 层单例
- `IndexManager` 从 per-Core 私有提升为各入口共享单例（Desktop/CLI/Server），消除磁盘锁冲突、缓存重复、scanning 状态割裂
- `IndexPlugin` 保持 per-session（不引入 per-session 状态竞态）

### 扫描许可 RAII 封装
- 扫描状态从散落各调用方的 `swap`/`store` 收敛为 `WorkspaceScanPermit`（RAII，Drop 自动复位含 panic 展开）
- `scanning_roots` 改 `Mutex<HashMap>`：DashMap `entry()` 在并发首次访问下会为同一 key 创建不同 Arc，改用锁保证 get-or-create 唯一
- 新增 `workspace_key()`：canonicalize 规范化路径，消除 `./..` /软链接导致等价目录生成不同 key

### 删除/重建走共享管理器
- 手动重建、删除索引改为取 app 层共享 manager + 扫描许可（与预热/插件后台扫描互斥）
- 修复既有 bug：缓存以 `workspace_key(root)` 为键，删除却用 `workspace_id`（hash_path）调 `remove`，键不匹配导致删除后进程内仍用旧索引对象
- 删除校验 `root` 与 `workspace_id` 一致（防御性）
- 移除绕过共享状态的公开入口（`prewarm/rebuild/delete_workspace_index_for_gui`）

## 验收对照
- [x] 创建新对话（选定 cwd）后，后台立即开始索引扫描，不阻塞 UI
- [x] 全新对话首次发送消息，延迟从 ~2s 降到接近 0
- [x] 即使预热未赶上，`set_workspace` 也不再同步阻塞
- [x] 索引扫描中调用 `index_search`，有合理降级行为，不报错
- [x] 现有对话（索引已存在）行为不变

## 测试
- 13 单测 + 7 集成测试，覆盖：后台化不阻塞、并发扫描许可去重（只有一个胜出）、permit drop 复位（含 panic）、等价路径共享状态、跨 plugin 降级一致、删除清缓存与磁盘目录、root/id 一致性校验
- `cargo build`：Desktop / CLI / Server 三入口
- `cargo clippy` 无警告，`cargo fmt --all --check` 通过
- 前端 `tsc --noEmit` 通过
- pre-push 钩子（cargo check/clippy/nextest + yarn build/test）全部通过

## 已知后续项（不阻塞合并）
- 搜索与删除之间存在理论竞态窗口，当前交互下风险极低且删除失败会报错，留作后续读写互斥统一处理
- 磁盘索引目录仍按原 `hash_path` 定位以兼容已建索引；内存映射已统一为 `workspace_key`