### PR TITLE
fix(scheduler): 创建/更新时校验 cron 表达式，修正 5 字段误用

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10248,6 +10248,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "cron",
  "dirs",
  "scru128",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ base64 = "0.22"
 chrono = { version = "0.4", default-features = false }
 clap = "4"
 crossterm = "0.29"
+cron = "0.16"
 dashmap = "6"
 diffy = "0.5"
 dirs = "6"

--- a/crates/plugins/tiangong-plugin-scheduler/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-scheduler/src/handler.rs
@@ -69,6 +69,14 @@ impl SchedulerPlugin {
             return param_error("缺少必填参数 payload");
         };
 
+        // 校验 cron 表达式：调度器要求 6 字段（秒 分 时 日 月 周），否则恢复期会解析失败。
+        // 在此提前拦截，避免无效表达式静默落库后开机才报错。
+        if let Err(e) = tiangong_scheduler::executor::validate_cron_schedule(&schedule) {
+            return param_error(&format!(
+                "schedule 不是合法的 cron 表达式（需 6 字段，如 '0 25 21 * * *' 表示每天 21:25）：{e}"
+            ));
+        }
+
         // 可选字段：session_id 为空时透传 None，沿用「首次触发时延迟创建会话」机制
         let session_id = get_opt_str_field(args, "session_id");
         let enabled = get_bool_field(args, "enabled").unwrap_or(true);
@@ -168,6 +176,16 @@ impl SchedulerPlugin {
             payload: get_opt_str_field(args, "payload"),
             enabled: get_bool_field(args, "enabled"),
         };
+
+        // 更新 schedule 时同样校验（三态：未传/None 表示不变，显式空串表示清空，
+        // 非空串才需校验）。与 create 用同一校验，确保落库即可解析。
+        if let Some(schedule) = req.schedule.as_ref().filter(|s| !s.is_empty()) {
+            if let Err(e) = tiangong_scheduler::executor::validate_cron_schedule(schedule) {
+                return param_error(&format!(
+                    "schedule 不是合法的 cron 表达式（需 6 字段，如 '0 25 21 * * *' 表示每天 21:25）：{e}"
+                ));
+            }
+        }
 
         let store = match self.open_store() {
             Ok(s) => s,
@@ -355,7 +373,7 @@ impl ToolSpecProvider for SchedulerPlugin {
                     "properties": {
                         "name": { "type": "string", "description": "任务名称" },
                         "description": { "type": "string", "description": "任务描述" },
-                        "schedule": { "type": "string", "description": "Cron 表达式，如 '0 9 * * *' 表示每天 9 点" },
+                        "schedule": { "type": "string", "description": "Cron 表达式（6 字段：秒 分 时 日 月 周），如 '0 0 9 * * *' 表示每天 9 点" },
                         "payload": { "type": "string", "description": "触发时发送给 LLM 的任务描述" },
                         "session_id": { "type": "string", "description": "关联已有会话 ID（可选，不指定则首次触发时自动创建新会话）" },
                         "enabled": { "type": "boolean", "description": "是否启用，默认 true" }
@@ -377,7 +395,7 @@ impl ToolSpecProvider for SchedulerPlugin {
                         "id": { "type": "string", "description": "任务 ID" },
                         "name": { "type": "string", "description": "任务名称" },
                         "description": { "type": "string", "description": "任务描述" },
-                        "schedule": { "type": "string", "description": "Cron 表达式" },
+                        "schedule": { "type": "string", "description": "Cron 表达式（6 字段：秒 分 时 日 月 周）" },
                         "payload": { "type": "string", "description": "触发时发送给 LLM 的任务描述" },
                         "session_id": { "type": "string", "description": "关联会话 ID" },
                         "enabled": { "type": "boolean", "description": "是否启用" }
@@ -688,7 +706,7 @@ mod tests {
             json!({
                 "name": "无会话任务",
                 "description": "验证 session_id 可选",
-                "schedule": "0 9 * * *",
+                "schedule": "0 0 9 * * *",
                 "payload": "ping",
             }),
         );
@@ -707,6 +725,66 @@ mod tests {
         let (handler, _dir) = handler_in_tmp();
         let call = make_call("not_a_scheduler_tool", json!({}));
         assert!(handler.dispatch(&call).is_none());
+    }
+
+    // ── cron 表达式校验（5 字段被拒、6 字段通过）──────────────────────
+
+    /// 5 字段 crontab 写法（如 `25 21 * * *`）应被 create 拒绝：调度器底层 cron
+    /// crate 要求 6 字段（秒 分 时 日 月 周），5 字段会在第 6 字段处 EOF 失败。
+    /// 回归保护：在线日志曾出现 `解析 cron 表达式失败 [25 21 * * *]`。
+    #[test]
+    fn create_job_rejects_five_field_cron() {
+        let (handler, _dir) = handler_in_tmp();
+        let call = make_call(
+            TOOL_CREATE_JOB,
+            json!({
+                "name": "五字段任务",
+                "description": "应被拒绝",
+                "schedule": "25 21 * * *",
+                "payload": "ping",
+            }),
+        );
+        let result = handler.dispatch(&call).expect("create 应被处理");
+        assert!(
+            !result.ok,
+            "5 字段 cron 应被拒绝，却成功了：{}",
+            result.summary
+        );
+        assert!(
+            result.summary.contains("cron") || result.stdout.contains("cron"),
+            "错误信息应说明是 cron 校验失败：{}",
+            result.summary
+        );
+    }
+
+    /// 等价的 6 字段写法（`0 25 21 * * *`，每天 21:25）应创建成功。
+    #[test]
+    fn create_job_accepts_six_field_cron() {
+        let (handler, _dir) = handler_in_tmp();
+        let call = make_call(
+            TOOL_CREATE_JOB,
+            json!({
+                "name": "六字段任务",
+                "description": "应通过",
+                "schedule": "0 25 21 * * *",
+                "payload": "ping",
+            }),
+        );
+        let result = handler.dispatch(&call).expect("create 应被处理");
+        assert!(result.ok, "6 字段 cron 应通过：{}", result.summary);
+    }
+
+    /// update 同样校验：传入 5 字段应被拒。
+    #[test]
+    fn update_job_rejects_five_field_cron() {
+        let (handler, _dir) = handler_in_tmp();
+        let id = seed_job(&handler, "原任务");
+        let call = make_call(
+            TOOL_UPDATE_JOB,
+            json!({ "id": id, "schedule": "0 9 * * *" }),
+        );
+        let result = handler.dispatch(&call).expect("update 应被处理");
+        assert!(!result.ok, "5 字段 cron 更新应被拒绝：{}", result.summary);
     }
 
     // ── 缺陷回归保护（Review #1/#3/#4，已修复）─────────────────────────
@@ -782,7 +860,7 @@ mod tests {
             json!({
                 "name": "带会话",
                 "description": "验证清空字段",
-                "schedule": "0 9 * * *",
+                "schedule": "0 0 9 * * *",
                 "payload": "ping",
                 "session_id": "sess-original",
             }),

--- a/crates/tiangong-scheduler/Cargo.toml
+++ b/crates/tiangong-scheduler/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
+cron = { workspace = true }
 scru128 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/tiangong-scheduler/src/executor.rs
+++ b/crates/tiangong-scheduler/src/executor.rs
@@ -241,6 +241,21 @@ pub async fn restore_cron_jobs(ctx: Arc<dyn SchedulerContext>) {
     }
 }
 
+/// 校验 schedule 字符串能否被调度器解析。
+///
+/// 与 [`restore_cron_jobs`] 用同一套 `cron::Schedule::from_str` 解析（silent 的
+/// `ProcessTime::try_from` 对 cron 字符串内部即调用它），确保「创建期校验通过」与
+/// 「恢复期能解析」行为一致。底层 `cron` crate 要求 6~7 字段表达式
+///（`秒 分 时 日 月 周 [年]`），5 字段的 crontab 写法（如 `25 21 * * *`）会在第 6
+/// 字段（周）处 EOF 失败。
+///
+/// 返回 `Ok(())` 表示可解析；`Err` 携带底层解析错误，调用方可直接展示给用户。
+pub fn validate_cron_schedule(expr: &str) -> anyhow::Result<()> {
+    use std::str::FromStr;
+    cron::Schedule::from_str(expr).map(|_| ())?;
+    Ok(())
+}
+
 // ── 内部方法 ──────────────────────────────────────────────────
 
 /// 将 session_id 写回 job/webhook，确保后续执行复用同一会话


### PR DESCRIPTION
## 问题

在线日志告警：
\`\`\`
WARN tiangong_scheduler::executor: 解析 cron 表达式失败 [25 21 * * *]: 25 21 * * *
           ^
\`\`\`

caret 指向第 11 列（EOF）——调度器底层 \`cron 0.16\` 要求 **6 字段**（\`秒 分 时 日 月 周\`），而 \`25 21 * * *\` 只有 5 字段，被当成秒/分/时/日/月后，等第 6 字段（周）时撞 EOF。

## 根因（两处叠加缺陷）

1. **工具 schema 示例误导**：\`handler.rs\` 给 LLM 的示例写的是 \`'0 9 * * *'\`（5 字段），LLM 照此产出 → 落库即错。
2. **创建/更新从不校验**：\`create_job\`/\`update_job\` 原样存盘，错误延迟到重启时 \`restore_cron_jobs\` 才暴露，与创建动作完全脱钩。

## 修复

- **新增校验函数** \`tiangong_scheduler::executor::validate_cron_schedule()\`：复用 \`cron::Schedule::from_str\`（与 \`restore_cron_jobs\` 同一套解析，行为一致）。为此 \`tiangong-scheduler\` 直接依赖 \`cron\`（已在 Cargo.lock 作为 silent 的传递依赖，不引入新编译）。
- **创建期拦截**：\`handle_create_job\` / \`handle_update_job\` 在落库前校验，非法表达式立即返回 \`param_error\`，错误信息附 6 字段示例（\`'0 25 21 * * *'\`），让 LLM 当场纠正。
- **修正误导示例**：schema 由 5 字段改为 6 字段（\`'0 0 9 * * *'\`）。
- **修正连带用错的既有测试**：\`create_job_without_session_id\`、\`update_job_can_clear_optional_field\` 原本也用了错误的 5 字段。
- **新增回归测试**：5 字段被拒、等价 6 字段通过、update 同样校验。

## 验证

- [x] \`cargo build -p tiangong-plugin-scheduler -p tiangong-scheduler\` 通过
- [x] \`cargo test -p tiangong-plugin-scheduler\`：15 个测试全过（含 3 个新增）
- [x] \`cargo test -p tiangong-scheduler\`：6 个测试全过、无回归
- [x] \`cargo clippy\`（两 crate，含 --all-targets）无警告

## 影响面

- 用户已存的非法 5 字段任务不会自动迁移（恢复期仍会告警并跳过，与现状一致）；本次只防新增。如需存量修复可后续单独处理。
- 正常 6 字段任务不受影响。