### PR TITLE
docs(readme): 同步最新发布内容至 v0.13.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Silent-Tiangong（天工）
 
-> 面向个人工作流的桌面级 AI 自动化中枢：对话、规划、执行、记忆、工具调用、嵌入式浏览器和多智能体协作。
+> 面向个人工作流的桌面级 AI 自动化中枢：对话、规划、执行、记忆、工具调用、嵌入式浏览器、多智能体协作、移动端控制和定时任务。
 
-天工是一个基于 Rust、Tauri 和 silent 构建的个人智能终端。它既可以作为桌面 AI 助手使用，也可以通过 CLI 和 Server API 接入脚本、服务或外部消息通道。核心目标不是只回答问题，而是让 Agent 能围绕真实工作区读取资料、拆解任务、调用工具、执行命令、保存长期记忆，并在复杂任务中动态创建 Sub Agent 分工协作。天工内置嵌入式浏览器，Agent 可自主打开网页、读取页面内容、点击元素和填写表单，同时感知用户在浏览器中的操作行为，实现人机协同浏览。项目完全适配 DeepSeek 的上下文缓存机制，多轮对话中历史消息可被高效命中缓存，显著降低重复传输成本并提升响应速度。模型推荐使用 [DeepSeek](https://www.deepseek.com/) 和 [智谱](https://www.bigmodel.cn/) 的GLM5.1，其他模型可以通过自定义供应商接入。
+天工是一个基于 Rust、Tauri 和 silent 构建的个人智能终端。它既可以作为桌面 AI 助手使用，也可以通过 CLI 和 Server API 接入脚本、服务或外部消息通道。核心目标不是只回答问题，而是让 Agent 能围绕真实工作区读取资料、拆解任务、调用工具、执行命令、保存长期记忆，并在你主动要求分工时招募 Sub Agent 协作。天工内置嵌入式浏览器，Agent 可自主打开网页、读取页面内容、点击元素和填写表单，同时感知用户在浏览器中的操作行为，实现人机协同浏览；通过飞书、微信、QQ 等 IM 平台接入移动端控制，可随时随地远程驱动 Agent，配合定时任务和 Webhook 实现按计划或按事件自动执行。项目完全适配 DeepSeek 的上下文缓存机制，多轮对话中历史消息可被高效命中缓存，显著降低重复传输成本并提升响应速度。模型推荐使用 [DeepSeek](https://www.deepseek.com/)、[Kimi](https://kimi.com/) 的 kimi-k3 和 [智谱](https://www.bigmodel.cn/) 的 GLM5.2，其他模型可以通过自定义供应商接入。
 
 > 安全提示：天工当前未使用沙箱技术隔离工具执行环境。如果你对本地文件访问、命令执行或自动化操作的隔离要求较高，建议暂时考虑其他软件。
 
@@ -22,6 +22,8 @@
 | 多智能体协作 | 主 Agent 可按任务创建 PM、Developer、Tester、Researcher 等 Sub Agent，并通过消息和文件锁协作 |
 | 工具执行     | 支持文件读写、命令执行、代码搜索、补丁应用、网页抓取、时间查询等本地工具                     |
 | MCP 与 Skill | 支持 MCP 工具接入、本地 Skill 安装启停、按任务意图匹配和详情加载                             |
+| 移动端控制   | 通过独立 Bot 制品接入飞书、微信、QQ，支持扫码配置、运行托管、日志查看和图片/文件收发         |
+| 定时与触发   | 内置 Cron 定时任务（简单/Cron 双模式）与 Webhook 触发，定时结果可推送到指定 Bot 通道         |
 | 长期记忆     | 基于 SQLite、Tantivy 和向量索引保存项目事实、偏好、决策、产物和历史问题                      |
 | 多媒体能力   | 支持图片、视频、语音识别、语音合成等能力路由，结果以结构化媒体资源进入会话                   |
 | 权限治理     | 桌面会话可在监督模式和信任模式之间切换，Server 模式使用受控的远程角色边界                    |
@@ -29,23 +31,21 @@
 
 ## 多智能体协作
 
-多智能体协作适合资料搜集、代码实现、测试验证、方案评审等需要分工的任务。主 Agent 会判断是否需要组建团队，创建的 Sub Agent 拥有独立角色、状态和上下文。
+多智能体协作适合资料搜集、代码实现、测试验证、方案评审等需要分工的任务。Sub Agent 由用户主动招募——当你明确要求并行处理、分工协作、组建团队，或用 `@角色` 提及一个尚未创建的成员时，主 Agent 才会创建对应的 Sub Agent；单轮可完成的任务则直接由主 Agent 处理，不会主动拆分团队。每个 Sub Agent 拥有独立的角色、状态和上下文。
 
 ```text
-用户提出复杂任务
+用户提出复杂任务并要求分工 / 并行 / @角色
     ↓
-Main Agent 判断是否需要协作
-    ↓
-create_agent 创建 Sub Agent
+主 Agent 按需求招募对应角色的 Sub Agent
     ↓
 Sub Agent 独立执行、互相发消息、必要时获取文件锁
     ↓
-Main Agent 汇总结果并回复用户
+主 Agent 汇总结果并回复用户
 ```
 
 已支持的协作方式：
 
-- 动态创建和解散 Sub Agent。
+- 按需招募和解散 Sub Agent，默认不主动创建。
 - `send_message` / `broadcast_message` 进行 Agent 间通讯。
 - `@dev`、`@test`、`@all` 等语法直接向指定 Agent 发送消息。
 - Sub Agent 可直接向前端推送进度、阻塞和问题。
@@ -63,6 +63,25 @@ Main Agent 汇总结果并回复用户
 - **浏览历史**：支持全局浏览历史和标签页内前进/后退导航，历史记录持久化存储。
 - **智能感知**：Agent 在执行过程中自动检测页面变化（URL 切换、内容更新、网络请求），仅在变化时注入数据，避免重复干扰。
 
+## 移动端控制
+
+天工通过独立 Bot 制品接入第三方 IM 平台，实现移动端远程控制：天工负责下载、配置、启动、监控和升级 Bot，Bot 通过 Server API 与天工通信。平台专属的扫码授权和凭证存储完全由对应 Bot 制品负责，天工只接收运行状态。
+
+- **已支持平台**：飞书、微信、QQ，并支持本地自有 Bot 接入与第三方 Bot 目录贡献。
+- **扫码配置**：桌面端调用 Bot 制品发起扫码，展示授权二维码与状态；扫码所得凭证由 Bot 自行保存，天工不接触明文。
+- **运行托管**：Bot 随天工自动运行或手动启停，支持日志查看、配置删除、自动注入天工服务地址和 Token，Windows 停止时抑制终端窗口闪现。
+- **MCP 主动推送**：Bot 自动维护已授权主动发过消息的多目标清单，具备文本、图片和文件推送能力，MCP 注册和注销绑定到 Bot 启停流程。
+- **远程管理**：通过 `tiangong bot` 子命令可在无图形界面环境下完成 Bot 的全生命周期管理。
+
+## 定时与触发
+
+天工内置独立的调度与触发能力，用于按计划或外部事件驱动 Agent 执行：
+
+- **定时任务**：基于 `tiangong-scheduler` crate 和 JSON 文件存储（`~/.tiangong/scheduler/`），复用 silent 框架内置 Scheduler，Server 启动时自动恢复已启用的 Cron Job。
+- **双模式编辑**：桌面端提供简单模式和 Cron 模式两种编辑器，内置校验和下次触发预览，可关联已有会话复用上下文或自动创建新会话。
+- **Webhook 触发**：Server 内置独立于定时任务的 HTTP 触发能力（`~/.tiangong/webhooks/`），提供无需认证的外部触发端点和需认证的管理端点，支持可选签名验证。
+- **结果推送**：定时任务和 Webhook 触发的结果可推送到指定 Bot 通道，与移动端控制联动。
+
 ## 架构
 
 天工采用 Cargo workspace 多 crate 结构，核心引擎和各入口解耦：
@@ -75,10 +94,13 @@ crates/
   tiangong-anthropic/   Anthropic Messages API 与 SSE 适配
   tiangong-core/        Agent 循环、工具调用、MCP、Skill、多 Agent 团队
   tiangong-memory/      长期记忆、检索、反刍和工作区隔离
+  tiangong-bots/        移动端控制：Bot 制品下载、配置、启停和监控
+  tiangong-scheduler/   定时任务（Cron）与 Webhook 触发
   tiangong-cli/         CLI / TUI 前端
   tiangong-entry/       统一命令入口
   tiangong-server/      HTTP REST + WebSocket Server
   tiangong-media/       图片、视频、语音等多媒体能力
+  plugins/              工具/媒体/记忆等可插拔能力
 frontend/               桌面前端
 src-tauri/              Tauri 桌面壳
 ```
@@ -92,7 +114,7 @@ src-tauri/              Tauri 桌面壳
   ↓
 ReAct 循环：推理、工具调用、观察、继续执行
   ↓
-单 Agent 直接完成，或创建 Sub Agent 分工协作
+默认由主 Agent 直接完成；用户要求分工时招募 Sub Agent 协作
   ↓
 结构化事件实时推送到 GUI / CLI / Server
 ```
@@ -193,6 +215,8 @@ tiangong model route set chat deepseek-chat  # 切换 chat 模型
 tiangong server token show               # 查看 Server Token
 tiangong memory enable                   # 启用 Memory
 tiangong prompt edit                     # 编辑自定义 Prompt
+tiangong bot list                        # 查看已配置 Bot
+tiangong bot start feishu                # 启动指定 Bot
 tiangong config show                     # 配置概览
 tiangong doctor                          # 环境诊断
 ```
@@ -249,6 +273,8 @@ yarn --cwd frontend dev
 - [CLI 配置指南](docs/cli-configuration-guide.md)
 - [Server API](docs/server-api.md)
 - [Linux 服务器部署指南](docs/linux-server-deployment.md)
+- [Bot MCP 主动推送设计](docs/bot-mcp-proactive-push-design.md)
+- [RFC 0011：多智能体协作系统](docs/rfc/0011-multi-agent-collaboration.md)
 - [RFC 0015：CLI 模块化配置](docs/rfc/0015-cli-modular-config.md)
 
 ## 许可证


### PR DESCRIPTION
## 变更说明

对照最新发布 v0.13.4 同步 README，并修正与实际机制不符的描述。

### 主要改动

- **首段与核心能力表**：补充「移动端控制」「定时与触发」两项 0.13 系列已发布但此前未体现的能力。
- **新增章节**：在「嵌入式浏览器」后新增「移动端控制」「定时与触发」两节，说明 Bot 制品接入、扫码配置、Cron 双模式编辑、Webhook 触发与结果推送。
- **推荐模型**：新增 Kimi 的 kimi-k3，智谱由 GLM5.1 调整为 GLM5.2。
- **修正多智能体协作描述**：原描述为主 Agent 自主判断是否组队，实际机制为用户主动招募（明确要求分工/并行/建团队或 @角色 时才创建 Sub Agent），已同步修正首段正文、核心执行流程图及协作章节。
- **架构图**：补全 `tiangong-bots`、`tiangong-scheduler`、`plugins` 等实际存在的 crate。
- **模块化配置**：补充 `tiangong bot list / start` 子命令示例。
- **文档列表**：补充 Bot MCP 主动推送设计、RFC 0011 多智能体协作文档链接。

### 测试

- 仅文档变更，无代码改动。
- 所有新增文档链接均已确认存在。
- pre-commit 钩子（行尾、空白、大小写冲突等）全部通过。

### 关联

- 对应最新发布：v0.13.4