### PR TITLE
feat(frontend): 优化定时任务消息呈现

### DIFF
--- a/crates/plugins/tiangong-plugin-scheduler/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-scheduler/src/handler.rs
@@ -100,9 +100,10 @@ impl SchedulerPlugin {
             updated_at: now,
         };
 
-        if let Err(e) = store.insert_job(&job) {
-            return io_error("写入任务", e);
-        }
+        let job = match store.insert_job(&job) {
+            Ok(job) => job,
+            Err(e) => return io_error("写入任务", e),
+        };
 
         let output = json!({
             "id": job.id,

--- a/crates/plugins/tiangong-plugin-scheduler/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-scheduler/src/handler.rs
@@ -363,8 +363,8 @@ impl ToolSpecProvider for SchedulerPlugin {
                 input_schema: json!({
                     "type": "object",
                     "properties": {
-                        "name": { "type": "string", "description": "任务名称（单行，不可包含换行）" },
-                        "description": { "type": "string", "description": "任务描述（单行，不可包含换行）" },
+                        "name": { "type": "string", "description": "任务名称" },
+                        "description": { "type": "string", "description": "任务描述" },
                         "schedule": { "type": "string", "description": "Cron 表达式（6 字段：秒 分 时 日 月 周），如 '0 0 9 * * *' 表示每天 9 点" },
                         "payload": { "type": "string", "description": "触发时发送给 LLM 的任务描述" },
                         "session_id": { "type": "string", "description": "关联已有会话 ID（可选，不指定则首次触发时自动创建新会话）" },
@@ -385,8 +385,8 @@ impl ToolSpecProvider for SchedulerPlugin {
                     "type": "object",
                     "properties": {
                         "id": { "type": "string", "description": "任务 ID" },
-                        "name": { "type": "string", "description": "任务名称（单行，不可包含换行）" },
-                        "description": { "type": "string", "description": "任务描述（单行，不可包含换行）" },
+                        "name": { "type": "string", "description": "任务名称" },
+                        "description": { "type": "string", "description": "任务描述" },
                         "schedule": { "type": "string", "description": "Cron 表达式（6 字段：秒 分 时 日 月 周）" },
                         "payload": { "type": "string", "description": "触发时发送给 LLM 的任务描述" },
                         "session_id": { "type": "string", "description": "关联会话 ID" },

--- a/crates/plugins/tiangong-plugin-scheduler/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-scheduler/src/handler.rs
@@ -363,8 +363,8 @@ impl ToolSpecProvider for SchedulerPlugin {
                 input_schema: json!({
                     "type": "object",
                     "properties": {
-                        "name": { "type": "string", "description": "任务名称" },
-                        "description": { "type": "string", "description": "任务描述" },
+                        "name": { "type": "string", "description": "任务名称（单行，不可包含换行）" },
+                        "description": { "type": "string", "description": "任务描述（单行，不可包含换行）" },
                         "schedule": { "type": "string", "description": "Cron 表达式（6 字段：秒 分 时 日 月 周），如 '0 0 9 * * *' 表示每天 9 点" },
                         "payload": { "type": "string", "description": "触发时发送给 LLM 的任务描述" },
                         "session_id": { "type": "string", "description": "关联已有会话 ID（可选，不指定则首次触发时自动创建新会话）" },
@@ -385,8 +385,8 @@ impl ToolSpecProvider for SchedulerPlugin {
                     "type": "object",
                     "properties": {
                         "id": { "type": "string", "description": "任务 ID" },
-                        "name": { "type": "string", "description": "任务名称" },
-                        "description": { "type": "string", "description": "任务描述" },
+                        "name": { "type": "string", "description": "任务名称（单行，不可包含换行）" },
+                        "description": { "type": "string", "description": "任务描述（单行，不可包含换行）" },
                         "schedule": { "type": "string", "description": "Cron 表达式（6 字段：秒 分 时 日 月 周）" },
                         "payload": { "type": "string", "description": "触发时发送给 LLM 的任务描述" },
                         "session_id": { "type": "string", "description": "关联会话 ID" },

--- a/crates/tiangong-scheduler/src/model.rs
+++ b/crates/tiangong-scheduler/src/model.rs
@@ -20,9 +20,7 @@ pub enum JobRunStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Job {
     pub id: String,
-    /// 单行任务名称，用于构造可识别的触发消息。
     pub name: String,
-    /// 单行任务描述，用于构造可识别的触发消息。
     pub description: String,
     pub trigger_type: TriggerType,
     /// Cron 表达式
@@ -42,9 +40,7 @@ pub struct Job {
 /// 创建 Job 请求
 #[derive(Debug, Deserialize)]
 pub struct CreateJobRequest {
-    /// 单行任务名称。
     pub name: String,
-    /// 单行任务描述。
     pub description: String,
     pub trigger_type: TriggerType,
     #[serde(default)]
@@ -60,10 +56,8 @@ pub struct CreateJobRequest {
 #[derive(Debug, Default, Deserialize)]
 pub struct UpdateJobRequest {
     #[serde(default)]
-    /// 单行任务名称。
     pub name: Option<String>,
     #[serde(default)]
-    /// 单行任务描述。
     pub description: Option<String>,
     #[serde(default)]
     pub schedule: Option<String>,

--- a/crates/tiangong-scheduler/src/model.rs
+++ b/crates/tiangong-scheduler/src/model.rs
@@ -20,7 +20,9 @@ pub enum JobRunStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Job {
     pub id: String,
+    /// 单行任务名称，用于构造可识别的触发消息。
     pub name: String,
+    /// 单行任务描述，用于构造可识别的触发消息。
     pub description: String,
     pub trigger_type: TriggerType,
     /// Cron 表达式
@@ -40,7 +42,9 @@ pub struct Job {
 /// 创建 Job 请求
 #[derive(Debug, Deserialize)]
 pub struct CreateJobRequest {
+    /// 单行任务名称。
     pub name: String,
+    /// 单行任务描述。
     pub description: String,
     pub trigger_type: TriggerType,
     #[serde(default)]
@@ -56,8 +60,10 @@ pub struct CreateJobRequest {
 #[derive(Debug, Default, Deserialize)]
 pub struct UpdateJobRequest {
     #[serde(default)]
+    /// 单行任务名称。
     pub name: Option<String>,
     #[serde(default)]
+    /// 单行任务描述。
     pub description: Option<String>,
     #[serde(default)]
     pub schedule: Option<String>,

--- a/crates/tiangong-scheduler/src/store.rs
+++ b/crates/tiangong-scheduler/src/store.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 use super::model::{Job, JobRun, JobRunStatus, UpdateJobRequest};
 
@@ -39,6 +39,7 @@ impl JobStore {
     // ── Job CRUD ──────────────────────────────────────────────────
 
     pub fn insert_job(&self, job: &Job) -> Result<()> {
+        validate_job_display_fields(&job.name, &job.description)?;
         let mut jobs = self.load_jobs()?;
         jobs.push(job.clone());
         self.save_jobs(&jobs)
@@ -68,6 +69,12 @@ impl JobStore {
         let Some(job) = jobs.iter_mut().find(|j| j.id == id) else {
             return Ok(false);
         };
+        if let Some(name) = req.name.as_deref() {
+            validate_single_line("任务名称", name)?;
+        }
+        if let Some(description) = req.description.as_deref() {
+            validate_single_line("任务描述", description)?;
+        }
         job.updated_at = now;
         if let Some(ref v) = req.name {
             job.name = v.clone();
@@ -184,6 +191,20 @@ impl JobStore {
         atomic_write(&path, &content).with_context(|| format!("写入 {} 失败", path.display()))?;
         Ok(())
     }
+}
+
+fn validate_job_display_fields(name: &str, description: &str) -> Result<()> {
+    for (field, value) in [("任务名称", name), ("任务描述", description)] {
+        validate_single_line(field, value)?;
+    }
+    Ok(())
+}
+
+fn validate_single_line(field: &str, value: &str) -> Result<()> {
+    if value.contains('\n') || value.contains('\r') {
+        bail!("{field}不能包含换行符");
+    }
+    Ok(())
 }
 
 fn scheduler_dir() -> PathBuf {

--- a/crates/tiangong-scheduler/src/store.rs
+++ b/crates/tiangong-scheduler/src/store.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 
 use super::model::{Job, JobRun, JobRunStatus, UpdateJobRequest};
 
@@ -39,7 +39,6 @@ impl JobStore {
     // ── Job CRUD ──────────────────────────────────────────────────
 
     pub fn insert_job(&self, job: &Job) -> Result<()> {
-        validate_job_display_fields(&job.name, &job.description)?;
         let mut jobs = self.load_jobs()?;
         jobs.push(job.clone());
         self.save_jobs(&jobs)
@@ -69,12 +68,6 @@ impl JobStore {
         let Some(job) = jobs.iter_mut().find(|j| j.id == id) else {
             return Ok(false);
         };
-        if let Some(name) = req.name.as_deref() {
-            validate_single_line("任务名称", name)?;
-        }
-        if let Some(description) = req.description.as_deref() {
-            validate_single_line("任务描述", description)?;
-        }
         job.updated_at = now;
         if let Some(ref v) = req.name {
             job.name = v.clone();
@@ -191,20 +184,6 @@ impl JobStore {
         atomic_write(&path, &content).with_context(|| format!("写入 {} 失败", path.display()))?;
         Ok(())
     }
-}
-
-fn validate_job_display_fields(name: &str, description: &str) -> Result<()> {
-    for (field, value) in [("任务名称", name), ("任务描述", description)] {
-        validate_single_line(field, value)?;
-    }
-    Ok(())
-}
-
-fn validate_single_line(field: &str, value: &str) -> Result<()> {
-    if value.contains('\n') || value.contains('\r') {
-        bail!("{field}不能包含换行符");
-    }
-    Ok(())
 }
 
 fn scheduler_dir() -> PathBuf {

--- a/crates/tiangong-scheduler/src/store.rs
+++ b/crates/tiangong-scheduler/src/store.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 use super::model::{Job, JobRun, JobRunStatus, UpdateJobRequest};
 
@@ -38,10 +38,14 @@ impl JobStore {
 
     // ── Job CRUD ──────────────────────────────────────────────────
 
-    pub fn insert_job(&self, job: &Job) -> Result<()> {
+    pub fn insert_job(&self, job: &Job) -> Result<Job> {
+        let mut job = job.clone();
+        job.name = normalize_required_single_line("任务名称", &job.name)?;
+        job.description = normalize_required_single_line("任务描述", &job.description)?;
         let mut jobs = self.load_jobs()?;
         jobs.push(job.clone());
-        self.save_jobs(&jobs)
+        self.save_jobs(&jobs)?;
+        Ok(job)
     }
 
     pub fn get_job(&self, id: &str) -> Result<Option<Job>> {
@@ -68,12 +72,22 @@ impl JobStore {
         let Some(job) = jobs.iter_mut().find(|j| j.id == id) else {
             return Ok(false);
         };
+        let name = req
+            .name
+            .as_deref()
+            .map(|value| normalize_required_single_line("任务名称", value))
+            .transpose()?;
+        let description = req
+            .description
+            .as_deref()
+            .map(|value| normalize_required_single_line("任务描述", value))
+            .transpose()?;
         job.updated_at = now;
-        if let Some(ref v) = req.name {
-            job.name = v.clone();
+        if let Some(v) = name {
+            job.name = v;
         }
-        if let Some(ref v) = req.description {
-            job.description = v.clone();
+        if let Some(v) = description {
+            job.description = v;
         }
         if let Some(ref v) = req.schedule {
             job.schedule = Some(v.clone());
@@ -184,6 +198,21 @@ impl JobStore {
         atomic_write(&path, &content).with_context(|| format!("写入 {} 失败", path.display()))?;
         Ok(())
     }
+}
+
+fn normalize_required_single_line(field: &str, value: &str) -> Result<String> {
+    let normalized = value
+        .split(['\r', '\n'])
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    if normalized.is_empty() {
+        bail!("{field}不能为空");
+    }
+
+    Ok(normalized)
 }
 
 fn scheduler_dir() -> PathBuf {

--- a/crates/tiangong-scheduler/tests/store_test.rs
+++ b/crates/tiangong-scheduler/tests/store_test.rs
@@ -27,13 +27,67 @@ fn sample_job(id: &str) -> Job {
 #[test]
 fn insert_and_get_job() {
     let (_dir, store) = setup();
-    let job = sample_job("job-1");
-    store.insert_job(&job).unwrap();
+    let mut job = sample_job("job-1");
+    job.name = "  第一行\r\n第二行\n\n第三行  ".to_string();
+    job.description = " 描述一\r描述二 ".to_string();
+    job.payload = "执行第一行\r\n执行第二行".to_string();
+    let saved = store.insert_job(&job).unwrap();
+
+    assert_eq!(saved.name, "第一行 第二行 第三行");
+    assert_eq!(saved.description, "描述一 描述二");
+    assert_eq!(saved.payload, "执行第一行\r\n执行第二行");
 
     let got = store.get_job("job-1").unwrap().unwrap();
     assert_eq!(got.id, "job-1");
-    assert_eq!(got.name, "测试任务");
+    assert_eq!(got.name, "第一行 第二行 第三行");
+    assert_eq!(got.description, "描述一 描述二");
+    assert_eq!(got.payload, "执行第一行\r\n执行第二行");
     assert!(got.session_id.is_none());
+
+    let mut empty_job = sample_job("empty-name");
+    empty_job.name = " \r\n ".to_string();
+    let error = store.insert_job(&empty_job).unwrap_err().to_string();
+    assert!(error.contains("任务名称"), "错误应指出空字段：{error}");
+}
+
+#[test]
+fn update_job_normalizes_display_fields_without_changing_payload() {
+    let (_dir, store) = setup();
+    store
+        .insert_job(&sample_job("job-normalize-update"))
+        .unwrap();
+
+    store
+        .update_job(
+            "job-normalize-update",
+            &UpdateJobRequest {
+                name: Some(" 新版\n任务 ".to_string()),
+                description: Some(" 描述一\r\n\r描述二 ".to_string()),
+                payload: Some("执行第一行\n执行第二行".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    let job = store.get_job("job-normalize-update").unwrap().unwrap();
+    assert_eq!(job.name, "新版 任务");
+    assert_eq!(job.description, "描述一 描述二");
+    assert_eq!(job.payload, "执行第一行\n执行第二行");
+
+    let error = store
+        .update_job(
+            "job-normalize-update",
+            &UpdateJobRequest {
+                description: Some(" \n\r ".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("任务描述"), "错误应指出空字段：{error}");
+
+    let job = store.get_job("job-normalize-update").unwrap().unwrap();
+    assert_eq!(job.description, "描述一 描述二");
 }
 
 #[test]

--- a/crates/tiangong-scheduler/tests/store_test.rs
+++ b/crates/tiangong-scheduler/tests/store_test.rs
@@ -37,6 +37,31 @@ fn insert_and_get_job() {
 }
 
 #[test]
+fn insert_job_rejects_multiline_name_and_description() {
+    let (_dir, store) = setup();
+
+    for (id, name, description, field) in [
+        ("multiline-name", "第一行\n第二行", "测试描述", "任务名称"),
+        (
+            "multiline-description",
+            "测试任务",
+            "第一行\r\n第二行",
+            "任务描述",
+        ),
+    ] {
+        let mut job = sample_job(id);
+        job.name = name.to_string();
+        job.description = description.to_string();
+
+        let error = store.insert_job(&job).unwrap_err().to_string();
+        assert!(error.contains(field), "错误应指出非法字段：{error}");
+        assert!(error.contains("换行"), "错误应说明换行限制：{error}");
+    }
+
+    assert!(store.list_jobs().unwrap().is_empty());
+}
+
+#[test]
 fn update_session_id_persists() {
     let (_dir, store) = setup();
     let job = sample_job("job-2");
@@ -57,6 +82,42 @@ fn update_session_id_persists() {
     let store2 = JobStore::open_at(PathBuf::from(_dir.path())).unwrap();
     let got = store2.get_job("job-2").unwrap().unwrap();
     assert_eq!(got.session_id.as_deref(), Some("session-abc"));
+}
+
+#[test]
+fn update_job_rejects_multiline_name_and_description() {
+    let (_dir, store) = setup();
+    store
+        .insert_job(&sample_job("job-multiline-update"))
+        .unwrap();
+
+    for (req, field) in [
+        (
+            UpdateJobRequest {
+                name: Some("第一行\n第二行".to_string()),
+                ..Default::default()
+            },
+            "任务名称",
+        ),
+        (
+            UpdateJobRequest {
+                description: Some("第一行\r\n第二行".to_string()),
+                ..Default::default()
+            },
+            "任务描述",
+        ),
+    ] {
+        let error = store
+            .update_job("job-multiline-update", &req)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(field), "错误应指出非法字段：{error}");
+        assert!(error.contains("换行"), "错误应说明换行限制：{error}");
+    }
+
+    let job = store.get_job("job-multiline-update").unwrap().unwrap();
+    assert_eq!(job.name, "测试任务");
+    assert_eq!(job.description, "测试描述");
 }
 
 #[test]

--- a/crates/tiangong-scheduler/tests/store_test.rs
+++ b/crates/tiangong-scheduler/tests/store_test.rs
@@ -37,31 +37,6 @@ fn insert_and_get_job() {
 }
 
 #[test]
-fn insert_job_rejects_multiline_name_and_description() {
-    let (_dir, store) = setup();
-
-    for (id, name, description, field) in [
-        ("multiline-name", "第一行\n第二行", "测试描述", "任务名称"),
-        (
-            "multiline-description",
-            "测试任务",
-            "第一行\r\n第二行",
-            "任务描述",
-        ),
-    ] {
-        let mut job = sample_job(id);
-        job.name = name.to_string();
-        job.description = description.to_string();
-
-        let error = store.insert_job(&job).unwrap_err().to_string();
-        assert!(error.contains(field), "错误应指出非法字段：{error}");
-        assert!(error.contains("换行"), "错误应说明换行限制：{error}");
-    }
-
-    assert!(store.list_jobs().unwrap().is_empty());
-}
-
-#[test]
 fn update_session_id_persists() {
     let (_dir, store) = setup();
     let job = sample_job("job-2");
@@ -82,42 +57,6 @@ fn update_session_id_persists() {
     let store2 = JobStore::open_at(PathBuf::from(_dir.path())).unwrap();
     let got = store2.get_job("job-2").unwrap().unwrap();
     assert_eq!(got.session_id.as_deref(), Some("session-abc"));
-}
-
-#[test]
-fn update_job_rejects_multiline_name_and_description() {
-    let (_dir, store) = setup();
-    store
-        .insert_job(&sample_job("job-multiline-update"))
-        .unwrap();
-
-    for (req, field) in [
-        (
-            UpdateJobRequest {
-                name: Some("第一行\n第二行".to_string()),
-                ..Default::default()
-            },
-            "任务名称",
-        ),
-        (
-            UpdateJobRequest {
-                description: Some("第一行\r\n第二行".to_string()),
-                ..Default::default()
-            },
-            "任务描述",
-        ),
-    ] {
-        let error = store
-            .update_job("job-multiline-update", &req)
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains(field), "错误应指出非法字段：{error}");
-        assert!(error.contains("换行"), "错误应说明换行限制：{error}");
-    }
-
-    let job = store.get_job("job-multiline-update").unwrap().unwrap();
-    assert_eq!(job.name, "测试任务");
-    assert_eq!(job.description, "测试描述");
 }
 
 #[test]

--- a/crates/tiangong-server/src/api/jobs.rs
+++ b/crates/tiangong-server/src/api/jobs.rs
@@ -50,7 +50,7 @@ pub async fn create_job(mut req: Request) -> Result<Response> {
     };
 
     let store = open_store()?;
-    store.insert_job(&job).map_err(|e| {
+    let job = store.insert_job(&job).map_err(|e| {
         SilentError::business_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("创建任务失败：{e}"),

--- a/frontend/src/__tests__/scheduledTaskMessage.test.tsx
+++ b/frontend/src/__tests__/scheduledTaskMessage.test.tsx
@@ -3,6 +3,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Message } from '@/api/tauri';
+import type { MentionEditorHandle } from '@/components/MentionEditor';
 import { UserMessageGroup } from '@/components/message/UserMessageGroup';
 import type { MessageGroup } from '@/components/message/types';
 import { useSearchStore } from '@/store/useSearchStore';
@@ -152,7 +153,7 @@ describe('定时任务消息展示与编辑保护', () => {
           editingMessageId="scheduled-message"
           editingContent={UNIX_MESSAGE}
           editingAttachments={[]}
-          editingTextareaRef={createRef<HTMLTextAreaElement>()}
+          editingTextareaRef={createRef<MentionEditorHandle>()}
           onStartEdit={onStartEdit}
           onConfirmEdit={vi.fn()}
           onCancelEdit={vi.fn()}
@@ -189,7 +190,7 @@ describe('定时任务消息展示与编辑保护', () => {
           editingMessageId={null}
           editingContent=""
           editingAttachments={[]}
-          editingTextareaRef={createRef<HTMLTextAreaElement>()}
+          editingTextareaRef={createRef<MentionEditorHandle>()}
           onStartEdit={vi.fn()}
           onConfirmEdit={vi.fn()}
           onCancelEdit={vi.fn()}
@@ -202,5 +203,48 @@ describe('定时任务消息展示与编辑保护', () => {
     });
 
     expect(container.textContent).toContain('无执行内容');
+  });
+
+  it('执行内容中的提及保持标签展示，并正确高亮其后的搜索结果', async () => {
+    const text = [
+      '[定时任务触发]',
+      '任务名称：夜间巡检',
+      '任务描述：检查服务状态',
+      '',
+      '请 @dev 处理巡检',
+    ].join('\n');
+    const query = '处理巡检';
+
+    useSearchStore.setState({
+      searchQuery: query,
+      currentMessageId: 'scheduled-message',
+      currentMatchStart: text.indexOf(query),
+      caseSensitive: false,
+    });
+
+    await act(async () => {
+      root.render(
+        <UserMessageGroup
+          group={group(text)}
+          runStatus="idle"
+          nonEditableIds={new Set()}
+          voiceMessages={{}}
+          editingMessageId={null}
+          editingContent=""
+          editingAttachments={[]}
+          editingTextareaRef={createRef<MentionEditorHandle>()}
+          onStartEdit={vi.fn()}
+          onConfirmEdit={vi.fn()}
+          onCancelEdit={vi.fn()}
+          onSetEditingContent={vi.fn()}
+          onSetEditingAttachments={vi.fn()}
+          onAttachFiles={vi.fn()}
+          onEditPaste={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.querySelector('[data-mention-token="@dev"]')).not.toBeNull();
+    expect(container.querySelector('.search-highlight-current')?.textContent).toBe(query);
   });
 });

--- a/frontend/src/__tests__/scheduledTaskMessage.test.tsx
+++ b/frontend/src/__tests__/scheduledTaskMessage.test.tsx
@@ -1,0 +1,206 @@
+import { act, createRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Message } from '@/api/tauri';
+import { UserMessageGroup } from '@/components/message/UserMessageGroup';
+import type { MessageGroup } from '@/components/message/types';
+import { useSearchStore } from '@/store/useSearchStore';
+import { findSearchMatches } from '@/utils/search';
+import { parseScheduledTaskMessage } from '@/utils/scheduledTaskMessage';
+
+const UNIX_MESSAGE = [
+  '[定时任务触发]',
+  '任务名称：夜间巡检',
+  '任务描述：检查服务状态',
+  '',
+  '读取监控数据',
+  '重启异常实例',
+].join('\n');
+
+function message(text: string): Message {
+  return {
+    id: 'scheduled-message',
+    role: 'user',
+    content: [{ type: 'text', text }],
+    reasoning_content: '',
+    phase: 'normal',
+    created_at: '2026-07-28 22:00:00',
+  };
+}
+
+function group(text: string): MessageGroup {
+  return {
+    key: 'scheduled-message',
+    type: 'user',
+    messages: [message(text)],
+  };
+}
+
+describe('定时任务消息解析与搜索', () => {
+  it('解析 Unix 换行和多行执行内容，并保留原文位置', () => {
+    expect(parseScheduledTaskMessage(UNIX_MESSAGE)).toEqual({
+      name: '夜间巡检',
+      description: '检查服务状态',
+      payload: '读取监控数据\n重启异常实例',
+      offsets: {
+        name: UNIX_MESSAGE.indexOf('夜间巡检'),
+        description: UNIX_MESSAGE.indexOf('检查服务状态'),
+        payload: UNIX_MESSAGE.indexOf('读取监控数据'),
+      },
+    });
+  });
+
+  it('解析 Windows 换行并保留多行内容', () => {
+    const text = [
+      '[定时任务触发]',
+      '任务名称：Windows 巡检',
+      '任务描述：检查磁盘',
+      '',
+      '第一行',
+      '第二行',
+    ].join('\r\n');
+
+    expect(parseScheduledTaskMessage(text)).toEqual({
+      name: 'Windows 巡检',
+      description: '检查磁盘',
+      payload: '第一行\r\n第二行',
+      offsets: {
+        name: text.indexOf('Windows 巡检'),
+        description: text.indexOf('检查磁盘'),
+        payload: text.indexOf('第一行'),
+      },
+    });
+  });
+
+  it('允许名称、描述和执行内容为空', () => {
+    const text = '[定时任务触发]\n任务名称：\n任务描述：\n\n';
+
+    expect(parseScheduledTaskMessage(text)).toMatchObject({
+      name: '',
+      description: '',
+      payload: '',
+    });
+  });
+
+  it.each([
+    '[定时任务触发] 只是普通文本',
+    '[定时任务触发中]\n任务名称：巡检\n任务描述：说明\n\n内容',
+    '[定时任务触发]\n名称：巡检\n任务描述：说明\n\n内容',
+    '[定时任务触发]\n任务名称：巡检\n任务描述：说明\n内容',
+  ])('不把格式相似的普通消息识别为定时任务：%s', (text) => {
+    expect(parseScheduledTaskMessage(text)).toBeNull();
+  });
+
+  it.each([
+    ['夜间巡检', 'name'],
+    ['检查服务状态', 'description'],
+    ['重启异常实例', 'payload'],
+  ] as const)('搜索命中%s时返回原消息中的准确位置', (query, section) => {
+    const parsed = parseScheduledTaskMessage(UNIX_MESSAGE)!;
+    const sourceOffset = parsed.offsets[section];
+    const localOffset = parsed[section].indexOf(query);
+    const matches = findSearchMatches(
+      [message(UNIX_MESSAGE)],
+      query,
+      [{ messages: [{ id: 'scheduled-message' }] }],
+      'messages',
+    );
+
+    expect(matches).toEqual([{
+      messageId: 'scheduled-message',
+      groupIndex: 0,
+      start: sourceOffset + localOffset,
+      end: sourceOffset + localOffset + query.length,
+    }]);
+  });
+});
+
+describe('定时任务消息展示与编辑保护', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    useSearchStore.setState({
+      searchQuery: '',
+      currentMessageId: null,
+      currentMatchStart: null,
+      caseSensitive: false,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('使用专用内容展示，并在外部要求编辑时仍不进入编辑状态', async () => {
+    const onStartEdit = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <UserMessageGroup
+          group={group(UNIX_MESSAGE)}
+          runStatus="idle"
+          nonEditableIds={new Set()}
+          voiceMessages={{}}
+          editingMessageId="scheduled-message"
+          editingContent={UNIX_MESSAGE}
+          editingAttachments={[]}
+          editingTextareaRef={createRef<HTMLTextAreaElement>()}
+          onStartEdit={onStartEdit}
+          onConfirmEdit={vi.fn()}
+          onCancelEdit={vi.fn()}
+          onSetEditingContent={vi.fn()}
+          onSetEditingAttachments={vi.fn()}
+          onAttachFiles={vi.fn()}
+          onEditPaste={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('定时任务');
+    expect(container.textContent).toContain('夜间巡检');
+    expect(container.textContent).toContain('检查服务状态');
+    expect(container.textContent).toContain('读取监控数据');
+    expect(container.textContent).toContain('重启异常实例');
+    expect(container.textContent).not.toContain('[定时任务触发]');
+    expect(container.querySelector('textarea')).toBeNull();
+    expect(container.querySelector('button[title="编辑并重发"]')).toBeNull();
+    expect(container.querySelector('button[title="复制"]')).not.toBeNull();
+    expect(onStartEdit).not.toHaveBeenCalled();
+  });
+
+  it('空执行内容显示明确占位', async () => {
+    const text = '[定时任务触发]\n任务名称：空任务\n任务描述：\n\n';
+
+    await act(async () => {
+      root.render(
+        <UserMessageGroup
+          group={group(text)}
+          runStatus="idle"
+          nonEditableIds={new Set()}
+          voiceMessages={{}}
+          editingMessageId={null}
+          editingContent=""
+          editingAttachments={[]}
+          editingTextareaRef={createRef<HTMLTextAreaElement>()}
+          onStartEdit={vi.fn()}
+          onConfirmEdit={vi.fn()}
+          onCancelEdit={vi.fn()}
+          onSetEditingContent={vi.fn()}
+          onSetEditingAttachments={vi.fn()}
+          onAttachFiles={vi.fn()}
+          onEditPaste={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('无执行内容');
+  });
+});

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -26,6 +26,7 @@ import {
   attachmentsFromContentBlocks,
   estimatedBase64Size,
 } from '@/utils/attachments';
+import { parseScheduledTaskMessage } from '@/utils/scheduledTaskMessage';
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
@@ -258,6 +259,18 @@ export function MessageList() {
       if (group.type === "user") {
         const msg = group.messages[0];
         const hasMedia = msg.media?.length || hasMediaBlocks(msg);
+        const scheduledTask = parseScheduledTaskMessage(textContent(msg));
+        if (scheduledTask) {
+          const textLength = scheduledTask.name.length
+            + scheduledTask.description.length
+            + scheduledTask.payload.length;
+          const explicitLines = scheduledTask.payload.split(/\r?\n/).length;
+          const contentHeight = Math.min(
+            Math.max(explicitLines, Math.ceil(textLength / 48)) * 20,
+            360,
+          );
+          return 140 + contentHeight + (hasMedia ? 220 : 0);
+        }
         return hasMedia ? 300 : 80;
       }
       if (group.type === "worker") return 120;
@@ -467,12 +480,13 @@ export function MessageList() {
   // 编辑相关回调
   const handleStartEdit = useCallback((messageId: string, text: string) => {
     if (runStatus !== "idle" || !activeSessionId) return;
+    const msg = messages.find(m => m.id === messageId);
+    if (msg && parseScheduledTaskMessage(textContent(msg))) return;
     setEditingMessageId(messageId);
     setEditingSessionId(activeSessionId);
     setEditingContent(text);
     editingRevisionRef.current = 0;
     editingGenerationRef.current += 1;
-    const msg = messages.find(m => m.id === messageId);
     if (msg) {
       editingBaseContentRef.current = msg.content.map((block) => structuredClone(block));
       const mediaAttachments = attachmentsFromContentBlocks(
@@ -636,7 +650,9 @@ export function MessageList() {
   const userPreviews = useMemo(
     () => userGroupIndices.map(idx => {
       const raw = textContent(completedGroups[idx].messages[0]);
-      return (raw.length > 15 ? raw.slice(0, 15) + '...' : raw) || '(空消息)';
+      const scheduledTask = parseScheduledTaskMessage(raw);
+      const preview = scheduledTask ? `定时：${scheduledTask.name || '未命名任务'}` : raw;
+      return (preview.length > 15 ? preview.slice(0, 15) + '...' : preview) || '(空消息)';
     }),
     [userGroupIndices, completedGroups],
   );

--- a/frontend/src/components/message/UserMessageActions.tsx
+++ b/frontend/src/components/message/UserMessageActions.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { Pencil, Copy, Check } from "lucide-react";
 
-export function UserMessageActions({ text, messageId, runStatus, canEdit, onStartEdit }: {
+export function UserMessageActions({ text, messageId, runStatus, canEdit, showEdit = true, onStartEdit }: {
   text: string; messageId: string; runStatus: string; canEdit: boolean;
+  showEdit?: boolean;
   onStartEdit: (messageId: string, text: string) => void;
 }) {
   const [copied, setCopied] = useState(false);
@@ -17,9 +18,11 @@ export function UserMessageActions({ text, messageId, runStatus, canEdit, onStar
       <button onClick={handleCopy} className={btnClass} title={copied ? "已复制" : "复制"}>
         {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
       </button>
-      <button onClick={() => onStartEdit(messageId, text)} className={`${btnClass} ${(!idle || !canEdit) ? 'opacity-30 cursor-not-allowed' : ''}`} title={!canEdit ? "已压缩消息无法编辑" : !idle ? "执行中无法编辑" : "编辑并重发"} disabled={!idle || !canEdit}>
-        <Pencil className="w-3.5 h-3.5" />
-      </button>
+      {showEdit && (
+        <button onClick={() => onStartEdit(messageId, text)} className={`${btnClass} ${(!idle || !canEdit) ? 'opacity-30 cursor-not-allowed' : ''}`} title={!canEdit ? "已压缩消息无法编辑" : !idle ? "执行中无法编辑" : "编辑并重发"} disabled={!idle || !canEdit}>
+          <Pencil className="w-3.5 h-3.5" />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/message/UserMessageGroup.tsx
+++ b/frontend/src/components/message/UserMessageGroup.tsx
@@ -3,8 +3,9 @@ import { findTextOccurrences } from "@/utils/search";
 import { HighlightText } from "../HighlightText";
 import { MentionChip } from "../MentionChip";
 import { MentionEditor, type MentionEditorHandle } from "../MentionEditor";
-import { X, Paperclip } from "lucide-react";
+import { Clock3, X, Paperclip } from "lucide-react";
 import { resolveAttachmentUrl, type Attachment } from "@/utils/attachments";
+import { parseScheduledTaskMessage } from "@/utils/scheduledTaskMessage";
 import { textContent } from "@/api/tauri";
 import { hasMention, parseBlocks } from "@/utils/mentionBlocks";
 import { formatMessageTime } from "./utils";
@@ -31,26 +32,34 @@ export function UserMessageGroup({ group, runStatus, nonEditableIds, voiceMessag
   onEditPaste: (e: React.ClipboardEvent<HTMLDivElement>) => void;
 }) {
   const message = group.messages[0];
+  const messageText = textContent(message);
+  const scheduledTask = parseScheduledTaskMessage(messageText);
   const voiceInfo = voiceMessages[message.id];
-  const isEditing = editingMessageId === message.id;
+  const isEditing = editingMessageId === message.id && !scheduledTask;
   const searchQuery = useSearchStore((s) => s.searchQuery);
   const currentMessageId = useSearchStore((s) => s.currentMessageId);
   const currentMatchStart = useSearchStore((s) => s.currentMatchStart);
   const caseSensitive = useSearchStore((s) => s.caseSensitive);
 
-  const renderUserText = (text: string) => {
+  const renderUserText = (text: string, sourceOffset = 0) => {
+    const isCurrent = message.id === currentMessageId;
+    const localCurrentMatch = isCurrent
+      && currentMatchStart !== null
+      && currentMatchStart >= sourceOffset
+      && currentMatchStart < sourceOffset + text.length
+      ? currentMatchStart - sourceOffset
+      : null;
+
     // 无提及：走原有纯文本 / 高亮路径，行为完全不变
     if (!hasMention(text)) {
       if (!searchQuery) return text;
       const occurrences = findTextOccurrences(text, searchQuery, caseSensitive);
       if (occurrences.length === 0) return text;
-      const isCurrent = message.id === currentMessageId;
-      return <HighlightText text={text} matches={occurrences} currentMatchStart={isCurrent ? currentMatchStart : null} />;
+      return <HighlightText text={text} matches={occurrences} currentMatchStart={localCurrentMatch} />;
     }
 
     // 有提及：按块分段渲染。搜索高亮的 offset 空间仍是原始字符串，
     // 因此对每个 text 段切分其在全串中的匹配，保留既有高亮语义。
-    const isCurrent = message.id === currentMessageId;
     const allOccurrences = searchQuery
       ? findTextOccurrences(text, searchQuery, caseSensitive)
       : [];
@@ -66,10 +75,10 @@ export function UserMessageGroup({ group, runStatus, nonEditableIds, voiceMessag
         if (segMatches.length === 0) {
           nodes.push(<span key={key++}>{block.value}</span>);
         } else {
-          // currentMatchStart 是全串偏移，落在本段内才传（并按段起点 rebase）
-          const rebasedCurrent = isCurrent && currentMatchStart != null
-            && currentMatchStart >= segStart && currentMatchStart < segEnd
-              ? currentMatchStart - segStart
+          // 当前搜索位置已换算到本分区，落在本段内时再按段起点换算。
+          const rebasedCurrent = localCurrentMatch != null
+            && localCurrentMatch >= segStart && localCurrentMatch < segEnd
+              ? localCurrentMatch - segStart
               : null;
           nodes.push(
             <HighlightText
@@ -140,21 +149,53 @@ export function UserMessageGroup({ group, runStatus, nonEditableIds, voiceMessag
         </div>
       ) : (
         <div className="flex justify-end" title={formatMessageTime(message.created_at)}>
-          <div className="max-w-[85%] rounded-2xl bg-primary/10 px-4 py-2.5 text-foreground">
-            {voiceInfo ? (
-              <VoiceBubble messageId={message.id} audioPath={voiceInfo.audioPath} duration={voiceInfo.duration} showText={voiceInfo.showText} content={textContent(message)} />
-            ) : (
-              <div>
-                <ContentMedia message={message} />
-                {textContent(message) && <p className="whitespace-pre-wrap break-words text-sm">{renderUserText(textContent(message))}</p>}
+          {scheduledTask ? (
+            <div className="w-full max-w-[92%] overflow-hidden rounded-lg border border-border/70 bg-card text-foreground shadow-sm sm:max-w-[85%]">
+              <div className="flex items-start gap-2.5 bg-muted/35 px-3 py-2.5">
+                <Clock3 className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                <div className="min-w-0 flex-1">
+                  <p className="text-xs font-medium text-muted-foreground">定时任务</p>
+                  <p className="mt-0.5 break-words text-sm font-medium">
+                    {scheduledTask.name
+                      ? renderUserText(scheduledTask.name, scheduledTask.offsets.name)
+                      : '未命名任务'}
+                  </p>
+                  {scheduledTask.description && (
+                    <p className="mt-1 whitespace-pre-wrap break-words text-xs text-muted-foreground">
+                      {renderUserText(scheduledTask.description, scheduledTask.offsets.description)}
+                    </p>
+                  )}
+                </div>
               </div>
-            )}
-          </div>
+              <div className="border-t border-border/60 px-3 py-2.5">
+                <p className="mb-1 text-[11px] font-medium text-muted-foreground">执行内容</p>
+                <ContentMedia message={message} />
+                {scheduledTask.payload ? (
+                  <p className="whitespace-pre-wrap break-words text-sm leading-6">
+                    {renderUserText(scheduledTask.payload, scheduledTask.offsets.payload)}
+                  </p>
+                ) : (
+                  <p className="text-sm text-muted-foreground">无执行内容</p>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="max-w-[85%] rounded-2xl bg-primary/10 px-4 py-2.5 text-foreground">
+              {voiceInfo ? (
+                <VoiceBubble messageId={message.id} audioPath={voiceInfo.audioPath} duration={voiceInfo.duration} showText={voiceInfo.showText} content={messageText} />
+              ) : (
+                <div>
+                  <ContentMedia message={message} />
+                  {messageText && <p className="whitespace-pre-wrap break-words text-sm">{renderUserText(messageText)}</p>}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
-      {textContent(message) && !isEditing && (
+      {messageText && !isEditing && (
         <div className="flex justify-end">
-          <UserMessageActions text={textContent(message)} messageId={message.id} runStatus={runStatus} canEdit={!nonEditableIds.has(message.id)} onStartEdit={onStartEdit} />
+          <UserMessageActions text={messageText} messageId={message.id} runStatus={runStatus} canEdit={!nonEditableIds.has(message.id)} showEdit={!scheduledTask} onStartEdit={onStartEdit} />
         </div>
       )}
     </div>

--- a/frontend/src/utils/scheduledTaskMessage.ts
+++ b/frontend/src/utils/scheduledTaskMessage.ts
@@ -1,0 +1,57 @@
+const SCHEDULED_TASK_HEADER = '[定时任务触发]';
+const TASK_NAME_PREFIX = '任务名称：';
+const TASK_DESCRIPTION_PREFIX = '任务描述：';
+
+interface MessageLine {
+  text: string;
+  start: number;
+  next: number;
+}
+
+export interface ScheduledTaskMessage {
+  name: string;
+  description: string;
+  payload: string;
+  offsets: {
+    name: number;
+    description: number;
+    payload: number;
+  };
+}
+
+function readLine(message: string, start: number): MessageLine | null {
+  const newline = message.indexOf('\n', start);
+  if (newline < 0) return null;
+
+  const end = message[newline - 1] === '\r' ? newline - 1 : newline;
+  const text = message.slice(start, end);
+  if (text.includes('\r')) return null;
+
+  return { text, start, next: newline + 1 };
+}
+
+/** 仅识别调度器生成的完整消息格式，避免普通用户消息被误判。 */
+export function parseScheduledTaskMessage(message: string): ScheduledTaskMessage | null {
+  const headerLine = readLine(message, 0);
+  if (!headerLine || headerLine.text !== SCHEDULED_TASK_HEADER) return null;
+
+  const nameLine = readLine(message, headerLine.next);
+  if (!nameLine || !nameLine.text.startsWith(TASK_NAME_PREFIX)) return null;
+
+  const descriptionLine = readLine(message, nameLine.next);
+  if (!descriptionLine || !descriptionLine.text.startsWith(TASK_DESCRIPTION_PREFIX)) return null;
+
+  const blankLine = readLine(message, descriptionLine.next);
+  if (!blankLine || blankLine.text !== '') return null;
+
+  return {
+    name: nameLine.text.slice(TASK_NAME_PREFIX.length),
+    description: descriptionLine.text.slice(TASK_DESCRIPTION_PREFIX.length),
+    payload: message.slice(blankLine.next),
+    offsets: {
+      name: nameLine.start + TASK_NAME_PREFIX.length,
+      description: descriptionLine.start + TASK_DESCRIPTION_PREFIX.length,
+      payload: blankLine.next,
+    },
+  };
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4311,7 +4311,7 @@ pub async fn job_create(
         created_at: now.clone(),
         updated_at: now,
     };
-    store.insert_job(&job).map_err(|e| e.to_string())?;
+    let job = store.insert_job(&job).map_err(|e| e.to_string())?;
     Ok(serde_json::to_value(job).unwrap())
 }
 


### PR DESCRIPTION
## 变更内容

- 严格识别调度器生成的定时任务消息，并用专用区域展示任务名称、描述和执行内容
- 调整消息列表高度估算与导航预览，保留复制、搜索和结果定位能力
- 隐藏定时任务消息的编辑入口，并在编辑流程中增加保护
- 基于最新主分支整合提及标签，确保执行内容中的提及与搜索高亮可同时正确显示

## 验证

- `yarn test`：12 个测试文件、199 项测试通过
- `yarn build`：通过
- 推送前检查：通过