### PR TITLE
fix(browser): 补齐 browser_open_url 权限，修复对话链接无法用嵌入式浏览器打开

### DIFF
--- a/crates/plugins/tiangong-plugin-browser/permissions/autogenerated/commands/browser_open_url.toml
+++ b/crates/plugins/tiangong-plugin-browser/permissions/autogenerated/commands/browser_open_url.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-browser-open-url"
+description = "Enables the browser_open_url command without any pre-configured scope."
+commands.allow = ["browser_open_url"]
+
+[[permission]]
+identifier = "deny-browser-open-url"
+description = "Denies the browser_open_url command without any pre-configured scope."
+commands.deny = ["browser_open_url"]

--- a/crates/plugins/tiangong-plugin-browser/permissions/autogenerated/reference.md
+++ b/crates/plugins/tiangong-plugin-browser/permissions/autogenerated/reference.md
@@ -5,6 +5,7 @@
 #### This default permission set includes the following:
 
 - `allow-browser-open`
+- `allow-browser-open-url`
 - `allow-browser-close`
 - `allow-browser-hide`
 - `allow-browser-set-position`
@@ -344,6 +345,32 @@ Enables the browser_open command without any pre-configured scope.
 <td>
 
 Denies the browser_open command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`tiangong-plugin-browser:allow-browser-open-url`
+
+</td>
+<td>
+
+Enables the browser_open_url command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`tiangong-plugin-browser:deny-browser-open-url`
+
+</td>
+<td>
+
+Denies the browser_open_url command without any pre-configured scope.
 
 </td>
 </tr>

--- a/crates/plugins/tiangong-plugin-browser/permissions/default.toml
+++ b/crates/plugins/tiangong-plugin-browser/permissions/default.toml
@@ -2,6 +2,7 @@
 description = "允许使用浏览器面板的全部功能。"
 permissions = [
     "allow-browser-open",
+    "allow-browser-open-url",
     "allow-browser-close",
     "allow-browser-hide",
     "allow-browser-set-position",


### PR DESCRIPTION
## 背景

点击对话中的链接时，预期使用嵌入式浏览器打开，但实际无反应。

调用链路：

1. `MessageList.tsx:627` — document click 监听拦截 `<a href>`，派发 `tiangong:open-browser` 事件
2. `MainApp.tsx:507` — `onOpenBrowser` 调用 `api.browserOpenUrl(sessionId, url)` → `invoke("plugin:browser|browser_open_url")`
3. **❌ Tauri ACL 拒绝** — `browser:default` 权限集不包含 `allow-browser-open-url`
4. 错误被 `.catch(console.error)` 静默吞掉 → 嵌入式浏览器不打开

## 根因

`browser_open_url` 命令在 `lib.rs:172` 的 `invoke_handler` 中已注册，但：

- `permissions/autogenerated/commands/` 下**缺少** `browser_open_url.toml`（对比同目录的 `browser_open.toml` 存在）
- `permissions/default.toml` 列出了 22 个 `allow-*`，唯独缺 `allow-browser-open-url`

由于该权限标识根本不存在，前端调用必然被 Tauri 安全层拒绝。

## 改动

| 文件 | 改动 |
|---|---|
| `permissions/autogenerated/commands/browser_open_url.toml` | 新增 `allow-browser-open-url` / `deny-browser-open-url` 权限定义，映射到 `browser_open_url` 命令 |
| `permissions/default.toml` | 在 `allow-browser-open` 后加入 `allow-browser-open-url` |
| `permissions/autogenerated/reference.md` | 同步补充文档条目 |

## 参考依据

对齐同插件既有命令范式 —— 每个在 `invoke_handler` 注册的命令都应有对应的 `autogenerated/commands/<name>.toml` 权限定义，并纳入 `default.toml`。`browser_open` / `browser_navigate` 等均遵循此模式。

## 验证

- `cargo check -p tiangong-plugin-browser` 通过
- 重建后的 `src-tauri/gen/schemas/acl-manifests.json` 确认：
  - `browser.default_permission.permissions` 已包含 `allow-browser-open-url`
  - 权限定义 `commands.allow = ["browser_open_url"]`，与前端 `invoke("plugin:browser|browser_open_url")` 精确匹配