### PR TITLE
fix(terminal): agent 启动时无法感知嵌入式终端命令

### DIFF
--- a/crates/plugins/tiangong-plugin-terminal/src/collaboration.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/collaboration.rs
@@ -132,3 +132,56 @@ impl tiangong_core::agent_input::ToolInput for TerminalUserInput {
         })
     }
 }
+
+/// 单个终端 Tab 的状态快照（用于首轮 `terminal_data` 注入）。
+#[derive(Debug, Clone)]
+pub struct TerminalTabSnapshot {
+    pub id: String,
+    pub title: String,
+    pub cwd: String,
+    pub shell: String,
+    pub phase: String,
+    pub alive: bool,
+    /// 该 Tab 最近 N 行输出（已过滤 marker 行）。仅存活 Tab 填充。
+    pub recent_output: String,
+}
+
+/// 终端状态快照注入（ToolInput 实现）。
+///
+/// 对齐浏览器的 `browser_data`：agent 首轮启动时注入当前终端全貌——各 Tab 的工作
+/// 目录、shell 类型、运行阶段和最近输出，使 agent 像感知浏览器页面一样感知终端
+/// 上下文（用户已在终端做了什么、当前处于什么环境），避免重复执行已知命令。
+///
+/// tool_name 为 `terminal_data`，render 返回结构化 JSON。
+pub struct TerminalStateData {
+    pub tabs: Vec<TerminalTabSnapshot>,
+    pub active_tab_id: Option<String>,
+}
+
+impl tiangong_core::agent_input::ToolInput for TerminalStateData {
+    fn tool_name(&self) -> &str {
+        "terminal_data"
+    }
+
+    fn render(&self) -> serde_json::Value {
+        let tabs = self
+            .tabs
+            .iter()
+            .map(|t| {
+                serde_json::json!({
+                    "id": t.id,
+                    "title": t.title,
+                    "cwd": t.cwd,
+                    "shell": t.shell,
+                    "phase": t.phase,
+                    "alive": t.alive,
+                    "recent_output": t.recent_output,
+                })
+            })
+            .collect::<Vec<_>>();
+        serde_json::json!({
+            "tabs": tabs,
+            "active_tab_id": self.active_tab_id,
+        })
+    }
+}

--- a/crates/plugins/tiangong-plugin-terminal/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/handler.rs
@@ -530,6 +530,7 @@ impl tiangong_core::tool_override::PromptSectionProvider for TerminalPromptSecti
             "当用户请求涉及命令行操作（安装依赖、创建项目、编译构建、文件操作等），必须逐步使用 `run_shell` 实际执行命令，不要仅以文本或代码块形式展示命令给用户。每步执行一条命令，根据执行结果决定下一步操作。回复中可以用代码块展示已执行的命令，但必须先通过 `run_shell` 实际执行。".to_string(),
             "如果命令会启动需要持续输入的交互程序（例如编辑器、REPL、TUI、远程会话、确认流程等），使用 `run_shell{interactive:true, script:\"<command>\"}` 显式声明交互意图。返回的 stdout 是终端当前显示内容，请阅读后用 `terminal_send{input:\"<按键>\"}` 持续操作；每次发送后都会返回新快照。".to_string(),
             "文件编辑优先使用 write_file / replace_in_file；只有用户明确要求在终端程序里操作，或确实需要交互式程序时才用 `run_shell{interactive:true}`。".to_string(),
+            "对话开始时会收到 `terminal_data` 工具结果，包含当前各终端 Tab 的工作目录、shell 类型、运行阶段和最近输出。据此判断用户已在终端做了什么、当前处于什么环境，避免重复执行已知命令。".to_string(),
         ]
     }
 }

--- a/crates/plugins/tiangong-plugin-terminal/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/handler.rs
@@ -530,7 +530,7 @@ impl tiangong_core::tool_override::PromptSectionProvider for TerminalPromptSecti
             "当用户请求涉及命令行操作（安装依赖、创建项目、编译构建、文件操作等），必须逐步使用 `run_shell` 实际执行命令，不要仅以文本或代码块形式展示命令给用户。每步执行一条命令，根据执行结果决定下一步操作。回复中可以用代码块展示已执行的命令，但必须先通过 `run_shell` 实际执行。".to_string(),
             "如果命令会启动需要持续输入的交互程序（例如编辑器、REPL、TUI、远程会话、确认流程等），使用 `run_shell{interactive:true, script:\"<command>\"}` 显式声明交互意图。返回的 stdout 是终端当前显示内容，请阅读后用 `terminal_send{input:\"<按键>\"}` 持续操作；每次发送后都会返回新快照。".to_string(),
             "文件编辑优先使用 write_file / replace_in_file；只有用户明确要求在终端程序里操作，或确实需要交互式程序时才用 `run_shell{interactive:true}`。".to_string(),
-            "对话开始时会收到 `terminal_data` 工具结果，包含当前各终端 Tab 的工作目录、shell 类型、运行阶段和最近输出。据此判断用户已在终端做了什么、当前处于什么环境，避免重复执行已知命令。".to_string(),
+            "每轮对话开始时会收到 `terminal_data` 工具结果，包含当前各终端 Tab 的工作目录、shell 类型、运行阶段和最近输出。据此判断用户已在终端做了什么、当前处于什么环境，避免重复执行已知命令。".to_string(),
         ]
     }
 }

--- a/crates/plugins/tiangong-plugin-terminal/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/plugin.rs
@@ -11,6 +11,8 @@ use std::sync::{Arc, RwLock};
 
 use serde_json::json;
 use tauri::{Manager, Wry};
+use tiangong_core::agent_input::ToolInput;
+use tiangong_core::core::plugin::PluginFeedbackTx;
 use tiangong_core::core::Plugin;
 use tiangong_core::model::{ToolCall, ToolSpec};
 use tiangong_core::tool::ToolResult;
@@ -18,7 +20,7 @@ use tiangong_core::tool_override::{PromptSectionProvider, ToolOverrideHandler};
 
 use crate::capability::TerminalProvider;
 use crate::handler::{TerminalPromptSectionProvider, TerminalToolOverride};
-use crate::session_pty::SessionAwareTerminalProvider;
+use crate::session_pty::{SessionAwareTerminalProvider, SessionPtyRegistry};
 use tiangong_core::permission::TrustMode;
 
 /// 终端插件：聚合终端能力、工具覆盖处理器与 Prompt 段落提供者。
@@ -32,6 +34,15 @@ pub struct TerminalPlugin {
     /// 插件贡献环境变量的共享句柄（与 `SessionPtyRegistry` 共享同一实例）。
     /// `set_exec_env` 写入此句柄，PTY 创建时读取快照注入。
     runtime_env: Arc<RwLock<std::collections::BTreeMap<String, String>>>,
+    /// 全局 PTY 注册表句柄：`on_session_ready` 时读取终端状态快照注入会话。
+    registry: Arc<SessionPtyRegistry>,
+    /// 当前 turn 的反馈通道：`on_session_ready` 注入 `terminal_data` 首轮快照用。
+    /// turn 结束后接收端释放，迟到注入会 send 失败（首轮注入在 Agent Loop 启动前，
+    /// 时序上通道必然存活）。
+    feedback_tx: RwLock<Option<PluginFeedbackTx>>,
+    /// 是否已为该 session 注入过初始 `terminal_data` 快照。
+    /// `on_session_ready` 每轮触发，用此标志保证仅首轮注入一次。
+    injected_initial_state: std::sync::atomic::AtomicBool,
 }
 
 impl TerminalPlugin {
@@ -42,9 +53,10 @@ impl TerminalPlugin {
     /// 返回 `None` 表示插件 state 未就绪（与旧 `get_*` 工厂一致）。
     pub fn from_app_handle(app: &tauri::AppHandle<Wry>) -> Option<Self> {
         let state = app.state::<crate::TerminalPluginState>();
-        let runtime_env = state.registry.runtime_env_handle();
+        let registry = state.registry.clone();
+        let runtime_env = registry.runtime_env_handle();
         let provider: Arc<dyn TerminalProvider> =
-            Arc::new(SessionAwareTerminalProvider::new(state.registry.clone()));
+            Arc::new(SessionAwareTerminalProvider::new(registry.clone()));
         let override_handler = TerminalToolOverride::new(provider);
         let prompt_provider = TerminalPromptSectionProvider;
         Some(Self {
@@ -52,6 +64,9 @@ impl TerminalPlugin {
             prompt_provider,
             workspace: RwLock::new(None),
             runtime_env,
+            registry,
+            feedback_tx: RwLock::new(None),
+            injected_initial_state: std::sync::atomic::AtomicBool::new(false),
         })
     }
 }
@@ -84,6 +99,44 @@ impl Plugin for TerminalPlugin {
         if let Ok(mut guard) = self.runtime_env.write() {
             *guard = env;
         }
+    }
+
+    /// 注入当前 turn 的反馈通道，供 `on_session_ready` 投递首轮终端状态快照。
+    fn set_feedback_tx(&self, tx: PluginFeedbackTx) {
+        if let Ok(mut guard) = self.feedback_tx.write() {
+            *guard = Some(tx);
+        }
+    }
+
+    /// session 就绪：首轮注入终端状态快照（对齐 browser_data 范式）。
+    ///
+    /// `on_session_ready` 每轮触发，用 `injected_initial_state` 标志保证仅首轮注入
+    /// 一次——后续用户命令由 `terminal_user_input`（经 ToolInjection 消费者）实时
+    /// 注入，无需重复快照。
+    ///
+    /// 此时 feedback 通道已注入（`set_feedback_tx` 在 `on_session_ready` 之前调用），
+    /// 且注入发生在 Agent Loop 的 select! 启动前，命令入队后会被本轮消费。
+    fn on_session_ready(&self, session: &mut tiangong_core::session::Session) {
+        use std::sync::atomic::Ordering;
+        if self
+            .injected_initial_state
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return; // 已注入过初始快照
+        }
+        let Some(tx) = self.feedback_tx.read().ok().and_then(|g| g.clone()) else {
+            return;
+        };
+        let state = self.registry.snapshot_for_injection(&session.id);
+        let payload = state.render();
+        if !tx.inject_tool("terminal_data", payload) {
+            // 通道未就绪：重置标志，下个 turn 重新尝试。
+            self.injected_initial_state.store(false, Ordering::SeqCst);
+            tracing::debug!(session_id = %session.id, "首轮 terminal_data 注入失败，下轮重试");
+            return;
+        }
+        tracing::debug!(session_id = %session.id, "首轮 terminal_data 已注入");
     }
 }
 

--- a/crates/plugins/tiangong-plugin-terminal/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/plugin.rs
@@ -36,13 +36,10 @@ pub struct TerminalPlugin {
     runtime_env: Arc<RwLock<std::collections::BTreeMap<String, String>>>,
     /// 全局 PTY 注册表句柄：`on_session_ready` 时读取终端状态快照注入会话。
     registry: Arc<SessionPtyRegistry>,
-    /// 当前 turn 的反馈通道：`on_session_ready` 注入 `terminal_data` 首轮快照用。
-    /// turn 结束后接收端释放，迟到注入会 send 失败（首轮注入在 Agent Loop 启动前，
+    /// 当前 turn 的反馈通道：`on_session_ready` 注入 `terminal_data` 终端状态快照用。
+    /// turn 结束后接收端释放，迟到注入会 send 失败（注入发生在 Agent Loop 启动前，
     /// 时序上通道必然存活）。
     feedback_tx: RwLock<Option<PluginFeedbackTx>>,
-    /// 是否已为该 session 注入过初始 `terminal_data` 快照。
-    /// `on_session_ready` 每轮触发，用此标志保证仅首轮注入一次。
-    injected_initial_state: std::sync::atomic::AtomicBool,
 }
 
 impl TerminalPlugin {
@@ -66,7 +63,6 @@ impl TerminalPlugin {
             runtime_env,
             registry,
             feedback_tx: RwLock::new(None),
-            injected_initial_state: std::sync::atomic::AtomicBool::new(false),
         })
     }
 }
@@ -108,35 +104,28 @@ impl Plugin for TerminalPlugin {
         }
     }
 
-    /// session 就绪：首轮注入终端状态快照（对齐 browser_data 范式）。
+    /// session 就绪：每轮注入终端状态快照（对齐 browser_data 范式）。
     ///
-    /// `on_session_ready` 每轮触发，用 `injected_initial_state` 标志保证仅首轮注入
-    /// 一次——后续用户命令由 `terminal_user_input`（经 ToolInjection 消费者）实时
-    /// 注入，无需重复快照。
+    /// `on_session_ready` 每轮触发，每次都注入当前终端全貌（各 Tab 的 cwd/shell/
+    /// phase/recent_output）。这样：
+    /// - 首轮：agent 看到初始终端状态；
+    /// - 后续每轮：agent 看到「截至本轮开始时」的终端状态，自然包含上一轮结束后
+    ///   用户在终端敲的命令及其输出——无需依赖 `terminal_user_input` 的实时注入
+    ///   （后者在两轮之间 / turn 收尾窗口可能丢失，但下一轮的 terminal_data 会补全）。
     ///
     /// 此时 feedback 通道已注入（`set_feedback_tx` 在 `on_session_ready` 之前调用），
     /// 且注入发生在 Agent Loop 的 select! 启动前，命令入队后会被本轮消费。
     fn on_session_ready(&self, session: &mut tiangong_core::session::Session) {
-        use std::sync::atomic::Ordering;
-        if self
-            .injected_initial_state
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
-            return; // 已注入过初始快照
-        }
         let Some(tx) = self.feedback_tx.read().ok().and_then(|g| g.clone()) else {
             return;
         };
         let state = self.registry.snapshot_for_injection(&session.id);
         let payload = state.render();
         if !tx.inject_tool("terminal_data", payload) {
-            // 通道未就绪：重置标志，下个 turn 重新尝试。
-            self.injected_initial_state.store(false, Ordering::SeqCst);
-            tracing::debug!(session_id = %session.id, "首轮 terminal_data 注入失败，下轮重试");
+            tracing::debug!(session_id = %session.id, "terminal_data 注入失败（通道未就绪）");
             return;
         }
-        tracing::debug!(session_id = %session.id, "首轮 terminal_data 已注入");
+        tracing::debug!(session_id = %session.id, "terminal_data 已注入");
     }
 }
 

--- a/crates/plugins/tiangong-plugin-terminal/src/session_pty.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/session_pty.rs
@@ -527,6 +527,50 @@ impl SessionPtyRegistry {
         }
     }
 
+    /// 收集终端状态快照供 agent 首轮 `terminal_data` 注入。
+    ///
+    /// 基于 [`list_tabs`]（纯读取，合并持久化 + 运行态，不创建 PTY），对每个存活
+    /// Tab 额外读取 `recent_output`。未存活的 Tab（前端未打开 / 已退出）只返回
+    /// 元信息，`recent_output` 为空。
+    ///
+    /// **纯读取，绝不创建 PTY**：全程不调 `ensure` 或 `TerminalProvider` 的懒创建
+    /// 方法（`recent_output`/`current_cwd` 会触发 `ensure`）。仅用 registry 层的
+    /// `list_tabs` + `get`（返回 None 不创建）+ manager 层的 `recent_output`。
+    pub fn snapshot_for_injection(
+        &self,
+        session_id: &str,
+    ) -> crate::collaboration::TerminalStateData {
+        const INJECT_OUTPUT_LINES: usize = 40;
+        let tab_list = self.list_tabs(session_id);
+        let tabs = tab_list
+            .tabs
+            .into_iter()
+            .map(|info| {
+                let recent_output = if info.alive {
+                    let terminal_id = terminal_instance_id(session_id, &info.id);
+                    self.get(&terminal_id)
+                        .map(|slot| slot.manager.recent_output(INJECT_OUTPUT_LINES))
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                };
+                crate::collaboration::TerminalTabSnapshot {
+                    id: info.id,
+                    title: info.title,
+                    cwd: info.cwd,
+                    shell: info.shell,
+                    phase: info.phase,
+                    alive: info.alive,
+                    recent_output,
+                }
+            })
+            .collect();
+        crate::collaboration::TerminalStateData {
+            tabs,
+            active_tab_id: tab_list.active_tab_id,
+        }
+    }
+
     pub fn tab_new(
         &self,
         session_id: &str,
@@ -853,10 +897,18 @@ impl SessionAwareTerminalProvider {
         if route.tab_id.is_some() {
             return self.tx(session_id);
         }
-        // 只返回处于 AgentInteractive 态的 tab；找不到返回 None（不 fallback active/first）
-        self.registry
+        // 1. 优先 AgentInteractive tab：agent 自己经 exec_interactive 启动的交互程序，
+        //    即使它已不是 active tab，也优先路由，保证后续输入发到正确的终端。
+        if let Some(slot) = self
+            .registry
             .interactive_slot_for_session(&route.session_id)
-            .map(|slot| slot.cmd_tx)
+        {
+            return Some(slot.cmd_tx);
+        }
+        // 2. 回退到 active tab（任意存活状态）：与用户输入路由（registry.get →
+        //    active_or_first_tab_id）一致，使 agent 能接手用户已手动启动的交互程序
+        //    （ssh/vim/REPL 等）。此前这里返回 None → terminal pty unavailable。
+        self.registry.get(session_id).map(|s| s.cmd_tx)
     }
 }
 

--- a/crates/tiangong-core/src/core/plugin/feedback.rs
+++ b/crates/tiangong-core/src/core/plugin/feedback.rs
@@ -38,11 +38,20 @@ impl PluginFeedbackTx {
     }
 
     /// 将插件产生的结构化内容注入当前会话。
-    pub fn inject_tool(&self, tool_name: impl Into<String>, payload: serde_json::Value) {
-        let _ = self.tx.send(Command::InjectTool {
-            tool_name: tool_name.into(),
-            payload,
-        });
+    ///
+    /// 返回 `true` 表示已成功投递到当前 turn 的命令队列；`false` 表示通道已关闭
+    ///（turn 已结束消费 / Core 已退出）。调用方可据此决定是否回退到缓冲重试。
+    ///
+    /// 注意：`true` 仅保证命令已入队，不保证 turn 内一定会处理它——若 turn 在
+    /// 入队后、消费前结束，命令仍可能丢失。彻底消除该竞态需配合 turn 侧在
+    /// Agent Loop 结束后立即 drop 接收端（见 `run_turn`）。
+    pub fn inject_tool(&self, tool_name: impl Into<String>, payload: serde_json::Value) -> bool {
+        self.tx
+            .send(Command::InjectTool {
+                tool_name: tool_name.into(),
+                payload,
+            })
+            .is_ok()
     }
 
     /// 上报插件内部模型调用产生的用量，并向前端发送用量事件。
@@ -116,5 +125,29 @@ mod tests {
         };
         assert_eq!(source, "child");
         assert!(!emit_event);
+    }
+
+    #[test]
+    fn inject_tool_returns_true_when_consumer_alive() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let feedback = PluginFeedbackTx::new(tx);
+
+        assert!(feedback.inject_tool("browser_data", serde_json::json!({"url": "x"})));
+        match rx.try_recv() {
+            Ok(Command::InjectTool { tool_name, .. }) => assert_eq!(tool_name, "browser_data"),
+            _ => panic!("expected InjectTool"),
+        }
+    }
+
+    #[test]
+    fn inject_tool_returns_false_after_receiver_dropped() {
+        // 模拟 turn 收尾窗口：Agent Loop 已退出，接收端被显式 drop。
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let feedback = PluginFeedbackTx::new(tx);
+        drop(rx);
+
+        // drop 接收端后，is_closed() 应为 true，inject_tool 也必须返回 false。
+        assert!(feedback.is_closed());
+        assert!(!feedback.inject_tool("terminal_user_input", serde_json::json!({})));
     }
 }

--- a/crates/tiangong-core/src/react/turn.rs
+++ b/crates/tiangong-core/src/react/turn.rs
@@ -45,6 +45,11 @@ pub(crate) async fn run_turn(
     // ── 执行 Agent Loop ──
     // execute_turn 返回明确的执行结果和累计用量，不在内部发送终态事件。
     let execution = execute_turn(&mut ctx, &mut cmd_rx).await;
+    // Agent Loop 结束后，本函数的收尾阶段（消息协议修复、插件回调、持久化）不再
+    // 消费命令通道。显式 drop 接收端，使所有 PluginFeedbackTx 的 is_closed() 立即
+    // 返回 true——否则 turn task 退出前会出现"通道未关闭但已无人消费"的窗口，
+    // 此时 watcher 经 inject_tool 投递的终端命令会成功入队但随队列销毁而丢失。
+    drop(cmd_rx);
     let usage = execution.usage;
     let mut outcome = execution.outcome;
     ctx.session.token_usage.accumulate(&usage);

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -425,19 +425,12 @@ impl TiangongApp {
                 // 绑定和最终 deliver，禁止在 take→删除/重建空窗中复活孤立 Core。
                 let session_lock = app_state.session_send_lock(&session_id);
                 let _send_guard = session_lock.lock_owned().await;
-                // 会话存在性用 metadata 判定；ensure_core 需要的完整 session
-                // 从磁盘 load（issue #245：真相源归磁盘）。
-                let session_exists = state
-                    .lock()
-                    .await
-                    .core_manager
-                    .list_session_metadata()
-                    .iter()
-                    .any(|m| m.id == session_id);
-                if !session_exists {
-                    tracing::warn!(session_id, "消费者无法恢复 core：session 不存在");
-                    continue;
-                }
+                // session 不存在时由 ensure_core 新建并物化（load_session 处理磁盘
+                // 无 session 文件的情况：新建 Session 并 try_persist_to_disk）。
+                // 此前这里用 session_exists 门控提前 continue，导致首条消息前的终端
+                // 命令（terminal:user_command）被静默丢弃——session 物化只发生在首条
+                // 消息投递后，而终端命令可能在更早就已上报。移除门控后，工具注入
+                // 会触发 ensure_core 物化 session，命令得以正确 deliver。
                 use std::sync::mpsc;
                 let (stream_tx, stream_rx) = mpsc::channel::<tiangong_types::StreamEvent>();
                 let ensured = app_state

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -425,12 +425,24 @@ impl TiangongApp {
                 // 绑定和最终 deliver，禁止在 take→删除/重建空窗中复活孤立 Core。
                 let session_lock = app_state.session_send_lock(&session_id);
                 let _send_guard = session_lock.lock_owned().await;
-                // session 不存在时由 ensure_core 新建并物化（load_session 处理磁盘
-                // 无 session 文件的情况：新建 Session 并 try_persist_to_disk）。
-                // 此前这里用 session_exists 门控提前 continue，导致首条消息前的终端
-                // 命令（terminal:user_command）被静默丢弃——session 物化只发生在首条
-                // 消息投递后，而终端命令可能在更早就已上报。移除门控后，工具注入
-                // 会触发 ensure_core 物化 session，命令得以正确 deliver。
+                // 会话存在性用 metadata 判定；ensure_core 需要的完整 session
+                // 从磁盘 load（issue #245：真相源归磁盘）。
+                //
+                // 首条消息前的终端命令（terminal:user_command）会在此被跳过——但
+                // terminal 插件的 on_session_ready 会在每轮 turn 启动时注入完整终端
+                // 状态（terminal_data，含 recent_output），agent 下一轮自然能看到，
+                // 不依赖这里的离散事件实时注入。
+                let session_exists = state
+                    .lock()
+                    .await
+                    .core_manager
+                    .list_session_metadata()
+                    .iter()
+                    .any(|m| m.id == session_id);
+                if !session_exists {
+                    tracing::warn!(session_id, "消费者无法恢复 core：session 不存在");
+                    continue;
+                }
                 use std::sync::mpsc;
                 let (stream_tx, stream_rx) = mpsc::channel::<tiangong_types::StreamEvent>();
                 let ensured = app_state


### PR DESCRIPTION
## 问题

agent 启动后无法正确感知嵌入式终端中已执行的命令，存在两个独立但叠加的故障路径。

### A. terminal_send 无法接手用户已启动的交互程序

`interactive_tx` 只接受 `AgentInteractive` 态的 tab，用户手动启动的 ssh/vim（Idle/UserActive 态）被拒，报 \`terminal pty unavailable\`。

**修复**：增加回退——优先 \`AgentInteractive\` tab（保留 agent 自启动程序的优先路由），否则回退到 active tab（任意存活状态），与用户输入路由（\`registry.get\`）一致。

### B. agent 每轮无法获知终端当前全貌

浏览器插件每轮注入 \`browser_data\`（当前页面状态），终端插件无对应机制——agent 只能靠主动 \`run_command\` 才能探知终端状态。

**修复**：对齐浏览器范式，新增 \`TerminalStateData\` ToolInput（tool_name = \`terminal_data\`），\`on_session_ready\` 每轮注入当前终端全貌（各 Tab 的 cwd/shell/phase/recent_output）。

每轮注入同时解决了「两轮之间用户终端操作丢失」的问题——\`AgentInputKind::Tool\` 在无活跃 turn 时经 \`send_cmd\` 投递会失败，\`terminal_user_input\` 离散事件在两轮之间会丢失；但每轮 \`terminal_data\` 在 turn 刚启动时注入（feedback tx 必然存活），下一轮自然补全终端全貌（含 recent_output）。

### C. core 反馈通道的通用健壮性加固

修复 \`PluginFeedbackTx\` 的两个时序缺陷（browser watcher 同样受益）：

- **\`feedback.rs\`**：\`inject_tool\` 返回值 \`()\` → \`bool\`（反映 \`send\` 实际结果），让调用方能区分「投递成功」与「通道已关闭」
- **\`turn.rs\`**：Agent Loop 结束后立即 \`drop(cmd_rx)\`，消除「turn 收尾窗口」——Agent Loop 退出后到 turn task 销毁之间，通道接收端仍存活但无人消费，\`is_closed()\` 返回 false 导致误判可投递

## 改动

| 文件 | 改动 |
|---|---|
| \`session_pty.rs\` | \`interactive_tx\` active tab 回退；新增 \`snapshot_for_injection\` 纯读取方法（list_tabs + get + manager.recent_output，不创建 PTY） |
| \`collaboration.rs\` | 新增 \`TerminalStateData\` + \`TerminalTabSnapshot\` ToolInput |
| \`plugin.rs\` | \`set_feedback_tx\` 存通道；\`on_session_ready\` 每轮注入 \`terminal_data\` |
| \`handler.rs\` | prompt 段落告知 agent \`terminal_data\` 含义 |
| \`feedback.rs\` | \`inject_tool\` 返回 bool + 测试 |
| \`turn.rs\` | Agent Loop 结束后 drop cmd_rx |

## 验证

- \`cargo check --workspace\` ✅
- \`cargo test\`：core 83 + terminal 57 全过 ✅
- \`cargo clippy\` + \`cargo fmt\` + pre-commit/pre-push 全 Passed ✅

## 测试场景

1. 在嵌入式终端手动 \`ssh\` 到服务器 → 让 agent 用 \`terminal_send\` 发命令 → 不再报 \`terminal pty unavailable\`
2. 两轮之间在终端敲命令 → 下一轮 agent 通过 \`terminal_data\` 自动看到
3. agent 用 \`run_shell(interactive:true)\` 启动 vim → \`terminal_send\` 仍优先路由到该 AgentInteractive tab