### PR TITLE
fix(bots): Windows 停止 Bot 时抑制终端窗口闪现并强制终止进程

### DIFF
--- a/crates/tiangong-bots/src/pid.rs
+++ b/crates/tiangong-bots/src/pid.rs
@@ -37,9 +37,11 @@ pub fn process_alive(pid: u32) -> bool {
 
 #[cfg(not(unix))]
 pub fn process_alive(pid: u32) -> bool {
-    Command::new("tasklist")
-        .args(["/FI", &format!("PID eq {pid}"), "/NH"])
-        .output()
+    // Desktop 模式下高频调用（health/is_running 轮询），必须抑制控制台窗口闪现（issue #290）。
+    let mut cmd = Command::new("tasklist");
+    tiangong_types::process::configure_no_window(&mut cmd);
+    cmd.args(["/FI", &format!("PID eq {pid}"), "/NH"]);
+    cmd.output()
         .is_ok_and(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
 }
 
@@ -78,8 +80,13 @@ pub fn send_terminate(pid: u32) -> Result<()> {
 
 #[cfg(not(unix))]
 pub fn send_terminate(pid: u32) -> Result<()> {
-    let output = Command::new("taskkill")
-        .args(["/PID", &pid.to_string(), "/T"])
+    // Desktop（GUI）进程没有可附加的控制台，`taskkill /T`（不带 /F）只能向目标投递
+    // WM_CLOSE，对独立后台 bot 几乎无效，导致 bot 长期无法停止（issue #290）。
+    // 与 supervisor 路径的 `child.kill()`（= TerminateProcess，强制终止）对齐，使用 /F。
+    let mut cmd = Command::new("taskkill");
+    tiangong_types::process::configure_no_window(&mut cmd);
+    let output = cmd
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
         .output()
         .context("执行 taskkill 失败")?;
     if !output.status.success() {
@@ -304,7 +311,9 @@ fn send_kill(pid: u32) -> Result<()> {
 
 #[cfg(not(unix))]
 fn send_kill(pid: u32) -> Result<()> {
-    let output = Command::new("taskkill")
+    let mut cmd = Command::new("taskkill");
+    tiangong_types::process::configure_no_window(&mut cmd);
+    let output = cmd
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .output()
         .context("执行 taskkill /F 失败")?;


### PR DESCRIPTION
## 背景

Closes #290

Windows 桌面模式关闭 Bot 时闪现终端窗口，且 Bot 无法正常停止。

## 根因

`crates/tiangong-bots/src/pid.rs` 的三处 Windows 分支：

1. **闪现终端窗口** — `process_alive`（`tasklist`）、`send_terminate`/`send_kill`（`taskkill`）以 `Command::new(...).output()` 启动控制台子进程时未设置 `CREATE_NO_WINDOW`，每次存活检查/停止都会闪现一个 conhost 窗口。同文件 `spawn_detached`（pid.rs:148）与 `supervisor.rs:218` 的 `spawn_child` 均已正确调用 `configure_no_window`，唯独这三处遗漏。
2. **无法正常停止** — `send_terminate` 使用不带 `/F` 的 `taskkill /T`，仅向目标投递 `WM_CLOSE`。从 GUI 进程（无可附加控制台）发起时，对独立后台 bot 几乎无效，导致 bot 长期无法停止，需等 10s 超时后才 escalate 到 `send_kill`，与 supervisor 路径的 `child.kill()`（= `TerminateProcess`，立即终止）行为不一致。

## 修复

- 三处 Windows 分支统一调用 `tiangong_types::process::configure_no_window`（`CREATE_NO_WINDOW`），与既有 `spawn_detached`/`spawn_child` 写法一致。
- `send_terminate` 改用 `taskkill /T /F`，与 supervisor 的强制终止行为对齐，确保 Bot 能被可靠停止。

## 变更

- `crates/tiangong-bots/src/pid.rs`
  - `process_alive`（Windows）：`tasklist` 加 `CREATE_NO_WINDOW`
  - `send_terminate`（Windows）：`taskkill` 加 `CREATE_NO_WINDOW`，`/T` → `/T /F`
  - `send_kill`（Windows）：`taskkill` 加 `CREATE_NO_WINDOW`

仅触及 Windows 分支，未改 Unix 路径或公共 API。

## 验证

- `cargo build -p tiangong-bots` ✅
- `cargo clippy -p tiangong-bots --all-targets` 无警告 ✅
- `cargo test -p tiangong-bots`：49 单元 + 6 集成测试全通过 ✅
- pre-commit（cargo fmt / nextest）✅

> Windows 分支因本机为 macOS 不参与本地编译；改动语法与既有 `spawn_detached` 一致，建议在 Windows CI 上复核。