### PR TITLE
fix(cli): 修复 tiangong cli 投递消息时因缺少 Tokio reactor 崩溃

### DIFF
--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -49,7 +49,14 @@ pub fn run(trust_mode: Option<tiangong_core::permission::TrustMode>) -> Result<(
     });
     let (stream_tx, stream_rx) = mpsc::channel::<StreamEvent>();
     // 初始化 Memory Handle（入口层负责，构造时注入 memory 插件）。
-    let runtime = tokio::runtime::Runtime::new()?;
+    // 对齐 server 入口（tiangong-server/src/lib.rs）：多线程 runtime + enter()，
+    // 让主线程在整个 REPL 生命周期内持有 reactor guard。这样主循环里同步执行的
+    // deliver_to_core_if_live → on_config_updated → tokio::spawn 才能找到 reactor
+    // （见 issue #313）。Core 的 turn 循环仍由进程级共享 runtime 独立承载。
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let _runtime_guard = runtime.enter();
     let memory_handle =
         runtime.block_on(tiangong_memory::registry::init_memory_handle_for_process(
             config.generation(),


### PR DESCRIPTION
## 关联 Issue

Fixes #313

## 问题

运行 \`tiangong cli\` 进入交互界面后，输入任意消息立即 panic：

\`\`\`
there is no reactor running, must be called from the context of a Tokio 1.x runtime
\`\`\`

崩溃点：`crates/plugins/tiangong-plugin-memory/src/plugin.rs:129` 的 `tokio::spawn`。

## 根因

CLI 主循环里，消息投递发生在 `block_on` **返回之后**的同步代码（`repl.rs` 的 `deliver_to_core_if_live`）。该调用链为：

\`deliver_to_core_if_live → Core::deliver → build_turn_context → prepare_plugins → on_config_updated → tokio::spawn\`

此刻主线程已脱离任何 Tokio reactor 上下文，因此 `tokio::spawn` 找不到 reactor 而崩溃。

> 注：原 issue #313 的判断（崩溃发生在 `ensure_core` 阶段、单线程 runtime 即可修复）与实际不符。`ensure_core` 只构建 Core、不触发插件方法；崩溃实际发生在**投递消息**阶段，因此仅切换 runtime 类型无法解决——无论多线程还是单线程，`block_on` 返回后主线程都不在 reactor 上下文。

## 对比各入口

| 入口 | runtime | 投递 deliver 的位置 | 投递时在 reactor 内？ |
|------|---------|---------------------|----------------------|
| Server | 多线程 + `enter()` | async 函数（worker 线程） | ✅ |
| Bot | 单线程 | `block_on` 内 | ✅（但仅管理 bot 制品，不投递对话） |
| Desktop | 复用 server | 同 server | ✅ |
| **CLI** | ~~单线程~~ | **`block_on` 返回后** | ❌ → 崩溃 |

只有 CLI 把"投递消息"放在了 reactor 上下文之外。

## 修复方案

对齐 server 入口（`tiangong-server/src/lib.rs`）：改用多线程 runtime + `enter()`，让主线程在整个 REPL 生命周期内持有 reactor guard。这样主循环里的同步投递调用始终在 reactor 上下文内，`tokio::spawn` 即可正常工作。

## 影响范围

- 仅改动 `crates/tiangong-cli/src/repl.rs` 一处
- Core 的 turn 循环仍由进程级共享 runtime（`shared_runtime`，硬编码多线程）独立承载，子智能体并发不受影响
- 对 server / bot / desktop 入口零影响

## 验证

- `cargo check` / `cargo clippy` 通过
- 实际运行 `tiangong cli`，输入消息不再崩溃，可正常对话