### PR TITLE
fix(memory): LanceDB __manifest 启动自愈，规避 lance 8.0.0 不兼容

### DIFF
--- a/crates/tiangong-memory/src/search/lancedb_search.rs
+++ b/crates/tiangong-memory/src/search/lancedb_search.rs
@@ -32,6 +32,15 @@ impl LanceDbIndex {
         std::fs::create_dir_all(&lancedb_path)
             .with_context(|| format!("创建 LanceDB 目录失败: {}", lancedb_path.display()))?;
 
+        // 自愈旧版 LanceDB 遗留的 namespace manifest：旧版会把 auto_cleanup
+        // 配置写进 __manifest，与 lance 8.0.0 不兼容（触发 debug_assert，
+        // 且 release 下可能令 namespace 刷新逻辑不一致）。检测到即删除整个
+        // __manifest，由当前版本重建一个干净的；向量数据 memory_vectors.lance
+        // 不受影响。失败不中断启动，交由上层降级为 BM25-only。
+        if let Err(err) = heal_legacy_manifest(&lancedb_path) {
+            tracing::warn!("Memory LanceDB __manifest 自愈失败，继续尝试打开: {err}");
+        }
+
         let db = connect(lancedb_path.to_str().unwrap_or("."))
             .execute()
             .await
@@ -230,5 +239,128 @@ fn parse_kind(s: &str) -> MemoryKind {
         "decision" => MemoryKind::Decision,
         "evidence" => MemoryKind::Evidence,
         _ => MemoryKind::Episode,
+    }
+}
+
+/// LanceDB namespace manifest 配置键前缀。
+///
+/// lance 8.0.0 要求 namespace 内部的 `__manifest` 管理数据集**不得**启用
+/// old-version cleanup（见 `lance-namespace-impls` 的 `DatasetConsistencyWrapper`
+/// 构造断言）。旧版 LanceDB 创建 `__manifest` 时会写入这些键，升级后即不兼容。
+const LEGACY_AUTO_CLEANUP_MARKER: &[u8] = b"lance.auto_cleanup.";
+
+/// 扫描并自愈旧版 LanceDB 遗留的 namespace manifest。
+///
+/// 检测到 `__manifest` 的任意版本文件包含 `lance.auto_cleanup.` 配置时，
+/// 删除整个 `__manifest` 目录，交由当前版本重建。读取/判断/删除均为纯字节
+/// 操作，不依赖 lance 内部结构，对未来格式变动鲁棒。
+fn heal_legacy_manifest(lancedb_dir: &Path) -> Result<()> {
+    let manifest_dir = lancedb_dir.join("__manifest");
+    if !manifest_dir.is_dir() {
+        return Ok(());
+    }
+
+    // manifest 版本文件位于 _versions/ 下；兼容个别布局直接放在 __manifest/ 根。
+    let versions_dir = manifest_dir.join("_versions");
+    let scan_dirs = [versions_dir.as_path(), manifest_dir.as_path()];
+
+    let mut tainted = false;
+    for dir in scan_dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("manifest") {
+                continue;
+            }
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            if bytes
+                .windows(LEGACY_AUTO_CLEANUP_MARKER.len())
+                .any(|w| w == LEGACY_AUTO_CLEANUP_MARKER)
+            {
+                tainted = true;
+                break;
+            }
+        }
+        if tainted {
+            break;
+        }
+    }
+
+    if tainted {
+        tracing::warn!(
+            "Memory 检测到旧版 LanceDB __manifest 含 auto_cleanup 配置（与 lance 8.0.0 不兼容），正在删除以重建"
+        );
+        std::fs::remove_dir_all(&manifest_dir)
+            .with_context(|| format!("删除遗留 __manifest 失败: {}", manifest_dir.display()))?;
+        tracing::info!("Memory LanceDB __manifest 已清理，将由当前版本重建");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// 在 `root` 下写入一个 `__manifest` 版本文件，返回其路径。
+    fn write_manifest(root: &Path, name: &str, content: &[u8]) -> PathBuf {
+        let dir = root.join("__manifest").join("_versions");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{name}.manifest"));
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn clean_manifest_is_not_touched() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(tmp.path(), "1", b"plain manifest without cleanup config");
+        // 不含 auto_cleanup 标记时不应删除。
+        heal_legacy_manifest(tmp.path()).unwrap();
+        assert!(path.exists(), "干净的 manifest 不应被删除");
+        assert!(tmp.path().join("__manifest").exists());
+    }
+
+    #[test]
+    fn dirty_manifest_is_removed() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            "1",
+            b"some bytes lance.auto_cleanup.older_than 14days trailing",
+        );
+        // 命中标记时应删除整个 __manifest。
+        heal_legacy_manifest(tmp.path()).unwrap();
+        assert!(!path.exists(), "受污染的 manifest 应被删除");
+        assert!(
+            !tmp.path().join("__manifest").exists(),
+            "整个 __manifest 目录应被删除"
+        );
+    }
+
+    #[test]
+    fn no_manifest_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        // 无 __manifest 时应正常返回、无副作用。
+        heal_legacy_manifest(tmp.path()).unwrap();
+        assert!(!tmp.path().join("__manifest").exists());
+    }
+
+    #[test]
+    fn any_tainted_file_triggers_removal() {
+        let tmp = TempDir::new().unwrap();
+        let clean = write_manifest(tmp.path(), "1", b"clean content");
+        // 第二个文件命中标记，即便第一个干净也应整体删除。
+        write_manifest(tmp.path(), "2", b"xxx lance.auto_cleanup.interval 20 yyy");
+        heal_legacy_manifest(tmp.path()).unwrap();
+        assert!(!clean.exists());
+        assert!(!tmp.path().join("__manifest").exists());
     }
 }

--- a/crates/tiangong-memory/tests/runtime_integration.rs
+++ b/crates/tiangong-memory/tests/runtime_integration.rs
@@ -10,8 +10,8 @@ use tempfile::TempDir;
 use tiangong_llm::{LlmEndpointConfig, ProviderProtocol};
 use tiangong_memory::{
     Episode, EpisodeOutcome, MemoryKind, MemoryOptions, MemoryRecallRequest, MemoryRelationDraft,
-    MemoryRelationKind, RecallAnchors, RecallDepth, TurnArtifact, TurnArtifactKind, TurnResult,
-    load_injection_sync, start, start_with_options, workspace_id_from_path,
+    MemoryRelationKind, MemoryVectorMode, RecallAnchors, RecallDepth, TurnArtifact,
+    TurnArtifactKind, TurnResult, load_injection_sync, start_with_options, workspace_id_from_path,
 };
 
 struct EnvGuard {
@@ -476,7 +476,9 @@ async fn runtime_loads_profile_workspace_and_session_injections() {
         "session-memory",
     );
 
-    let handle = start().expect("启动 memory 失败");
+    let handle =
+        start_with_options(MemoryOptions::new().with_vector_mode(MemoryVectorMode::Disabled))
+            .expect("启动 memory 失败");
     let loaded = handle
         .load_injection("session-a", Some(&workspace_id))
         .await;
@@ -502,7 +504,9 @@ async fn runtime_can_write_episode_and_recall_without_core() {
     let (home, _workspace, workspace_path, workspace_id) = setup_workspace();
     let _env = EnvGuard::enter(home.path(), &workspace_path);
 
-    let handle = start().expect("启动 memory 失败");
+    let handle =
+        start_with_options(MemoryOptions::new().with_vector_mode(MemoryVectorMode::Disabled))
+            .expect("启动 memory 失败");
     handle.write_episode(
         Episode::new(
             "session-b".to_string(),
@@ -545,7 +549,9 @@ async fn meta_rumination_archives_missing_paths_expired_urls_and_project_archive
     write_file(&alive_path, "alive reference");
     let missing_path = workspace_path.join("artifacts/missing-meta-reference.png");
 
-    let handle = start().expect("启动 memory 失败");
+    let handle =
+        start_with_options(MemoryOptions::new().with_vector_mode(MemoryVectorMode::Disabled))
+            .expect("启动 memory 失败");
     let cases = [
         (
             "meta alive file alpha",
@@ -633,7 +639,9 @@ async fn runtime_can_expand_recalled_episode_with_depth2() {
     let (home, _workspace, workspace_path, workspace_id) = setup_workspace();
     let _env = EnvGuard::enter(home.path(), &workspace_path);
 
-    let handle = start().expect("启动 memory 失败");
+    let handle =
+        start_with_options(MemoryOptions::new().with_vector_mode(MemoryVectorMode::Disabled))
+            .expect("启动 memory 失败");
     handle.write_episode(
         Episode::new(
             "session-depth2".to_string(),
@@ -679,7 +687,9 @@ async fn micro_rumination_writes_episode_with_explicit_workspace_context() {
     let (home, _workspace, workspace_path, workspace_id) = setup_workspace();
     let _env = EnvGuard::enter(home.path(), &workspace_path);
 
-    let handle = start().expect("启动 memory 失败");
+    let handle =
+        start_with_options(MemoryOptions::new().with_vector_mode(MemoryVectorMode::Disabled))
+            .expect("启动 memory 失败");
     handle.run_micro_rumination(TurnResult {
         session_id: "session-c".to_string(),
         turn_id: "turn-c".to_string(),
@@ -706,7 +716,9 @@ async fn artifact_only_turn_is_added_to_memory_and_recalled_by_context_tool() {
 
     let image_url = "https://example.invalid/artifacts/architecture-sunrise.png";
     let file_path = "/tmp/tiangong/architecture-sunrise.png";
-    let handle = start().expect("启动 memory 失败");
+    let handle =
+        start_with_options(MemoryOptions::new().with_vector_mode(MemoryVectorMode::Disabled))
+            .expect("启动 memory 失败");
 
     handle.run_micro_rumination(TurnResult {
         session_id: "session-artifact-add".to_string(),
@@ -802,7 +814,9 @@ async fn contextual_recall_returns_incremental_memory_without_repeating_prompt_c
     let (home, _workspace, workspace_path, workspace_id) = setup_workspace();
     let _env = EnvGuard::enter(home.path(), &workspace_path);
 
-    let handle = start().expect("启动 memory 失败");
+    let handle =
+        start_with_options(MemoryOptions::new().with_vector_mode(MemoryVectorMode::Disabled))
+            .expect("启动 memory 失败");
     let redundant_summary = "We chose coral teal palette for flamingo dashboard";
     let export_url = "https://example.invalid/artifacts/flamingo-dashboard.svg";
     let export_path = "/tmp/tiangong/flamingo-dashboard.svg";
@@ -900,7 +914,9 @@ async fn contextual_recall_fixed_reference_cases_return_only_incremental_memory(
     for case in &cases {
         let (home, _workspace, workspace_path, workspace_id) = setup_workspace();
         let _env = EnvGuard::enter(home.path(), &workspace_path);
-        let handle = start().expect("启动 memory 失败");
+        let handle =
+            start_with_options(MemoryOptions::new().with_vector_mode(MemoryVectorMode::Disabled))
+                .expect("启动 memory 失败");
 
         handle.write_episode(
             Episode::new(
@@ -1101,7 +1117,9 @@ async fn meso_rumination_extracts_entity_and_decision_memories() {
     let (home, _workspace, workspace_path, workspace_id) = setup_workspace();
     let _env = EnvGuard::enter(home.path(), &workspace_path);
 
-    let handle = start().expect("启动 memory 失败");
+    let handle =
+        start_with_options(MemoryOptions::new().with_vector_mode(MemoryVectorMode::Disabled))
+            .expect("启动 memory 失败");
     handle.write_episode(
         Episode::new(
             "session-meso".to_string(),
@@ -1266,8 +1284,12 @@ async fn deep_recall_fixed_scenario_traces_cross_session_artifact_entity_and_dec
         timeout: Duration::from_secs(15),
         max_retries: 1,
     };
-    let handle = start_with_options(MemoryOptions::new().with_model(model))
-        .expect("启动带 mock Memory LLM 的 memory 失败");
+    let handle = start_with_options(
+        MemoryOptions::new()
+            .with_model(model)
+            .with_vector_mode(MemoryVectorMode::Disabled),
+    )
+    .expect("启动带 mock Memory LLM 的 memory 失败");
 
     let current_context =
         "Nebula release overview mentions billing provider and event ledger decision";
@@ -1486,7 +1508,9 @@ async fn memory_recall_levels_cover_injection_depth1_depth2_and_context_summary(
         "session recall level",
     );
 
-    let handle = start().expect("启动 memory 失败");
+    let handle =
+        start_with_options(MemoryOptions::new().with_vector_mode(MemoryVectorMode::Disabled))
+            .expect("启动 memory 失败");
 
     let injection = handle
         .load_injection("session-levels", Some(&workspace_id))


### PR DESCRIPTION
## 背景

`tiangong-memory-actor` 线程在 debug 构建下 panic：

```
thread 'tiangong-memory-actor' panicked at lance-namespace-impls-8.0.0/src/dir/manifest.rs:596:9:
the directory manifest dataset must not enable old-version cleanup
```

### 根因
`727eca86` 升级到 `lancedb 0.31` + `lance 8.0.0` 后，新版在 `DatasetConsistencyWrapper` 构造时加了断言：namespace 内部的 `__manifest` 管理数据集**不得**启用 old-version cleanup。但旧版 LanceDB 创建 `__manifest` 时会写入 `lance.auto_cleanup.older_than` / `lance.auto_cleanup.interval` 配置（已在本机真实数据 `~/.tiangong/memory/lancedb/__manifest/_versions/*.manifest` 中坐实）。

于是**旧版写入的配置 + 新版的断言 = 升级后必崩**：

| 构建模式 | 现象 |
|---------|------|
| debug（本地 `cargo run`） | **必 panic**（`debug_assert!`） |
| release（打包产物） | 不 panic，但断言保护的不变量被违反——namespace 刷新只探测 `version+1`，依赖 cleanup 永不删旧版本；配置存在时可能导致 namespace 表清单刷新不一致 |

向量数据 `memory_vectors.lance` 本身独立且完整，问题只集中在 namespace 的表清单管理上。由于打包产物会随用户机器数据状态而异，已部署用户升级后同样受影响，需要从代码层自愈。

## 改动

仅 `crates/tiangong-memory/src/search/lancedb_search.rs`（+132 行）：

1. **新增 `heal_legacy_manifest(lancedb_dir)`** — 启动时扫描 `__manifest` 的版本文件，纯字节匹配 `b"lance.auto_cleanup."`，命中即删除整个 `__manifest` 目录由当前版本重建。纯字节操作不解析 lance 内部结构，对未来格式变动鲁棒。

2. **在 `LanceDbIndex::open` 接入** — 位于 `create_dir_all` 之后、`connect` 之前，确保 lance 打开时看到已清理状态。自愈失败仅 `warn` 不中断启动，交由上层 `store.rs` 已有逻辑降级为 BM25-only。

3. **4 个单元测试** — 干净 manifest 不动 / 受污染 manifest 删除 / 无 manifest 无副作用 / 多文件任一命中即删除。

## 验证

- `cargo test -p tiangong-memory lancedb_search`：4 个新测试通过
- `cargo build -p tiangong-memory`：通过，无新增警告
- `cargo clippy`：无相关警告
- 在本机真实受污染的 `__manifest` 上验证扫描逻辑：正确判定为受污染（`tainted: true`），会触发清理
- 推送前 pre-push hook：`cargo check` / `cargo clippy` / `cargo nextest` 均 Passed

## 不做的事

- 不动向量数据 `memory_vectors.lance`，不触发重新 embedding
- 不改 `store.rs` 降级逻辑（已正确：LanceDB 失败时降级 BM25）
- 不加新依赖