### PR TITLE
feat(plugin): mention 候选标准接口（WIT 兼容 + Core 聚合）

### DIFF
--- a/crates/plugins/tiangong-plugin-agent-team/src/adapter.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/adapter.rs
@@ -8,7 +8,9 @@ use tiangong_core::core::Plugin;
 use tiangong_core::model::{ToolCall, ToolSpec};
 use tiangong_core::session::Session;
 use tiangong_core::tool::ToolResult;
-use tiangong_core::tool_override::{PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider};
+use tiangong_core::tool_override::{
+    MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
+};
 
 use crate::constants::{PLUGIN_ID, TOOL_CREATE_AGENT, TOOL_DISMISS_AGENT};
 use crate::coordinator::Coordinator;
@@ -96,6 +98,8 @@ impl PromptSectionProvider for AgentTeamPlugin {
     }
 }
 
+impl MentionCandidateProvider for AgentTeamPlugin {}
+
 impl Plugin for AgentTeamPlugin {
     fn id(&self) -> &str {
         PLUGIN_ID
@@ -170,7 +174,7 @@ mod tests {
     use tiangong_core::permission::TrustMode;
     use tiangong_core::session::Session;
     use tiangong_core::tool_override::{
-        PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
+        MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
     };
     use tiangong_types::{ContentBlock, MessagePhase, MessageRole, StreamEvent};
 
@@ -225,6 +229,7 @@ mod tests {
     impl ToolSpecProvider for SlowSessionEndedPlugin {}
     impl ToolOverrideHandler for SlowSessionEndedPlugin {}
     impl PromptSectionProvider for SlowSessionEndedPlugin {}
+    impl MentionCandidateProvider for SlowSessionEndedPlugin {}
 
     impl Plugin for SlowSessionEndedPlugin {
         fn id(&self) -> &str {

--- a/crates/plugins/tiangong-plugin-agent-team/src/child_runtime.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/child_runtime.rs
@@ -1088,7 +1088,7 @@ mod tests {
     use tiangong_core::core::Plugin;
     use tiangong_core::core_config::ModelEndpoint;
     use tiangong_core::tool_override::{
-        PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
+        MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
     };
 
     #[derive(Default)]
@@ -1097,6 +1097,7 @@ mod tests {
     impl ToolOverrideHandler for EmptyPlugin {}
     impl ToolSpecProvider for EmptyPlugin {}
     impl PromptSectionProvider for EmptyPlugin {}
+    impl MentionCandidateProvider for EmptyPlugin {}
 
     impl Plugin for EmptyPlugin {
         fn id(&self) -> &str {
@@ -1112,6 +1113,7 @@ mod tests {
     impl ToolOverrideHandler for FeedbackCapturePlugin {}
     impl ToolSpecProvider for FeedbackCapturePlugin {}
     impl PromptSectionProvider for FeedbackCapturePlugin {}
+    impl MentionCandidateProvider for FeedbackCapturePlugin {}
 
     impl Plugin for FeedbackCapturePlugin {
         fn id(&self) -> &str {

--- a/crates/plugins/tiangong-plugin-agent-team/src/coordinator.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/coordinator.rs
@@ -13,7 +13,9 @@ use tiangong_core::model::{ToolCall, ToolSpec};
 use tiangong_core::permission::TrustMode;
 use tiangong_core::session::{now_text, Message, MessageRole, Session};
 use tiangong_core::tool::ToolResult;
-use tiangong_core::tool_override::{PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider};
+use tiangong_core::tool_override::{
+    MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
+};
 use tiangong_types::{ContentBlock, StreamEvent};
 
 use crate::child_runtime::{child_config, ChildRuntime, SharedFeedback};
@@ -834,6 +836,8 @@ impl PromptSectionProvider for ChildTeamClientPlugin {
         ]
     }
 }
+
+impl MentionCandidateProvider for ChildTeamClientPlugin {}
 
 impl Plugin for ChildTeamClientPlugin {
     fn id(&self) -> &str {

--- a/crates/plugins/tiangong-plugin-analyze-attachment/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-analyze-attachment/wasm/src/lib.rs
@@ -245,5 +245,4 @@ impl UiGuest for Component {
         Err(plugin_err("Attachment 插件无设置页消息"))
     }
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-browser/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/plugin.rs
@@ -188,3 +188,6 @@ impl tiangong_core::tool_override::ToolSpecProvider for BrowserPlugin {
 
 // PromptSectionProvider 使用默认空实现（浏览器不注入 prompt 段落）
 impl tiangong_core::tool_override::PromptSectionProvider for BrowserPlugin {}
+
+// MentionCandidateProvider 使用默认空实现（浏览器不贡献 mention 候选）
+impl tiangong_core::tool_override::MentionCandidateProvider for BrowserPlugin {}

--- a/crates/plugins/tiangong-plugin-coding/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-coding/wasm/src/lib.rs
@@ -387,5 +387,4 @@ const CODING_WORKFLOW: &str = r#"## Coding 工作模式
 9. 只有需求全部完成且相关验证通过后才结束，并用简单直白的语言说明完成内容和结果。
 
 通用文件、检索、命令和终端能力继续由现有工具提供；Coding 插件只补充开发工作流、项目上下文、进度记录和交付审查，不重复实现这些原子能力。"#;
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-command/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-command/wasm/src/lib.rs
@@ -342,5 +342,4 @@ impl UiGuest for Component {
         Err(plugin_err("Command 插件暂无页面消息"))
     }
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-fetch/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-fetch/wasm/src/lib.rs
@@ -252,5 +252,4 @@ impl UiGuest for Component {
         Err(plugin_err("Fetch 插件暂无页面消息"))
     }
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-fs/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-fs/wasm/src/lib.rs
@@ -464,5 +464,4 @@ impl UiGuest for Component {
         Err(plugin_err("Fs 插件暂无页面消息"))
     }
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-generate-image/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-generate-image/wasm/src/lib.rs
@@ -150,5 +150,4 @@ impl UiGuest for Component {
         Err(plugin_err("Image 插件无设置页消息"))
     }
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-generate-video/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-generate-video/wasm/src/lib.rs
@@ -196,5 +196,4 @@ impl UiGuest for Component {
         Err(plugin_err("Video 插件无设置页消息"))
     }
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-index/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-index/wasm/src/lib.rs
@@ -461,5 +461,4 @@ where
     let response = sidecar_client::invoke::<O>(request).map_err(|e| plugin_err(e.to_string()))?;
     serde_json::to_string(&response).map_err(|e| plugin_err(e.to_string()))
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-mcp/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-mcp/wasm/src/lib.rs
@@ -15,10 +15,12 @@ use bindings::exports::tiangong::plugin::plugin_ui::{
     ViewResponse,
 };
 use tiangong_plugin_mcp_protocol::capability::Reconfigure;
-use tiangong_plugin_mcp_protocol::config::{RegisterMcpServerRequest, UpdateConfigEntryRequest};
+use tiangong_plugin_mcp_protocol::config::{
+    McpServerConfig, RegisterMcpServerRequest, UpdateConfigEntryRequest,
+};
 use tiangong_plugin_mcp_protocol::management::{
     ConfigGet, ConfigSnapshot, RemoveServerRequest, ServerMergeDisk, ServerRegister, ServerRemove,
-    ServerSetEnabled, ServerUpdate, SetEnabledRequest, UpdateServerRequest,
+    ServerSetEnabled, ServerUpdate, ServersResponse, SetEnabledRequest, UpdateServerRequest,
 };
 use tiangong_plugin_mcp_protocol::query::{
     ServerCachedTools, ServerDetail, ServerHealth, ServerList, ServerNameRequest, ServerSummary,
@@ -226,6 +228,7 @@ impl UiGuest for Component {
         request: ViewMessageRequest,
     ) -> Result<ViewMessageResponse, PluginError> {
         let payload = match request.method.as_str() {
+            "__tiangong.mention_candidates.v1" => mcp_mention_candidates()?,
             "bootstrap" => invoke_for_ui::<ConfigSnapshot>(&Empty {})?,
             "config.get" => invoke_for_ui::<ConfigGet>(&Empty {})?,
             "config.update_entry" => {
@@ -342,6 +345,34 @@ fn parse_mcp_function_name(function_name: &str) -> Option<(String, String)> {
     Some((server.to_string(), tool.to_string()))
 }
 
+fn mcp_mention_candidates() -> Result<String, PluginError> {
+    let servers: ServersResponse =
+        sidecar_client::invoke::<ServerList>(&Empty {}).map_err(|e| plugin_err(e.to_string()))?;
+    let tool_counts: std::collections::HashMap<String, usize> =
+        match sidecar_client::invoke::<ListTools>(&Empty {}) {
+            Ok(response) => response
+                .servers
+                .into_iter()
+                .map(|entry| (entry.server, entry.tools.len()))
+                .collect(),
+            Err(_) => std::collections::HashMap::new(),
+        };
+    let candidates = servers
+        .servers
+        .into_iter()
+        .filter(|server: &McpServerConfig| server.enabled)
+        .map(|server| {
+            serde_json::json!({
+                "value": format!("@mcp:{}", server.name),
+                "label": server.name,
+                "kind": "mcp",
+                "hint": format!("{} 工具", tool_counts.get(&server.name).copied().unwrap_or(0)),
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_string(&candidates).map_err(|e| plugin_err(e.to_string()))
+}
+
 fn sanitize_fn_name(value: &str) -> String {
     let mut out = String::new();
     for ch in value.chars() {
@@ -358,5 +389,4 @@ fn sanitize_fn_name(value: &str) -> String {
         trimmed
     }
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-memory/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-memory/wasm/src/lib.rs
@@ -709,5 +709,4 @@ fn recall_tool_result(
         }),
     }
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-prompt/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-prompt/wasm/src/lib.rs
@@ -193,5 +193,4 @@ fn write_custom_prompt(content: &str) -> Result<(), PluginError> {
 
 // 从 ToolSpec 的 WIT 类型引用（prompt 不暴露工具，但 WIT 要求实现 Guest trait 全部方法）
 use bindings::exports::tiangong::plugin::plugin::ToolSpec;
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-scheduler/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-scheduler/wasm/src/lib.rs
@@ -465,5 +465,4 @@ where
     let response = sidecar_client::invoke::<O>(request).map_err(|e| plugin_err(e.to_string()))?;
     serde_json::to_string(&response).map_err(|e| plugin_err(e.to_string()))
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-skill/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-skill/wasm/src/lib.rs
@@ -17,7 +17,7 @@ use bindings::exports::tiangong::plugin::plugin_ui::{
 use serde_json::Value;
 use tiangong_plugin_skill_protocol::{
     Empty, GetSkillDetail, GetSkillDetailRequest, GetSkillEnv, GetSkillEnvRequest, GetSkillSummary,
-    ListSkills, RefreshSkills, RemoveSkill, RemoveSkillRequest, RevealSkillDir,
+    ListSkills, ListSkillsResponse, RefreshSkills, RemoveSkill, RemoveSkillRequest, RevealSkillDir,
     RevealSkillDirRequest, SetSkillEnabled, SetSkillEnabledRequest, SetSkillEnv,
     SetSkillEnvRequest, SkillOperation, SkillSummaryResponse, TOOL_GET_SKILL_DETAIL, UpdateSkillMd,
     UpdateSkillMdRequest,
@@ -286,6 +286,7 @@ impl UiGuest for Component {
         request: ViewMessageRequest,
     ) -> Result<ViewMessageResponse, PluginError> {
         let payload = match request.method.as_str() {
+            "__tiangong.mention_candidates.v1" => skill_mention_candidates()?,
             "list" => invoke_for_ui::<ListSkills>(&Empty {})?,
             "detail" => {
                 let req: GetSkillDetailRequest = serde_json::from_str(&request.payload)
@@ -335,6 +336,29 @@ impl UiGuest for Component {
     }
 }
 
+fn skill_mention_candidates() -> Result<String, PluginError> {
+    let response: ListSkillsResponse =
+        sidecar_client::invoke::<ListSkills>(&Empty {}).map_err(|e| plugin_err(e.to_string()))?;
+    let candidates = response
+        .skills
+        .into_iter()
+        .filter(|skill| skill.enabled)
+        .map(|skill| {
+            serde_json::json!({
+                "value": format!("@skill:{}", skill.id),
+                "label": skill.name,
+                "kind": "skill",
+                "hint": if skill.description.is_empty() {
+                    format!("v{}", skill.version)
+                } else {
+                    skill.description
+                },
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_string(&candidates).map_err(|e| plugin_err(e.to_string()))
+}
+
 /// 通用 sidecar 转发器：调用操作 O 并把响应序列化成 JSON 字符串（供 iframe 消费）。
 fn invoke_for_ui<O>(request: &O::Request) -> Result<String, PluginError>
 where
@@ -344,5 +368,4 @@ where
     let response = sidecar_client::invoke::<O>(request).map_err(|e| plugin_err(e.to_string()))?;
     serde_json::to_string(&response).map_err(|e| plugin_err(e.to_string()))
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-speech-to-text/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-speech-to-text/wasm/src/lib.rs
@@ -151,5 +151,4 @@ impl UiGuest for Component {
         Err(plugin_err("STT 插件无设置页消息"))
     }
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/plugins/tiangong-plugin-terminal/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-terminal/src/plugin.rs
@@ -17,7 +17,9 @@ use tiangong_core::core::plugin::PluginFeedbackTx;
 use tiangong_core::core::Plugin;
 use tiangong_core::model::{ToolCall, ToolSpec};
 use tiangong_core::tool::ToolResult;
-use tiangong_core::tool_override::{PromptSectionProvider, ToolOverrideHandler};
+use tiangong_core::tool_override::{
+    MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler,
+};
 
 use crate::capability::TerminalProvider;
 use crate::handler::{TerminalPromptSectionProvider, TerminalToolOverride};
@@ -273,6 +275,9 @@ impl PromptSectionProvider for TerminalPlugin {
         PromptSectionProvider::prompt_sections(&self.prompt_provider)
     }
 }
+
+// MentionCandidateProvider 使用默认空实现（终端不贡献 mention 候选）
+impl MentionCandidateProvider for TerminalPlugin {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/plugins/tiangong-plugin-text-to-speech/wasm/src/lib.rs
+++ b/crates/plugins/tiangong-plugin-text-to-speech/wasm/src/lib.rs
@@ -142,5 +142,4 @@ impl UiGuest for Component {
         Err(plugin_err("TTS 插件无设置页消息"))
     }
 }
-
 bindings::export!(Component with_types_in bindings);

--- a/crates/tiangong-core-manager/src/core_manager/ensure.rs
+++ b/crates/tiangong-core-manager/src/core_manager/ensure.rs
@@ -149,6 +149,32 @@ impl CoreManager {
         }
     }
 
+    /// 获取指定会话 Core 全部插件贡献的 @提及候选。
+    ///
+    /// 经 [`TiangongCore::get_mentions`] 聚合（遍历 native + WASM 插件）。
+    /// 会话不存在 Core 时返回空列表（mention 与会话绑定，无 Core 即无候选）。
+    pub fn get_core_mentions(&self, session_id: &str) -> Vec<tiangong_types::MentionCandidate> {
+        let registry = self.registry();
+        registry
+            .get(session_id)
+            .map(|core| core.get_mentions())
+            .unwrap_or_default()
+    }
+
+    /// 获取任意一个活跃 Core 的 @提及候选。
+    ///
+    /// mention 候选（skill/mcp 列表等）与具体会话内容无关——同一宿主内各 Core 注册
+    /// 的插件集合一致，故任意活跃 Core 返回的结果相同。供无 session_id 上下文的
+    /// 宿主命令（如 `get_mention_candidates`）使用；无任何活跃 Core 时返回空。
+    pub fn get_any_mentions(&self) -> Vec<tiangong_types::MentionCandidate> {
+        let registry = self.registry();
+        registry
+            .iter()
+            .next()
+            .map(|(_, core)| core.get_mentions())
+            .unwrap_or_default()
+    }
+
     /// 更新指定会话标题（落盘始终由 Core 负责，保证不与 turn 对 session 的读写竞争）。
     ///
     /// 必须存在 live Core（标题可编辑意味着 Core 应已创建）；不存在则视为异常并报错。

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -114,6 +114,19 @@ impl TiangongCore {
         let _ = self.send_cmd(Command::SetReasoningEffort(effort));
     }
 
+    /// 收集当前 Core 全部插件贡献的 @提及候选（native + WASM 统一经此聚合）。
+    ///
+    /// 调用时实时遍历 `self.plugins`（lazy 收集，不预存）：native 插件直接调
+    /// `MentionCandidateProvider::mention_candidates`，WASM 插件经 adapter 桥接到
+    /// 同一 trait。宿主（src-tauri 的 `get_mention_candidates` 命令）经 CoreManager
+    /// 调用本方法，不再硬编码 skill/mcp。
+    pub fn get_mentions(&self) -> Vec<crate::MentionCandidate> {
+        self.plugins
+            .iter()
+            .flat_map(|plugin| plugin.mention_candidates())
+            .collect()
+    }
+
     /// 更新会话标题。用于用户手动编辑（不可放弃）。
     ///
     /// 与 trust_mode 一致的双分支协调：
@@ -403,6 +416,62 @@ impl Drop for TiangongCore {
 mod shared_runtime_tests {
     use super::*;
     use crate::core_config::{CoreConfig, CoreConfigProvider};
+
+    struct MentionPlugin {
+        id: &'static str,
+        values: Vec<crate::MentionCandidate>,
+    }
+
+    impl crate::tool_override::ToolSpecProvider for MentionPlugin {}
+    impl crate::tool_override::ToolOverrideHandler for MentionPlugin {}
+    impl crate::tool_override::PromptSectionProvider for MentionPlugin {}
+    impl crate::tool_override::MentionCandidateProvider for MentionPlugin {
+        fn mention_candidates(&self) -> Vec<crate::MentionCandidate> {
+            self.values.clone()
+        }
+    }
+    impl Plugin for MentionPlugin {
+        fn id(&self) -> &str {
+            self.id
+        }
+    }
+
+    #[test]
+    fn get_mentions_aggregates_all_plugin_candidates() {
+        let root = tempfile::tempdir().unwrap();
+        let (event_tx, _event_rx) = std::sync::mpsc::channel();
+        let candidate = |value: &str| crate::MentionCandidate {
+            value: value.to_string(),
+            label: value.to_string(),
+            kind: "test".to_string(),
+            hint: String::new(),
+        };
+        let core = TiangongCore::builder()
+            .session_id("mention-test")
+            .config(CoreConfigProvider::new(CoreConfig::default()))
+            .trust_mode(crate::permission::TrustMode::FullTrust)
+            .storage_root(root.path())
+            .workspace_dir(root.path().to_string_lossy())
+            .stream_tx(event_tx)
+            .plugins(vec![
+                Arc::new(MentionPlugin {
+                    id: "one",
+                    values: vec![candidate("@one")],
+                }),
+                Arc::new(MentionPlugin {
+                    id: "two",
+                    values: vec![candidate("@two")],
+                }),
+            ])
+            .build();
+
+        let values = core
+            .get_mentions()
+            .into_iter()
+            .map(|item| item.value)
+            .collect::<Vec<_>>();
+        assert_eq!(values, vec!["@one", "@two"]);
+    }
 
     /// 多个空闲 Core 不创建 turn task，且可正常关闭。
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/tiangong-core/src/core/plugin/trait_def.rs
+++ b/crates/tiangong-core/src/core/plugin/trait_def.rs
@@ -17,7 +17,9 @@ use std::path::Path;
 
 use crate::core::plugin::feedback::PluginFeedbackTx;
 use crate::permission::TrustMode;
-use crate::tool_override::{PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider};
+use crate::tool_override::{
+    MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
+};
 
 /// 进程内插件：封装自己的全部能力，在 engine 创建/重建时自行注册。
 ///
@@ -38,7 +40,9 @@ use crate::tool_override::{PromptSectionProvider, ToolOverrideHandler, ToolSpecP
 /// 此外，core 在 worker_loop 的关键生命周期节点遍历插件，回调下述生命周期钩子
 ///（均提供默认空实现），传入 `&mut Session` 供插件做必要处理（如维护索引、归档
 /// 记忆等）。插件按需覆写关心的节点即可。
-pub trait Plugin: ToolSpecProvider + ToolOverrideHandler + PromptSectionProvider {
+pub trait Plugin:
+    ToolSpecProvider + ToolOverrideHandler + PromptSectionProvider + MentionCandidateProvider
+{
     /// 插件唯一标识（日志/调试用）。
     fn id(&self) -> &str;
 

--- a/crates/tiangong-core/src/lib.rs
+++ b/crates/tiangong-core/src/lib.rs
@@ -3,6 +3,9 @@ pub const MAX_TOOL_ROUNDS: usize = 30;
 /// 总结阶段后重新进入工具执行阶段的最大次数。
 pub const MAX_OUTER_ITERATIONS: u32 = 3;
 
+/// @提及候选（见 [`tiangong_types::MentionCandidate`]）。
+pub use tiangong_types::MentionCandidate;
+
 pub mod agent_config;
 pub mod agent_input;
 pub mod context;

--- a/crates/tiangong-core/src/react/execute.rs
+++ b/crates/tiangong-core/src/react/execute.rs
@@ -1683,7 +1683,9 @@ mod tests {
     use crate::prompt::SystemPromptConfig;
     use crate::session::{Message, MessageRole, MessageToolCall, Session};
     use crate::tool::ToolResult;
-    use crate::tool_override::{PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider};
+    use crate::tool_override::{
+        MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
+    };
     use crate::turn_context::TurnContext;
     use std::collections::HashMap;
     use std::future::Future;
@@ -1970,6 +1972,7 @@ mod tests {
     impl ToolOverrideHandler for TrustTrackingPlugin {}
     impl ToolSpecProvider for TrustTrackingPlugin {}
     impl PromptSectionProvider for TrustTrackingPlugin {}
+    impl MentionCandidateProvider for TrustTrackingPlugin {}
 
     impl Plugin for TrustTrackingPlugin {
         fn id(&self) -> &str {

--- a/crates/tiangong-core/src/tool_override.rs
+++ b/crates/tiangong-core/src/tool_override.rs
@@ -48,3 +48,15 @@ pub trait PromptSectionProvider: Send + Sync + 'static {
         Vec::new()
     }
 }
+
+/// @提及候选提供者。
+///
+/// Plugin 通过此机制向 UI 输入框贡献 @补全候选（如 skill 列表、mcp server 列表）。
+/// Core 在 [`get_mentions`](crate::core::TiangongCore::get_mentions) 中遍历全部插件
+/// 收集；native 插件直接实现本 trait，WASM 插件经 WIT mention interface 由
+/// `WasmPluginAdapter` 桥接到本 trait。默认返回空，不贡献 mention 的插件无需覆写。
+pub trait MentionCandidateProvider: Send + Sync + 'static {
+    fn mention_candidates(&self) -> Vec<crate::MentionCandidate> {
+        Vec::new()
+    }
+}

--- a/crates/tiangong-plugin-runtime/src/adapter.rs
+++ b/crates/tiangong-plugin-runtime/src/adapter.rs
@@ -20,7 +20,9 @@ use tiangong_core::model::{ToolCall, ToolSpec};
 use tiangong_core::permission::TrustMode;
 use tiangong_core::session::Session;
 use tiangong_core::tool::{ToolExecutionRecord, ToolResult};
-use tiangong_core::tool_override::{PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider};
+use tiangong_core::tool_override::{
+    MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
+};
 use tokio::task;
 
 use crate::config::PluginRuntimeConfig;
@@ -522,6 +524,31 @@ impl PromptSectionProvider for WasmPluginAdapter {
             Ok(sections) => sections,
             Err(e) => {
                 tracing::warn!("wasm prompt_sections 失败: {e}");
+                Vec::new()
+            }
+        }
+    }
+}
+
+// MentionCandidateProvider：调 WASM 的 mention-candidates 导出，供 Core.get_mentions 收集。
+// 错误（含插件未启用）降级为空列表——mention 是 UI 辅助，不应阻塞输入补全。
+impl MentionCandidateProvider for WasmPluginAdapter {
+    fn mention_candidates(&self) -> Vec<tiangong_core::MentionCandidate> {
+        if !self.is_enabled() {
+            return Vec::new();
+        }
+        match self.call_wasm_off_runtime(WasmPlugin::mention_candidates) {
+            Ok(candidates) => candidates
+                .into_iter()
+                .map(|c| tiangong_core::MentionCandidate {
+                    value: c.value,
+                    label: c.label,
+                    kind: c.kind,
+                    hint: c.hint,
+                })
+                .collect(),
+            Err(e) => {
+                tracing::warn!("wasm mention_candidates 失败: {e}");
                 Vec::new()
             }
         }

--- a/crates/tiangong-plugin-runtime/src/lib.rs
+++ b/crates/tiangong-plugin-runtime/src/lib.rs
@@ -25,5 +25,8 @@ pub mod signature;
 
 pub use adapter::WasmPluginAdapter;
 pub use config::PluginRuntimeConfig;
-pub use loader::{Contribution, Descriptor, Outcome, Spec, ToolCall, WasmPlugin, WasmPluginLoader};
+pub use loader::{
+    Contribution, Descriptor, MentionCandidate, Outcome, Spec, ToolCall, WasmPlugin,
+    WasmPluginLoader,
+};
 pub use sidecar::{ProcessSidecarConnection, SidecarConfig, SidecarConnection};

--- a/crates/tiangong-plugin-runtime/src/loader.rs
+++ b/crates/tiangong-plugin-runtime/src/loader.rs
@@ -349,6 +349,30 @@ impl WasmPlugin {
             .collect())
     }
 
+    /// 返回插件贡献的 @提及候选。
+    ///
+    /// 复用 0.1.0 world 已有的 plugin-ui 消息通道，避免给现有 world 增加强制导出：
+    /// 旧插件收到未知方法会返回 plugin-error，此处按“不支持 Mention”降级为空列表；
+    /// 新插件返回 MentionCandidate JSON 数组。
+    pub fn mention_candidates(&mut self) -> Result<Vec<MentionCandidate>> {
+        const METHOD: &str = "__tiangong.mention_candidates.v1";
+        let request = crate::bindings::exports::tiangong::plugin::plugin_ui::ViewMessageRequest {
+            method: METHOD.to_string(),
+            payload: "{}".to_string(),
+        };
+        let response = self
+            .instance
+            .tiangong_plugin_plugin_ui()
+            .call_handle_view_message(&mut self.store, &request)
+            .map_err(|e| anyhow::anyhow!("mention-candidates 调用失败: {e}"))?;
+        let payload = match response {
+            Ok(response) => response.payload,
+            Err(_) => return Ok(Vec::new()),
+        };
+        serde_json::from_str(&payload)
+            .map_err(|e| anyhow::anyhow!("mention-candidates 响应格式错误: {e}"))
+    }
+
     /// 打开页面，返回入口 HTML。
     pub fn open_view(&mut self, contribution_id: String) -> Result<String> {
         Ok(self
@@ -444,7 +468,7 @@ pub struct OutcomeExecution {
 }
 
 /// 设置页贡献项（镜像 WIT record）。
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Contribution {
     pub id: String,
     pub title: String,
@@ -452,6 +476,15 @@ pub struct Contribution {
     pub icon: String,
     pub group: String,
     pub has_view: bool,
+}
+
+/// @提及候选项（镜像 WIT record）。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MentionCandidate {
+    pub value: String,
+    pub label: String,
+    pub kind: String,
+    pub hint: String,
 }
 
 /// 把 WIT 层的 `plugin-error` 转为 anyhow。

--- a/crates/tiangong-plugin-runtime/tests/load_and_call.rs
+++ b/crates/tiangong-plugin-runtime/tests/load_and_call.rs
@@ -14,7 +14,9 @@ use std::time::{Duration, Instant};
 use tiangong_core::core::Plugin;
 use tiangong_core::core_config::CoreConfig;
 use tiangong_core::session::Session;
-use tiangong_core::tool_override::{PromptSectionProvider, ToolSpecProvider};
+use tiangong_core::tool_override::{
+    MentionCandidateProvider, PromptSectionProvider, ToolSpecProvider,
+};
 use tiangong_plugin_runtime::{
     PluginRuntimeConfig, SidecarConnection, ToolCall, WasmPluginAdapter, WasmPluginLoader,
 };
@@ -636,4 +638,20 @@ fn set_workspace_and_prompt_sections_flow() {
     // prompt_sections 应能正常调用（返回注入段落或空）。
     let _sections = <WasmPluginAdapter as PromptSectionProvider>::prompt_sections(&adapter);
     assert!(sidecar.called("load_injection"));
+}
+
+#[test]
+fn legacy_plugin_without_mention_method_returns_empty_candidates() {
+    // Memory WASM 按旧 0.1.0 world 构建，不实现保留的 Mention 消息方法；
+    // 运行时必须保持正常加载，并把未知方法降级为空候选。
+    let Some(wasm) = wasm_or_skip() else {
+        return;
+    };
+    let config = PluginRuntimeConfig::default();
+    let loader = WasmPluginLoader::new(&config).expect("创建加载器失败");
+    let plugin = loader.load(&wasm, &config).expect("旧插件应保持可加载");
+    let adapter = WasmPluginAdapter::new(plugin, config);
+
+    let candidates = <WasmPluginAdapter as MentionCandidateProvider>::mention_candidates(&adapter);
+    assert!(candidates.is_empty(), "旧插件不支持 Mention 时应返回空候选");
 }

--- a/crates/tiangong-types/src/lib.rs
+++ b/crates/tiangong-types/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod attachment;
 pub mod event;
+pub mod mention;
 pub mod message;
 pub mod plugin_session;
 pub mod remote;
@@ -19,6 +20,7 @@ pub use attachment::{
     validate_ready_content_blocks,
 };
 pub use event::{EventSource, RuntimeEvent, RuntimeEventType};
+pub use mention::MentionCandidate;
 pub use message::{
     ContentBlock, DeferredToolInjection, MediaAsset, MediaKind, Message, MessagePhase, MessageRole,
     MessageToolCall, TurnStatus, now_text,

--- a/crates/tiangong-types/src/mention.rs
+++ b/crates/tiangong-types/src/mention.rs
@@ -1,0 +1,21 @@
+//! @提及候选数据结构。
+//!
+//! 供 Core（`MentionCandidateProvider`）与 UI 输入补全共享。Core 在
+//! `get_mentions()` 中遍历插件收集，src-tauri 的 `get_mention_candidates`
+//! 命令经 Core 取回后返回前端。
+
+use serde::{Deserialize, Serialize};
+
+/// @提及候选项。
+///
+/// - `value`：插入值，如 `@skill:xxx` / `@mcp:yyy`，命中后写入输入框
+/// - `label`：展示名
+/// - `kind`：类型标签，如 `skill` / `mcp` / `agent`
+/// - `hint`：副标题（描述、工具数等）
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MentionCandidate {
+    pub value: String,
+    pub label: String,
+    pub kind: String,
+    pub hint: String,
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1979,65 +1979,17 @@ pub async fn stop_audio() -> Result<(), String> {
     Ok(())
 }
 
-/// 获取 @提及补全候选列表（已启用的 Skill 和 MCP 服务器）
+/// 获取 @提及补全候选列表。
+///
+/// 经 Core 聚合（CoreManager::get_any_mentions 遍历任意活跃 Core 的全部插件，
+/// 含 native 与 WASM 插件经 mention 标准接口贡献的候选）。原硬编码的 skill/mcp
+/// 调用已迁入各自 WASM 插件的 mention-candidates 导出，host 不再区分插件类型。
+/// 无活跃 Core 时返回空列表。
 #[tauri::command]
 pub async fn get_mention_candidates(
-    _state: State<'_, TiangongApp>,
+    state: State<'_, TiangongApp>,
 ) -> Result<Vec<MentionCandidate>, String> {
-    // Skill + MCP servers + active tools 均由各自 plugin 自管，先读取快照。
-    let storage_root = tiangong_config::io::storage_root();
-    let skills = list_enabled_skills_for_mention(&storage_root);
-    let mcp_servers: Vec<tiangong_plugin_mcp_protocol::config::McpServerConfig> =
-        serde_json::from_value::<tiangong_plugin_mcp_protocol::management::ServersResponse>(
-            mcp_invoke("mcp.server.list", serde_json::json!({}))?,
-        )
-        .map_err(|e: serde_json::Error| e.to_string())?
-        .servers;
-    let active_tools: Vec<(String, usize)> =
-        serde_json::from_value::<tiangong_plugin_mcp_protocol::tool::ListToolsResponse>(
-            mcp_invoke("mcp.list_tools", serde_json::json!({}))?,
-        )
-        .map_err(|e: serde_json::Error| e.to_string())?
-        .servers
-        .into_iter()
-        .map(|entry| (entry.server, entry.tools.len()))
-        .collect();
-    let mut candidates = Vec::new();
-
-    // 已启用的 Skill（数据来自 skill plugin）
-    for skill in &skills {
-        if skill.enabled {
-            candidates.push(MentionCandidate {
-                value: format!("@skill:{}", skill.id),
-                label: skill.name.clone(),
-                kind: "skill".to_string(),
-                hint: if skill.description.is_empty() {
-                    format!("v{}", skill.version)
-                } else {
-                    skill.description.clone()
-                },
-            });
-        }
-    }
-
-    // 已启用的 MCP 服务器（数据来自 mcp plugin）
-    for server in &mcp_servers {
-        if server.enabled {
-            let tool_count = active_tools
-                .iter()
-                .find(|(name, _)| name == &server.name)
-                .map(|(_, count)| *count)
-                .unwrap_or(0);
-            candidates.push(MentionCandidate {
-                value: format!("@mcp:{}", server.name),
-                label: server.name.clone(),
-                kind: "mcp".to_string(),
-                hint: format!("{} 工具", tool_count),
-            });
-        }
-    }
-
-    Ok(candidates)
+    Ok(state.core_manager.get_any_mentions())
 }
 
 /// 获取输入框缓存。
@@ -3357,29 +3309,9 @@ pub async fn bot_upgrade(
 // Skill 管理
 //
 // skill 列表/详情/启停/删除/env 编辑等管理操作全部经插件设置页（WASM UI）
-// 走 handle_view_message 通道，不再暴露 Tauri 命令。@提及补全仍需列出已启用
-// skill，经 sidecar 通道查询。
+// 走 handle_view_message 通道，不再暴露 Tauri 命令。@提及补全候选由 skill
+// WASM 插件的 mention-candidates 导出贡献，经 Core.get_mentions 聚合。
 // ============================================================================
-
-/// 列出已启用的 Skill（供 @提及补全用，经 sidecar 通道查询）。
-pub fn list_enabled_skills_for_mention(
-    storage_root: &std::path::Path,
-) -> Vec<tiangong_plugin_skill_protocol::InstalledSkillConfig> {
-    let payload =
-        serde_json::to_value(tiangong_plugin_skill_protocol::Empty {}).unwrap_or_default();
-    tiangong_plugin_runtime::registry::invoke_sidecar(
-        storage_root,
-        "skill",
-        tiangong_plugin_skill_protocol::LIST_SKILLS_OPERATION,
-        payload,
-    )
-    .ok()
-    .and_then(|v| {
-        serde_json::from_value::<tiangong_plugin_skill_protocol::ListSkillsResponse>(v).ok()
-    })
-    .map(|r| r.skills)
-    .unwrap_or_default()
-}
 
 // ============================================================================
 // Server 管理
@@ -4060,7 +3992,7 @@ mod tests {
     };
     use tiangong_core::core::Plugin;
     use tiangong_core::tool_override::{
-        PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
+        MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
     };
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -4107,6 +4039,7 @@ mod tests {
     impl ToolSpecProvider for SlowTurnFinishedPlugin {}
     impl ToolOverrideHandler for SlowTurnFinishedPlugin {}
     impl PromptSectionProvider for SlowTurnFinishedPlugin {}
+    impl MentionCandidateProvider for SlowTurnFinishedPlugin {}
 
     impl Plugin for SlowTurnFinishedPlugin {
         fn id(&self) -> &str {

--- a/src-tauri/src/view.rs
+++ b/src-tauri/src/view.rs
@@ -98,14 +98,8 @@ pub struct TranscribeResult {
     pub duration: Option<f64>,
 }
 
-/// @提及候选项
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MentionCandidate {
-    pub value: String,
-    pub label: String,
-    pub kind: String,
-    pub hint: String,
-}
+/// @提及候选项（统一使用 tiangong_types::MentionCandidate，避免重复定义）。
+pub use tiangong_types::MentionCandidate;
 
 /// 会话列表项（前端使用）
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Closes #347

## 变更内容

### WIT 向后兼容策略
- **不修改 0.1.0 world**，复用 plugin-ui `handle_view_message` 通道传递 mention 候选
- 方法名：`__tiangong.mention_candidates.v1`
- 旧插件收到未知方法返回 plugin-error → 降级为空候选列表
- 新插件（Skill/MCP）响应该方法返回 JSON 候选数组

### Core 聚合
- `tool_override.rs` 新增 `MentionCandidateProvider` trait（默认空实现）
- `TiangongCore::get_mentions()` 实时遍历全部插件聚合候选（native + WASM 统一）
- CoreManager 新增 `get_core_mentions` / `get_any_mentions` 封装

### 运行时桥接
- `loader.rs` 新增 `MentionCandidate` 结构 + `WasmPlugin::mention_candidates`
- `adapter.rs` impl `MentionCandidateProvider` 桥接 WIT → Core trait

### 插件适配
- Skill 插件：返回已安装 skill 列表作为候选
- MCP 插件：返回已配置 MCP server 列表作为候选
- 其他 WASM 插件：移除 mention::Guest 空实现

## 测试
- `legacy_plugin_without_mention_method_returns_empty_candidates`：旧插件兼容
- `get_mentions_aggregates_all_plugin_candidates`：Core 聚合
- 全部 639 项测试通过
- WASM 编译通过（wasm32-wasip2）
- 前端构建通过