### PR TITLE
fix(frontend): read_file 内容含 ok=false 时不再误判为失败

### DIFF
--- a/frontend/src/components/message/utils.ts
+++ b/frontend/src/components/message/utils.ts
@@ -94,7 +94,10 @@ export function llmOutputHasToolCalls(content: string): boolean {
 }
 
 export function toolItemSucceeded(tool: MessageItem): boolean {
-  return !textContent(tool).includes("ok=false") && !tool.tool_result_is_error;
+  // 只用后端透传的结构化字段判断；不要扫描正文文本。
+  // read_file 的正文是被读取文件的原始内容，若文件里恰好含 "ok=false"
+  // 字样（配置/日志/源码），基于文本的启发式会把它误判为失败。
+  return !tool.tool_result_is_error;
 }
 
 export function summarizeToolGroup(tools: MessageItem[]): string {


### PR DESCRIPTION
## 问题

`read_file` 工具调用被 UI 标记为「失败」（如「成功 0 / 失败 1」），但下方工具执行面板却正常展示了读到的文件内容——即数据已成功返回，状态却判错。

## 根因

`frontend/src/components/message/utils.ts` 中的 `toolItemSucceeded()` 除使用结构化字段 `tool_result_is_error` 外，还额外扫描**正文文本**是否包含 `"ok=false"` 来兜底判断失败：

```ts
return !textContent(tool).includes("ok=false") && !tool.tool_result_is_error;
```

对 `read_file` 而言，`textContent(tool)` 即**被读取文件的原始内容**。一旦该文件里恰好出现 `ok=false` 字样（配置文件、日志、源码注释，甚至是讨论本 bug 的代码），就会被误判为失败——尽管后端返回的 `ok` 为 `true`、数据完整。

该文本启发式最初是为 agent-team 系统转发消息（格式 `工具执行 [name]\nok=...\n`）做的兜底，但对所有 tool result 正文一视同仁地扫描，会误伤 `read_file`。

## 修复

移除文本启发式，仅保留结构化字段判断。后端已通过 `StreamEvent.ok` → `Message.tool_result_is_error`（`useStore.ts:348`）提供可靠的成功/失败信号，其余判定点（流式落库、`getToolMessageMeta`）也都只用字段且工作正常，文本兜底既多余又有害。

```ts
export function toolItemSucceeded(tool: MessageItem): boolean {
  // 只用后端透传的结构化字段判断；不要扫描正文文本。
  // read_file 的正文是被读取文件的原始内容，若文件里恰好含 "ok=false"
  // 字样（配置/日志/源码），基于文本的启发式会把它误判为失败。
  return !tool.tool_result_is_error;
}
```

## 验证

- pre-commit hooks 全部通过
- 推送时远端 `yarn build` / `yarn test`（frontend）均 Passed