### PR TITLE
chore(release): v0.13.5 临时发布分支（已完成）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "发布标签，留空时使用 v0.13.4"
+        description: "发布标签，留空时使用 v0.13.5"
         required: false
         type: string
       release_draft:
@@ -66,7 +66,7 @@ jobs:
           else
             tag="${{ inputs.tag }}"
             if [[ -z "$tag" ]]; then
-              tag="v0.13.4"
+              tag="v0.13.5"
             fi
             draft="${{ inputs.release_draft }}"
           fi
@@ -219,7 +219,8 @@ jobs:
         with:
           projectPath: .
           tagName: ${{ steps.release.outputs.tag }}
-          releaseName: "天工 v0.13.4"
+          releaseName: "天工 v0.13.5"
+          releaseCommitish: release/0.13.5
           releaseBody: ${{ steps.release_notes.outputs.body }}
           releaseDraft: ${{ steps.release.outputs.draft }}
           prerelease: false
@@ -245,7 +246,7 @@ jobs:
           else
             tag="${{ inputs.tag }}"
             if [[ -z "$tag" ]]; then
-              tag="v0.13.4"
+              tag="v0.13.5"
             fi
           fi
           # Strip leading 'v' or 'app-v' to get bare version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9967,7 +9967,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "tiangong-config",
@@ -9976,7 +9976,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-anthropic"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "eventsource-stream",
  "futures-util",
@@ -9988,7 +9988,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-app"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -10053,7 +10053,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-app-state"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "serde",
  "tiangong-config",
@@ -10064,7 +10064,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-bots"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10087,7 +10087,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-cli"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -10122,7 +10122,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-config"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "fs4 0.8.4",
@@ -10141,7 +10141,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-core"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10172,7 +10172,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-core-manager"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -10198,8 +10198,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiangong-deepseek"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "814688dbff79c1c2b8a7d8f31c7a19d1f33445b7d4b1d7096a4b1d5c0f0e8932"
+dependencies = [
+ "eventsource-stream",
+ "futures-util",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
 name = "tiangong-entry"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -10227,7 +10242,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-llm"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -10240,7 +10255,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tiangong-anthropic",
- "tiangong-deepseek",
+ "tiangong-deepseek 0.1.1",
  "tiangong-types",
  "tokio",
  "tracing",
@@ -10248,7 +10263,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-media"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10261,7 +10276,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-media-archive"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "base64 0.22.1",
  "reqwest 0.13.4",
@@ -10273,7 +10288,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-memory"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10300,7 +10315,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-agent-team"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "chrono",
  "scru128",
@@ -10316,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-analyze-attachment"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -10329,7 +10344,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-browser"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "base64-url",
@@ -10349,7 +10364,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-command"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -10362,7 +10377,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-fetch"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "reqwest 0.13.4",
@@ -10379,7 +10394,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-fs"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10396,7 +10411,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-generate-image"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -10409,7 +10424,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-generate-video"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -10422,7 +10437,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-index"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10442,7 +10457,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-mcp"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "http",
@@ -10459,7 +10474,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "scru128",
  "serde",
@@ -10473,14 +10488,14 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-prompt"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "tiangong-core",
 ]
 
 [[package]]
 name = "tiangong-plugin-scheduler"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10497,7 +10512,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-skill"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "scru128",
@@ -10513,7 +10528,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-speech-to-text"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -10525,7 +10540,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-task"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "scru128",
  "serde",
@@ -10537,7 +10552,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-terminal"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "descape",
@@ -10561,7 +10576,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-text-to-speech"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "scru128",
  "serde",
@@ -10574,7 +10589,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-scheduler"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10592,7 +10607,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-server"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -10643,7 +10658,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-toolkit"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "tiangong-types",
@@ -10651,7 +10666,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-types"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "chrono",
  "scru128",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,13 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.4"
+version = "0.13.5"
 
 [workspace.dependencies]
 tiangong-anthropic = { path = "crates/tiangong-anthropic" }
 tiangong-app-state = { path = "crates/tiangong-app-state" }
 tiangong-cli = { path = "crates/tiangong-cli" }
-tiangong-deepseek = { path = "crates/tiangong-deepseek" }
+tiangong-deepseek = "0.1.1"
 tiangong-config = { path = "crates/tiangong-config" }
 tiangong-core = { path = "crates/tiangong-core" }
 tiangong-core-manager = { path = "crates/tiangong-core-manager" }

--- a/crates/tiangong-core/src/react/execute.rs
+++ b/crates/tiangong-core/src/react/execute.rs
@@ -139,7 +139,7 @@ fn record_tool_calls(
     ctx: &mut TurnContext,
     pending_msg_id: &str,
     response: &ModelFunctionResponse,
-    round: usize,
+    stage: String,
 ) -> Vec<ToolCall> {
     let calls = response.tool_calls.clone();
     debug_assert!(!calls.is_empty(), "工具批次不能为空");
@@ -149,7 +149,7 @@ fn record_tool_calls(
         .map(|call| call.name.clone())
         .collect::<Vec<_>>();
     let output = LlmOutputRecord {
-        stage: format!("react-round-{round}"),
+        stage,
         content: response.text.clone(),
         reasoning_content: response.reasoning_content.clone(),
         tool_calls: tool_names.clone(),
@@ -1175,7 +1175,12 @@ pub(super) async fn execute_turn(
                             }
                         } else {
                             state.executed_tool_in_phase = true;
-                            let calls = record_tool_calls(ctx, &pending_msg_id, &response, state.round);
+                            let calls = record_tool_calls(
+                                ctx,
+                                &pending_msg_id,
+                                &response,
+                                format!("react-round-{}", state.round),
+                            );
                             state.tool_batch = Some(ToolBatchState {
                                 calls: calls.into_iter().enumerate().collect(),
                                 ready_tools: Vec::new(),
@@ -1230,20 +1235,26 @@ pub(super) async fn execute_turn(
                             tracing::warn!(
                                 count = response.tool_calls.len(),
                                 protocol = ?ctx.client().protocol(),
-                                "summary phase returned tool calls despite ToolChoice::None"
+                                "summary phase returned tool calls; continuing tool execution"
                             );
-                            if response.text.trim().is_empty() {
-                                let message =
-                                    "总结阶段无视 ToolChoice::None 返回了工具调用且无文本回复"
-                                        .to_string();
-                                persist_error(ctx, format!("总结阶段失败：{message}"));
-                                state.next_step = NextStep::StartForceFinal {
-                                    reason: ForceFinalReason::SummaryError,
-                                    request_injection_generation,
-                                    summary_error: Some(message),
-                                };
-                                continue 'agent_loop;
-                            }
+                            state.reset_react_phase();
+                            state.executed_tool_in_phase = true;
+                            let calls = record_tool_calls(
+                                ctx,
+                                &pending_msg_id,
+                                &response,
+                                format!("summary-iteration-{iteration}-continuation"),
+                            );
+                            state.tool_batch = Some(ToolBatchState {
+                                calls: calls.into_iter().enumerate().collect(),
+                                ready_tools: Vec::new(),
+                                prepared_keys: HashSet::new(),
+                                response_usage: response.usage,
+                                request_injection_generation,
+                                needs_failure_recovery: false,
+                            });
+                            state.next_step = NextStep::DriveTools;
+                            continue 'agent_loop;
                         }
 
                         let decision = parse_summary_phase_output(&response.text);

--- a/crates/tiangong-llm/src/providers/deepseek/mapping.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/mapping.rs
@@ -252,14 +252,12 @@ fn build_thinking(req: &ProviderRequest) -> Option<tiangong_deepseek::types::Thi
     if req.thinking_disabled {
         Some(tiangong_deepseek::types::ThinkingConfig {
             thinking_type: "disabled".to_string(),
-            budget_tokens: None,
         })
     } else {
         req.thinking
             .as_ref()
-            .map(|thinking| tiangong_deepseek::types::ThinkingConfig {
+            .map(|_| tiangong_deepseek::types::ThinkingConfig {
                 thinking_type: "enabled".to_string(),
-                budget_tokens: Some(thinking.budget_tokens),
             })
     }
 }

--- a/crates/tiangong-llm/src/providers/deepseek/stream.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/stream.rs
@@ -40,6 +40,22 @@ fn map_event(
                 partial_json: arguments,
             })]
         }
+        tiangong_deepseek::types::StreamEvent::TextProtocolToolCall {
+            id,
+            name,
+            arguments,
+        } => vec![
+            Ok(ProviderStreamEvent::ToolCallStart(ToolCall {
+                id: id.clone(),
+                name,
+                arguments: serde_json::json!({}),
+            })),
+            Ok(ProviderStreamEvent::ToolCallDelta {
+                call_id: id.clone(),
+                partial_json: arguments,
+            }),
+            Ok(ProviderStreamEvent::ToolCallEnd { call_id: id }),
+        ],
         tiangong_deepseek::types::StreamEvent::Usage(usage) => {
             vec![Ok(ProviderStreamEvent::Usage(parse_stream_usage(&usage)))]
         }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiangong-frontend",
   "private": true,
-  "version": "0.13.4",
+  "version": "0.13.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tiangong",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "identifier": "com.silent.tiangong",
   "build": {
     "beforeDevCommand": "yarn --cwd ../frontend dev",


### PR DESCRIPTION
## 用途

此 PR 基于 v0.13.4 创建，仅用于临时发布 v0.13.5。

- 不包含插件 WASM 化改造
- 不合入 main
- v0.13.5 已完成正式发布
- 主干版本同步将通过单独的干净 PR 处理

发布结果：https://github.com/silent-rs/silent-Tiangong/releases/tag/v0.13.5

成功任务：https://github.com/silent-rs/silent-Tiangong/actions/runs/30877440695