### PR TITLE
fix(browser): 修复 macOS WebView 空 URL 崩溃

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12270,8 +12270,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wry"
 version = "0.55.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
+source = "git+https://github.com/silent-rs/wry.git?rev=4fb16fa0ca6b4b8fa65edc5d3875d9726429285b#4fb16fa0ca6b4b8fa65edc5d3875d9726429285b"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,11 @@ tracing-appender = "0.2"
 tracing-subscriber = "0.3"
 typed-builder = "0.23"
 wiremock = "0.6"
-wry = "0.55"
+wry = "=0.55.1"
 zip = { version = "8", default-features = false }
+
+[patch.crates-io]
+wry = { git = "https://github.com/silent-rs/wry.git", rev = "4fb16fa0ca6b4b8fa65edc5d3875d9726429285b" }
 
 [package]
 name = "tiangong"


### PR DESCRIPTION
## 变更

- 将 wry 精确锁定在 0.55.1，避免临时补丁意外跟随版本升级。
- 通过 crates.io 补丁入口使用 silent-rs/wry 的已验证提交 4fb16fa0ca6b4b8fa65edc5d3875d9726429285b。
- 锁文件仅切换 wry 来源，不更新其他依赖。

## 效果

macOS WKWebView 在导航期间暂时取不到 URL 时不再导致天工退出；无 URL 的导航请求会沿错误或取消路径结束。其他平台仍使用相同版本和原有实现。

## 验证

- cargo fmt --all -- --check
- cargo tree -p tiangong-app -i wry --locked，确认只解析一份修复版 wry
- cargo test -p tiangong-plugin-browser --lib --locked，26 项测试通过
- cargo check -p tiangong-app --locked
- cargo build -p tiangong-app --locked
- 推送前自动 cargo check、cargo clippy 和 cargo nextest 全部通过
- wry 空 URL 最小复现已验证进程不再退出

上游修复提交：https://github.com/silent-rs/wry/commit/4fb16fa0ca6b4b8fa65edc5d3875d9726429285b