### PR TITLE
chore(feishu-bot): 发布 0.2.2 小版本

### DIFF
--- a/bots/feishu/Cargo.lock
+++ b/bots/feishu/Cargo.lock
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-bot-feishu"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/bots/feishu/Cargo.toml
+++ b/bots/feishu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-bot-feishu"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "天工飞书 bot 制品——WebSocket 长连接接收飞书消息并转发到天工"


### PR DESCRIPTION
## 背景

承接 #298（fix #295）：WebSocket 断开后自动重连，修复 Linux 常驻 Bot 断网后持续收不到消息。

## 改动

仅 bump 版本号 `0.2.1` → `0.2.2`（`Cargo.toml` + `Cargo.lock`），对齐上次 [v0.2.1](https://github.com/silent-rs/silent-Tiangong/commit/4bf0d34a) 的发布 pattern。

## 发布流程

本 PR 合并后，手动打 tag `bot-feishu-v0.2.2` 触发 `release-feishu.yml`：

- 多平台构建制品（darwin aarch64/x86_64、linux x86_64、windows x86_64）
- 生成 `bots-index.json` 上传 OSS
- 主程序运行时自动拉取最新版本，无需改主程序

## Test Plan

- [ ] CI（Bot Check feishu）通过
- [ ] 合并后打 tag `bot-feishu-v0.2.2`
- [ ] release workflow 构建并上传 OSS 成功