### PR TITLE
feat(frontend): 欢迎页展示当前工作目录

### DIFF
--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -41,8 +41,19 @@ import {
 } from "./message";
 import { type MentionEditorHandle } from "./MentionEditor";
 
+/** 取路径最后 1-2 级目录用于简短展示，例如 /a/b/tiangong -> b/tiangong */
+function shortDir(path: string): string {
+  if (!path) return '';
+  const trimmed = path.replace(/[\\/]+$/, '');
+  const parts = trimmed.split(/[\\/]/).filter(Boolean);
+  if (parts.length <= 2) return parts.join('/');
+  return parts.slice(-2).join('/');
+}
+
 export function MessageList() {
   const messages = useStore(s => s.messages);
+  const workspaceDir = useStore(s => s.workspaceDir);
+  const sessionCwd = useStore(s => s.sessionCwd);
   const runStatus = useStore(s => s.runStatus);
   const runSummary = useStore(s => s.runSummary);
   const streamingMessageId = useStore(s => s.streamingMessageId);
@@ -706,8 +717,15 @@ export function MessageList() {
               <h2 className="text-xl font-medium text-foreground mb-2">
                 欢迎使用天工
               </h2>
-              <p className="text-muted-foreground text-sm">
-                我可以帮助您完成各种任务
+              <p
+                className="text-muted-foreground text-sm"
+                title={(sessionCwd || workspaceDir) || undefined}
+              >
+                我可以帮助您在{' '}
+                <span className="text-foreground font-medium font-mono">
+                  {shortDir(sessionCwd || workspaceDir) || '当前工作区'}
+                </span>
+                {' '}中完成各种任务
               </p>
             </div>
           ) : (


### PR DESCRIPTION
## 变更内容

新对话消息列表区中间的欢迎文案由「我可以帮助您完成各种任务」调整为：

> 我可以帮助您在 **`工作目录`** 中完成各种任务

具体调整：
- 读取当前会话工作目录（优先 sessionCwd，其次全局 workspaceDir），展示在欢迎文案中
- 路径取最后 1-2 级做简短展示（与侧边栏分组 basename 思路一致，避免过长）
- 目录名采用主色 + 加粗 + 等宽字体加以突出，并与前后文字各留一个空格
- 鼠标悬停在目录名上以 title 形式查看完整路径

## 测试情况

- [x] 前端类型检查 `tsc --noEmit` 通过
- [x] pre-commit 钩子通过
- [x] 推送时 CI（yarn build / yarn test）通过