### PR TITLE
fix(server): 修复 server 模式定时任务无法触发

### DIFF
--- a/crates/tiangong-scheduler/src/executor.rs
+++ b/crates/tiangong-scheduler/src/executor.rs
@@ -200,13 +200,18 @@ pub async fn restore_cron_jobs(ctx: Arc<dyn SchedulerContext>) {
         }
     };
 
+    // 捕获当前 tokio runtime 句柄：silent 调度器内部用 async-global-executor
+    //（独立线程池，无 tokio reactor）执行任务回调，回调里直接 await tokio 异步代码
+    // 会 panic（there is no reactor running）。这里把句柄捕获进闭包，回调被触发时
+    // 用 handle.spawn 把真正执行投递回 tokio runtime，回调自身立即返回。
+    let handle = tokio::runtime::Handle::current();
+
     let mut scheduler = silent::SCHEDULER.lock().await;
     for job in jobs {
         let schedule = match &job.schedule {
             Some(s) => s.clone(),
             None => continue,
         };
-        let job_clone = job.clone();
         let process_time = match schedule.try_into() {
             Ok(pt) => pt,
             Err(e) => {
@@ -214,27 +219,45 @@ pub async fn restore_cron_jobs(ctx: Arc<dyn SchedulerContext>) {
                 continue;
             }
         };
-        let ctx_clone = ctx.clone();
-        let task = silent::Task::create_with_action_async(
-            job.id.clone(),
-            process_time,
-            job.name.clone(),
-            Arc::new(move || {
-                let job = job_clone.clone();
-                let ctx = ctx_clone.clone();
-                Box::pin(async move {
-                    tracing::info!("定时任务触发：{} [{}]", job.name, job.id);
-                    execute_job(ctx, job).await;
-                    Ok(())
-                })
-            }),
-        );
+        let task = build_cron_task(&job, process_time, ctx.clone(), &handle);
         if let Err(e) = scheduler.add_task(task) {
             tracing::warn!("注册定时任务失败 [{}]：{e}", job.id);
         } else {
             tracing::info!("已恢复定时任务：{} [{}]", job.name, job.id);
         }
     }
+}
+
+/// 构造一个 silent cron Task：到点被调度器调用时，把 `execute_job` 投递到 tokio runtime。
+///
+/// silent 的调度器用 async-global-executor 执行任务回调（非 tokio 线程池），
+/// 直接在回调里 await tokio 异步逻辑会因找不到 reactor 而 panic。这里捕获 tokio
+/// runtime 句柄，回调被触发时用 `Handle::spawn` 把执行转发回 tokio runtime，
+/// 回调立即返回，不阻塞调度器。
+fn build_cron_task(
+    job: &Job,
+    process_time: silent::ProcessTime,
+    ctx: Arc<dyn SchedulerContext>,
+    handle: &tokio::runtime::Handle,
+) -> silent::Task {
+    let job_clone = job.clone();
+    let ctx = ctx.clone();
+    let handle = handle.clone();
+    silent::Task::create_with_action_async(
+        job.id.clone(),
+        process_time,
+        job.name.clone(),
+        Arc::new(move || {
+            let job = job_clone.clone();
+            let ctx = ctx.clone();
+            let handle = handle.clone();
+            Box::pin(async move {
+                tracing::info!("定时任务触发：{} [{}]", job.name, job.id);
+                handle.spawn(async move { execute_job(ctx, job).await });
+                Ok(())
+            })
+        }),
+    )
 }
 
 /// 校验 schedule 字符串能否被调度器解析。

--- a/crates/tiangong-server/src/lib.rs
+++ b/crates/tiangong-server/src/lib.rs
@@ -10,7 +10,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::Result;
-use silent::Scheduler;
 use silent::prelude::*;
 use tiangong_core::permission::TrustMode;
 use tiangong_scheduler::executor::SchedulerContext;
@@ -26,7 +25,6 @@ pub fn run_server(host: &str, port: u16, token: Option<String>) -> Result<()> {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
-    let _runtime_guard = runtime.enter();
 
     tracing::info!("正在初始化应用状态...");
     let mut app_state = tiangong_app_state::app_state::TiangongState::new();
@@ -56,15 +54,21 @@ pub fn run_server(host: &str, port: u16, token: Option<String>) -> Result<()> {
     let mut route = Route::new_root().append(api_routes);
     route.set_state(Some(configs));
 
-    // 初始化调度器，恢复已启用的 cron job
-    let scheduler_ctx = app.scheduler_context.clone();
-    tokio::spawn(async move {
-        tiangong_scheduler::executor::restore_cron_jobs(scheduler_ctx).await;
-        Scheduler::schedule(silent::SCHEDULER.clone()).await;
-    });
-
     tracing::info!("Server 启动：http://{addr}");
-    Server::new().bind(addr).run(route);
+
+    // 自建 runtime 并真正用 block_on 驱动：恢复定时任务与 HTTP 服务跑在同一个
+    // runtime 上。若只用 runtime.enter() 而不 block_on，spawn 的 future 永远不会被
+    // poll（恢复 cron job 不执行，SCHEDULER 为空，定时任务永不触发）；而
+    // Server::run 会另行创建独立 runtime 驱动 HTTP，两者互不相干。
+    runtime.block_on(async move {
+        // 先恢复已启用的 cron job 到全局 SCHEDULER，再启动 HTTP。silent 的
+        // Server::serve 内部会调用 ensure_scheduler_running() 拉起
+        // Scheduler::schedule 循环，从而真正按 cron 触发已注册的任务。
+        let scheduler_ctx = app.scheduler_context.clone();
+        tiangong_scheduler::executor::restore_cron_jobs(scheduler_ctx).await;
+
+        Server::new().bind(addr).serve(route).await;
+    });
 
     Ok(())
 }


### PR DESCRIPTION
## 问题

server 模式（含 `--daemon` 后台）下，已启用的定时任务永不触发；触发执行时还会 panic（`there is no reactor running, must be called from the context of a Tokio 1.x runtime`）。

## 根因

两处独立问题叠加：

1. **`run_server` 的 runtime 未被驱动**：自建 tokio runtime 只调用 `runtime.enter()`（仅设置线程上下文，不驱动），把恢复任务的 `tokio::spawn` 丢进了这个永远不会被 poll 的 runtime；而 `Server::run` 内部又新建了一个独立 runtime 驱动 HTTP，两者互不相干。结果 `restore_cron_jobs` 从不执行，`SCHEDULER` 为空。

2. **调度器执行器不兼容**：silent 调度器用 `async-global-executor`（独立线程池，无 tokio reactor）执行任务回调，回调内直接 `await` tokio 异步逻辑会 panic。

## 改动

- `run_server`：改用 `runtime.block_on` 真正驱动 runtime，在其中先 `restore_cron_jobs` 再 `Server::serve().await`；恢复的任务由 silent 的 `ensure_scheduler_running()` 自动拉起 `Scheduler::schedule` 循环调度。
- `restore_cron_jobs` / 新增 `build_cron_task`：捕获当前 tokio runtime 句柄，任务到点被触发时用 `handle.spawn` 把 `execute_job` 转发回 tokio runtime，回调立即返回，不再 panic。

## 影响范围

- `restore_cron_jobs` 为 `tiangong-scheduler` 共享代码，desktop 同样调用，改动对 desktop 等价且更健壮（已跑 `tiangong-app` scheduler 测试通过）。
- server/desktop 启动 schedule 循环方式不同是合理的：desktop 不走 silent HTTP 服务，需显式启动；server 走 `Server::serve` 由 `ensure_scheduler_running` 自动启动（再显式启动反而会因 `SCHEDULER_RUNNING` 幂等保护而重复跑）。

## 验证

- `cargo check` / `clippy` 通过。
- `tiangong-scheduler`、`tiangong-app` scheduler 测试通过。
- 端到端实测：隔离 HOME 启动 server，预置每秒触发的 cron 任务，修复前 panic，修复后日志显示按秒触发并完整执行链路（到 LLM 调用前因测试环境无 API_MODEL 报错，属预期）。