### PR TITLE
feat(frontend): 优化输入框内联提及交互

### DIFF
--- a/frontend/src/__tests__/mentionBlocks.test.ts
+++ b/frontend/src/__tests__/mentionBlocks.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyMention,
+  hasMention,
+  parseBlocks,
+  serializeBlocks,
+} from '@/utils/mentionBlocks';
+
+describe('classifyMention', () => {
+  it('识别 @skill:<id>', () => {
+    expect(classifyMention('@skill:my-skill')).toEqual({ kind: 'skill', label: 'my-skill' });
+    expect(classifyMention('@skill:a1_b-2')).toEqual({ kind: 'skill', label: 'a1_b-2' });
+  });
+
+  it('识别 @mcp:<name>', () => {
+    expect(classifyMention('@mcp:github')).toEqual({ kind: 'mcp', label: 'github' });
+    // mcp 名字字符集不做强约束，只要有内容即可
+    expect(classifyMention('@mcp:my.server-1')).toEqual({ kind: 'mcp', label: 'my.server-1' });
+  });
+
+  it('识别 @all', () => {
+    expect(classifyMention('@all')).toEqual({ kind: 'all', label: 'All' });
+  });
+
+  it('识别 @<role>', () => {
+    expect(classifyMention('@dev')).toEqual({ kind: 'agent', label: 'dev' });
+    expect(classifyMention('@Reviewer_1')).toEqual({ kind: 'agent', label: 'Reviewer_1' });
+  });
+
+  it('拒绝不合法 token', () => {
+    expect(classifyMention('@')).toBeNull();
+    expect(classifyMention('hello')).toBeNull();
+    expect(classifyMention('@skill:')).toBeNull();
+    expect(classifyMention('@mcp:')).toBeNull();
+    expect(classifyMention('@all-dev')).toBeNull();
+    // role 不允许非字母数字下划线
+    expect(classifyMention('@dev-bot!')).toBeNull();
+  });
+});
+
+describe('parseBlocks', () => {
+  it('纯文本无提及返回单文本块', () => {
+    expect(parseBlocks('hello world')).toEqual([{ type: 'text', value: 'hello world' }]);
+  });
+
+  it('切分前后文本与提及', () => {
+    expect(parseBlocks('用 @skill:my-skill 重构')).toEqual([
+      { type: 'text', value: '用 ' },
+      { type: 'mention', token: '@skill:my-skill', kind: 'skill', label: 'my-skill' },
+      { type: 'text', value: ' 重构' },
+    ]);
+  });
+
+  it('开头与结尾的提及', () => {
+    expect(parseBlocks('@all 广播')).toEqual([
+      { type: 'mention', token: '@all', kind: 'all', label: 'All' },
+      { type: 'text', value: ' 广播' },
+    ]);
+    expect(parseBlocks('广播给 @dev')).toEqual([
+      { type: 'text', value: '广播给 ' },
+      { type: 'mention', token: '@dev', kind: 'agent', label: 'dev' },
+    ]);
+  });
+
+  it('多个连续提及', () => {
+    expect(parseBlocks('@skill:a @mcp:b @all')).toEqual([
+      { type: 'mention', token: '@skill:a', kind: 'skill', label: 'a' },
+      { type: 'text', value: ' ' },
+      { type: 'mention', token: '@mcp:b', kind: 'mcp', label: 'b' },
+      { type: 'text', value: ' ' },
+      { type: 'mention', token: '@all', kind: 'all', label: 'All' },
+    ]);
+  });
+
+  it('邮箱里的 @ 不误判（前置非空白）', () => {
+    expect(parseBlocks('联系 me@host.com')).toEqual([
+      { type: 'text', value: '联系 me@host.com' },
+    ]);
+    expect(hasMention('联系 me@host.com')).toBe(false);
+  });
+
+  it('多行文本里仍按空白切分', () => {
+    expect(parseBlocks('line1\n@skill:x\nline3')).toEqual([
+      { type: 'text', value: 'line1\n' },
+      { type: 'mention', token: '@skill:x', kind: 'skill', label: 'x' },
+      { type: 'text', value: '\nline3' },
+    ]);
+  });
+
+  it('不合法的 @ 当作普通文本', () => {
+    expect(parseBlocks('@ 不带名字')).toEqual([{ type: 'text', value: '@ 不带名字' }]);
+  });
+
+  it('空串与纯提及', () => {
+    expect(parseBlocks('')).toEqual([]);
+    expect(parseBlocks('@all')).toEqual([
+      { type: 'mention', token: '@all', kind: 'all', label: 'All' },
+    ]);
+  });
+});
+
+describe('serializeBlocks 往返不变量', () => {
+  const cases = [
+    '',
+    '纯文本',
+    '用 @skill:my-skill 重构',
+    '@all 广播给 @dev',
+    '@skill:a @mcp:b @all @qa',
+    '联系 me@host.com 别误判',
+    'line1\n@skill:x\nline3 @mcp:server-1 收尾',
+    '@skill:只字面量',
+    '中@间也算文本',
+    '@all',
+  ];
+
+  for (const text of cases) {
+    it(`serialize(parse(${JSON.stringify(text)})) === 原文`, () => {
+      expect(serializeBlocks(parseBlocks(text))).toBe(text);
+    });
+  }
+});

--- a/frontend/src/__tests__/mentionEditor.test.tsx
+++ b/frontend/src/__tests__/mentionEditor.test.tsx
@@ -1,0 +1,232 @@
+import {
+  act,
+  createRef,
+  type ComponentProps,
+  type RefObject,
+} from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MentionEditor, type MentionEditorHandle } from '@/components/MentionEditor';
+import { UserMessageGroup } from '@/components/message/UserMessageGroup';
+import type { MessageGroup } from '@/components/message/types';
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+async function mountEditor(
+  value: string,
+  onChange: (text: string) => void,
+  editorRef: RefObject<MentionEditorHandle | null>,
+  props: Partial<ComponentProps<typeof MentionEditor>> = {},
+) {
+  root = createRoot(container!);
+  await act(async () => {
+    root!.render(
+      <MentionEditor
+        {...props}
+        ref={editorRef}
+        value={value}
+        onChange={onChange}
+      />,
+    );
+  });
+  return editorRef.current!.element!;
+}
+
+function dispatchKey(editor: HTMLElement, key: string) {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  act(() => editor.dispatchEvent(event));
+  return event;
+}
+
+function selectAll(editor: HTMLElement) {
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  const selection = window.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+describe('MentionEditor 轻量交互', () => {
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root!.unmount());
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    window.getSelection()?.removeAllRanges();
+    vi.unstubAllGlobals();
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('组合输入期间不提交，组合结束后提交中文内容', async () => {
+    const onChange = vi.fn();
+    const editorRef = createRef<MentionEditorHandle>();
+    const editor = await mountEditor('', onChange, editorRef);
+
+    act(() => {
+      editor.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      editor.replaceChildren(document.createTextNode('中文'));
+      editor.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        inputType: 'insertCompositionText',
+        data: '中文',
+      }));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      editor.dispatchEvent(new CompositionEvent('compositionend', {
+        bubbles: true,
+        data: '中文',
+      }));
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith('中文');
+  });
+
+  it('方向键跨过连续提及，鼠标落在标签与空格之间时吸附到标签后', async () => {
+    const editorRef = createRef<MentionEditorHandle>();
+    const onChange = vi.fn();
+    const editor = await mountEditor('@dev @qa ', onChange, editorRef);
+
+    act(() => editorRef.current!.setSelection(0));
+    dispatchKey(editor, 'ArrowRight');
+    expect(editorRef.current!.getSelection()).toEqual({ start: 5, end: 5 });
+    dispatchKey(editor, 'ArrowRight');
+    expect(editorRef.current!.getSelection()).toEqual({ start: 9, end: 9 });
+    dispatchKey(editor, 'ArrowLeft');
+    expect(editorRef.current!.getSelection()).toEqual({ start: 4, end: 4 });
+    dispatchKey(editor, 'ArrowLeft');
+    expect(editorRef.current!.getSelection()).toEqual({ start: 0, end: 0 });
+
+    act(() => editorRef.current!.setSelection(4));
+    act(() => editor.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })));
+    expect(editorRef.current!.getSelection()).toEqual({ start: 5, end: 5 });
+
+    const originalRect = Object.getOwnPropertyDescriptor(Range.prototype, 'getBoundingClientRect');
+    Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => new DOMRect(68, 10, 4, 20),
+    });
+    try {
+      // 浏览器可能把共享空格上的点击错误落到整行末尾；仍应按真实点击点吸附。
+      act(() => editorRef.current!.setSelection(9));
+      act(() => editor.dispatchEvent(new MouseEvent('mouseup', {
+        bubbles: true,
+        clientX: 70,
+        clientY: 20,
+      })));
+      expect(editorRef.current!.getSelection()).toEqual({ start: 5, end: 5 });
+    } finally {
+      if (originalRect) {
+        Object.defineProperty(Range.prototype, 'getBoundingClientRect', originalRect);
+      } else {
+        delete (Range.prototype as Range & { getBoundingClientRect?: () => DOMRect })
+          .getBoundingClientRect;
+      }
+    }
+
+    act(() => editorRef.current!.setSelection(4));
+    dispatchKey(editor, 'x');
+    expect(onChange).toHaveBeenLastCalledWith('@dev x @qa ');
+  });
+
+  it('跨标签全选删除后提交空内容，不留下浏览器占位换行', async () => {
+    const onChange = vi.fn();
+    const editorRef = createRef<MentionEditorHandle>();
+    const editor = await mountEditor('@dev\n第二行 @qa ', onChange, editorRef);
+
+    act(() => selectAll(editor));
+    const event = dispatchKey(editor, 'Delete');
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onChange).toHaveBeenLastCalledWith('');
+
+    act(() => {
+      editor.replaceChildren(document.createElement('br'));
+      editor.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenLastCalledWith('');
+  });
+
+  it('多行纯文本粘贴保留换行并清除不同平台的换行差异', async () => {
+    const onChange = vi.fn();
+    const editorRef = createRef<MentionEditorHandle>();
+    const editor = await mountEditor('开头', onChange, editorRef);
+    act(() => editorRef.current!.focus());
+
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        getData: (type: string) => type === 'text/plain' ? '第一行\r\n第二行\r第三行' : '',
+      },
+    });
+    act(() => editor.dispatchEvent(pasteEvent));
+
+    expect(pasteEvent.defaultPrevented).toBe(true);
+    expect(onChange).toHaveBeenLastCalledWith('开头第一行\n第二行\n第三行');
+  });
+
+  it('历史消息编辑状态复用提及编辑器并整块删除标签', async () => {
+    const editorRef = createRef<MentionEditorHandle>();
+    const onSetEditingContent = vi.fn();
+    const group: MessageGroup = {
+      key: 'message-1',
+      type: 'user',
+      messages: [{
+        id: 'message-1',
+        role: 'user',
+        content: [{ type: 'text', text: '请 @dev 处理' }],
+        reasoning_content: '',
+        created_at: '2026-07-28 12:00:00',
+      }],
+    };
+
+    root = createRoot(container!);
+    await act(async () => {
+      root!.render(
+        <UserMessageGroup
+          group={group}
+          runStatus="idle"
+          nonEditableIds={new Set()}
+          voiceMessages={{}}
+          editingMessageId="message-1"
+          editingContent="请 @dev 处理"
+          editingAttachments={[]}
+          editingTextareaRef={editorRef}
+          onStartEdit={vi.fn()}
+          onConfirmEdit={vi.fn()}
+          onCancelEdit={vi.fn()}
+          onSetEditingContent={onSetEditingContent}
+          onSetEditingAttachments={vi.fn()}
+          onAttachFiles={vi.fn()}
+          onEditPaste={vi.fn()}
+        />,
+      );
+    });
+
+    const editor = editorRef.current!.element!;
+    expect(editor.querySelector('[data-mention-token="@dev"]')).not.toBeNull();
+    act(() => editorRef.current!.setSelection(7));
+    dispatchKey(editor, 'Backspace');
+    expect(onSetEditingContent).toHaveBeenLastCalledWith('请 处理');
+  });
+});

--- a/frontend/src/__tests__/mentionEditorModel.test.ts
+++ b/frontend/src/__tests__/mentionEditorModel.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deleteMentionSelection,
+  getMentionBoundaries,
+  insertTextAtMentionBoundary,
+  normalizePastedText,
+  replaceMentionCompletion,
+  resolveMentionKeyAction,
+  type MentionKeyAction,
+} from '@/utils/mentionEditorModel';
+
+function applyKeyAction(text: string, action: MentionKeyAction | null): string {
+  if (!action || action.type === 'move') return text;
+  return text.slice(0, action.start) + text.slice(action.end);
+}
+
+describe('提及编辑规则', () => {
+  it('计算连续提及及两侧分隔位置', () => {
+    expect(getMentionBoundaries('@dev @qa ')).toEqual([
+      {
+        start: 0,
+        end: 4,
+        leadingSeparatorStart: null,
+        trailingSeparatorEnd: 5,
+      },
+      {
+        start: 5,
+        end: 8,
+        leadingSeparatorStart: 4,
+        trailingSeparatorEnd: 9,
+      },
+    ]);
+  });
+
+  it('Delete 在提及左侧一次删除提及及右侧分隔', () => {
+    const text = '@dev 继续';
+    const action = resolveMentionKeyAction(text, 0, 'Delete');
+
+    expect(action).toEqual({ type: 'delete', start: 0, end: 5, offset: 0 });
+    expect(applyKeyAction(text, action)).toBe('继续');
+  });
+
+  it('Backspace 在提及右侧一次删除提及及左侧分隔', () => {
+    const text = '继续 @dev';
+    const action = resolveMentionKeyAction(text, text.length, 'Backspace');
+
+    expect(action).toEqual({ type: 'delete', start: 2, end: 7, offset: 2 });
+    expect(applyKeyAction(text, action)).toBe('继续');
+  });
+
+  it('连续提及左右移动时自动跨过标签及分隔', () => {
+    const text = '@dev @qa ';
+    const right1 = resolveMentionKeyAction(text, 0, 'ArrowRight');
+    const right2 = resolveMentionKeyAction(text, right1?.type === 'move' ? right1.offset : -1, 'ArrowRight');
+    const left1 = resolveMentionKeyAction(text, 9, 'ArrowLeft');
+    const left2 = resolveMentionKeyAction(text, left1?.type === 'move' ? left1.offset : -1, 'ArrowLeft');
+
+    expect(right1).toEqual({ type: 'move', offset: 5 });
+    expect(right2).toEqual({ type: 'move', offset: 9 });
+    expect(left1).toEqual({ type: 'move', offset: 4 });
+    expect(left2).toEqual({ type: 'move', offset: 0 });
+  });
+
+  it('跨多个提及选择删除时扩展到完整标签并保留单个分隔', () => {
+    expect(deleteMentionSelection('前 @dev @qa 后', 4, 8)).toEqual({
+      value: '前 后',
+      offset: 2,
+    });
+  });
+
+  it('全选删除后结果为空', () => {
+    const text = '@dev\n第二行 @qa ';
+    expect(deleteMentionSelection(text, 0, text.length)).toEqual({
+      value: '',
+      offset: 0,
+    });
+  });
+
+  it('候选替换后返回标签右侧的光标位置', () => {
+    expect(replaceMentionCompletion('@de', 0, 3, '@dev')).toEqual({
+      value: '@dev ',
+      offset: 5,
+    });
+    expect(replaceMentionCompletion('请 @de处理', 2, 5, '@dev')).toEqual({
+      value: '请 @dev 处理',
+      offset: 7,
+    });
+  });
+
+  it('在连续标签的共享分隔两侧输入时都保留两个标签', () => {
+    expect(insertTextAtMentionBoundary('@dev @qa ', 4, '中')).toEqual({
+      value: '@dev 中 @qa ',
+      offset: 6,
+    });
+    expect(insertTextAtMentionBoundary('@dev @qa ', 5, '中')).toEqual({
+      value: '@dev 中 @qa ',
+      offset: 6,
+    });
+  });
+
+  it('拒绝越界的候选替换位置', () => {
+    expect(replaceMentionCompletion('@de', -1, 3, '@dev')).toBeNull();
+    expect(replaceMentionCompletion('@de', 2, 1, '@dev')).toBeNull();
+  });
+
+  it('粘贴文本统一 Windows 和旧式换行', () => {
+    expect(normalizePastedText('第一行\r\n第二行\r第三行')).toBe('第一行\n第二行\n第三行');
+  });
+});

--- a/frontend/src/components/MentionChip.tsx
+++ b/frontend/src/components/MentionChip.tsx
@@ -1,0 +1,73 @@
+import type { MentionKind } from '@/utils/mentionBlocks';
+
+interface MentionChipProps {
+  kind: MentionKind;
+  label: string;
+  token?: string;
+}
+
+export const MENTION_MARK: Record<MentionKind, string> = {
+  skill: 'S',
+  mcp: 'M',
+  agent: '@',
+  all: '*',
+};
+
+export const MENTION_CHIP_BASE_CLASS =
+  'mention-chip inline-flex max-w-[14rem] items-center gap-1 rounded border px-1.5 align-baseline text-xs leading-5 text-foreground';
+
+export const MENTION_MARK_BASE_CLASS =
+  'inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-sm bg-background/80 px-0.5 text-[10px] font-semibold leading-none';
+
+export const MENTION_LABEL_CLASS = 'min-w-0 truncate font-medium';
+
+const MENTION_KIND_CLASS: Record<MentionKind, string> = {
+  skill: 'border-amber-500/30 bg-amber-500/10',
+  mcp: 'border-cyan-500/30 bg-cyan-500/10',
+  agent: 'border-blue-500/30 bg-blue-500/10',
+  all: 'border-rose-500/30 bg-rose-500/10',
+};
+
+const MENTION_MARK_KIND_CLASS: Record<MentionKind, string> = {
+  skill: 'text-amber-700 dark:text-amber-300',
+  mcp: 'text-cyan-700 dark:text-cyan-300',
+  agent: 'text-blue-700 dark:text-blue-300',
+  all: 'text-rose-700 dark:text-rose-300',
+};
+
+export function mentionChipClass(kind: MentionKind): string {
+  return `${MENTION_CHIP_BASE_CLASS} ${MENTION_KIND_CLASS[kind]}`;
+}
+
+export function mentionMarkClass(kind: MentionKind): string {
+  return `${MENTION_MARK_BASE_CLASS} ${MENTION_MARK_KIND_CLASS[kind]}`;
+}
+
+const TOKEN_PREFIX: Record<MentionKind, string> = {
+  skill: '@skill:',
+  mcp: '@mcp:',
+  agent: '@',
+  all: '@',
+};
+
+/**
+ * @提及内联标签块（消息气泡展示用，React 渲染）。
+ *
+ * 输入框编辑器（MentionEditor）走 contenteditable 直建 DOM 路径，复用同一
+ * 样式常量与标记，两条路径视觉一致。
+ */
+export function MentionChip({ kind, label, token }: MentionChipProps) {
+  const rawToken = token ?? `${TOKEN_PREFIX[kind]}${label}`;
+  return (
+    <span
+      className={mentionChipClass(kind)}
+      title={rawToken}
+      aria-label={rawToken}
+      data-mention-token={token}
+      data-mention-kind={kind}
+    >
+      <span className={mentionMarkClass(kind)} aria-hidden="true">{MENTION_MARK[kind]}</span>
+      <span className={MENTION_LABEL_CLASS}>{label}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/MentionEditor.tsx
+++ b/frontend/src/components/MentionEditor.tsx
@@ -393,64 +393,70 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
     };
 
     // ===== 整块删除 / 跨块方向键 / 边界守卫 =====
-    // 判断当前光标是否紧邻一个 mention chip（中间可隔哨兵 ZWSP，但不可隔普通文本）。
-    //   afterCaret=false（Backspace / ArrowLeft）：找"光标之前"方向上紧邻的 chip。
-    //     光标在哨兵内（任意位置）或普通文本起点时，向前跳过哨兵找第一个 chip；
-    //     若先遇到普通文本/br 则不算紧邻（中间有内容）。
-    //   afterCaret=true（Delete / ArrowRight）：对称地找"光标之后"的 chip。
+    interface MentionBoundary {
+      chip: HTMLElement;
+      start: number;
+      end: number;
+      leadingSeparatorStart: number | null;
+      trailingSeparatorEnd: number | null;
+    }
+
+    // 以序列化文本为准计算 mention 边界，避免浏览器合并空格与 ZWSP 后 DOM 邻接失真。
+    function mentionBoundaries(): MentionBoundary[] {
+      const root = rootRef.current;
+      if (!root) return [];
+      const text = domToText(root);
+      const chips = Array.from(root.querySelectorAll<HTMLElement>('.mention-chip'));
+      const boundaries: MentionBoundary[] = [];
+      let offset = 0;
+      let chipIndex = 0;
+
+      for (const block of parseBlocks(text)) {
+        if (block.type === 'text') {
+          offset += block.value.length;
+          continue;
+        }
+        const chip = chips[chipIndex];
+        chipIndex += 1;
+        if (!chip) break;
+        const start = offset;
+        const end = start + block.token.length;
+        boundaries.push({
+          chip,
+          start,
+          end,
+          leadingSeparatorStart: start > 0 && text[start - 1] === ' ' ? start - 1 : null,
+          trailingSeparatorEnd: text[end] === ' ' ? end + 1 : null,
+        });
+        offset = end;
+      }
+      return boundaries;
+    }
+
+    function boundaryForChip(chip: HTMLElement): MentionBoundary | null {
+      return mentionBoundaries().find((boundary) => boundary.chip === chip) ?? null;
+    }
+
+    // afterCaret=true 用于 Delete / ArrowRight；false 用于 Backspace / ArrowLeft。
+    // includeSeparator=true 时，把紧贴 mention 的一个普通空格视为原子块边界的一部分。
     function adjacentMention(afterCaret: boolean, includeSeparator = false): HTMLElement | null {
       const sel = window.getSelection();
       if (!sel || sel.rangeCount === 0) return null;
       const range = sel.getRangeAt(0);
       if (!range.collapsed) return null;
-      const root = rootRef.current!;
-      const segs = collectSegments(root);
-      const container = range.startContainer;
-      const offset = range.startOffset;
+      const selection = currentSelectionOffsets();
+      if (!selection || selection.start !== selection.end) return null;
+      const caret = selection.start;
 
-      // 从 startIdx 向 step 方向跳过哨兵，返回第一个非哨兵 seg
-      const findNeighbor = (startIdx: number, step: 1 | -1): Seg | null => {
-        for (let j = startIdx; j >= 0 && j < segs.length; j += step) {
-          if (segs[j].kind === 'sentinel') continue;
-          return segs[j];
+      const boundary = mentionBoundaries().find((item) => {
+        if (afterCaret) {
+          return caret === item.start
+            || (includeSeparator && item.leadingSeparatorStart === caret);
         }
-        return null;
-      };
-
-      // 光标在文本节点内（普通文本或哨兵）
-      if (container.nodeType === Node.TEXT_NODE) {
-        const value = container.nodeValue ?? '';
-        const idx = segs.findIndex((s) => s.node === container);
-        if (idx < 0) return null;
-        const isSentinel = segs[idx].kind === 'sentinel';
-        if (!afterCaret) {
-          // Backspace/ArrowLeft：哨兵任意位置，或普通文本在起点（offset===0）才向前找
-          // 候选项会在 chip 后自动插入一个分隔空格；ArrowLeft 从该空格右侧移动时，
-          // 连同空格一起跨过 chip，避免光标停在会破坏 mention 边界的位置。
-          const afterSeparator = includeSeparator && offset === 1 && value.startsWith(' ');
-          if (!isSentinel && offset !== 0 && !afterSeparator) return null;
-          const neighbor = findNeighbor(idx - 1, -1);
-          return neighbor && neighbor.kind === 'chip' ? (neighbor.node as HTMLElement) : null;
-        } else {
-          // Delete/ArrowRight：哨兵任意位置，或普通文本在末尾才向后找
-          if (!isSentinel && offset !== value.length) return null;
-          const neighbor = findNeighbor(idx + 1, 1);
-          return neighbor && neighbor.kind === 'chip' ? (neighbor.node as HTMLElement) : null;
-        }
-      }
-
-      // 光标在元素边界（container 为 root），offset 是子序号
-      if (container === root) {
-        if (!afterCaret) {
-          // 向前：offset-1 处的子节点
-          const child = container.childNodes[offset - 1];
-          if (child && isChip(child)) return child as HTMLElement;
-        } else {
-          const child = container.childNodes[offset];
-          if (child && isChip(child)) return child as HTMLElement;
-        }
-      }
-      return null;
+        return caret === item.end
+          || (includeSeparator && item.trailingSeparatorEnd === caret);
+      });
+      return boundary?.chip ?? null;
     }
 
     const isChip = (node: Node): boolean =>
@@ -487,7 +493,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       }
 
       if (e.key === 'Backspace' && !hasSelection) {
-        const chip = adjacentMention(false);
+        const chip = adjacentMention(false, true);
         if (chip) {
           e.preventDefault();
           removeChip(chip);
@@ -495,7 +501,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         }
       }
       if (e.key === 'Delete' && !hasSelection) {
-        const chip = adjacentMention(true);
+        const chip = adjacentMention(true, true);
         if (chip) {
           e.preventDefault();
           removeChip(chip);
@@ -511,7 +517,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         }
       }
       if (e.key === 'ArrowRight' && !hasSelection) {
-        const chip = adjacentMention(true);
+        const chip = adjacentMention(true, true);
         if (chip) {
           e.preventDefault();
           placeAfter(chip);
@@ -529,32 +535,28 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       }
     };
 
-    // 删除 chip 及其相邻哨兵，提交并把光标放回原位（chip 前哨兵位置）
+    // 删除 mention 及一个右侧分隔；没有右侧分隔时改删一个左侧分隔。
+    // 这样既整块删除，又能在前后文本之间保留至多一个必要空格。
     function removeChip(chip: HTMLElement) {
-      const root = rootRef.current!;
-      const segs = collectSegments(root);
-      const idx = segs.findIndex((s) => s.node === chip);
-      // chip 前哨兵：idx-1；chip 后哨兵：idx+1
-      const beforeSentinel = segs[idx - 1];
-      const afterSentinel = segs[idx + 1];
-      // 删除 chip 与两个哨兵中"在删除后会冗余"的部分：
-      // 保留 beforeSentinel 作为光标落点，删除 chip + afterSentinel
-      // （afterSentinel 若与 beforeSentinel 相邻会造成两个 ZWSP 拼一起，剥离即可）
-      chip.remove();
-      if (isTextLike(afterSentinel)) {
-        afterSentinel.node.parentNode?.removeChild(afterSentinel.node);
+      const root = rootRef.current;
+      const boundary = boundaryForChip(chip);
+      if (!root || !boundary) return;
+      const text = domToText(root);
+      let removeStart = boundary.start;
+      let removeEnd = boundary.end;
+      if (boundary.trailingSeparatorEnd != null) {
+        removeEnd = boundary.trailingSeparatorEnd;
+        if (removeEnd === text.length && boundary.leadingSeparatorStart != null) {
+          removeStart = boundary.leadingSeparatorStart;
+        }
+      } else if (boundary.leadingSeparatorStart != null) {
+        removeStart = boundary.leadingSeparatorStart;
       }
-      // 先把光标落在 beforeSentinel 末尾，再提交新文本，让补全状态读取到正确位置。
+
       root.focus();
-      if (isTextLike(beforeSentinel) && beforeSentinel.node.parentNode) {
-        const range = document.createRange();
-        range.setStart(beforeSentinel.node, (beforeSentinel.node.nodeValue ?? '').length);
-        range.collapse(true);
-        applyRange(range);
-      } else {
-        restoreCaretEnd();
-      }
-      commit();
+      selectionRevisionRef.current += 1;
+      pendingSelectionRef.current = removeStart;
+      onChange(text.slice(0, removeStart) + text.slice(removeEnd));
     }
 
     function shouldPreventArrow(text: string, pos: number, key: string): boolean {
@@ -583,39 +585,23 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
     }
 
     function placeBefore(chip: HTMLElement) {
-      const root = rootRef.current!;
-      const segs = collectSegments(root);
-      const idx = segs.findIndex((s) => s.node === chip);
-      const sentinel = segs[idx - 1];
-      root.focus();
-      if (isTextLike(sentinel)) {
-        const range = document.createRange();
-        range.setStart(sentinel.node, 0);
-        range.collapse(true);
-        applyRange(range);
-      } else {
-        const parent = chip.parentNode!;
-        const range = document.createRange();
-        range.setStart(parent, indexOf(chip));
-        range.collapse(true);
-        applyRange(range);
-      }
+      const boundary = boundaryForChip(chip);
+      if (!boundary) return;
+      placeCaretAtOffset(boundary.leadingSeparatorStart ?? boundary.start);
     }
     function placeAfter(chip: HTMLElement) {
-      const root = rootRef.current!;
-      const segs = collectSegments(root);
-      const idx = segs.findIndex((s) => s.node === chip);
-      const sentinel = segs[idx + 1];
+      const boundary = boundaryForChip(chip);
+      if (!boundary) return;
+      placeCaretAtOffset(boundary.trailingSeparatorEnd ?? boundary.end);
+    }
+    function placeCaretAtOffset(offset: number) {
+      const root = rootRef.current;
+      if (!root) return;
       root.focus();
-      if (isTextLike(sentinel)) {
+      const target = resolveOffset(offset);
+      if (target) {
         const range = document.createRange();
-        range.setStart(sentinel.node, (sentinel.node.nodeValue ?? '').length);
-        range.collapse(true);
-        applyRange(range);
-      } else {
-        const parent = chip.parentNode!;
-        const range = document.createRange();
-        range.setStart(parent, indexOf(chip) + 1);
+        range.setStart(target.node, target.offset);
         range.collapse(true);
         applyRange(range);
       }
@@ -808,8 +794,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       commit();
     }
 
-    // 点击定位：contenteditable 在点击 chip 紧邻空白处时可能把光标选进 chip，
-    // 这里兜底——若选区落在 chip 内部，夹到 chip 一侧的哨兵。
+    // 点击定位：chip 与相邻分隔之间不是合法停靠点，统一吸附到原子块外侧。
     const handleMouseUp = () => {
       const sel = window.getSelection();
       if (!sel || sel.rangeCount === 0) return;
@@ -824,6 +809,20 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
           return;
         }
         node = node.parentNode;
+      }
+
+      const selection = currentSelectionOffsets();
+      if (!selection || selection.start !== selection.end) return;
+      const caret = selection.start;
+      for (const boundary of mentionBoundaries()) {
+        if (boundary.trailingSeparatorEnd != null && caret === boundary.end) {
+          placeAfter(boundary.chip);
+          return;
+        }
+        if (boundary.leadingSeparatorStart != null && caret === boundary.start) {
+          placeBefore(boundary.chip);
+          return;
+        }
       }
     };
 

--- a/frontend/src/components/MentionEditor.tsx
+++ b/frontend/src/components/MentionEditor.tsx
@@ -7,7 +7,17 @@ import {
   type ClipboardEvent,
   type FormEvent,
   type KeyboardEvent,
+  type MouseEvent,
 } from 'react';
+import {
+  deleteMentionSelection,
+  getMentionBoundaries,
+  insertTextAtMentionBoundary,
+  normalizePastedText,
+  resolveMentionKeyAction,
+  type MentionBoundary,
+  type MentionKey,
+} from '@/utils/mentionEditorModel';
 import {
   MENTION_LABEL_CLASS,
   MENTION_MARK,
@@ -86,6 +96,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
 
     const rootRef = useRef<HTMLDivElement>(null);
     const isComposingRef = useRef(false);
+    const compositionSnapshotRef = useRef<{ text: string; caret: number } | null>(null);
     // 重建 DOM 后需要恢复的光标偏移（解决 selectCandidate 先改 value、
     // 后设光标的时序竞态：DOM 重建会清掉光标）。
     const pendingSelectionRef = useRef<number | null>(null);
@@ -201,6 +212,12 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
     }
 
     function rawDomText(root: HTMLElement): string {
+      if (
+        root.childNodes.length === 1
+        && root.firstChild?.nodeType === Node.ELEMENT_NODE
+        && (root.firstChild as HTMLElement).tagName === 'BR'
+      ) return '';
+
       let text = '';
       root.childNodes.forEach((node) => {
         if (node.nodeType === Node.TEXT_NODE) {
@@ -393,70 +410,23 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
     };
 
     // ===== 整块删除 / 跨块方向键 / 边界守卫 =====
-    interface MentionBoundary {
+    interface DomMentionBoundary extends MentionBoundary {
       chip: HTMLElement;
-      start: number;
-      end: number;
-      leadingSeparatorStart: number | null;
-      trailingSeparatorEnd: number | null;
     }
 
     // 以序列化文本为准计算 mention 边界，避免浏览器合并空格与 ZWSP 后 DOM 邻接失真。
-    function mentionBoundaries(): MentionBoundary[] {
+    function mentionBoundaries(): DomMentionBoundary[] {
       const root = rootRef.current;
       if (!root) return [];
       const text = domToText(root);
       const chips = Array.from(root.querySelectorAll<HTMLElement>('.mention-chip'));
-      const boundaries: MentionBoundary[] = [];
-      let offset = 0;
-      let chipIndex = 0;
-
-      for (const block of parseBlocks(text)) {
-        if (block.type === 'text') {
-          offset += block.value.length;
-          continue;
-        }
-        const chip = chips[chipIndex];
-        chipIndex += 1;
-        if (!chip) break;
-        const start = offset;
-        const end = start + block.token.length;
-        boundaries.push({
-          chip,
-          start,
-          end,
-          leadingSeparatorStart: start > 0 && text[start - 1] === ' ' ? start - 1 : null,
-          trailingSeparatorEnd: text[end] === ' ' ? end + 1 : null,
-        });
-        offset = end;
-      }
-      return boundaries;
+      return getMentionBoundaries(text)
+        .slice(0, chips.length)
+        .map((boundary, index) => ({ ...boundary, chip: chips[index] }));
     }
 
     function boundaryForChip(chip: HTMLElement): MentionBoundary | null {
       return mentionBoundaries().find((boundary) => boundary.chip === chip) ?? null;
-    }
-
-    // afterCaret=true 用于 Delete / ArrowRight；false 用于 Backspace / ArrowLeft。
-    // includeSeparator=true 时，把紧贴 mention 的一个普通空格视为原子块边界的一部分。
-    function adjacentMention(afterCaret: boolean, includeSeparator = false): HTMLElement | null {
-      const sel = window.getSelection();
-      if (!sel || sel.rangeCount === 0) return null;
-      const range = sel.getRangeAt(0);
-      if (!range.collapsed) return null;
-      const selection = currentSelectionOffsets();
-      if (!selection || selection.start !== selection.end) return null;
-      const caret = selection.start;
-
-      const boundary = mentionBoundaries().find((item) => {
-        if (afterCaret) {
-          return caret === item.start
-            || (includeSeparator && item.leadingSeparatorStart === caret);
-        }
-        return caret === item.end
-          || (includeSeparator && item.trailingSeparatorEnd === caret);
-      });
-      return boundary?.chip ?? null;
     }
 
     const isChip = (node: Node): boolean =>
@@ -474,9 +444,11 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
 
       const sel = window.getSelection();
       const hasSelection = !!sel && sel.rangeCount > 0 && !sel.getRangeAt(0).collapsed;
+      const offsets = currentSelectionOffsets();
 
       if (
         !hasSelection
+        && offsets
         && !isComposingRef.current
         && !e.metaKey
         && !e.ctrlKey
@@ -484,43 +456,48 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         && e.key.length === 1
         && !/\s/.test(e.key)
       ) {
-        const chip = adjacentMention(true);
-        if (chip) {
+        const replacement = insertTextAtMentionBoundary(
+          domToText(rootRef.current!),
+          offsets.start,
+          e.key,
+        );
+        if (replacement) {
           e.preventDefault();
-          insertTextBeforeMention(e.key);
+          applyValue(replacement.value, replacement.offset);
           return;
         }
       }
 
-      if (e.key === 'Backspace' && !hasSelection) {
-        const chip = adjacentMention(false, true);
-        if (chip) {
-          e.preventDefault();
-          removeChip(chip);
-          return;
-        }
+      if (
+        hasSelection
+        && offsets
+        && hasChip()
+        && (e.key === 'Backspace' || e.key === 'Delete')
+      ) {
+        e.preventDefault();
+        const text = domToText(rootRef.current!);
+        const replacement = deleteMentionSelection(text, offsets.start, offsets.end);
+        applyValue(replacement.value, replacement.offset);
+        return;
       }
-      if (e.key === 'Delete' && !hasSelection) {
-        const chip = adjacentMention(true, true);
-        if (chip) {
+
+      if (
+        !hasSelection
+        && offsets
+        && isMentionKey(e.key)
+      ) {
+        const text = domToText(rootRef.current!);
+        const action = resolveMentionKeyAction(text, offsets.start, e.key);
+        if (action) {
           e.preventDefault();
-          removeChip(chip);
-          return;
-        }
-      }
-      if (e.key === 'ArrowLeft' && !hasSelection) {
-        const chip = adjacentMention(false, true);
-        if (chip) {
-          e.preventDefault();
-          placeBefore(chip);
-          return;
-        }
-      }
-      if (e.key === 'ArrowRight' && !hasSelection) {
-        const chip = adjacentMention(true, true);
-        if (chip) {
-          e.preventDefault();
-          placeAfter(chip);
+          if (action.type === 'move') {
+            placeCaretAtOffset(action.offset);
+          } else {
+            applyValue(
+              text.slice(0, action.start) + text.slice(action.end),
+              action.offset,
+            );
+          }
           return;
         }
       }
@@ -535,28 +512,20 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       }
     };
 
-    // 删除 mention 及一个右侧分隔；没有右侧分隔时改删一个左侧分隔。
-    // 这样既整块删除，又能在前后文本之间保留至多一个必要空格。
-    function removeChip(chip: HTMLElement) {
+    function applyValue(text: string, offset: number) {
       const root = rootRef.current;
-      const boundary = boundaryForChip(chip);
-      if (!root || !boundary) return;
-      const text = domToText(root);
-      let removeStart = boundary.start;
-      let removeEnd = boundary.end;
-      if (boundary.trailingSeparatorEnd != null) {
-        removeEnd = boundary.trailingSeparatorEnd;
-        if (removeEnd === text.length && boundary.leadingSeparatorStart != null) {
-          removeStart = boundary.leadingSeparatorStart;
-        }
-      } else if (boundary.leadingSeparatorStart != null) {
-        removeStart = boundary.leadingSeparatorStart;
-      }
-
+      if (!root) return;
       root.focus();
       selectionRevisionRef.current += 1;
-      pendingSelectionRef.current = removeStart;
-      onChange(text.slice(0, removeStart) + text.slice(removeEnd));
+      pendingSelectionRef.current = offset;
+      onChange(text);
+    }
+
+    function isMentionKey(key: string): key is MentionKey {
+      return key === 'Backspace'
+        || key === 'Delete'
+        || key === 'ArrowLeft'
+        || key === 'ArrowRight';
     }
 
     function shouldPreventArrow(text: string, pos: number, key: string): boolean {
@@ -612,21 +581,6 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       sel?.addRange(range);
     }
 
-    function insertTextBeforeMention(text: string) {
-      const selection = window.getSelection();
-      if (!selection || selection.rangeCount === 0) return;
-      const range = selection.getRangeAt(0);
-      if (!range.collapsed) return;
-
-      const textNode = document.createTextNode(`${text} `);
-      range.insertNode(textNode);
-      range.setStart(textNode, text.length);
-      range.collapse(true);
-      applyRange(range);
-      normalizeSentinels();
-      commit();
-    }
-
     function restoreCaretEnd() {
       const root = rootRef.current!;
       root.focus();
@@ -652,7 +606,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       // 仅当存在 chip 时才检查哨兵完整性（避免每次普通输入都跑 normalize 破坏光标）
       if (hasChip()) {
         normalizeSentinels();
-        normalizeMentionLeftBoundaries();
+        normalizeMentionBoundaries();
       }
       commit();
     };
@@ -674,15 +628,17 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         || /^\s+$/.test(insertedText)
       ) return;
 
-      const chip = adjacentMention(true);
-      if (!chip) return;
-      const selection = window.getSelection();
-      if (!selection || selection.rangeCount === 0) return;
-      const range = selection.getRangeAt(0);
-      if (!range.collapsed) return;
+      const selection = currentSelectionOffsets();
+      if (!selection || selection.start !== selection.end) return;
+      const replacement = insertTextAtMentionBoundary(
+        domToText(rootRef.current!),
+        selection.start,
+        insertedText,
+      );
+      if (!replacement) return;
 
       e.preventDefault();
-      insertTextBeforeMention(insertedText);
+      applyValue(replacement.value, replacement.offset);
     };
 
     const hasChip = (): boolean => {
@@ -715,14 +671,11 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       return changed;
     }
 
-    // 在 chip 前直接输入非空白字符时补回分隔，避免序列化后与 mention token 粘连。
-    // 光标仍停在新文字末尾、分隔之前，后续连续输入保持自然顺序。
-    function normalizeMentionLeftBoundaries() {
+    // 浏览器原生输入或粘贴可能紧贴 chip 落字；补齐两侧分隔，避免标签被当成普通文本。
+    function normalizeMentionBoundaries() {
       const root = rootRef.current;
-      const selection = currentSelectionOffsets();
-      if (!root || !selection || selection.start !== selection.end) return;
+      if (!root) return;
 
-      let changed = false;
       for (const chip of Array.from(root.querySelectorAll<HTMLElement>('.mention-chip'))) {
         let previous = chip.previousSibling;
         while (previous) {
@@ -734,20 +687,24 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
             }
             if (!/\s$/.test(visibleText)) {
               chip.parentNode?.insertBefore(document.createTextNode(' '), chip);
-              changed = true;
             }
           }
           break;
         }
-      }
 
-      if (changed) {
-        const target = resolveOffset(selection.start);
-        if (target) {
-          const range = document.createRange();
-          range.setStart(target.node, target.offset);
-          range.collapse(true);
-          applyRange(range);
+        let next = chip.nextSibling;
+        while (next) {
+          if (next.nodeType === Node.TEXT_NODE) {
+            const visibleText = stripZwsp(next.nodeValue ?? '');
+            if (visibleText.length === 0) {
+              next = next.nextSibling;
+              continue;
+            }
+            if (!/^\s/.test(visibleText)) {
+              chip.parentNode?.insertBefore(document.createTextNode(' '), chip.nextSibling);
+            }
+          }
+          break;
         }
       }
     }
@@ -777,7 +734,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       range.deleteContents();
 
       const fragment = document.createDocumentFragment();
-      const lines = text.replace(/\r\n?/g, '\n').split('\n');
+      const lines = normalizePastedText(text).split('\n');
       lines.forEach((line, index) => {
         if (index > 0) fragment.appendChild(document.createElement('br'));
         if (line) fragment.appendChild(document.createTextNode(line));
@@ -790,12 +747,44 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       }
       range.collapse(true);
       applyRange(range);
-      if (hasChip()) normalizeSentinels();
+      if (hasChip()) {
+        normalizeSentinels();
+        normalizeMentionBoundaries();
+      }
       commit();
     }
 
+    function separatorClientRect(chip: HTMLElement, after: boolean): DOMRect | null {
+      let node: ChildNode | null = after ? chip.nextSibling : chip.previousSibling;
+      while (node) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          const value = node.nodeValue ?? '';
+          const indexes = after
+            ? Array.from(value, (_, index) => index)
+            : Array.from(value, (_, index) => value.length - index - 1);
+          for (const index of indexes) {
+            if (value[index] === ZWSP) continue;
+            if (value[index] !== ' ') return null;
+            const range = document.createRange();
+            range.setStart(node, index);
+            range.setEnd(node, index + 1);
+            if (typeof range.getBoundingClientRect !== 'function') return null;
+            return range.getBoundingClientRect();
+          }
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+          return null;
+        }
+        node = after ? node.nextSibling : node.previousSibling;
+      }
+      return null;
+    }
+
+    function pointInRect(x: number, y: number, rect: DOMRect): boolean {
+      return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+    }
+
     // 点击定位：chip 与相邻分隔之间不是合法停靠点，统一吸附到原子块外侧。
-    const handleMouseUp = () => {
+    const handleMouseUp = (e: MouseEvent<HTMLDivElement>) => {
       const sel = window.getSelection();
       if (!sel || sel.rangeCount === 0) return;
       const range = sel.getRangeAt(0);
@@ -811,10 +800,35 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         node = node.parentNode;
       }
 
+      const boundaries = mentionBoundaries();
+      for (let index = 0; index < boundaries.length; index += 1) {
+        const boundary = boundaries[index];
+        if (boundary.trailingSeparatorEnd != null) {
+          const rect = separatorClientRect(boundary.chip, true);
+          if (rect && pointInRect(e.clientX, e.clientY, rect)) {
+            const nextBoundary = boundaries[index + 1];
+            const separatorIsShared = nextBoundary?.leadingSeparatorStart === boundary.end;
+            if (separatorIsShared && e.clientX > (rect.left + rect.right) / 2) {
+              placeBefore(nextBoundary.chip);
+            } else {
+              placeAfter(boundary.chip);
+            }
+            return;
+          }
+        }
+        if (boundary.leadingSeparatorStart != null) {
+          const rect = separatorClientRect(boundary.chip, false);
+          if (rect && pointInRect(e.clientX, e.clientY, rect)) {
+            placeBefore(boundary.chip);
+            return;
+          }
+        }
+      }
+
       const selection = currentSelectionOffsets();
       if (!selection || selection.start !== selection.end) return;
       const caret = selection.start;
-      for (const boundary of mentionBoundaries()) {
+      for (const boundary of boundaries) {
         if (boundary.trailingSeparatorEnd != null && caret === boundary.end) {
           placeAfter(boundary.chip);
           return;
@@ -897,13 +911,32 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         onMouseUp={handleMouseUp}
         onCompositionStart={() => {
           isComposingRef.current = true;
+          const root = rootRef.current;
+          const selection = currentSelectionOffsets();
+          compositionSnapshotRef.current = root
+            && selection
+            && selection.start === selection.end
+            ? { text: domToText(root), caret: selection.start }
+            : null;
           onCompositionStart?.();
         }}
-        onCompositionEnd={() => {
+        onCompositionEnd={(event) => {
           isComposingRef.current = false;
+          const snapshot = compositionSnapshotRef.current;
+          const composedText = event.data;
+          compositionSnapshotRef.current = null;
           // 合成结束：把合成结果提交
           // 部分浏览器 compositionEnd 在 DOM 更新前触发，下一帧提交
-          requestAnimationFrame(() => commitInput());
+          requestAnimationFrame(() => {
+            const replacement = snapshot
+              ? insertTextAtMentionBoundary(snapshot.text, snapshot.caret, composedText)
+              : null;
+            if (replacement) {
+              applyValue(replacement.value, replacement.offset);
+            } else {
+              commitInput();
+            }
+          });
           onCompositionEnd?.();
         }}
         onBlur={onBlur}

--- a/frontend/src/components/MentionEditor.tsx
+++ b/frontend/src/components/MentionEditor.tsx
@@ -5,6 +5,7 @@ import {
   useImperativeHandle,
   useRef,
   type ClipboardEvent,
+  type FormEvent,
   type KeyboardEvent,
 } from 'react';
 import {
@@ -88,6 +89,8 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
     // 重建 DOM 后需要恢复的光标偏移（解决 selectCandidate 先改 value、
     // 后设光标的时序竞态：DOM 重建会清掉光标）。
     const pendingSelectionRef = useRef<number | null>(null);
+    // 异步恢复执行前若已有更新的程序化选区，则丢弃旧恢复，避免光标被拉回。
+    const selectionRevisionRef = useRef(0);
 
     // ===== DOM 构建 =====
     const renderBlocks = useCallback((blocks: Block[]) => {
@@ -149,7 +152,9 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       }
       const selectionToRestore = pending ?? selectionBeforeRebuild;
       if (selectionToRestore != null) {
+        const selectionRevision = selectionRevisionRef.current;
         requestAnimationFrame(() => {
+          if (selectionRevisionRef.current !== selectionRevision) return;
           root.focus();
           const target = resolveOffset(selectionToRestore);
           if (target) {
@@ -393,7 +398,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
     //     光标在哨兵内（任意位置）或普通文本起点时，向前跳过哨兵找第一个 chip；
     //     若先遇到普通文本/br 则不算紧邻（中间有内容）。
     //   afterCaret=true（Delete / ArrowRight）：对称地找"光标之后"的 chip。
-    function adjacentMention(afterCaret: boolean): HTMLElement | null {
+    function adjacentMention(afterCaret: boolean, includeSeparator = false): HTMLElement | null {
       const sel = window.getSelection();
       if (!sel || sel.rangeCount === 0) return null;
       const range = sel.getRangeAt(0);
@@ -420,7 +425,10 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         const isSentinel = segs[idx].kind === 'sentinel';
         if (!afterCaret) {
           // Backspace/ArrowLeft：哨兵任意位置，或普通文本在起点（offset===0）才向前找
-          if (!isSentinel && offset !== 0) return null;
+          // 候选项会在 chip 后自动插入一个分隔空格；ArrowLeft 从该空格右侧移动时，
+          // 连同空格一起跨过 chip，避免光标停在会破坏 mention 边界的位置。
+          const afterSeparator = includeSeparator && offset === 1 && value.startsWith(' ');
+          if (!isSentinel && offset !== 0 && !afterSeparator) return null;
           const neighbor = findNeighbor(idx - 1, -1);
           return neighbor && neighbor.kind === 'chip' ? (neighbor.node as HTMLElement) : null;
         } else {
@@ -461,6 +469,23 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       const sel = window.getSelection();
       const hasSelection = !!sel && sel.rangeCount > 0 && !sel.getRangeAt(0).collapsed;
 
+      if (
+        !hasSelection
+        && !isComposingRef.current
+        && !e.metaKey
+        && !e.ctrlKey
+        && !e.altKey
+        && e.key.length === 1
+        && !/\s/.test(e.key)
+      ) {
+        const chip = adjacentMention(true);
+        if (chip) {
+          e.preventDefault();
+          insertTextBeforeMention(e.key);
+          return;
+        }
+      }
+
       if (e.key === 'Backspace' && !hasSelection) {
         const chip = adjacentMention(false);
         if (chip) {
@@ -478,7 +503,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         }
       }
       if (e.key === 'ArrowLeft' && !hasSelection) {
-        const chip = adjacentMention(false);
+        const chip = adjacentMention(false, true);
         if (chip) {
           e.preventDefault();
           placeBefore(chip);
@@ -601,6 +626,21 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       sel?.addRange(range);
     }
 
+    function insertTextBeforeMention(text: string) {
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return;
+      const range = selection.getRangeAt(0);
+      if (!range.collapsed) return;
+
+      const textNode = document.createTextNode(`${text} `);
+      range.insertNode(textNode);
+      range.setStart(textNode, text.length);
+      range.collapse(true);
+      applyRange(range);
+      normalizeSentinels();
+      commit();
+    }
+
     function restoreCaretEnd() {
       const root = rootRef.current!;
       root.focus();
@@ -622,13 +662,41 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       applyRange(range);
     }
 
-    const handleInput = () => {
-      if (isComposingRef.current) return;
+    const commitInput = () => {
       // 仅当存在 chip 时才检查哨兵完整性（避免每次普通输入都跑 normalize 破坏光标）
       if (hasChip()) {
         normalizeSentinels();
+        normalizeMentionLeftBoundaries();
       }
       commit();
+    };
+
+    const handleInput = () => {
+      if (isComposingRef.current) return;
+      commitInput();
+    };
+
+    // 浏览器可能把“紧贴 chip 左侧”的文字直接写进 contenteditable=false 节点。
+    // 在写入前手工插入文字与分隔，保持 chip 原子结构和后续连续输入位置。
+    const handleBeforeInput = (e: FormEvent<HTMLDivElement>) => {
+      if (disabled || isComposingRef.current) return;
+      const inputEvent = e.nativeEvent as InputEvent;
+      const insertedText = inputEvent.data;
+      if (
+        (inputEvent.inputType && inputEvent.inputType !== 'insertText')
+        || !insertedText
+        || /^\s+$/.test(insertedText)
+      ) return;
+
+      const chip = adjacentMention(true);
+      if (!chip) return;
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return;
+      const range = selection.getRangeAt(0);
+      if (!range.collapsed) return;
+
+      e.preventDefault();
+      insertTextBeforeMention(insertedText);
     };
 
     const hasChip = (): boolean => {
@@ -659,6 +727,43 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         }
       }
       return changed;
+    }
+
+    // 在 chip 前直接输入非空白字符时补回分隔，避免序列化后与 mention token 粘连。
+    // 光标仍停在新文字末尾、分隔之前，后续连续输入保持自然顺序。
+    function normalizeMentionLeftBoundaries() {
+      const root = rootRef.current;
+      const selection = currentSelectionOffsets();
+      if (!root || !selection || selection.start !== selection.end) return;
+
+      let changed = false;
+      for (const chip of Array.from(root.querySelectorAll<HTMLElement>('.mention-chip'))) {
+        let previous = chip.previousSibling;
+        while (previous) {
+          if (previous.nodeType === Node.TEXT_NODE) {
+            const visibleText = stripZwsp(previous.nodeValue ?? '');
+            if (visibleText.length === 0) {
+              previous = previous.previousSibling;
+              continue;
+            }
+            if (!/\s$/.test(visibleText)) {
+              chip.parentNode?.insertBefore(document.createTextNode(' '), chip);
+              changed = true;
+            }
+          }
+          break;
+        }
+      }
+
+      if (changed) {
+        const target = resolveOffset(selection.start);
+        if (target) {
+          const range = document.createRange();
+          range.setStart(target.node, target.offset);
+          range.collapse(true);
+          applyRange(range);
+        }
+      }
     }
 
     const handlePaste = (e: ClipboardEvent<HTMLDivElement>) => {
@@ -737,6 +842,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       setSelection: (offset: number) => {
         const root = rootRef.current;
         if (!root) return;
+        selectionRevisionRef.current += 1;
         // 同时登记 pending，应对紧接着的 DOM 重建清掉光标
         pendingSelectionRef.current = offset;
         root.focus();
@@ -785,6 +891,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         contentEditable={!disabled}
         suppressContentEditableWarning
         spellCheck={false}
+        onBeforeInput={handleBeforeInput}
         onInput={handleInput}
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}
@@ -797,7 +904,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
           isComposingRef.current = false;
           // 合成结束：把合成结果提交
           // 部分浏览器 compositionEnd 在 DOM 更新前触发，下一帧提交
-          requestAnimationFrame(() => commit());
+          requestAnimationFrame(() => commitInput());
           onCompositionEnd?.();
         }}
         onBlur={onBlur}

--- a/frontend/src/components/MentionEditor.tsx
+++ b/frontend/src/components/MentionEditor.tsx
@@ -1,0 +1,807 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  type ClipboardEvent,
+  type KeyboardEvent,
+} from 'react';
+import {
+  MENTION_LABEL_CLASS,
+  MENTION_MARK,
+  mentionChipClass,
+  mentionMarkClass,
+} from './MentionChip';
+import { parseBlocks, type Block } from '@/utils/mentionBlocks';
+import { cn } from '@/lib/utils';
+
+// 零宽空格：作为 mention chip 两侧的光标哨兵。
+// contenteditable=false 的原子节点无法承载光标，浏览器在两个 chip 之间、
+// 或 chip 与边界之间没有可编辑文本节点时，光标无处安放、点击无效。
+// 在每个 chip 前后插入一个 ZWSP 文本节点即可提供可靠的光标锚点，
+// 序列化时剥离（见 stripZwsp）。这是 Slack/Notion/ProseMirror 的通用做法。
+const ZWSP = '\u200b';
+
+export interface MentionEditorHandle {
+  /** 聚焦编辑器并把光标置于文本末尾 */
+  focus(): void;
+  /** 当前序列化文本（从 DOM 读取，避免依赖外部受控值时序） */
+  getText(): string;
+  /** 选区信息：光标相对文本起点的偏移；用于 @ 补全定位 mentionStart */
+  getSelection(): { start: number; end: number } | null;
+  /** 把光标设置到给定文本偏移（用于 selectCandidate 后定位） */
+  setSelection(offset: number): void;
+  /** DOM 根元素 */
+  element: HTMLDivElement | null;
+}
+
+interface MentionEditorProps {
+  value: string;
+  onChange: (text: string) => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLDivElement>) => void;
+  onPaste?: (e: ClipboardEvent<HTMLDivElement>) => void;
+  onCompositionStart?: () => void;
+  onCompositionEnd?: () => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  /** 既有自动高度逻辑：clamp 到 [minH, maxH] */
+  minHeight?: number;
+  maxHeight?: number;
+  autoFocus?: boolean;
+}
+
+/**
+ * 受控的 contenteditable 编辑器，把 @ 提及渲染成原子块。
+ *
+ * 关键：每个 chip 两侧插入零宽空格（ZWSP）哨兵，提供可靠的光标锚点，
+ * 解决"chip 紧邻/在边界时光标无处安放、点击无效"的 contenteditable 经典问题。
+ *
+ * 策略（避免 React 受控 contenteditable 的光标/IME 抖动）：
+ *  - 外部 value 与当前 DOM 序列化结果不一致时重建内部 DOM；
+ *  - 用户输入（onInput）只读 DOM → 序列化 → onChange 上抛，不触发内部重渲染，
+ *    光标与 IME 由浏览器原生维护；
+ *  - 整块删除 / 跨块方向键 / 边界方向键守卫在 keydown 拦截处理。
+ */
+export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>(
+  function MentionEditor(props, ref) {
+    const {
+      value,
+      onChange,
+      onKeyDown,
+      onPaste,
+      onCompositionStart,
+      onCompositionEnd,
+      onBlur,
+      placeholder,
+      disabled,
+      className,
+      minHeight = 60,
+      maxHeight = 200,
+      autoFocus,
+    } = props;
+
+    const rootRef = useRef<HTMLDivElement>(null);
+    const isComposingRef = useRef(false);
+    // 重建 DOM 后需要恢复的光标偏移（解决 selectCandidate 先改 value、
+    // 后设光标的时序竞态：DOM 重建会清掉光标）。
+    const pendingSelectionRef = useRef<number | null>(null);
+
+    // ===== DOM 构建 =====
+    const renderBlocks = useCallback((blocks: Block[]) => {
+      const root = rootRef.current;
+      if (!root) return;
+      const frag = document.createDocumentFragment();
+      for (const b of blocks) {
+        if (b.type === 'text') {
+          frag.appendChild(document.createTextNode(b.value));
+        } else {
+          // chip 前哨兵：保证光标可落在 chip 之前
+          frag.appendChild(document.createTextNode(ZWSP));
+          const span = document.createElement('span');
+          span.className = mentionChipClass(b.kind);
+          span.setAttribute('contenteditable', 'false');
+          span.setAttribute('data-mention-token', b.token);
+          span.setAttribute('data-mention-kind', b.kind);
+          span.setAttribute('title', b.token);
+          span.setAttribute('aria-label', b.token);
+          const icon = document.createElement('span');
+          icon.className = mentionMarkClass(b.kind);
+          icon.textContent = MENTION_MARK[b.kind];
+          icon.setAttribute('aria-hidden', 'true');
+          span.appendChild(icon);
+          const label = document.createElement('span');
+          label.className = MENTION_LABEL_CLASS;
+          label.textContent = b.label;
+          span.appendChild(label);
+          frag.appendChild(span);
+          // chip 后哨兵：保证光标可落在 chip 之后
+          frag.appendChild(document.createTextNode(ZWSP));
+        }
+      }
+      root.replaceChildren(frag);
+    }, []);
+
+    // 仅在外部 value 与当前 DOM 序列化结果不一致时重建。
+    // 用户输入时 commit() 已上抛新文本，父组件回填的 value 必然与 DOM 一致，
+    // 因此 current === value 这道比较即可挡住重渲染，光标与 IME 由浏览器原生维护。
+    // 额外：value 为空但 DOM 仍有残留（如删除最后一个 chip 后的孤立哨兵）也需清空，
+    // 否则 :empty 占位符失效。
+    // 重建后若存在待恢复光标（selectCandidate 触发），落到目标偏移。
+    useEffect(() => {
+      const root = rootRef.current;
+      if (!root) return;
+      const current = domToText(root);
+      const needsRebuild = current !== value
+        || (value === '' && root.childNodes.length > 0)
+        || !existingMentionsMatchValue(root, value);
+      const selectionBeforeRebuild = needsRebuild && document.activeElement === root
+        ? currentSelectionOffsets()?.start ?? null
+        : null;
+      if (needsRebuild) {
+        renderBlocks(parseBlocks(value));
+      }
+      const pending = pendingSelectionRef.current;
+      if (pending != null) {
+        pendingSelectionRef.current = null;
+      }
+      const selectionToRestore = pending ?? selectionBeforeRebuild;
+      if (selectionToRestore != null) {
+        requestAnimationFrame(() => {
+          root.focus();
+          const target = resolveOffset(selectionToRestore);
+          if (target) {
+            const range = document.createRange();
+            range.setStart(target.node, target.offset);
+            range.collapse(true);
+            applyRange(range);
+          }
+        });
+      }
+    }, [value, renderBlocks]);
+
+    // 手工输入合法 @ 文本时仍保持普通文字；只有 DOM 已经存在标签时，才校验
+    // 标签 token 是否仍与当前文本解析结果一致。
+    function existingMentionsMatchValue(root: HTMLElement, text: string): boolean {
+      const actual = Array.from(root.querySelectorAll<HTMLElement>('.mention-chip'))
+        .map((chip) => chip.dataset.mentionToken ?? '');
+      if (actual.length === 0) return true;
+      const expected = parseBlocks(text)
+        .filter((block) => block.type === 'mention')
+        .map((block) => block.token);
+      return actual.length === expected.length
+        && actual.every((token, index) => token === expected[index]);
+    }
+
+    // 高度自适应
+    useEffect(() => {
+      const root = rootRef.current;
+      if (!root) return;
+      root.style.height = `${minHeight}px`;
+      root.style.height = `${Math.min(root.scrollHeight, maxHeight)}px`;
+    }, [value, minHeight, maxHeight]);
+
+    // ===== DOM <-> 文本 =====
+    // 序列化时剥离哨兵 ZWSP，保证 round-trip 等价
+    function stripZwsp(s: string): string {
+      return s.split(ZWSP).join('');
+    }
+
+    function domToText(root: HTMLElement): string {
+      // contenteditable 在不同内核中可能用 CR、LF 或 BR 表示换行；对齐 textarea
+      // 的 value 语义，统一向上层提交 LF。
+      return stripZwsp(rawDomText(root)).replace(/\r\n?/g, '\n');
+    }
+
+    function rawDomText(root: HTMLElement): string {
+      let text = '';
+      root.childNodes.forEach((node) => {
+        if (node.nodeType === Node.TEXT_NODE) {
+          text += node.nodeValue ?? '';
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+          const el = node as HTMLElement;
+          if (el.classList.contains('mention-chip')) {
+            text += el.getAttribute('data-mention-token') ?? '';
+          } else if (el.tagName === 'BR') {
+            text += '\n';
+          } else {
+            text += rawDomText(el);
+          }
+        }
+      });
+      return text;
+    }
+
+    const commit = useCallback(() => {
+      const root = rootRef.current;
+      if (!root) return;
+      onChange(domToText(root));
+    }, [onChange]);
+
+    // ===== 光标/选区相对文本偏移 =====
+    // 收集叶子段（文本节点/哨兵/chip/br），按文档顺序，供偏移换算复用。
+    interface Seg {
+      node: Node;
+      // 该段贡献到"纯文本（无 ZWSP）"的字符长度
+      len: number;
+      // 该段在"原始 DOM 文本（含 ZWSP）"里的长度，用于把光标端点（DOM 偏移）换算
+      rawLen: number;
+      // text=普通文本；sentinel=chip 两侧的 ZWSP 哨兵（纯文本贡献 0）；chip；br
+      kind: 'text' | 'sentinel' | 'chip' | 'br';
+      token?: string;
+    }
+
+    function collectSegments(root: HTMLElement): Seg[] {
+      const segs: Seg[] = [];
+      const walk = (node: Node) => {
+        if (node.nodeType === Node.TEXT_NODE) {
+          const value = node.nodeValue ?? '';
+          // 纯 ZWSP 哨兵节点：对纯文本贡献 0，但是 chip 两侧的光标锚点
+          if (value.split(ZWSP).join('') === '') {
+            segs.push({ node, len: 0, rawLen: value.length, kind: 'sentinel' });
+          } else {
+            const len = stripZwsp(value).length;
+            segs.push({ node, len, rawLen: value.length, kind: 'text' });
+          }
+          return;
+        }
+        if (node.nodeType !== Node.ELEMENT_NODE) return;
+        const el = node as HTMLElement;
+        if (el.classList.contains('mention-chip')) {
+          const token = el.getAttribute('data-mention-token') ?? '';
+          segs.push({ node: el, len: token.length, rawLen: 0, kind: 'chip', token });
+          return;
+        }
+        if (el.tagName === 'BR') {
+          segs.push({ node: el, len: 1, rawLen: 0, kind: 'br' });
+          return;
+        }
+        el.childNodes.forEach(walk);
+      };
+      root.childNodes.forEach(walk);
+      return segs;
+    }
+
+    // DOM 端点（container + offset）→ 相对纯文本起点的字符偏移
+    function offsetFromStart(container: Node, offset: number): number {
+      const root = rootRef.current!;
+      const segs = collectSegments(root);
+
+      // container 是文本节点：找到它，累加前面段长度，再加 offset（但跳过其内部的 ZWSP）
+      if (container.nodeType === Node.TEXT_NODE) {
+        let total = 0;
+        for (const seg of segs) {
+          if (seg.node === container) {
+            const value = container.nodeValue ?? '';
+            // offset 是 DOM 文本偏移（含 ZWSP），换算成纯文本偏移
+            const before = value.slice(0, offset);
+            total += stripZwsp(before).length;
+            return total;
+          }
+          total += seg.len;
+        }
+        return total;
+      }
+
+      // container 是元素：offset 指向其第 offset 个子节点之前
+      // 找到 offset 指向的子节点（或末尾）在 segs 中的累积位置
+      if (container.nodeType === Node.ELEMENT_NODE || container === root) {
+        const el = container as HTMLElement;
+        const child = el.childNodes[offset];
+        if (!child) {
+          // 指向末尾：累加所有属于 container 子树的段
+          return sumSegmentsUnder(segs, el, true);
+        }
+        return offsetOfNode(segs, child);
+      }
+      return 0;
+    }
+
+    function offsetOfNode(segs: Seg[], target: Node): number {
+      let total = 0;
+      for (const seg of segs) {
+        if (seg.node === target) return total;
+        total += seg.len;
+      }
+      return total;
+    }
+
+    // 累加落在 parent 子树内、且（end=true 时全部 / end=false 时到边界）的段
+    function sumSegmentsUnder(segs: Seg[], parent: Node, end: boolean): number {
+      let total = 0;
+      for (const seg of segs) {
+        if (parent.contains(seg.node)) total += seg.len;
+        if (!end) break;
+      }
+      return total;
+    }
+
+    // 纯文本偏移 → DOM 端点。优先落在文本节点内；落在 chip 处时定位到 chip 前的哨兵。
+    function resolveOffset(offset: number): { node: Node; offset: number } | null {
+      const root = rootRef.current!;
+      const segs = collectSegments(root);
+      let remaining = offset;
+      for (let i = 0; i < segs.length; i++) {
+        const seg = segs[i];
+        if (seg.kind === 'chip') {
+          if (remaining < seg.len) {
+            // 落在 chip 内部：定位到 chip 之前的哨兵文本节点末尾
+            const sentinel = segs[i - 1];
+            if (sentinel && (sentinel.kind === 'sentinel' || sentinel.kind === 'text')) {
+              return { node: sentinel.node, offset: (sentinel.node.nodeValue ?? '').length };
+            }
+            return { node: root, offset: indexOf(seg.node) };
+          }
+          remaining -= seg.len;
+          continue;
+        }
+        if (seg.kind === 'text') {
+          const value = seg.node.nodeValue ?? '';
+          const pure = stripZwsp(value);
+          if (remaining <= pure.length) {
+            // 把纯文本偏移换算回 DOM 文本偏移（含 ZWSP）
+            let domOffset = 0;
+            let pureCount = 0;
+            for (const ch of value) {
+              if (pureCount >= remaining) break;
+              domOffset += 1;
+              if (ch !== ZWSP) pureCount += 1;
+            }
+            return { node: seg.node, offset: domOffset };
+          }
+          remaining -= pure.length;
+          continue;
+        }
+        if (seg.kind === 'sentinel') {
+          // 哨兵对纯文本贡献 0：remaining<=0 时可在此定位
+          if (remaining <= 0) {
+            return { node: seg.node, offset: 0 };
+          }
+          continue;
+        }
+        // br
+        if (remaining <= 0) {
+          return { node: seg.node.parentNode!, offset: indexOf(seg.node) };
+        }
+        remaining -= 1;
+      }
+      // 落到末尾：选最后一个文本/哨兵节点末尾，否则 root 末尾
+      for (let i = segs.length - 1; i >= 0; i--) {
+        if (segs[i].kind === 'text' || segs[i].kind === 'sentinel') {
+          return { node: segs[i].node, offset: (segs[i].node.nodeValue ?? '').length };
+        }
+      }
+      return { node: root, offset: root.childNodes.length };
+    }
+
+    const indexOf = (node: Node) => {
+      const parent = node.parentNode;
+      if (!parent) return 0;
+      let i = 0;
+      for (const child of Array.from(parent.childNodes)) {
+        if (child === node) return i;
+        i += 1;
+      }
+      return 0;
+    };
+
+    // ===== 整块删除 / 跨块方向键 / 边界守卫 =====
+    // 判断当前光标是否紧邻一个 mention chip（中间可隔哨兵 ZWSP，但不可隔普通文本）。
+    //   afterCaret=false（Backspace / ArrowLeft）：找"光标之前"方向上紧邻的 chip。
+    //     光标在哨兵内（任意位置）或普通文本起点时，向前跳过哨兵找第一个 chip；
+    //     若先遇到普通文本/br 则不算紧邻（中间有内容）。
+    //   afterCaret=true（Delete / ArrowRight）：对称地找"光标之后"的 chip。
+    function adjacentMention(afterCaret: boolean): HTMLElement | null {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return null;
+      const range = sel.getRangeAt(0);
+      if (!range.collapsed) return null;
+      const root = rootRef.current!;
+      const segs = collectSegments(root);
+      const container = range.startContainer;
+      const offset = range.startOffset;
+
+      // 从 startIdx 向 step 方向跳过哨兵，返回第一个非哨兵 seg
+      const findNeighbor = (startIdx: number, step: 1 | -1): Seg | null => {
+        for (let j = startIdx; j >= 0 && j < segs.length; j += step) {
+          if (segs[j].kind === 'sentinel') continue;
+          return segs[j];
+        }
+        return null;
+      };
+
+      // 光标在文本节点内（普通文本或哨兵）
+      if (container.nodeType === Node.TEXT_NODE) {
+        const value = container.nodeValue ?? '';
+        const idx = segs.findIndex((s) => s.node === container);
+        if (idx < 0) return null;
+        const isSentinel = segs[idx].kind === 'sentinel';
+        if (!afterCaret) {
+          // Backspace/ArrowLeft：哨兵任意位置，或普通文本在起点（offset===0）才向前找
+          if (!isSentinel && offset !== 0) return null;
+          const neighbor = findNeighbor(idx - 1, -1);
+          return neighbor && neighbor.kind === 'chip' ? (neighbor.node as HTMLElement) : null;
+        } else {
+          // Delete/ArrowRight：哨兵任意位置，或普通文本在末尾才向后找
+          if (!isSentinel && offset !== value.length) return null;
+          const neighbor = findNeighbor(idx + 1, 1);
+          return neighbor && neighbor.kind === 'chip' ? (neighbor.node as HTMLElement) : null;
+        }
+      }
+
+      // 光标在元素边界（container 为 root），offset 是子序号
+      if (container === root) {
+        if (!afterCaret) {
+          // 向前：offset-1 处的子节点
+          const child = container.childNodes[offset - 1];
+          if (child && isChip(child)) return child as HTMLElement;
+        } else {
+          const child = container.childNodes[offset];
+          if (child && isChip(child)) return child as HTMLElement;
+        }
+      }
+      return null;
+    }
+
+    const isChip = (node: Node): boolean =>
+      node.nodeType === Node.ELEMENT_NODE
+      && (node as HTMLElement).classList.contains('mention-chip');
+
+    // 文本节点段（普通文本或哨兵）都可作为光标锚点
+    const isTextLike = (seg: Seg | undefined): seg is Seg =>
+      !!seg && (seg.kind === 'text' || seg.kind === 'sentinel');
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+      onKeyDown?.(e);
+      if (e.defaultPrevented) return;
+      if (disabled) return;
+
+      const sel = window.getSelection();
+      const hasSelection = !!sel && sel.rangeCount > 0 && !sel.getRangeAt(0).collapsed;
+
+      if (e.key === 'Backspace' && !hasSelection) {
+        const chip = adjacentMention(false);
+        if (chip) {
+          e.preventDefault();
+          removeChip(chip);
+          return;
+        }
+      }
+      if (e.key === 'Delete' && !hasSelection) {
+        const chip = adjacentMention(true);
+        if (chip) {
+          e.preventDefault();
+          removeChip(chip);
+          return;
+        }
+      }
+      if (e.key === 'ArrowLeft' && !hasSelection) {
+        const chip = adjacentMention(false);
+        if (chip) {
+          e.preventDefault();
+          placeBefore(chip);
+          return;
+        }
+      }
+      if (e.key === 'ArrowRight' && !hasSelection) {
+        const chip = adjacentMention(true);
+        if (chip) {
+          e.preventDefault();
+          placeAfter(chip);
+          return;
+        }
+      }
+
+      // WKWebView 方向键边界守卫（contenteditable 版，复刻 textarea 守卫语义）
+      if (!hasSelection && isComposingRef.current === false) {
+        const text = domToText(rootRef.current!);
+        const offsets = currentSelectionOffsets();
+        if (offsets && shouldPreventArrow(text, offsets.start, e.key)) {
+          e.preventDefault();
+        }
+      }
+    };
+
+    // 删除 chip 及其相邻哨兵，提交并把光标放回原位（chip 前哨兵位置）
+    function removeChip(chip: HTMLElement) {
+      const root = rootRef.current!;
+      const segs = collectSegments(root);
+      const idx = segs.findIndex((s) => s.node === chip);
+      // chip 前哨兵：idx-1；chip 后哨兵：idx+1
+      const beforeSentinel = segs[idx - 1];
+      const afterSentinel = segs[idx + 1];
+      // 删除 chip 与两个哨兵中"在删除后会冗余"的部分：
+      // 保留 beforeSentinel 作为光标落点，删除 chip + afterSentinel
+      // （afterSentinel 若与 beforeSentinel 相邻会造成两个 ZWSP 拼一起，剥离即可）
+      chip.remove();
+      if (isTextLike(afterSentinel)) {
+        afterSentinel.node.parentNode?.removeChild(afterSentinel.node);
+      }
+      // 先把光标落在 beforeSentinel 末尾，再提交新文本，让补全状态读取到正确位置。
+      root.focus();
+      if (isTextLike(beforeSentinel) && beforeSentinel.node.parentNode) {
+        const range = document.createRange();
+        range.setStart(beforeSentinel.node, (beforeSentinel.node.nodeValue ?? '').length);
+        range.collapse(true);
+        applyRange(range);
+      } else {
+        restoreCaretEnd();
+      }
+      commit();
+    }
+
+    function shouldPreventArrow(text: string, pos: number, key: string): boolean {
+      switch (key) {
+        case 'ArrowLeft':
+          return pos === 0;
+        case 'ArrowRight':
+          return pos === text.length;
+        case 'ArrowUp':
+          return !text.slice(0, pos).includes('\n');
+        case 'ArrowDown':
+          return !text.slice(pos).includes('\n');
+        default:
+          return false;
+      }
+    }
+
+    function currentSelectionOffsets(): { start: number; end: number } | null {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return null;
+      const range = sel.getRangeAt(0);
+      return {
+        start: offsetFromStart(range.startContainer, range.startOffset),
+        end: offsetFromStart(range.endContainer, range.endOffset),
+      };
+    }
+
+    function placeBefore(chip: HTMLElement) {
+      const root = rootRef.current!;
+      const segs = collectSegments(root);
+      const idx = segs.findIndex((s) => s.node === chip);
+      const sentinel = segs[idx - 1];
+      root.focus();
+      if (isTextLike(sentinel)) {
+        const range = document.createRange();
+        range.setStart(sentinel.node, 0);
+        range.collapse(true);
+        applyRange(range);
+      } else {
+        const parent = chip.parentNode!;
+        const range = document.createRange();
+        range.setStart(parent, indexOf(chip));
+        range.collapse(true);
+        applyRange(range);
+      }
+    }
+    function placeAfter(chip: HTMLElement) {
+      const root = rootRef.current!;
+      const segs = collectSegments(root);
+      const idx = segs.findIndex((s) => s.node === chip);
+      const sentinel = segs[idx + 1];
+      root.focus();
+      if (isTextLike(sentinel)) {
+        const range = document.createRange();
+        range.setStart(sentinel.node, (sentinel.node.nodeValue ?? '').length);
+        range.collapse(true);
+        applyRange(range);
+      } else {
+        const parent = chip.parentNode!;
+        const range = document.createRange();
+        range.setStart(parent, indexOf(chip) + 1);
+        range.collapse(true);
+        applyRange(range);
+      }
+    }
+    function applyRange(range: Range) {
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+    }
+
+    function restoreCaretEnd() {
+      const root = rootRef.current!;
+      root.focus();
+      // 定位到最后一个文本节点末尾（哨兵优先），避免 selectNodeContents 把光标
+      // 落进不可编辑的 chip 内部
+      const segs = collectSegments(root);
+      for (let i = segs.length - 1; i >= 0; i--) {
+        if (isTextLike(segs[i])) {
+          const range = document.createRange();
+          range.setStart(segs[i].node, (segs[i].node.nodeValue ?? '').length);
+          range.collapse(true);
+          applyRange(range);
+          return;
+        }
+      }
+      const range = document.createRange();
+      range.selectNodeContents(root);
+      range.collapse(false);
+      applyRange(range);
+    }
+
+    const handleInput = () => {
+      if (isComposingRef.current) return;
+      // 仅当存在 chip 时才检查哨兵完整性（避免每次普通输入都跑 normalize 破坏光标）
+      if (hasChip()) {
+        normalizeSentinels();
+      }
+      commit();
+    };
+
+    const hasChip = (): boolean => {
+      const root = rootRef.current;
+      return !!root && !!root.querySelector('.mention-chip');
+    };
+
+    // 归一化：为缺少哨兵的 chip 补哨兵。仅在 chip 存在且哨兵缺失时修改 DOM，
+    // 避免无谓的 normalize() 破坏光标。
+    function normalizeSentinels() {
+      const root = rootRef.current;
+      if (!root) return;
+      let changed = false;
+      const childNodes = Array.from(root.childNodes);
+      for (let i = 0; i < childNodes.length; i++) {
+        const node = childNodes[i];
+        if (node.nodeType === Node.ELEMENT_NODE && isChip(node)) {
+          const prev = childNodes[i - 1];
+          const next = childNodes[i + 1];
+          if (!prev || prev.nodeType !== Node.TEXT_NODE) {
+            node.parentNode?.insertBefore(document.createTextNode(ZWSP), node);
+            changed = true;
+          }
+          if (!next || next.nodeType !== Node.TEXT_NODE) {
+            node.parentNode?.insertBefore(document.createTextNode(ZWSP), node.nextSibling);
+            changed = true;
+          }
+        }
+      }
+      return changed;
+    }
+
+    const handlePaste = (e: ClipboardEvent<HTMLDivElement>) => {
+      if (onPaste) {
+        onPaste(e);
+        if (e.defaultPrevented) return;
+      }
+      e.preventDefault();
+      insertPlainText(e.clipboardData.getData('text/plain'));
+    };
+
+    // 仅插入文本与换行节点，避免富文本样式污染，同时保留多行粘贴语义。
+    function insertPlainText(text: string) {
+      const root = rootRef.current;
+      const selection = window.getSelection();
+      if (!root || !selection) return;
+
+      const range = selection.rangeCount > 0
+        ? selection.getRangeAt(0)
+        : document.createRange();
+      if (selection.rangeCount === 0 || !root.contains(range.commonAncestorContainer)) {
+        range.selectNodeContents(root);
+        range.collapse(false);
+      }
+      range.deleteContents();
+
+      const fragment = document.createDocumentFragment();
+      const lines = text.replace(/\r\n?/g, '\n').split('\n');
+      lines.forEach((line, index) => {
+        if (index > 0) fragment.appendChild(document.createElement('br'));
+        if (line) fragment.appendChild(document.createTextNode(line));
+      });
+      const lastInsertedNode = fragment.lastChild;
+      range.insertNode(fragment);
+
+      if (lastInsertedNode) {
+        range.setStartAfter(lastInsertedNode);
+      }
+      range.collapse(true);
+      applyRange(range);
+      if (hasChip()) normalizeSentinels();
+      commit();
+    }
+
+    // 点击定位：contenteditable 在点击 chip 紧邻空白处时可能把光标选进 chip，
+    // 这里兜底——若选区落在 chip 内部，夹到 chip 一侧的哨兵。
+    const handleMouseUp = () => {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return;
+      const range = sel.getRangeAt(0);
+      if (!range.collapsed) return;
+      // 若光标在 chip 内部，向上找 chip
+      let node: Node | null = range.startContainer;
+      while (node && node !== rootRef.current) {
+        if (node.nodeType === Node.ELEMENT_NODE && isChip(node)) {
+          // 夹到该 chip 的前哨兵
+          placeBefore(node as HTMLElement);
+          return;
+        }
+        node = node.parentNode;
+      }
+    };
+
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        const root = rootRef.current;
+        if (!root) return;
+        root.focus();
+        restoreCaretEnd();
+      },
+      getText: () => {
+        const root = rootRef.current;
+        return root ? domToText(root) : '';
+      },
+      getSelection: () => currentSelectionOffsets(),
+      setSelection: (offset: number) => {
+        const root = rootRef.current;
+        if (!root) return;
+        // 同时登记 pending，应对紧接着的 DOM 重建清掉光标
+        pendingSelectionRef.current = offset;
+        root.focus();
+        const target = resolveOffset(offset);
+        if (target) {
+          const range = document.createRange();
+          range.setStart(target.node, target.offset);
+          range.collapse(true);
+          applyRange(range);
+        }
+        // setSelection 通常发生在 value 已重建之后。若本帧没有重建消费 pending，
+        // 及时清理，避免下一次普通输入又把光标拉回旧位置。
+        requestAnimationFrame(() => {
+          if (pendingSelectionRef.current === offset) {
+            pendingSelectionRef.current = null;
+          }
+        });
+      },
+      element: rootRef.current,
+    }), []);
+
+    // autoFocus
+    useEffect(() => {
+      if (autoFocus) {
+        const root = rootRef.current;
+        if (root) {
+          root.focus();
+          restoreCaretEnd();
+        }
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+      <div
+        ref={rootRef}
+        className={cn(
+          'mention-editor block w-full cursor-text overflow-x-hidden overflow-y-auto rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+          className,
+        )}
+        role="textbox"
+        aria-multiline="true"
+        aria-disabled={disabled}
+        aria-placeholder={placeholder}
+        data-placeholder={placeholder}
+        contentEditable={!disabled}
+        suppressContentEditableWarning
+        spellCheck={false}
+        onInput={handleInput}
+        onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
+        onMouseUp={handleMouseUp}
+        onCompositionStart={() => {
+          isComposingRef.current = true;
+          onCompositionStart?.();
+        }}
+        onCompositionEnd={() => {
+          isComposingRef.current = false;
+          // 合成结束：把合成结果提交
+          // 部分浏览器 compositionEnd 在 DOM 更新前触发，下一帧提交
+          requestAnimationFrame(() => commit());
+          onCompositionEnd?.();
+        }}
+        onBlur={onBlur}
+      />
+    );
+  },
+);

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -1,7 +1,7 @@
 import { useState, KeyboardEvent, ClipboardEvent, DragEvent, useEffect, useRef, useCallback } from 'react';
 import type { SetStateAction } from 'react';
 import { selectCurrentInputCacheKey, selectCurrentInputCache, useStore } from '@/store/useStore';
-import { Textarea } from './ui/textarea';
+import { MentionEditor, type MentionEditorHandle } from './MentionEditor';
 import { Button } from './ui/button';
 import { Send, Square, FolderOpen, Wrench, Cpu, Mic, Loader2, Keyboard, MessageSquarePlus, ShieldCheck, ShieldOff, Circle, Paperclip, X, Users, Brain, Clock } from 'lucide-react';
 import { open } from '@tauri-apps/plugin-dialog';
@@ -75,7 +75,7 @@ export function MessageInput() {
   const reasoningEffort = useStore((state) => state.reasoningEffort);
   const setReasoningEffort = useStore((state) => state.setReasoningEffort);
   const isComposingRef = useRef(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const editorRef = useRef<MentionEditorHandle>(null);
   const inputAreaRef = useRef<HTMLDivElement>(null);
   const lastNativeDropAtRef = useRef(0);
 
@@ -179,14 +179,7 @@ export function MessageInput() {
     ? `${Math.floor(lastDurationMs / 1000)}s`
     : '';
 
-  // 自动调整文本框高度
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = '60px';
-      textarea.style.height = Math.min(textarea.scrollHeight, 200) + 'px';
-    }
-  }, [inputContent]);
+  // 自动调整文本框高度（MentionEditor 内部按 value 自适应，这里不再单独维护）
 
   // ===== 文字模式相关 =====
   const loadCandidates = useCallback(async () => {
@@ -278,9 +271,7 @@ export function MessageInput() {
 
   const handleInputChange = (value: string) => {
     setInputContent(value);
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-    const cursorPos = textarea.selectionStart;
+    const cursorPos = editorRef.current?.getSelection()?.start ?? value.length;
     const beforeCursor = value.slice(0, cursorPos);
     if (beforeCursor.startsWith('/') && !/\s/.test(beforeCursor)) {
       setMentionStart(0);
@@ -319,18 +310,18 @@ export function MessageInput() {
       void executeSlashCommand(candidate.value);
       return;
     }
-    const textarea = textareaRef.current;
-    const cursorPos = textarea?.selectionStart ?? inputContent.length;
+    const editor = editorRef.current;
+    const cursorPos = editor?.getSelection()?.start ?? inputContent.length;
     const before = inputContent.slice(0, mentionStart);
     const after = inputContent.slice(cursorPos);
     const newValue = `${before}${candidate.value} ${after}`;
     setInputContent(newValue);
     setMentionOpen(false);
     setTimeout(() => {
-      if (textarea) {
+      if (editor) {
         const newPos = mentionStart + candidate.value.length + 1;
-        textarea.focus();
-        textarea.setSelectionRange(newPos, newPos);
+        editor.focus();
+        editor.setSelection(newPos);
       }
     }, 0);
   };
@@ -376,7 +367,7 @@ export function MessageInput() {
         if (payload.paths.length > 0) {
           lastNativeDropAtRef.current = Date.now();
           addAttachmentsFromPaths(payload.paths);
-          textareaRef.current?.focus();
+          editorRef.current?.focus();
         }
       }
     }).then((stopListening) => {
@@ -442,14 +433,14 @@ export function MessageInput() {
     if (Date.now() - lastNativeDropAtRef.current < 500) return;
     try {
       await filesToAttachments(files);
-      textareaRef.current?.focus();
+      editorRef.current?.focus();
     } catch (err) {
       console.error('读取拖放文件失败:', err);
       alert(err instanceof Error ? err.message : '读取拖放文件失败');
     }
   };
 
-  const handlePaste = async (e: ClipboardEvent<HTMLTextAreaElement>) => {
+  const handlePaste = async (e: ClipboardEvent<HTMLDivElement>) => {
     const files = Array.from(e.clipboardData.files);
     if (files.length > 0) {
       e.preventDefault();
@@ -523,7 +514,7 @@ export function MessageInput() {
     }
   };
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (mentionOpen && filteredCandidates.length > 0) {
       if (e.key === 'ArrowDown') { e.preventDefault(); setMentionIndex(i => (i + 1) % filteredCandidates.length); return; }
       if (e.key === 'ArrowUp') { e.preventDefault(); setMentionIndex(i => (i - 1 + filteredCandidates.length) % filteredCandidates.length); return; }
@@ -962,10 +953,10 @@ export function MessageInput() {
                 </div>
               )}
 
-              <Textarea
-                ref={textareaRef}
+              <MentionEditor
+                ref={editorRef}
                 value={inputContent}
-                onChange={(e) => handleInputChange(e.target.value)}
+                onChange={handleInputChange}
                 onKeyDown={handleKeyDown}
                 onPaste={handlePaste}
                 onCompositionStart={() => { isComposingRef.current = true; }}

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -21,6 +21,7 @@ import {
   estimatedBase64Size,
   resolveAttachmentUrl,
 } from '@/utils/attachments';
+import { replaceMentionCompletion } from '@/utils/mentionEditorModel';
 
 interface MentionCandidate {
   value: string;
@@ -312,16 +313,19 @@ export function MessageInput() {
     }
     const editor = editorRef.current;
     const cursorPos = editor?.getSelection()?.start ?? inputContent.length;
-    const before = inputContent.slice(0, mentionStart);
-    const after = inputContent.slice(cursorPos);
-    const newValue = `${before}${candidate.value} ${after}`;
-    setInputContent(newValue);
+    const replacement = replaceMentionCompletion(
+      inputContent,
+      mentionStart,
+      cursorPos,
+      candidate.value,
+    );
+    if (!replacement) return;
+    setInputContent(replacement.value);
     setMentionOpen(false);
     setTimeout(() => {
       if (editor) {
-        const newPos = mentionStart + candidate.value.length + 1;
         editor.focus();
-        editor.setSelection(newPos);
+        editor.setSelection(replacement.offset);
       }
     }, 0);
   };

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -37,6 +37,7 @@ import {
   UserMessageGroup,
   AgentTurn,
 } from "./message";
+import { type MentionEditorHandle } from "./MentionEditor";
 
 export function MessageList() {
   const messages = useStore(s => s.messages);
@@ -78,7 +79,7 @@ export function MessageList() {
   const editingRevisionRef = useRef(0);
   const editingGenerationRef = useRef(0);
   const editingBaseContentRef = useRef<ContentBlock[]>([]);
-  const editingTextareaRef = useRef<HTMLTextAreaElement>(null!);
+  const editingTextareaRef = useRef<MentionEditorHandle>(null!);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const isAtBottomRef = useRef(true);
   // 百分比轨道：鼠标 Y 比例映射到的用户提问序号，-1 表示未在轨道内
@@ -482,13 +483,6 @@ export function MessageList() {
       editingBaseContentRef.current = [];
       setEditingAttachments([]);
     }
-    setTimeout(() => {
-      const textarea = editingTextareaRef.current;
-      if (textarea) {
-        textarea.style.height = '60px';
-        textarea.style.height = Math.min(textarea.scrollHeight, 200) + 'px';
-      }
-    }, 0);
   }, [activeSessionId, runStatus, messages]);
 
   const handleConfirmEdit = useCallback(async () => {
@@ -584,7 +578,7 @@ export function MessageList() {
     }
   }, [handleSetEditingAttachments]);
 
-  const handleEditPaste = useCallback(async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+  const handleEditPaste = useCallback(async (e: React.ClipboardEvent<HTMLDivElement>) => {
     const files = Array.from(e.clipboardData.files);
     if (files.length === 0) return;
     e.preventDefault();

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -683,7 +683,7 @@ export function MessageList() {
                 欢迎使用天工
               </h2>
               <p className="text-muted-foreground text-sm">
-                我可以帮助您完成各种编程任务
+                我可以帮助您完成各种任务
               </p>
             </div>
           ) : (

--- a/frontend/src/components/message/UserMessageGroup.tsx
+++ b/frontend/src/components/message/UserMessageGroup.tsx
@@ -1,10 +1,12 @@
 import { useSearchStore } from "@/store/useSearchStore";
 import { findTextOccurrences } from "@/utils/search";
 import { HighlightText } from "../HighlightText";
-import { Textarea } from "../ui/textarea";
+import { MentionChip } from "../MentionChip";
+import { MentionEditor, type MentionEditorHandle } from "../MentionEditor";
 import { X, Paperclip } from "lucide-react";
 import { resolveAttachmentUrl, type Attachment } from "@/utils/attachments";
 import { textContent } from "@/api/tauri";
+import { hasMention, parseBlocks } from "@/utils/mentionBlocks";
 import { formatMessageTime } from "./utils";
 import type { MessageGroup } from "./types";
 import { VoiceBubble } from "./VoiceBubble";
@@ -19,14 +21,14 @@ export function UserMessageGroup({ group, runStatus, nonEditableIds, voiceMessag
   editingMessageId: string | null;
   editingContent: string;
   editingAttachments: Attachment[];
-  editingTextareaRef: React.RefObject<HTMLTextAreaElement>;
+  editingTextareaRef: React.RefObject<MentionEditorHandle>;
   onStartEdit: (messageId: string, text: string) => void;
   onConfirmEdit: () => void;
   onCancelEdit: () => void;
   onSetEditingContent: (v: string) => void;
   onSetEditingAttachments: React.Dispatch<React.SetStateAction<Attachment[]>>;
   onAttachFiles: () => void;
-  onEditPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
+  onEditPaste: (e: React.ClipboardEvent<HTMLDivElement>) => void;
 }) {
   const message = group.messages[0];
   const voiceInfo = voiceMessages[message.id];
@@ -37,11 +39,61 @@ export function UserMessageGroup({ group, runStatus, nonEditableIds, voiceMessag
   const caseSensitive = useSearchStore((s) => s.caseSensitive);
 
   const renderUserText = (text: string) => {
-    if (!searchQuery) return text;
-    const occurrences = findTextOccurrences(text, searchQuery, caseSensitive);
-    if (occurrences.length === 0) return text;
+    // 无提及：走原有纯文本 / 高亮路径，行为完全不变
+    if (!hasMention(text)) {
+      if (!searchQuery) return text;
+      const occurrences = findTextOccurrences(text, searchQuery, caseSensitive);
+      if (occurrences.length === 0) return text;
+      const isCurrent = message.id === currentMessageId;
+      return <HighlightText text={text} matches={occurrences} currentMatchStart={isCurrent ? currentMatchStart : null} />;
+    }
+
+    // 有提及：按块分段渲染。搜索高亮的 offset 空间仍是原始字符串，
+    // 因此对每个 text 段切分其在全串中的匹配，保留既有高亮语义。
     const isCurrent = message.id === currentMessageId;
-    return <HighlightText text={text} matches={occurrences} currentMatchStart={isCurrent ? currentMatchStart : null} />;
+    const allOccurrences = searchQuery
+      ? findTextOccurrences(text, searchQuery, caseSensitive)
+      : [];
+    const nodes: React.ReactNode[] = [];
+    let segStart = 0;
+    let key = 0;
+    for (const block of parseBlocks(text)) {
+      if (block.type === 'text') {
+        const segEnd = segStart + block.value.length;
+        const segMatches = allOccurrences
+          .filter((m) => m.start >= segStart && m.end <= segEnd)
+          .map((m) => ({ start: m.start - segStart, end: m.end - segStart }));
+        if (segMatches.length === 0) {
+          nodes.push(<span key={key++}>{block.value}</span>);
+        } else {
+          // currentMatchStart 是全串偏移，落在本段内才传（并按段起点 rebase）
+          const rebasedCurrent = isCurrent && currentMatchStart != null
+            && currentMatchStart >= segStart && currentMatchStart < segEnd
+              ? currentMatchStart - segStart
+              : null;
+          nodes.push(
+            <HighlightText
+              key={key++}
+              text={block.value}
+              matches={segMatches}
+              currentMatchStart={rebasedCurrent}
+            />,
+          );
+        }
+        segStart = segEnd;
+      } else {
+        nodes.push(
+          <MentionChip
+            key={key++}
+            kind={block.kind}
+            label={block.label}
+            token={block.token}
+          />,
+        );
+        segStart += block.token.length;
+      }
+    }
+    return <>{nodes}</>;
   };
 
   return (
@@ -61,14 +113,10 @@ export function UserMessageGroup({ group, runStatus, nonEditableIds, voiceMessag
               ))}
             </div>
           )}
-          <Textarea
+          <MentionEditor
             ref={editingTextareaRef}
             value={editingContent}
-            onChange={(e) => {
-              onSetEditingContent(e.target.value);
-              const textarea = editingTextareaRef.current;
-              if (textarea) { textarea.style.height = "60px"; textarea.style.height = Math.min(textarea.scrollHeight, 200) + "px"; }
-            }}
+            onChange={onSetEditingContent}
             onKeyDown={(e) => {
               if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229) { e.preventDefault(); onConfirmEdit(); }
               if (e.key === "Escape") { onCancelEdit(); }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -260,6 +260,33 @@
   animation: fade-in 0.2s ease-out;
 }
 
+/* @提及内联块（输入框 contenteditable 与消息气泡共用） */
+.mention-chip {
+  vertical-align: baseline;
+}
+.mention-editor .mention-chip {
+  cursor: default;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.mention-editor:empty:before {
+  content: attr(data-placeholder);
+  color: hsl(var(--muted-foreground));
+  pointer-events: none;
+}
+.mention-editor {
+  outline: none;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.mention-editor::-webkit-scrollbar {
+  width: 6px;
+}
+.mention-editor::-webkit-scrollbar-thumb {
+  border-radius: 3px;
+  background: hsl(var(--muted-foreground) / 0.3);
+}
+
 /* 搜索高亮样式 */
 .search-highlight {
   background-color: hsl(50 80% 60% / 0.3);

--- a/frontend/src/utils/mentionBlocks.ts
+++ b/frontend/src/utils/mentionBlocks.ts
@@ -1,0 +1,110 @@
+/**
+ * @提及结构化块模型
+ *
+ * 把输入文本里的 @ 提及（@skill: / @mcp: / @<role> / @all）切分为原子块，
+ * 供输入框 contenteditable 编辑器与已发送消息气泡渲染成内联标签。
+ *
+ * 关键不变量（契约）：`serialize(parse(text)) === text`。
+ * 后端从不解析 @ 提及、原文直送模型，所以编辑器底层模型任何改动都必须能
+ * 序列化回与原来完全一致的字符串。
+ *
+ * 块边界规则（镜像 MessageInput 的 handleInputChange）：
+ *   - `@` 仅在位于 index 0 或前置字符为空白时才视为提及起点；
+ *   - 提及延伸到下一个空白或文末，无引号/转义。
+ */
+
+export type MentionKind = 'skill' | 'mcp' | 'agent' | 'all';
+
+export type Block =
+  | { type: 'text'; value: string }
+  | { type: 'mention'; token: string; kind: MentionKind; label: string };
+
+/** `@` 之后允许构成提及 token 的字符（不含空白）。 */
+const TOKEN_CHAR = /[^\s]/;
+
+/**
+ * 判定一个已捕获的提及 token 的类型与展示标签。
+ *
+ * - `@skill:<id>`：`<id>` ∈ `[a-z0-9][a-z0-9_-]*`（后端 normalize_skill_id 产物）
+ * - `@mcp:<name>`：取到下一空白，字符集不做强约束
+ * - `@all`：字面量
+ * - `@<role>`：`@[A-Za-z0-9_]+`（后端 validate_role_identifier）
+ *
+ * 不符合上述语法的 token 视为普通文本（返回 null），不渲染成块。
+ */
+export function classifyMention(token: string): { kind: MentionKind; label: string } | null {
+  // token 一定以 @ 开头
+  if (!token.startsWith('@')) return null;
+
+  if (token === '@all') return { kind: 'all', label: 'All' };
+
+  const mSkill = /^@skill:([a-z0-9][a-z0-9_-]*)$/.exec(token);
+  if (mSkill) return { kind: 'skill', label: mSkill[1] };
+
+  const mMcp = /^@mcp:(\S+)$/.exec(token);
+  if (mMcp) return { kind: 'mcp', label: mMcp[1] };
+
+  const mRole = /^@([A-Za-z0-9_]+)$/.exec(token);
+  if (mRole) return { kind: 'agent', label: mRole[1] };
+
+  return null;
+}
+
+/**
+ * 将纯文本切分为 text / mention 块序列。
+ *
+ * 扫描每个 `@`：仅当它位于 index 0 或前置字符为空白时尝试捕获一个 token，
+ * token 从 `@` 起延伸到下一个空白或文末；若 token 能被 {@link classifyMention}
+ * 识别，则作为一个 mention 块，否则当作普通文本继续。
+ */
+export function parseBlocks(text: string): Block[] {
+  const blocks: Block[] = [];
+  let buffer = '';
+  let i = 0;
+
+  const flush = () => {
+    if (buffer) {
+      blocks.push({ type: 'text', value: buffer });
+      buffer = '';
+    }
+  };
+
+  while (i < text.length) {
+    const ch = text[i];
+    const atStart = i === 0 || /\s/.test(text[i - 1]);
+    if (ch === '@' && atStart) {
+      // 捕获从 i 到下一个空白/文末的 token
+      let j = i + 1;
+      while (j < text.length && TOKEN_CHAR.test(text[j])) j++;
+      const token = text.slice(i, j);
+      const cls = classifyMention(token);
+      if (cls) {
+        flush();
+        blocks.push({ type: 'mention', token, kind: cls.kind, label: cls.label });
+        i = j;
+        continue;
+      }
+    }
+    buffer += ch;
+    i += 1;
+  }
+  flush();
+  return blocks;
+}
+
+/** 将块序列拼回字符串。保证 `serialize(parse(text)) === text`。 */
+export function serializeBlocks(blocks: Block[]): string {
+  let out = '';
+  for (const b of blocks) {
+    out += b.type === 'text' ? b.value : b.token;
+  }
+  return out;
+}
+
+/** 是否包含至少一个 mention 块（用于气泡决定走块渲染或纯文本路径）。 */
+export function hasMention(text: string): boolean {
+  for (const b of parseBlocks(text)) {
+    if (b.type === 'mention') return true;
+  }
+  return false;
+}

--- a/frontend/src/utils/mentionEditorModel.ts
+++ b/frontend/src/utils/mentionEditorModel.ts
@@ -1,0 +1,172 @@
+import { parseBlocks } from './mentionBlocks';
+
+export interface MentionBoundary {
+  start: number;
+  end: number;
+  leadingSeparatorStart: number | null;
+  trailingSeparatorEnd: number | null;
+}
+
+export type MentionKey = 'Backspace' | 'Delete' | 'ArrowLeft' | 'ArrowRight';
+
+export type MentionKeyAction =
+  | { type: 'move'; offset: number }
+  | { type: 'delete'; start: number; end: number; offset: number };
+
+export interface TextReplacement {
+  value: string;
+  offset: number;
+}
+
+export function getMentionBoundaries(text: string): MentionBoundary[] {
+  const boundaries: MentionBoundary[] = [];
+  let offset = 0;
+
+  for (const block of parseBlocks(text)) {
+    if (block.type === 'text') {
+      offset += block.value.length;
+      continue;
+    }
+
+    const start = offset;
+    const end = start + block.token.length;
+    boundaries.push({
+      start,
+      end,
+      leadingSeparatorStart: start > 0 && text[start - 1] === ' ' ? start - 1 : null,
+      trailingSeparatorEnd: text[end] === ' ' ? end + 1 : null,
+    });
+    offset = end;
+  }
+
+  return boundaries;
+}
+
+export function resolveMentionKeyAction(
+  text: string,
+  caret: number,
+  key: MentionKey,
+): MentionKeyAction | null {
+  if (caret < 0 || caret > text.length) return null;
+
+  const forward = key === 'Delete' || key === 'ArrowRight';
+  const boundary = getMentionBoundaries(text).find((item) => (
+    forward
+      ? caret === item.start || caret === item.leadingSeparatorStart
+      : caret === item.end || caret === item.trailingSeparatorEnd
+  ));
+  if (!boundary) return null;
+
+  if (key === 'ArrowLeft') {
+    return {
+      type: 'move',
+      offset: boundary.leadingSeparatorStart ?? boundary.start,
+    };
+  }
+  if (key === 'ArrowRight') {
+    return {
+      type: 'move',
+      offset: boundary.trailingSeparatorEnd ?? boundary.end,
+    };
+  }
+
+  let start = boundary.start;
+  let end = boundary.end;
+  if (boundary.trailingSeparatorEnd != null) {
+    end = boundary.trailingSeparatorEnd;
+    if (end === text.length && boundary.leadingSeparatorStart != null) {
+      start = boundary.leadingSeparatorStart;
+    }
+  } else if (boundary.leadingSeparatorStart != null) {
+    start = boundary.leadingSeparatorStart;
+  }
+
+  return { type: 'delete', start, end, offset: start };
+}
+
+export function deleteMentionSelection(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+): TextReplacement {
+  let start = Math.max(0, Math.min(selectionStart, selectionEnd, text.length));
+  let end = Math.max(0, Math.min(Math.max(selectionStart, selectionEnd), text.length));
+
+  if (start === end) return { value: text, offset: start };
+
+  for (const boundary of getMentionBoundaries(text)) {
+    if (start < boundary.end && end > boundary.start) {
+      start = Math.min(start, boundary.start);
+      end = Math.max(end, boundary.end);
+    }
+  }
+
+  if (start > 0 && end < text.length && text[start - 1] === ' ' && text[end] === ' ') {
+    end += 1;
+  }
+
+  return {
+    value: text.slice(0, start) + text.slice(end),
+    offset: start,
+  };
+}
+
+export function replaceMentionCompletion(
+  text: string,
+  mentionStart: number,
+  cursor: number,
+  token: string,
+): TextReplacement | null {
+  if (
+    mentionStart < 0
+    || mentionStart > text.length
+    || cursor < mentionStart
+    || cursor > text.length
+  ) return null;
+
+  return {
+    value: `${text.slice(0, mentionStart)}${token} ${text.slice(cursor)}`,
+    offset: mentionStart + token.length + 1,
+  };
+}
+
+export function insertTextAtMentionBoundary(
+  text: string,
+  caret: number,
+  insertedText: string,
+): TextReplacement | null {
+  if (caret < 0 || caret > text.length || insertedText.length === 0) return null;
+
+  const boundaries = getMentionBoundaries(text);
+  const atMentionBoundary = boundaries.some((boundary) => (
+    caret === boundary.start
+    || caret === boundary.end
+    || caret === boundary.leadingSeparatorStart
+    || caret === boundary.trailingSeparatorEnd
+  ));
+  if (!atMentionBoundary) return null;
+
+  const before = text.slice(0, caret);
+  const after = text.slice(caret);
+  const touchesMentionOnLeft = boundaries.some((boundary) => boundary.end === caret);
+  const touchesMentionOnRight = boundaries.some((boundary) => boundary.start === caret);
+  const leadingSeparator = touchesMentionOnLeft
+    && !/\s$/.test(before)
+    && !/^\s/.test(insertedText)
+    ? ' '
+    : '';
+  const trailingSeparator = touchesMentionOnRight
+    && !/\s$/.test(insertedText)
+    && !/^\s/.test(after)
+    ? ' '
+    : '';
+
+  return {
+    value: `${before}${leadingSeparator}${insertedText}${trailingSeparator}${after}`,
+    offset: caret + leadingSeparator.length + insertedText.length,
+  };
+}
+
+export function normalizePastedText(text: string): string {
+  return text.replace(/\r\n?/g, '\n');
+}


### PR DESCRIPTION
## 变更内容
- 在输入框、已发送消息和历史消息编辑中统一展示内联提及标签
- 修复提及选择后的光标位置、方向键跨越、整块删除和鼠标精确点击边界
- 修复连续提及之间输入中文时标签被破坏的问题
- 使用现有轻量测试覆盖提及规则和关键输入事件，不增加浏览器测试依赖

## 验证
- yarn test：186 项通过
- yarn build：通过
- 真实页面复验：连续提及间空格两侧点击后输入中文，两个标签均保持完整