### PR TITLE
fix(release): 修正 v0.13.5 发布来源

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "发布标签，留空时使用 v0.13.4"
+        description: "发布标签，留空时使用 v0.13.5"
         required: false
         type: string
       release_draft:
@@ -66,7 +66,7 @@ jobs:
           else
             tag="${{ inputs.tag }}"
             if [[ -z "$tag" ]]; then
-              tag="v0.13.4"
+              tag="v0.13.5"
             fi
             draft="${{ inputs.release_draft }}"
           fi
@@ -219,7 +219,8 @@ jobs:
         with:
           projectPath: .
           tagName: ${{ steps.release.outputs.tag }}
-          releaseName: "天工 v0.13.4"
+          releaseName: "天工 v0.13.5"
+          releaseCommitish: release/0.13.5
           releaseBody: ${{ steps.release_notes.outputs.body }}
           releaseDraft: ${{ steps.release.outputs.draft }}
           prerelease: false
@@ -245,7 +246,7 @@ jobs:
           else
             tag="${{ inputs.tag }}"
             if [[ -z "$tag" ]]; then
-              tag="v0.13.4"
+              tag="v0.13.5"
             fi
           fi
           # Strip leading 'v' or 'app-v' to get bare version


### PR DESCRIPTION
## 变更

- 将发布默认标签和显示名称更新为 v0.13.5
- 明确使用 release/0.13.5 作为 GitHub Release 发布来源
- 保持标签构建内容基于 v0.13.4，不引入插件 WASM 化改造

## 原因

原标签提交没有对应远端分支，Tauri 发布步骤创建 GitHub Release 时被 GitHub 拒绝。此次让标签指向发布分支最新提交，并明确发布来源。

## 验证

- release.yml YAML 解析通过
- git diff --check 通过
- cargo check --workspace 通过
- yarn --cwd frontend build 通过
- 相对 v0.13.4 的发布差异仅包含 7 个修复/版本文件与 release.yml