### PR TITLE
fix(terminal): 嵌入式终端以登录 shell 启动，修复命令无法识别

### DIFF
--- a/crates/plugins/tiangong-plugin-terminal/src/manager.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/manager.rs
@@ -458,6 +458,33 @@ fn default_shell() -> String {
     }
 }
 
+/// 推导以「登录 shell」方式启动所需的命令行参数。
+///
+/// `shell` 可能是绝对路径（`/bin/zsh`、`/usr/local/bin/bash`）或裸名（`bash`），
+/// 取 basename 判定。各 shell 的登录启动参数：
+/// - **bash / zsh**：`--login`。会读 `/etc/profile`、`~/.zprofile`/`~/.bash_profile`；
+///   PTY 是交互式 TTY，zsh 还会读 `~/.zshrc`。Homebrew 默认把
+///   `eval "$(brew shellenv)"` 写进 `~/.zprofile`，恰好在此被加载，
+///   从而注入 `/opt/homebrew/bin` 等 PATH。
+/// - **sh**：`-l`（POSIX 登录 shell 约定）。
+/// - **Windows / powershell / 未知 shell**：不传登录参数（无等价概念或语义不明）。
+///
+/// 返回静态字符串切片以直接喂给 `CommandBuilder::arg`。
+fn login_shell_args(shell: &str) -> Vec<&'static str> {
+    if cfg!(target_os = "windows") {
+        return Vec::new();
+    }
+    let basename = std::path::Path::new(shell)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(shell);
+    match basename {
+        "bash" | "zsh" => vec!["--login"],
+        "sh" => vec!["-l"],
+        _ => Vec::new(),
+    }
+}
+
 pub(crate) fn start_pty(
     session_id: &str,
     cwd: &str,
@@ -475,6 +502,13 @@ pub(crate) fn start_pty(
         .map_err(|e| anyhow::anyhow!("PTY 创建失败: {}", e))?;
 
     let mut cmd = CommandBuilder::new(shell);
+    // 以登录 shell 方式启动（对齐 Terminal.app / iTerm2 / VSCode 的默认行为）：
+    // 让 shell source /etc/profile → /etc/paths、~/.zprofile/~/.bash_profile，
+    // 从而拿到用户真实 PATH（如 Homebrew 的 /opt/homebrew/bin），避免 GUI 主进程
+    // 继承的残缺 PATH 导致 gh 等命令 "command not found"。见 issue #151。
+    for arg in login_shell_args(shell) {
+        cmd.arg(arg);
+    }
     cmd.cwd(cwd);
     cmd.env("TERM", "xterm-256color");
     // 追加各插件贡献的环境变量（MCP/skill 等注入的 token、.env.local 等）。
@@ -562,5 +596,35 @@ mod tests {
         // 没有新输出
         let inc3 = manager.incremental_output();
         assert!(inc3.is_empty());
+    }
+
+    // login_shell_args 仅在非 Windows 上产出登录参数，相关断言限定平台编译，
+    // 避免 Windows 下因函数固定返回空而必然失败。
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn test_login_shell_args() {
+        // macOS 常见绝对路径 → basename 判定
+        assert_eq!(login_shell_args("/bin/zsh"), vec!["--login"]);
+        assert_eq!(login_shell_args("/bin/bash"), vec!["--login"]);
+        // Homebrew 安装的 shell 路径
+        assert_eq!(login_shell_args("/opt/homebrew/bin/zsh"), vec!["--login"]);
+        assert_eq!(login_shell_args("/usr/local/bin/bash"), vec!["--login"]);
+        // 裸名
+        assert_eq!(login_shell_args("zsh"), vec!["--login"]);
+        assert_eq!(login_shell_args("bash"), vec!["--login"]);
+        // POSIX sh
+        assert_eq!(login_shell_args("/bin/sh"), vec!["-l"]);
+        assert_eq!(login_shell_args("sh"), vec!["-l"]);
+        // 未知 shell：不传登录参数（保持原行为，避免错误语义）
+        assert!(login_shell_args("/usr/bin/fish").is_empty());
+        assert!(login_shell_args("fish").is_empty());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_login_shell_args_on_windows() {
+        // Windows 下无论什么 shell 都不应传登录参数（无 -l/--login 概念）。
+        assert!(login_shell_args("powershell.exe").is_empty());
+        assert!(login_shell_args("bash").is_empty());
     }
 }


### PR DESCRIPTION
## 问题

macOS 从 Dock/Finder/Spotlight 启动的 GUI 主进程只继承到残缺 PATH（\`/usr/bin:/bin:/usr/sbin:/sbin\`，不含 \`/opt/homebrew/bin\`），而嵌入式终端的 PTY 又以**非登录**方式启动 shell，不会 source \`~/.zprofile\`。两层叠加导致实际存在的命令（如 \`gh\`，位于 \`/opt/homebrew/bin/gh\`）在嵌入式终端里报 \`command not found\`。

## 根因

\`crates/plugins/tiangong-plugin-terminal/src/manager.rs\` 的 \`start_pty\` 用 \`CommandBuilder::new(shell)\` 启动 shell 时**不传任何参数**，shell 既非登录、又继承残缺 PATH，不会加载 \`/etc/profile\` → \`/etc/paths\`、\`~/.zprofile\`（Homebrew 默认在此注入 \`/opt/homebrew/bin\`）。

## 修复

让 PTY 以**登录 shell** 方式启动，对齐 Terminal.app / iTerm2 / VSCode 的默认行为：

- 新增 \`login_shell_args()\`：按 basename 推导
  - \`bash\` / \`zsh\` → \`["--login"]\`
  - \`sh\` → \`["-l"]\`
  - Windows / powershell / 未知 shell → \`[]\`
- 在 \`start_pty\` 里喂给 \`CommandBuilder\`；所有 PTY 创建路径（首次启动 + \`Reset\` 重置）都经此函数，改一处全覆盖。
- 测试按平台 \`#[cfg]\` gate（Windows 下函数固定返回空，断言只在对应平台编译）。

## 验证

- [x] \`cargo build -p tiangong-plugin-terminal\` 通过
- [x] \`cargo test -p tiangong-plugin-terminal\` 全部 57 个测试通过、无回归
- [x] 运行时手测：GUI 嵌入式终端敲 \`which gh\` → \`/opt/homebrew/bin/gh\`，\`gh --version\` 正常

## 不做什么

- 不在主进程启动期 \`set_var(\"PATH\", ...)\`：登录 shell 已能覆盖标准环境，保持最小改动面。
- 不硬编码路径列表：依赖用户 \`~/.zprofile\`/ \`~/.bash_profile\`（Homebrew 安装时默认提示写入）。
- 不改 CLI/Server 的 command 插件路径（其 \`run_shell\` 已用 \`bash -lc\`，本就是登录）。