### PR TITLE
feat(core): 标题更新收归 Core 内部并改为事件驱动

### DIFF
--- a/crates/tiangong-cli/src/repl.rs
+++ b/crates/tiangong-cli/src/repl.rs
@@ -604,6 +604,8 @@ impl ResponseState {
                     output::status(&format!("索引扫描完成: {count} 个文件"));
                 }
             }
+            // 标题变更由 GUI 消费；CLI 不维护会话列表视图，无需处理。
+            StreamEvent::TitleChanged { .. } => {}
         }
         false
     }

--- a/crates/tiangong-core-manager/src/core_manager/ensure.rs
+++ b/crates/tiangong-core-manager/src/core_manager/ensure.rs
@@ -123,4 +123,25 @@ impl CoreManager {
             core.set_trust_mode(mode);
         }
     }
+
+    /// 更新指定会话标题（落盘始终由 Core 负责，保证不与 turn 对 session 的读写竞争）。
+    ///
+    /// 必须存在 live Core（标题可编辑意味着 Core 应已创建）；不存在则视为异常并报错。
+    /// Core 内部按 is_busy 分流：忙时投递 turn task，Core 空闲时 Core 自己写盘。
+    ///
+    /// `only_if_default=true` 时仅当当前标题仍是默认值才覆盖（lite 自动生成用，
+    /// 用户手动改过则不覆盖）；用户手动编辑传 false。
+    pub fn set_core_title(
+        &self,
+        session_id: &str,
+        title: String,
+        only_if_default: bool,
+    ) -> Result<(), String> {
+        let registry = self.registry();
+        let Some(core) = registry.get(session_id) else {
+            return Err(format!("会话 {session_id} 无可用 Core，无法更新标题"));
+        };
+        core.set_title(title, only_if_default)
+            .map_err(|_| "更新会话标题失败".to_string())
+    }
 }

--- a/crates/tiangong-core/src/core/command.rs
+++ b/crates/tiangong-core/src/core/command.rs
@@ -9,6 +9,13 @@ pub enum Command {
     Approval { request_id: String, approved: bool },
     /// 运行时切换信任模式(即时生效到活跃 turn task)
     SetTrustMode(crate::permission::TrustMode),
+    /// 更新会话标题。
+    /// `only_if_default=true` 时仅当当前标题仍是默认值（"新对话"/"会话 X"）才覆盖，
+    /// 用于 lite 自动生成（用户手动改过则不覆盖）；false 时无条件覆盖（用户手动编辑）。
+    SetTitle {
+        title: String,
+        only_if_default: bool,
+    },
     /// 工具类内容自动注入（浏览器页面、终端用户操作等，不触发 turn）。
     InjectTool {
         tool_name: String,

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -24,6 +24,13 @@ pub mod storage_location;
 pub use error::CoreError;
 pub use storage_location::CoreStorageLocation;
 
+/// 判断标题是否仍是默认值（"新对话"/"会话 X"）。
+///
+/// 用于 lite 自动生成标题写回时，避免覆盖用户已手动改过的标题。
+pub(crate) fn is_default_title(title: &str) -> bool {
+    title == "新对话" || title.starts_with("会话 ")
+}
+
 /// 天工智能体核心
 #[derive(TypedBuilder)]
 #[builder(
@@ -98,6 +105,39 @@ impl TiangongCore {
         let _ = self.send_cmd(Command::SetTrustMode(mode));
     }
 
+    /// 更新会话标题。用于用户手动编辑（不可放弃）。
+    ///
+    /// 与 trust_mode 一致的双分支协调：
+    /// - turn 进行中：发 `Command::SetTitle`，由 turn task 在命令分支写入 `ctx.session`，
+    ///   turn 结束 run_turn 统一落盘（避免与 turn 对 session 的读写竞争）。
+    /// - Core 空闲：Core 是 session 权威持有者且无并发 turn，直接 load+改+persist。
+    ///
+    /// `only_if_default=true` 时仅当当前标题仍是默认值才覆盖（用于 lite 自动生成，
+    /// 但那条路径直接走 `shared_runtime::send_command`，不经过此方法）；用户手动编辑传 false。
+    pub fn set_title(&self, title: String, only_if_default: bool) -> Result<(), CoreError> {
+        let title = title.trim().to_string();
+        if title.is_empty() {
+            return Err(CoreError::WorkerStopped);
+        }
+        if crate::shared_runtime::is_running(&self.session_id) {
+            self.send_cmd(Command::SetTitle {
+                title,
+                only_if_default,
+            })
+        } else {
+            let mut session = self.load_session()?;
+            if only_if_default && !is_default_title(&session.title) {
+                return Ok(());
+            }
+            session.title = title;
+            session.updated_at = tiangong_types::now_text();
+            session
+                .try_persist_to_disk()
+                .map_err(|_| CoreError::WorkerStopped)?;
+            Ok(())
+        }
+    }
+
     fn load_session(&self) -> Result<Session, CoreError> {
         match Session::load_from_storage(&self.storage_root, &self.session_id) {
             Ok(session) => Ok(session),
@@ -160,11 +200,13 @@ impl TiangongCore {
                 });
             });
         let client = SingleProviderClient::new(config.llm.chat.clone()).with_on_retry(on_retry);
+        let lite_client = config.llm.lite.clone().map(SingleProviderClient::new);
         let prepared_plugins =
             crate::core::plugin::prepare_plugins(&plugins, &config, trust_mode, &session);
 
         Ok(TurnContext::builder()
             .client(client)
+            .lite_client(lite_client)
             .session(session)
             .stream_tx(stream_tx)
             .plugins(plugins)

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -129,11 +129,13 @@ impl TiangongCore {
             if only_if_default && !is_default_title(&session.title) {
                 return Ok(());
             }
-            session.title = title;
+            session.title = title.clone();
             session.updated_at = tiangong_types::now_text();
             session
                 .try_persist_to_disk()
                 .map_err(|_| CoreError::WorkerStopped)?;
+            // 空闲时也发 TitleChanged，让前端统一经事件更新标题（手动改空闲会话同样通知）。
+            let _ = self.stream_tx.send(StreamEvent::TitleChanged { title });
             Ok(())
         }
     }

--- a/crates/tiangong-core/src/react/execute.rs
+++ b/crates/tiangong-core/src/react/execute.rs
@@ -958,6 +958,20 @@ pub(super) async fn execute_turn(
                 Some(Command::InjectTool { tool_name, payload }) => {
                     injections.receive(&stream_tx, tool_name, payload);
                 }
+                Some(Command::SetTitle {
+                    title,
+                    only_if_default,
+                }) => {
+                    if !only_if_default
+                        || crate::core::is_default_title(&ctx.session.title)
+                    {
+                        ctx.session.title = title.clone();
+                        ctx.session.updated_at = tiangong_types::now_text();
+                        // 通知消费线程转发 sessions_updated（core 层不碰 tauri，走自有 StreamEvent 通道）。
+                        let _ = stream_tx.send(tiangong_types::StreamEvent::TitleChanged { title });
+                    }
+                    // 不立即 persist：turn 结束 run_turn 统一落盘。
+                }
                 Some(Command::EmitStreamEvent(event)) => {
                     let _ = stream_tx.send(*event);
                 }

--- a/crates/tiangong-core/src/react/turn.rs
+++ b/crates/tiangong-core/src/react/turn.rs
@@ -42,6 +42,11 @@ pub(crate) async fn run_turn(
         plugin.on_turn_started(&mut ctx.session, turn_start_idx);
     }
 
+    // ── 标题自动生成（与 Agent Loop 并行）──
+    // 仅当标题仍是默认值时，用 lite 模型据首条用户消息生成标题，
+    // 完成后经 Command::SetTitle 投回 turn task 安全写入 ctx.session。
+    spawn_title_generation(&ctx);
+
     // ── 执行 Agent Loop ──
     // execute_turn 返回明确的执行结果和累计用量，不在内部发送终态事件。
     let execution = execute_turn(&mut ctx, &mut cmd_rx).await;
@@ -120,4 +125,49 @@ pub(crate) async fn run_turn(
     // ── 发布唯一终态 ──
     // 宿主在收到终态后从磁盘重载权威 Session，不再需要额外的最终消息快照。
     let _ = stream_tx.send(outcome.terminal_event(usage));
+}
+
+/// 标题仍是默认值时，并行用 lite 模型据首条用户消息生成标题。
+///
+/// 在独立阻塞线程上执行 `complete_lite`（同步网络请求），完成后经
+/// `shared_runtime::send_command` 投递 `Command::SetTitle` 回当前 turn task。
+/// turn task 收到后在 execute.rs 命令分支写入 `ctx.session.title`，
+/// 由 run_turn 统一落盘——标题落盘始终在 Core 内部，外部不参与。
+///
+/// 生成期间 turn 可能已结束（命令通道关闭），此时 `send_command` 返回 false，
+/// 标题本次未写入；下次提问时本函数发现标题仍是默认值会再次触发，天然自愈。
+fn spawn_title_generation(ctx: &TurnContext) {
+    use crate::core::is_default_title;
+    // 标题非默认值（用户已改过或已生成过）则跳过。
+    if !is_default_title(&ctx.session.title) {
+        return;
+    }
+    // 取首条用户消息文本作为生成输入。
+    let Some(input) = ctx
+        .session
+        .messages
+        .iter()
+        .find(|m| m.role == MessageRole::User)
+        .map(|m| m.text_content())
+    else {
+        return;
+    };
+    let lite_client = ctx.lite_client().clone();
+    let session_id = ctx.session.id.clone();
+    tokio::task::spawn_blocking(move || {
+        let Ok(title) = lite_client.complete_lite(&input) else {
+            return;
+        };
+        let clean = title.trim().trim_matches('"').to_string();
+        if clean.is_empty() {
+            return;
+        }
+        let _ = crate::shared_runtime::send_command(
+            &session_id,
+            Command::SetTitle {
+                title: clean,
+                only_if_default: true,
+            },
+        );
+    });
 }

--- a/crates/tiangong-core/src/turn_context.rs
+++ b/crates/tiangong-core/src/turn_context.rs
@@ -32,6 +32,9 @@ use typed_builder::TypedBuilder;
 pub struct TurnContext {
     /// 模型请求客户端
     pub client: SingleProviderClient,
+    /// 轻量任务客户端（标题生成等）。未配置 lite 模型时为 None，回退到 chat client。
+    #[builder(default)]
+    pub lite_client: Option<SingleProviderClient>,
     /// 本轮会话（turn 期间独占,turn 结束时取回落盘）
     pub session: Session,
     /// 本轮内部事件发送端。
@@ -64,6 +67,11 @@ impl TurnContext {
 
     pub fn client(&self) -> &SingleProviderClient {
         &self.client
+    }
+
+    /// 轻量任务客户端，未配置 lite 时回退到 chat client。
+    pub fn lite_client(&self) -> &SingleProviderClient {
+        self.lite_client.as_ref().unwrap_or(&self.client)
     }
 
     pub fn agent_config(&self) -> &AgentConfig {

--- a/crates/tiangong-types/src/stream.rs
+++ b/crates/tiangong-types/src/stream.rs
@@ -235,6 +235,8 @@ pub enum StreamEvent {
         #[serde(default)]
         count: usize,
     },
+    /// 会话标题变更（标题生成完成 / 用户编辑）。消费线程据此 emit sessions_updated。
+    TitleChanged { title: String },
 }
 
 fn is_false(value: &bool) -> bool {

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -240,6 +240,8 @@ export interface StreamEvent {
   count?: number;
   holder_agent_label?: string | null;
   path?: string;
+  /** title_changed 事件携带的新标题。 */
+  title?: string;
 }
 
 export interface SessionStreamEvent {

--- a/frontend/src/components/StatusPanel.tsx
+++ b/frontend/src/components/StatusPanel.tsx
@@ -48,7 +48,7 @@ function SearchButton() {
 }
 
 export function StatusPanel({ browserActive, onOpenBrowser, terminalActive, onOpenTerminal }: StatusPanelProps) {
-  const { activeSessionId, isNewConversation, sessions, loadSessions, startNewConversation, updateAvailable, setPendingSettingsTab } = useStore();
+  const { activeSessionId, isNewConversation, sessions, startNewConversation, updateAvailable, setPendingSettingsTab } = useStore();
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -134,8 +134,8 @@ export function StatusPanel({ browserActive, onOpenBrowser, terminalActive, onOp
 
     if (finalTitle !== currentTitle) {
       try {
+        // 标题更新由 Core 发 title_changed 事件驱动前端刷新，不再整表 loadSessions。
         await api.updateSessionTitle(finalTitle);
-        await loadSessions();
       } catch (e) {
         console.error('保存标题失败:', e);
       }

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -558,7 +558,13 @@ function applyEventToSessionView(
   let streamingReasoningContent = current.streamingReasoningContent;
   let currentPlan = current.currentPlan;
 
-  if (event.type !== 'done' && event.type !== 'error' && runStatus === 'idle') {
+  // title_changed 是纯通知事件，不改变对话运行状态（自动/手动标题变更都会发）。
+  if (
+    event.type !== 'done'
+    && event.type !== 'error'
+    && event.type !== 'title_changed'
+    && runStatus === 'idle'
+  ) {
     runStatus = 'executing';
   }
 
@@ -1790,10 +1796,25 @@ export const useStore = create<AppState>((set, get) => ({
     const sessionRunStatuses = { ...previousStatuses };
     let currentCache: SessionViewCache | null = null;
     let refreshCurrentAgents = false;
+    // 标题变更直接更新内存中的会话标题，不触发整表 sessions_updated 刷新。
+    let sessions = state.sessions;
+    let titleChanged = false;
 
     for (const envelope of events) {
       const sessionId = envelope.session_id;
       const event = envelope.event;
+      // title_changed：直接改对应会话标题，不进入会话视图状态机。
+      if (event.type === 'title_changed' && typeof event.title === 'string') {
+        const idx = sessions.findIndex((s) => s.id === sessionId);
+        if (idx >= 0 && sessions[idx].title !== event.title) {
+          if (!titleChanged) {
+            sessions = sessions.slice();
+            titleChanged = true;
+          }
+          sessions[idx] = { ...sessions[idx], title: event.title };
+        }
+        continue;
+      }
       const targetsCurrent = !!currentSessionId && sessionId === currentSessionId;
       const initial = sessionViewCaches.get(sessionId)
         || (targetsCurrent
@@ -1835,6 +1856,7 @@ export const useStore = create<AppState>((set, get) => ({
           ? parseAgentsFromMessages(currentCache.messages)
           : state.agents,
       } : {}),
+      ...(titleChanged ? { sessions } : {}),
       sessionRunStatuses,
     });
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -570,7 +570,6 @@ pub(crate) async fn shutdown_join_core_if_current(state: &TiangongApp, session_i
 #[tauri::command]
 pub async fn update_session_title(
     title: String,
-    app: AppHandle,
     state: State<'_, TiangongApp>,
 ) -> Result<(), String> {
     if title.trim().is_empty() {
@@ -589,10 +588,10 @@ pub async fn update_session_title(
         return Err("活动会话已切换，请重新修改标题".to_string());
     }
     // 统一经 CoreManager（有 live Core 时委托 Core 走 turn 安全写入，否则直写盘）。
+    // 标题变更通知由 Core 统一发 TitleChanged 事件，前端据此更新，不再 emit sessions_updated。
     state
         .core_manager
         .set_core_title(&session_id, title, false)?;
-    let _ = app.emit("sessions_updated", &());
     Ok(())
 }
 
@@ -983,10 +982,10 @@ pub(crate) fn start_stream_consumer(
                 continue;
             }
 
-            // 标题变更：通知类事件，不触碰消息投递临界区，转发并刷新会话列表。
+            // 标题变更：通知类事件，不触碰消息投递临界区，只转发流事件。
+            // 前端收到 title_changed 后直接更新内存中对应会话标题，无需整表刷新。
             if matches!(&session_event, StreamEvent::TitleChanged { .. }) {
                 emit_session_stream_event(&app, &session_id, &session_event);
-                let _ = app.emit("sessions_updated", &());
                 continue;
             }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -29,6 +29,7 @@ fn configure_no_window(command: &mut tokio::process::Command) -> &mut tokio::pro
     command
 }
 
+#[allow(dead_code)]
 fn done_event_keeps_turn_running(
     event: &tiangong_types::StreamEvent,
     has_pending_turn: bool,
@@ -569,6 +570,7 @@ pub(crate) async fn shutdown_join_core_if_current(state: &TiangongApp, session_i
 #[tauri::command]
 pub async fn update_session_title(
     title: String,
+    app: AppHandle,
     state: State<'_, TiangongApp>,
 ) -> Result<(), String> {
     if title.trim().is_empty() {
@@ -586,8 +588,11 @@ pub async fn update_session_title(
     if active_session_id != session_id {
         return Err("活动会话已切换，请重新修改标题".to_string());
     }
-    crate::session_ops::update_title(&state.core_manager, &session_id, title)
-        .map_err(|error| error.to_string())?;
+    // 统一经 CoreManager（有 live Core 时委托 Core 走 turn 安全写入，否则直写盘）。
+    state
+        .core_manager
+        .set_core_title(&session_id, title, false)?;
+    let _ = app.emit("sessions_updated", &());
     Ok(())
 }
 
@@ -978,6 +983,13 @@ pub(crate) fn start_stream_consumer(
                 continue;
             }
 
+            // 标题变更：通知类事件，不触碰消息投递临界区，转发并刷新会话列表。
+            if matches!(&session_event, StreamEvent::TitleChanged { .. }) {
+                emit_session_stream_event(&app, &session_id, &session_event);
+                let _ = app.emit("sessions_updated", &());
+                continue;
+            }
+
             let event_lock = app_state.session_send_lock(&session_id);
             let _event_guard = rt.block_on(event_lock.lock_owned());
             if !app_state.core_manager.has_live_core(&session_id) {
@@ -1050,32 +1062,6 @@ pub(crate) fn start_stream_consumer(
                 let final_sid = sid.clone();
                 let completed_remote_message_id = app_state.remote_turn_owner(&final_sid);
 
-                let title_provider =
-                    rt.block_on(app.state::<TiangongApp>().with_state_read(|core_state| {
-                        if done_event_keeps_turn_running(
-                            &event,
-                            crate::state_ops::has_pending_turn(core_state, &final_sid),
-                        ) {
-                            return Ok(None);
-                        }
-                        let models = &core_state.config.models;
-                        Ok(Some(
-                            models
-                                .resolve_slot(tiangong_llm::models_config::RoutingSlot::Lite)
-                                .or_else(|| {
-                                    models.resolve_slot(
-                                        tiangong_llm::models_config::RoutingSlot::Chat,
-                                    )
-                                })
-                                .map(tiangong_llm::ModelEndpoint::from_resolved)
-                                .unwrap_or_default(),
-                        ))
-                    }));
-                // 标题输入的单次磁盘读取不持有 TiangongState 锁，不影响会话切换。
-                let title_task =
-                    crate::session_ops::title_generation_input(&app_state.core_manager, &final_sid)
-                        .zip(title_provider.ok().flatten());
-
                 if let Some(message_id) = completed_remote_message_id {
                     rt.block_on(crate::embedded_server::complete_remote_turn_from_stream(
                         app.state::<TiangongApp>().inner(),
@@ -1086,47 +1072,8 @@ pub(crate) fn start_stream_consumer(
 
                 emit_session_stream_event(&app, &final_sid, &event);
                 let _ = app.emit("sessions_updated", &());
-
-                // 异步生成标题（不阻塞消费线程）
-                if let Some((input, provider_config)) = title_task {
-                    let app_for_title = app.clone();
-                    let sid_for_title = final_sid.clone();
-                    let rt2 = rt.clone();
-                    thread::spawn(move || {
-                        let client =
-                            tiangong_core::model::SingleProviderClient::new(provider_config);
-                        if let Ok(t) = client.complete_lite(&input) {
-                            let clean = t.trim().trim_matches('"').to_string();
-                            if !clean.is_empty() {
-                                let app_state = app_for_title.state::<TiangongApp>();
-                                let title_lock = app_state.session_send_lock(&sid_for_title);
-                                let _title_guard = rt2.block_on(title_lock.lock_owned());
-                                let title_is_still_default = app_state
-                                    .core_manager
-                                    .list_session_metadata()
-                                    .into_iter()
-                                    .find(|metadata| metadata.id == sid_for_title)
-                                    .is_some_and(|metadata| {
-                                        metadata.title == "新对话"
-                                            || metadata.title.starts_with("会话 ")
-                                    });
-                                if !title_is_still_default {
-                                    return;
-                                }
-                                if crate::session_ops::update_title(
-                                    &app_state.core_manager,
-                                    &sid_for_title,
-                                    clean,
-                                )
-                                .is_err()
-                                {
-                                    return;
-                                }
-                                let _ = app_for_title.emit("sessions_updated", &());
-                            }
-                        }
-                    });
-                }
+                // 标题生成已在 send_message_inner 投递后并行启动（与 chat turn 同时跑），
+                // 完成后经 Command::SetTitle 投递给 turn task 安全写入，此处不再串行处理。
                 // 不 break — 消费线程继续运行，等待下一轮消息的 StreamEvent
             }
         }

--- a/src-tauri/src/session_ops.rs
+++ b/src-tauri/src/session_ops.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use tiangong_app_state::app_state::{CoreManager, TiangongState};
-use tiangong_core::session::{now_text, MessageRole, Session, SessionCwdMode};
+use tiangong_core::session::{now_text, Session, SessionCwdMode};
 use tiangong_types::{ContentBlock, TrustMode};
 
 pub(crate) fn remove_session_state(
@@ -76,26 +76,6 @@ pub(crate) fn restore_session(snapshot: Session) -> Result<()> {
     snapshot
         .try_persist_to_disk()
         .map_err(|error| anyhow!("恢复会话失败：{error}"))
-}
-
-pub(crate) fn update_title(
-    manager: &CoreManager,
-    session_id: &str,
-    title: String,
-) -> Result<String> {
-    let title = title.trim().to_string();
-    if title.is_empty() {
-        return Err(anyhow!("会话标题不能为空"));
-    }
-    let mut session = manager
-        .load_session(session_id)
-        .map_err(|error| anyhow!("加载会话失败：{error}"))?;
-    let previous = std::mem::replace(&mut session.title, title);
-    session.updated_at = now_text();
-    session
-        .try_persist_to_disk()
-        .map_err(|error| anyhow!("保存会话标题失败：{error}"))?;
-    Ok(previous)
 }
 
 pub(crate) fn update_trust_mode(
@@ -176,16 +156,4 @@ pub(crate) fn update_workspace_dir(
             .map_err(|error| anyhow!("保存会话工作目录失败：{error}"))?;
     }
     Ok(())
-}
-
-pub(crate) fn title_generation_input(manager: &CoreManager, session_id: &str) -> Option<String> {
-    let session = manager.load_session(session_id).ok()?;
-    if session.title != "新对话" && !session.title.starts_with("会话 ") {
-        return None;
-    }
-    session
-        .messages
-        .iter()
-        .find(|message| message.role == MessageRole::User)
-        .map(|message| message.text_content())
 }


### PR DESCRIPTION
## 背景

会话标题的更新（lite 自动生成与用户手动编辑）此前存在两个问题：

1. **绕过 Core 直接读写磁盘 session 文件**，与 turn task 对 session 的独占读写存在覆盖竞争，可能导致标题丢失；
2. **自动生成标题串行排在对话结束后**，无法与对话并行；改为并行后又因前端依赖重新读文件，要等对话结束才显示；
3. 手动改标题会触发 2~3 次整表 `sessions_updated` 刷新。

## 改动

### 标题更新收归 Core 内部（commit a12b5319）

- 新增 `Command::SetTitle`（带 `only_if_default` 标志，保护用户已改标题）与 `StreamEvent::TitleChanged`（core 层通知，走自有事件通道，不碰 tauri）。
- `TurnContext` 增加 `lite_client` 字段，`build_turn_context` 时从配置构建，未配置 lite 时回退 chat client。
- **自动生成标题完全在 Core 内部**：`run_turn` turn 开始时据首条用户消息 `spawn_blocking` 调 lite 生成，完成后经 `Command::SetTitle` 投回 turn task 写入 `ctx.session`，`run_turn` 统一落盘。外部（`send_message` / tauri command）不再参与自动生成，`send_message_inner` 回归只负责发消息。
- **用户手动编辑**走 Tauri command → `CoreManager::set_core_title` → `core.set_title`（`is_busy` 分流：忙时投 turn task，空闲 Core 直写），无 live Core 视为异常报错。**session 落盘始终由 Core 负责**。
- 生成期间 turn 若已结束则放弃本次，下次提问标题仍是默认值时自动补发。

### 标题变更改为事件驱动（commit cc766975）

- Core 的 `set_title` 空闲分支也发 `TitleChanged`（手动改空闲会话同样通知）。
- 后端不再主动 emit `sessions_updated`：`update_session_title` 与消费线程的 `TitleChanged` 分支都只走流事件通道。
- 前端 `applyStreamEvents` 正式处理 `title_changed`：直接更新内存中对应会话标题，不触发整表 `loadSessions`，且从 `runStatus` 判定中豁免（不再误设为执行中）。
- `StatusPanel` 手动改标题后去掉 `loadSessions()`。

## 效果

- 自动生成标题：对话过程中算完即显示，不再等对话结束。
- 手动改标题：只更新对应标题，不再刷新整个对话列表。
- 标题落盘统一由 Core 控制，避免并发覆盖。

## 验证

- `cargo clippy --workspace` ✅
- `cargo check --workspace` ✅
- `yarn build`（前端）✅