### PR TITLE
fix(scheduler): Agent 手动触发定时任务真正执行，CLI 不注册调度插件

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10095,7 +10095,6 @@ dependencies = [
  "tiangong-plugin-mcp",
  "tiangong-plugin-memory",
  "tiangong-plugin-prompt",
- "tiangong-plugin-scheduler",
  "tiangong-plugin-skill",
  "tiangong-plugin-speech-to-text",
  "tiangong-plugin-task",
@@ -10466,6 +10465,7 @@ name = "tiangong-plugin-scheduler"
 version = "0.13.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "scru128",
  "serde",

--- a/crates/plugins/tiangong-plugin-scheduler/Cargo.toml
+++ b/crates/plugins/tiangong-plugin-scheduler/Cargo.toml
@@ -13,7 +13,10 @@ scru128 = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
+# tokio::spawn 用于 handle_trigger_job 异步派发 execute_job_with_store
+tokio = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt"] }
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/crates/plugins/tiangong-plugin-scheduler/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-scheduler/src/handler.rs
@@ -11,7 +11,7 @@ use serde_json::{json, Value};
 use tiangong_core::model::{ToolCall, ToolSpec};
 use tiangong_core::tool::ToolResult;
 use tiangong_core::tool_override::{ToolOverrideHandler, ToolSpecProvider};
-use tiangong_scheduler::model::{Job, JobRun, JobRunStatus, TriggerType, UpdateJobRequest};
+use tiangong_scheduler::model::{Job, TriggerType, UpdateJobRequest};
 use tiangong_scheduler::store::JobStore;
 
 use crate::plugin::SchedulerPlugin;
@@ -272,36 +272,28 @@ impl SchedulerPlugin {
             Err(e) => return io_error("查询任务", e),
         };
 
-        // 记录一次手动触发（Agent 发起）的执行记录。
-        //
-        // 说明：plugin handler 所在链路无法访问 SchedulerContext（运行时上下文，含发消息/建会话能力），
-        // 真正执行 LLM 调用由 GUI/Server 的 `job_trigger`（Tauri command / API）通过 execute_job 完成。
-        // 此处只补记一条 JobRun，让 scheduler_get_job_runs 能查到手动触发历史，避免「已标记触发」
-        // 但执行历史为空的不一致。状态直接记为 Succeeded（已成功登记触发请求）。
-        let now = chrono::Local::now().naive_local().to_string();
-        let run = JobRun {
-            id: scru128::new().to_string(),
-            job_id: job.id.clone(),
-            session_id: job.session_id.clone().unwrap_or_default(),
-            status: JobRunStatus::Succeeded,
-            started_at: now.clone(),
-            finished_at: Some(now),
-            result_summary: Some("Agent 手动触发（已登记，实际执行由调度器完成）".to_string()),
-        };
-        if let Err(e) = store.insert_job_run(&run) {
-            return io_error("记录触发历史", e);
-        }
+        // 交给 execute_job_with_store 真正执行：解析/新建任务专属会话、写
+        // Running→Succeeded/Failed 的真实 JobRun、把 `[定时任务触发]` 消息经宿主路由
+        // 投递给 Core。行为与 UI 按钮（job_trigger）和 cron 调度完全一致。异步执行，
+        // 不阻塞当前 Agent turn。context 由入口层必填注入，无需降级处理。
+        let ctx = self.context.clone();
+        let job_clone = job.clone();
+        let store_clone = store.clone();
+        tokio::spawn(async move {
+            tracing::info!(job_id = %job_clone.id, "Agent 手动触发定时任务，开始执行");
+            tiangong_scheduler::executor::execute_job_with_store(ctx, job_clone, store_clone).await;
+        });
 
         ToolResult {
             ok: true,
             summary: format!(
-                "定时任务 '{}' 已标记为触发（实际执行需通过调度器或 API 触发）",
+                "定时任务 '{}' 已触发并开始执行（异步，结果见执行历史）",
                 job.name
             ),
             stdout: serde_json::to_string_pretty(&json!({
                 "id": job.id,
                 "name": job.name,
-                "status": "trigger_requested"
+                "status": "triggered"
             }))
             .unwrap_or_default(),
             stderr: String::new(),
@@ -416,7 +408,7 @@ impl ToolSpecProvider for SchedulerPlugin {
             },
             ToolSpec {
                 name: TOOL_TRIGGER_JOB.to_string(),
-                description: "按 ID 手动触发一次定时任务（标记为触发，实际执行由调度器执行）。".to_string(),
+                description: "按 ID 立即手动触发一次定时任务执行（会真正执行任务并把结果写入执行历史）。".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -551,13 +543,57 @@ fn not_found(id: &str) -> ToolResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
     use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc as StdArc;
     use tiangong_core::model::ToolCall;
+    use tiangong_scheduler::executor::SchedulerContext;
+    use tiangong_scheduler::model::JobRunStatus;
 
-    /// 构造一个绑定到临时存储目录的插件，避免污染真实的 `~/.tiangong/scheduler`。
+    /// 记录消息投递次数的 mock 执行上下文。
+    ///
+    /// 复用 execute_job_with_store 真实链路（resolve_session_id + send_message），
+    /// 通过 send_count 断言「任务确实被执行」，而非只登记。
+    #[derive(Default)]
+    struct RecordingContext {
+        send_count: StdArc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl SchedulerContext for RecordingContext {
+        async fn send_message(&self, _session_id: &str, _content: String) -> Result<()> {
+            self.send_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn resolve_session_id(
+            &self,
+            requested_session_id: Option<&str>,
+        ) -> Result<(String, bool)> {
+            if let Some(sid) = requested_session_id {
+                return Ok((sid.to_string(), false));
+            }
+            Ok((scru128::new().to_string(), true))
+        }
+    }
+
+    /// 构造一个绑定到临时存储目录、注入 RecordingContext 的插件。
+    ///
+    /// context 为必填项，测试统一注入 RecordingContext，避免污染真实的
+    /// `~/.tiangong/scheduler`。需要断言 execute_job 是否被调用时，用
+    /// [`handler_in_tmp_with_send_count`] 取回计数器。
     fn handler_in_tmp() -> (SchedulerPlugin, tempfile::TempDir) {
+        handler_in_tmp_with_send_count(StdArc::new(AtomicUsize::new(0)))
+    }
+
+    /// 同 [`handler_in_tmp`]，但返回 RecordingContext 的 send_count 供测试轮询。
+    fn handler_in_tmp_with_send_count(
+        send_count: StdArc<AtomicUsize>,
+    ) -> (SchedulerPlugin, tempfile::TempDir) {
         let dir = tempfile::TempDir::new().unwrap();
-        let handler = SchedulerPlugin::with_store_base(dir.path().to_path_buf());
+        let ctx: StdArc<dyn SchedulerContext> = StdArc::new(RecordingContext { send_count });
+        let handler = SchedulerPlugin::new(ctx).with_store_base(dir.path().to_path_buf());
         (handler, dir)
     }
 
@@ -789,10 +825,9 @@ mod tests {
 
     // ── 缺陷回归保护（Review #1/#3/#4，已修复）─────────────────────────
     //
-    // 以下三个测试原为暴露缺陷的失败基线（#[ignore]），对应生产代码已修复，
-    // 现作为永久回归保护运行。
+    // 以下测试为永久回归保护：
     //
-    //   - trigger_job_should_record_run            → Review 第 1 项：手动触发补记执行历史
+    //   - trigger_job_actually_executes            → 手动触发真正执行（execute_job + send_message）
     //   - get_job_runs_unknown_job_should_error    → Review 第 3 项：校验任务存在
     //   - update_job_can_clear_optional_field      → Review 第 4 项：显式空串清空字段
 
@@ -801,29 +836,59 @@ mod tests {
         tiangong_scheduler::store::JobStore::open_at(dir.path().to_path_buf()).unwrap()
     }
 
-    /// Review 第 1 项：`scheduler_trigger_job` 原先只返回「已标记触发」提示，不写任何
-    /// 执行历史，导致 scheduler_get_job_runs 查不到手动触发记录。修复后应补记一条
-    /// JobRun（状态 Succeeded）。
+    /// 核心回归：Agent 手动触发应真正执行任务（调用 `execute_job_with_store` →
+    /// `send_message`），而非只登记。
     ///
-    /// 说明：plugin handler 链路无法访问 SchedulerContext，无法真正执行 LLM 调用——
-    /// 那由 GUI/Server 的 job_trigger（execute_job）完成。此处仅校验「补记」行为。
-    #[test]
-    fn trigger_job_should_record_run() {
-        let (handler, dir) = handler_in_tmp();
+    /// 修复前 handler 只写假 Succeeded 记录（started_at == finished_at）就返回，
+    /// 从不调用 execute_job，是本次 Bug 的直接现场。现在 context 必填注入，触发即执行。
+    ///
+    /// 断言三件事：
+    /// 1. handler 立即返回 ok=true（已派发执行）；
+    /// 2. 后台 send_message 被真正调用（证明 execute_job 跑通）；
+    /// 3. JobRun 为 Succeeded 且 started_at != finished_at（真实执行，非假记录）。
+    #[tokio::test]
+    async fn trigger_job_actually_executes() {
+        let send_count = StdArc::new(AtomicUsize::new(0));
+        let (handler, dir) = handler_in_tmp_with_send_count(send_count.clone());
         let id = seed_job(&handler, "待触发");
 
         let call = make_call(TOOL_TRIGGER_JOB, json!({ "id": id }));
         let result = handler.dispatch(&call).expect("trigger 应被处理");
-        assert!(result.ok, "触发应成功：{}", result.summary);
+        assert!(result.ok, "注入上下文后触发应成功派发：{}", result.summary);
 
-        // 触发后应补记至少一条执行记录
+        // execute_job 在后台 tokio::spawn 中异步执行，轮询等待 send_message 被调用。
+        let waited = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            poll_until(send_count.clone(), 1),
+        )
+        .await;
+        assert!(
+            waited.is_ok(),
+            "execute_job 应在后台调用 send_message，但 3s 内未触发"
+        );
+
+        // 真实执行应写一条 Succeeded 记录，且起止时间不同（execute_core 各写一次 now）。
         let store = store_at(&dir);
         let runs = store.list_job_runs(&id, 10).unwrap();
-        assert!(
-            !runs.is_empty(),
-            "手动触发应产生执行记录，当前 {} 条",
-            runs.len()
+        let succeeded = runs
+            .iter()
+            .find(|r| matches!(r.status, JobRunStatus::Succeeded))
+            .expect("应存在一条 Succeeded 记录");
+        assert_ne!(
+            succeeded.started_at,
+            succeeded.finished_at.clone().unwrap_or_default(),
+            "真实执行的起止时间应不同（修复前假记录两者相同）"
         );
+    }
+
+    /// 轮询直到 send_count 达到 target，用于异步等待后台 execute_job 完成。
+    async fn poll_until(counter: StdArc<AtomicUsize>, target: usize) {
+        loop {
+            if counter.load(Ordering::SeqCst) >= target {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
     }
 
     /// Review 第 3 项：`scheduler_get_job_runs` 原先不校验任务存在，未知 id 返回

--- a/crates/plugins/tiangong-plugin-scheduler/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-scheduler/src/lib.rs
@@ -4,8 +4,12 @@
 //! `LocalToolExecutor` 位置参数实现。核心收益：工具调用直接从命名参数 JSON
 //! 按 key 取参，彻底消除参数顺序错位导致的「任务不存在」问题。
 //!
-//! 与 browser/terminal 插件不同，scheduler 不依赖 Tauri 句柄，纯文件存储，
-//! 因此可在 GUI / CLI / Server 全入口无条件启用。
+//! 与 browser/terminal 插件不同，scheduler 不依赖 Tauri 句柄，纯文件存储，但需要
+//! 宿主注入 [`SchedulerContext`] 才能真正触发任务。因此**仅在长期运行的宿主
+//!（Desktop / Server）注册**；CLI 这类前台交互工具不注册本插件——定时任务属于
+//! 长期运行宿主的能力。
+//!
+//! [`SchedulerContext`]: tiangong_scheduler::executor::SchedulerContext
 
 pub mod handler;
 pub mod plugin;
@@ -15,19 +19,17 @@ pub use plugin::SchedulerPlugin;
 use std::sync::Arc;
 
 use tiangong_core::core::Plugin;
+use tiangong_scheduler::executor::SchedulerContext;
 
 /// 构造定时任务插件实例，返回 `Arc<dyn Plugin>` 供入口注册。
 ///
-/// 与 browser/terminal 的 `build_plugin` 对齐。scheduler 不依赖 Tauri 句柄，
-/// 始终返回 `Some`。
-pub fn build_plugin() -> Arc<dyn Plugin> {
-    Arc::new(SchedulerPlugin::new())
+/// 必填注入 `context`：让 Agent 手动触发 `scheduler_trigger_job` 时能通过 `execute_job`
+/// 真正执行任务。Server / Desktop 入口在构建 Core 时调用本函数。
+pub fn build_plugin(context: Arc<dyn SchedulerContext>) -> Arc<dyn Plugin> {
+    Arc::new(SchedulerPlugin::new(context))
 }
 
-/// 构造默认的定时任务插件列表，供各入口（CLI / Server）注入 core 时使用。
-///
-/// GUI 入口已在 `main.rs` 显式注册；CLI / Server 入口调用此函数获取插件并传入
-/// `TiangongCore::builder().plugins(...)`。
-pub fn default_plugins() -> Vec<Arc<dyn Plugin>> {
-    vec![build_plugin()]
+/// 构造定时任务插件列表，供 Server / Desktop 注入 core 时使用。
+pub fn default_plugins(context: Arc<dyn SchedulerContext>) -> Vec<Arc<dyn Plugin>> {
+    vec![build_plugin(context)]
 }

--- a/crates/plugins/tiangong-plugin-scheduler/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-scheduler/src/plugin.rs
@@ -1,31 +1,49 @@
 //! 定时任务进程内插件（issue #156 自注册架构）。
 //!
 //! [`SchedulerPlugin`] 封装定时任务的工具规格与覆盖处理器。与 browser/terminal 插件
-//! 不同，scheduler 不依赖 Tauri 句柄（纯文件存储），因此可在 GUI / CLI / Server
-//! 全入口无条件启用。
+//! 不同，scheduler 不依赖 Tauri 句柄（纯文件存储），但需要宿主注入执行上下文才能
+//! 真正触发任务，因此**仅在长期运行的宿主（Desktop / Server）注册**。CLI 这类前台
+//! 交互工具不注册本插件——定时任务属于长期运行宿主的能力。
 //!
 //! 工具规格与覆盖处理器直接在 [`SchedulerPlugin`] 上实现（supertrait 自动收集），
 //! 无需在 `register` 中手动注册。
+//!
+//! 执行上下文（[`SchedulerContext`]）由入口层经 [`SchedulerPlugin::new`] 必填注入：
+//! Agent 手动触发 `scheduler_trigger_job` 会经它调用 `execute_job` 真正执行任务（复用
+//! 宿主的消息路由）。注入模式与 memory 插件的 `memory_handle` 一致。
+
+use std::sync::Arc;
+
+use tiangong_scheduler::executor::SchedulerContext;
 
 /// 定时任务插件：聚合工具规格与覆盖处理器。
 ///
-/// 无外部依赖（不持有 Tauri 句柄或共享 state），可跨 GUI / CLI / Server 入口复用。
-#[derive(Clone, Default)]
+/// - `store_base`：可选存储根目录，测试隔离用；`None` 表示用默认 `~/.tiangong/scheduler`。
+/// - `context`：调度执行上下文（**必填**）。Agent 手动触发定时任务经它真正执行。
+///
+/// 不持有 Tauri 句柄或共享 state，可跨 GUI / Server 入口复用。
 pub struct SchedulerPlugin {
-    /// 可选的存储根目录，用于测试隔离。生产环境为 None，使用默认的 `~/.tiangong/scheduler`。
     pub(crate) store_base: Option<std::path::PathBuf>,
+    pub(crate) context: Arc<dyn SchedulerContext>,
 }
 
 impl SchedulerPlugin {
-    pub fn new() -> Self {
-        Self::default()
+    /// 构造插件，必填注入调度执行上下文。
+    ///
+    /// 入口层（Server / Desktop）在构造插件时传入，让 `scheduler_trigger_job`
+    /// 能通过 `execute_job` 真正执行任务。
+    pub fn new(context: Arc<dyn SchedulerContext>) -> Self {
+        Self {
+            store_base: None,
+            context,
+        }
     }
 
     /// 指定存储根目录（测试用），返回新的实例。
-    #[cfg(test)]
-    pub(crate) fn with_store_base(store_base: std::path::PathBuf) -> Self {
+    pub fn with_store_base(self, store_base: std::path::PathBuf) -> Self {
         Self {
             store_base: Some(store_base),
+            ..self
         }
     }
 }

--- a/crates/tiangong-cli/Cargo.toml
+++ b/crates/tiangong-cli/Cargo.toml
@@ -18,7 +18,6 @@ tiangong-plugin-generate-video = { workspace = true }
 tiangong-plugin-text-to-speech = { workspace = true }
 tiangong-plugin-speech-to-text = { workspace = true }
 tiangong-plugin-memory = { workspace = true }
-tiangong-plugin-scheduler = { workspace = true }
 tiangong-plugin-task = { workspace = true }
 tiangong-plugin-analyze-attachment = { workspace = true }
 tiangong-plugin-skill = { workspace = true }

--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -221,7 +221,8 @@ fn build_cli_plugins(
     ));
     plugins.extend(tiangong_plugin_fetch::default_plugins());
     plugins.extend(tiangong_plugin_command::default_plugins());
-    plugins.extend(tiangong_plugin_scheduler::default_plugins());
+    // 不注册 scheduler 插件：定时任务属于 Desktop / Server 这类长期运行宿主的能力。
+    // CLI 作为前台交互工具，生命周期不稳定，不承载调度执行（见 issue 说明）。
     plugins.extend(tiangong_plugin_task::default_plugins());
     if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new) {
         plugins.push(tiangong_plugin_analyze_attachment::build_plugin(client));
@@ -255,7 +256,7 @@ fn build_cli_plugins(
             ));
             child_plugins.extend(tiangong_plugin_fetch::default_plugins());
             child_plugins.extend(tiangong_plugin_command::default_plugins());
-            child_plugins.extend(tiangong_plugin_scheduler::default_plugins());
+            // 子 Core 同样不注册 scheduler 插件，与主 Core 一致。
             child_plugins.extend(tiangong_plugin_task::default_plugins());
             if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new) {
                 child_plugins.push(tiangong_plugin_analyze_attachment::build_plugin(client));

--- a/crates/tiangong-scheduler/src/executor.rs
+++ b/crates/tiangong-scheduler/src/executor.rs
@@ -54,7 +54,9 @@ type MessageSender = Box<
 static RUNNING: std::sync::LazyLock<std::sync::Mutex<HashSet<String>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(HashSet::new()));
 
-/// 执行定时任务
+/// 执行定时任务（生产入口，使用默认存储目录 `~/.tiangong/scheduler`）。
+///
+/// 由 cron 调度（`restore_cron_jobs`）和 REST API / Tauri 手动触发调用。
 pub async fn execute_job(ctx: Arc<dyn SchedulerContext>, job: Job) {
     let store = match JobStore::open() {
         Ok(s) => s,
@@ -63,7 +65,14 @@ pub async fn execute_job(ctx: Arc<dyn SchedulerContext>, job: Job) {
             return;
         }
     };
+    execute_job_with_store(ctx, job, store).await;
+}
 
+/// 执行定时任务（使用指定的存储，供 plugin 触发链路复用以保持存储一致）。
+///
+/// 与 [`execute_job`] 唯一区别：store 由调用方传入，而非固定打开默认目录。plugin
+/// handler 已持有自己的 store（可能指向测试临时目录），直接复用避免重复打开和路径分叉。
+pub async fn execute_job_with_store(ctx: Arc<dyn SchedulerContext>, job: Job, store: JobStore) {
     let fresh = store.get_job(&job.id).ok().flatten().unwrap_or(job);
 
     let params = ExecuteParams {

--- a/crates/tiangong-scheduler/src/store.rs
+++ b/crates/tiangong-scheduler/src/store.rs
@@ -5,6 +5,10 @@ use anyhow::{Context, Result};
 use super::model::{Job, JobRun, JobRunStatus, UpdateJobRequest};
 
 /// Job 存储（JSON 文件）
+///
+/// 仅持有两个路径，派生 `Clone` 便于把同一存储根传给后台执行任务（如 Agent 触发
+/// 后 `tokio::spawn(execute_job_with_store(..., store.clone()))`）。
+#[derive(Clone)]
 pub struct JobStore {
     jobs_path: PathBuf,
     runs_dir: PathBuf,

--- a/crates/tiangong-server/src/api/mod.rs
+++ b/crates/tiangong-server/src/api/mod.rs
@@ -66,11 +66,15 @@ impl ServerAppContext {
             mcp_plugin.clone(),
             index_manager,
         ));
-        let core_backend: Arc<dyn ServerCoreBackend> = cores;
+        let core_backend: Arc<dyn ServerCoreBackend> = cores.clone();
         let scheduler_context: Arc<dyn SchedulerContext> = Arc::new(ServerSchedulerContext {
             state: state.clone(),
             core_backend: core_backend.clone(),
         });
+        // 回填执行上下文，让 Agent 手动触发定时任务（scheduler_trigger_job）能真正执行。
+        // 存在循环依赖（ServerSchedulerContext 需 core_backend，而 core_backend 即 cores），
+        // 故用回填而非构造参数。
+        cores.set_scheduler_context(scheduler_context.clone());
         Self::with_backend(
             state,
             config,

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -28,6 +28,13 @@ pub struct ServerCoreManager {
     mcp_plugin: Arc<tiangong_plugin_mcp::McpPlugin>,
     /// 工作区索引单例（issue #259）：跨 Core 共享底层索引缓存与扫描状态。
     index_manager: Arc<tiangong_plugin_index::IndexManager>,
+    /// 调度器执行上下文（构造后由入口层经 [`Self::set_scheduler_context`] 注入）。
+    ///
+    /// 持有它仅为了让 Agent 手动触发（`scheduler_trigger_job`）的 plugin 能拿到
+    /// 真正的执行能力。用 `OnceLock` 而非构造参数：`ServerSchedulerContext` 自身
+    /// 需要本结构作为 `core_backend`，存在循环依赖，只能在结构体创建后回填。
+    scheduler_context:
+        Arc<std::sync::OnceLock<Arc<dyn tiangong_scheduler::executor::SchedulerContext>>>,
     /// 同一会话的 Core 创建、消息投递和删除共用这一把锁。
     ///
     /// 锁对象不主动删除，避免旧等待者尚未退出时为同一 session 创建第二把锁。
@@ -54,6 +61,7 @@ impl ServerCoreManager {
             event_bus,
             mcp_plugin,
             index_manager,
+            scheduler_context: Arc::new(std::sync::OnceLock::new()),
             session_operation_locks: Arc::new(Mutex::new(HashMap::new())),
             session_wait_locks: Arc::new(Mutex::new(HashMap::new())),
             config_update_lock: Arc::new(AsyncMutex::new(())),
@@ -61,6 +69,22 @@ impl ServerCoreManager {
             trackers: Arc::new(Mutex::new(HashMap::new())),
             remote_sessions: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// 回填调度器执行上下文（入口层在构造本结构后立即调用一次）。
+    ///
+    /// 用于让 Agent 手动触发定时任务（`scheduler_trigger_job`）时能拿到真正的
+    /// 执行能力。存在循环依赖（context 需要本结构作 backend），故用回填而非构造参数。
+    pub fn set_scheduler_context(
+        &self,
+        ctx: Arc<dyn tiangong_scheduler::executor::SchedulerContext>,
+    ) {
+        let _ = self.scheduler_context.set(ctx);
+    }
+
+    /// 取调度器执行上下文（未注入时返回 None，仅降级触发用得到）。
+    fn scheduler_context(&self) -> Option<Arc<dyn tiangong_scheduler::executor::SchedulerContext>> {
+        self.scheduler_context.get().cloned()
     }
 
     /// 从 App State 刷新全局模板，并按 session 为每个 Core 替换独立配置快照。
@@ -397,7 +421,11 @@ impl ServerCoreManager {
             ));
             plugins.extend(tiangong_plugin_fetch::default_plugins());
             plugins.extend(tiangong_plugin_command::default_plugins());
-            plugins.extend(tiangong_plugin_scheduler::default_plugins());
+            // 调度器插件注入执行上下文：让 Agent 手动触发 scheduler_trigger_job 时
+            // 能真正执行任务（execute_job）。context 由 ServerAppContext 启动时回填。
+            if let Some(ctx) = self.scheduler_context() {
+                plugins.extend(tiangong_plugin_scheduler::default_plugins(ctx));
+            }
             plugins.extend(tiangong_plugin_task::default_plugins());
             if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new) {
                 plugins.push(tiangong_plugin_analyze_attachment::build_plugin(client));
@@ -414,6 +442,7 @@ impl ServerCoreManager {
             let child_plugin_factory = Arc::new({
                 let storage_root = storage_root.clone();
                 let index_manager = self.index_manager.clone();
+                let scheduler_context = self.scheduler_context.clone();
                 move || {
                     let mut child_plugins = tiangong_plugin_prompt::default_plugins();
                     child_plugins.extend(tiangong_plugin_fs::default_plugins());
@@ -437,7 +466,10 @@ impl ServerCoreManager {
                     ));
                     child_plugins.extend(tiangong_plugin_fetch::default_plugins());
                     child_plugins.extend(tiangong_plugin_command::default_plugins());
-                    child_plugins.extend(tiangong_plugin_scheduler::default_plugins());
+                    // 子 Core（Agent Team）同样注入调度执行上下文，保持与主 Core 一致。
+                    if let Some(ctx) = scheduler_context.get().cloned() {
+                        child_plugins.extend(tiangong_plugin_scheduler::default_plugins(ctx));
+                    }
                     child_plugins.extend(tiangong_plugin_task::default_plugins());
                     if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new)
                     {

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -208,6 +208,8 @@ impl TiangongApp {
             config: config.clone(),
             storage_root: storage_root.clone(),
             index_manager: index_manager.clone(),
+            scheduler_context: scheduler_context.clone()
+                as std::sync::Arc<dyn tiangong_scheduler::executor::SchedulerContext>,
         });
         Self {
             state,

--- a/src-tauri/src/core_factory.rs
+++ b/src-tauri/src/core_factory.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use tauri::AppHandle;
 use tiangong_core::core::Plugin;
 use tiangong_core::core_config::CoreConfigProvider;
+use tiangong_scheduler::executor::SchedulerContext;
 
 /// 桌面端 Core 构造依赖。
 ///
@@ -21,6 +22,7 @@ use tiangong_core::core_config::CoreConfigProvider;
 /// - `config`：全局 CoreConfigProvider（取 generation 用于 memory handle 初始化）
 /// - `storage_root`：会话文件根
 /// - `index_manager`：工作区索引单例（issue #259，跨 Core 共享底层索引缓存与扫描状态）
+/// - `scheduler_context`：调度器执行上下文（让 Agent 手动触发定时任务能真正执行）
 #[derive(Clone)]
 pub struct DesktopCoreFactory {
     pub app_handle: Arc<std::sync::OnceLock<AppHandle>>,
@@ -29,6 +31,7 @@ pub struct DesktopCoreFactory {
     pub config: CoreConfigProvider,
     pub storage_root: std::path::PathBuf,
     pub index_manager: Arc<tiangong_plugin_index::IndexManager>,
+    pub scheduler_context: Arc<dyn SchedulerContext>,
 }
 
 impl DesktopCoreFactory {
@@ -107,7 +110,11 @@ impl DesktopCoreFactory {
             plugins.push(tiangong_plugin_speech_to_text::build_plugin(ep));
         }
         plugins.push(tiangong_plugin_memory::build_plugin(memory_handle.clone()));
-        plugins.push(tiangong_plugin_scheduler::build_plugin());
+        // 调度器插件注入执行上下文：让 Agent 手动触发 scheduler_trigger_job 时
+        // 能真正执行任务（execute_job）。
+        plugins.push(tiangong_plugin_scheduler::build_plugin(
+            self.scheduler_context.clone(),
+        ));
         plugins.push(tiangong_plugin_task::build_plugin());
         if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new) {
             plugins.push(tiangong_plugin_analyze_attachment::build_plugin(client));
@@ -121,6 +128,7 @@ impl DesktopCoreFactory {
             let app_handle = app_handle.clone();
             let storage_root = storage_root.clone();
             let index_manager = self.index_manager.clone();
+            let scheduler_context = self.scheduler_context.clone();
             move || {
                 let mut child_plugins: Vec<Arc<dyn Plugin>> = Vec::new();
                 child_plugins.extend(tiangong_plugin_prompt::default_plugins());
@@ -151,7 +159,10 @@ impl DesktopCoreFactory {
                     child_plugins.push(tiangong_plugin_speech_to_text::build_plugin(ep));
                 }
                 child_plugins.push(tiangong_plugin_memory::build_plugin(memory_handle.clone()));
-                child_plugins.push(tiangong_plugin_scheduler::build_plugin());
+                // 子 Core（Agent Team）同样注入调度执行上下文，保持与主 Core 一致。
+                child_plugins.push(tiangong_plugin_scheduler::build_plugin(
+                    scheduler_context.clone(),
+                ));
                 child_plugins.push(tiangong_plugin_task::build_plugin());
                 if let Some(client) = multimodal_endpoint.clone().map(SingleProviderClient::new) {
                     child_plugins.push(tiangong_plugin_analyze_attachment::build_plugin(client));


### PR DESCRIPTION
## 背景

Agent 通过 `scheduler_trigger_job` 工具手动触发定时任务时，只写了一条**假的 \`Succeeded\` 记录**（\`started_at == finished_at\`）就返回，**从未真正执行任务**：归档目录、简报文件、飞书消息均未生成。用户误以为任务已执行成功。

## 根因

plugin handler 作为 Core 的子组件，**拿不到宿主级的消息路由句柄**（\`SchedulerContext\`），无法调用 \`execute_job\`。代码注释自己都承认了这个架构缺口。

对比正常路径：UI 按钮（\`job_trigger\` Tauri command / REST API \`trigger_job\`）和 cron 调度都能拿到 \`SchedulerContext\` 并真正执行，唯独 Agent 触发的 plugin 链路断开。

## 修复

把 \`SchedulerContext\` **必填注入** \`SchedulerPlugin\`（与 \`memory_handle\` / \`index_manager\` 注入模式一致），\`handle_trigger_job\` 走 \`execute_job_with_store\` 真正执行，行为与 UI 按钮和 cron 调度完全一致。

**架构边界**：定时任务仅由 Desktop / Server 这类**长期运行宿主**承载；CLI 作为前台交互工具不注册 scheduler 插件——模型根本看不到定时任务工具，避免误导。

## 改动

| 区域 | 改动 |
|---|---|
| **tiangong-scheduler** | 新增 \`execute_job_with_store\`（接受 store 参数，保证测试隔离）；\`JobStore\` 派生 \`Clone\` |
| **tiangong-plugin-scheduler** | \`context\` 改**必填**；移除无参 \`build_plugin\` 和误导性降级路径（不再「假装成功」）；\`handle_trigger_job\` 注入即 \`tokio::spawn(execute_job_with_store)\`；tool 描述更新 |
| **Server** | \`ServerCoreManager\` 经 \`OnceLock\` 回填 \`scheduler_context\`（解决 context 需 core_backend 的循环依赖），主/子 Core 注入执行上下文 |
| **Desktop** | \`DesktopCoreFactory\` 加 \`scheduler_context\` 字段，接入现有 \`create_scheduler_context()\` |
| **CLI** | **不注册** scheduler 插件（主/子 Core）+ 注释说明边界；移除相关依赖 |

## 验证

- \`cargo test\`：plugin 15 项、scheduler 12 项、server 15 项全过
- \`cargo build\`（全工作区 + Desktop）通过
- \`cargo clippy\` + \`cargo fmt --all --check\` 无问题
- pre-push hooks（含 \`cargo nextest\`）全过

## 测试

新增 \`trigger_job_actually_executes\`：注入 mock context，断言 \`send_message\` 被真正调用（证明 \`execute_job\` 跑通）+ \`JobRun\` 为 \`Succeeded\` 且 \`started_at != finished_at\`（真实执行，非假记录）。

## 待跟进

Desktop + 独立 Server 共享同一份 \`~/.tiangong/scheduler\` 时，cron 调度重复触发的并发风险暂未处理，后续单独排查。