### PR TITLE
fix(scheduler): 定时任务未设置对话时触发后正确创建并关联新会话

### DIFF
--- a/crates/tiangong-scheduler/src/executor.rs
+++ b/crates/tiangong-scheduler/src/executor.rs
@@ -148,12 +148,7 @@ async fn execute_core(
         }
     };
 
-    // 首次执行时将 session_id 写回 job/webhook，后续复用同一会话
-    if created_new {
-        pin_session_to_tracker(tracker, &params.trigger_id, &session_id);
-    }
-
-    // 记录开始执行
+    // 记录开始执行（本轮使用的 session，即便随后失败也保留痕迹）
     insert_run(tracker, &run_id, &params.trigger_id, &session_id, &now);
 
     // 构造消息
@@ -163,11 +158,17 @@ async fn execute_core(
     );
 
     // 发送消息到 core（不等结果）
-    let result = sender(session_id, message).await;
+    let result = sender(session_id.clone(), message).await;
 
     let finished_at = chrono::Local::now().naive_local().to_string();
     match result {
         Ok(()) => {
+            // 投递成功后才把新 session_id 写回 job/webhook：失败时新会话很可能尚未
+            // 落盘，立刻绑定会让后续触发因 session_exists==false 反复换新 id，
+            // 彻底丢失关联（见 resolve_session_id 仅按磁盘文件判定）。
+            if created_new {
+                pin_session_to_tracker(tracker, &params.trigger_id, &session_id);
+            }
             update_run_success(
                 tracker,
                 &run_id,
@@ -564,5 +565,114 @@ mod tests {
         let reader = JobStore::open_at(store_path).unwrap();
         let runs = reader.list_job_runs("test-job-concurrent", 10).unwrap();
         assert_eq!(runs.len(), 1, "并发执行应被跳过，只有一条记录");
+    }
+
+    // 投递成功才把新 session_id 写回 Job：失败时不绑定，下轮重新创建。
+    #[tokio::test]
+    async fn pins_session_id_only_after_successful_delivery() {
+        let dir = TempDir::new().unwrap();
+        let (store, _) = setup_job_store(&dir, "test-job-pin-success");
+        let store_path = dir.path().to_path_buf();
+
+        let ctx = Arc::new(MockContext {
+            sessions: StdMutex::new(vec![]),
+        });
+        let params = ExecuteParams {
+            trigger_id: "test-job-pin-success".to_string(),
+            trigger_name: "测试任务".to_string(),
+            trigger_description: "测试".to_string(),
+            session_id: None,
+            payload: "hello".to_string(),
+        };
+
+        execute_core(
+            ctx.as_ref(),
+            params,
+            &RunTracker::Job { store },
+            &mock_sender_ok(),
+        )
+        .await;
+
+        let reader = JobStore::open_at(store_path).unwrap();
+        let job = reader.get_job("test-job-pin-success").unwrap().unwrap();
+        assert!(
+            job.session_id.is_some(),
+            "投递成功后应把新 session_id 写回 Job"
+        );
+    }
+
+    // 投递失败不得绑定新 session_id：否则该 id 多半未落盘，下次触发会因
+    // session_exists==false 反复换新 id，关联彻底丢失。
+    #[tokio::test]
+    async fn does_not_pin_session_id_on_delivery_failure() {
+        let dir = TempDir::new().unwrap();
+        let (store, _) = setup_job_store(&dir, "test-job-pin-failure");
+        let store_path = dir.path().to_path_buf();
+
+        let ctx = Arc::new(MockContext {
+            sessions: StdMutex::new(vec![]),
+        });
+        let params = ExecuteParams {
+            trigger_id: "test-job-pin-failure".to_string(),
+            trigger_name: "测试任务".to_string(),
+            trigger_description: "测试".to_string(),
+            session_id: None,
+            payload: "hello".to_string(),
+        };
+
+        execute_core(
+            ctx.as_ref(),
+            params,
+            &RunTracker::Job { store },
+            &mock_sender_err("core 投递失败"),
+        )
+        .await;
+
+        let reader = JobStore::open_at(store_path).unwrap();
+        let job = reader.get_job("test-job-pin-failure").unwrap().unwrap();
+        assert!(
+            job.session_id.is_none(),
+            "投递失败时不得把未落盘的 session_id 写回 Job"
+        );
+    }
+
+    // 复用既有会话（created_new=false）时不应触发写回。
+    #[tokio::test]
+    async fn reuse_existing_session_does_not_rewrite_job() {
+        let dir = TempDir::new().unwrap();
+        let existing_session = "session-existing";
+        let (store, _job) = setup_job_store(&dir, "test-job-reuse");
+        // 预置既有 session_id，模拟任务已绑定到一个落盘会话
+        let store_path = dir.path().to_path_buf();
+        {
+            let req = UpdateJobRequest {
+                session_id: Some(existing_session.to_string()),
+                ..Default::default()
+            };
+            store.update_job("test-job-reuse", &req).unwrap();
+        }
+
+        let ctx = Arc::new(MockContext {
+            sessions: StdMutex::new(vec![existing_session.to_string()]),
+        });
+        let params = ExecuteParams {
+            trigger_id: "test-job-reuse".to_string(),
+            trigger_name: "测试任务".to_string(),
+            trigger_description: "测试".to_string(),
+            session_id: Some(existing_session.to_string()),
+            payload: "hello".to_string(),
+        };
+
+        execute_core(
+            ctx.as_ref(),
+            params,
+            &RunTracker::Job { store },
+            &mock_sender_ok(),
+        )
+        .await;
+
+        let reader = JobStore::open_at(store_path).unwrap();
+        let job = reader.get_job("test-job-reuse").unwrap().unwrap();
+        assert_eq!(job.session_id.as_deref(), Some(existing_session));
     }
 }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 use tiangong_core::agent_input::AgentInputKind;
 use tiangong_core::core_config::CoreConfigProvider;
@@ -542,7 +542,11 @@ impl TiangongApp {
         }
 
         if ensured.is_new {
-            crate::commands::start_stream_consumer(app_handle, sid, stream_rx);
+            crate::commands::start_stream_consumer(app_handle.clone(), sid, stream_rx);
+            // 与 send_message_inner / 嵌入式 Server / Server 端入口一致：新建会话后
+            // 通知前端刷新会话列表。否则定时消息虽已入队、Core 已建，但用户在 UI
+            // 上看不到新对话，表现为「定时任务未设置对话时触发后没有创建新对话」。
+            let _ = app_handle.emit("sessions_updated", &());
         }
         Ok(())
     }


### PR DESCRIPTION
## 背景

定时任务未设置关联对话时，触发后无法创建新对话并与任务建立关联。

## 根因（两处独立缺陷叠加）

### 缺陷一：Desktop 定时消息路径新建会话不通知前端
`src-tauri/src/app.rs` 的 `enqueue_scheduled_message` 在 `ensure_core` 返回 `is_new=true` 时，只启动了 stream consumer，**完全没有发射 `sessions_updated` 事件**。

对比同仓库其它入口的既有模式均会通知前端：
- 普通发消息 `send_message_inner`（commands.rs）→ `app.emit("sessions_updated", &())`
- 嵌入式 Server 入口（embedded_server.rs）→ `event_bus.publish(TiangongEvent::SessionCreated)`
- Server 端 `send_message_and_wait`（remote/core.rs）→ `event_bus.publish(TiangongEvent::SessionCreated)`

唯独定时消息路径漏发 → Core 创建了、消息也送进去了，但前端会话列表不刷新，用户感知「没创建新对话」。

### 缺陷二：executor 过早绑定 session_id，导致 job 反复绑定不存在的 session
`executor.rs` 首次触发时，`resolve_session_id` 铸出新 scru128 id 返回 `created_new=true`，**立刻** `pin_session_to_tracker` 把 id 写回 `Job.session_id`。

但两端的 `resolve_session_id` 只用 `core_manager.session_exists(sid)`（即「磁盘上有 sessions/{id}.json」）判定会话是否存在。此刻新 id 的 Session 文件**尚未落盘**（Core 懒持久化，Desktop 端 `enqueue_scheduled_message` 只等稳定入队 ACK）。一旦本轮后续失败或 Core 在持久化前被回收，磁盘上不会出现该文件，于是下次触发 `resolve_session_id` 落入 else 分支再铸新 id —— **每次触发都换新 session_id，关联彻底丢失**。

## 修复

### 改动 1：executor 延迟绑定到投递成功后（共享层，两端通用）
把 `pin_session_to_tracker` 从 sender **之前**移到 `Ok(())` 分支**之后**：
- 失败分支不再绑定 → 下轮重新铸 id，避免 job 被钉在一个不会落盘的 id 上反复漂移
- 成功分支绑定 → 此时消息已确认入队，session 大概率已落盘

新增三个单测：
- `pins_session_id_only_after_successful_delivery`：首次成功 → Job.session_id 被绑定
- `does_not_pin_session_id_on_delivery_failure`：首次失败 → Job.session_id 保持 None
- `reuse_existing_session_does_not_rewrite_job`：复用既有会话不受影响

### 改动 2：Desktop 定时消息补发 sessions_updated 事件
`enqueue_scheduled_message` 在新建会话后补发 `app_handle.emit("sessions_updated", &())`，补齐 `tauri::Emitter` 导入。

### Server 端
经评估 `crates/tiangong-server/src/scheduler/context.rs` 无需改动：`send_message_and_wait` 成功返回时 session 文件已落盘（Core worker 持久化是 turn 一部分），改动 1 在共享层已覆盖 Server 端的 id 漂移问题。

## 验证
- [x] `cargo build -p tiangong-scheduler` / `-p tiangong-app` 编译通过
- [x] `cargo test -p tiangong-scheduler`：12/12 通过（含 3 个新测试）
- [x] `cargo test -p tiangong-server`：15/15 通过，Server 路径无回归
- [x] pre-push 钩子（cargo check / clippy / nextest）全部 Passed
- [ ] 手动验证（需运行时环境）：创建不绑定 session 的定时任务并触发，确认前端出现新对话且再次触发复用同一会话

## 改动文件
- `crates/tiangong-scheduler/src/executor.rs` — 延迟绑定 + 3 个单测
- `src-tauri/src/app.rs` — `enqueue_scheduled_message` 补发 sessions_updated 事件