### PR TITLE
fix(cli): 注册 --version 标志，修复 tiangong --version 无法输出版本信息

### DIFF
--- a/crates/tiangong-entry/src/args.rs
+++ b/crates/tiangong-entry/src/args.rs
@@ -6,6 +6,7 @@ use tiangong_plugin_mcp::McpTransportMode;
 #[derive(Debug, Parser)]
 #[command(
     name = "tiangong",
+    version,
     disable_help_subcommand = true,
     arg_required_else_help = false,
     about = "天工应用入口"


### PR DESCRIPTION
## 问题

运行 `tiangong --version`（或 `-V`）无法输出版本信息，而是返回未知参数错误。

## 根因

`crates/tiangong-entry/src/args.rs` 中 `MainArgs` 的 `#[command(...)]` 属性未设置 `version`。在 clap v4 中，`--version` / `-V` 标志**仅在命令上声明 `version` 时才会自动注册**。

由于未注册，`--version` 走的是「未知参数」错误分支，而非 `ErrorKind::DisplayVersion`。`lib.rs` 中虽然已处理 `DisplayVersion` 事件：

```rust
let args = match MainArgs::try_parse() {
    Err(err) if matches!(err.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) => {
        print!("{err}");
        return Ok(());
    }
    Err(err) => return Err(anyhow::anyhow!(err.to_string())),
    ...
};
```

但 `DisplayVersion` 永远不会触发，最终落入 `Err(anyhow::anyhow!(...))` 分支返回错误。

## 修复

在 `#[command(...)]` 中补上 `version`，使 clap 自动注册 `--version` / `-V` 标志，并使用工作区包版本（`0.13.3`）：

```diff
 #[command(
     name = "tiangong",
+    version,
     disable_help_subcommand = true,
     arg_required_else_help = false,
     about = "天工应用入口"
 )]
 pub(crate) struct MainArgs {
```

## 验证

- ✅ `tiangong --version` → `tiangong 0.13.3`（退出码 0）
- ✅ `tiangong -V` → `tiangong 0.13.3`（退出码 0）
- ✅ `tiangong --help` 现在也正确列出 `-V, --version` 选项，子命令列表无变化
- ✅ 本地与远程 pre-commit / push hooks 全部通过（fmt / clippy / nextest）