### PR TITLE
fix(ci): 添加 .gitattributes 强制发布制品使用 LF 换行

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# 发布制品必须跨平台字节一致，强制使用 LF 换行
+*.json text eol=lf
+*.toml text eol=lf
+*.md text eol=lf
+SHA256SUMS* text eol=lf
+
+# 二进制制品，禁止 git 任何转换
+*.wasm binary


### PR DESCRIPTION
## 问题
\`plugin/prompt/v0.1.0\` 标签触发发布后,卡在 **Merge and validate selected plugin**:
\`\`\`
xtask 失败: 插件 prompt@0.1.0 的 plugin.json 或 WASM 在不同平台不一致
\`\`\`

## 根因
对比三平台制品 checksum:
- WASM checksum 一致(共享 WASM 机制正常)
- **plugin.json checksum 不一致**:darwin/linux 为 \`9495ef98...\`(179 字节),windows 为 \`7f25046f...\`(**189 字节**)

Windows runner 的 git \`core.autocrlf=true\` 把 plugin.json 的 LF 换行转成了 CRLF,多出 10 个 \\r 字节,导致 checksum 不一致。

## 修复
添加 \`.gitattributes\`:
- \`*.json\` \`*.toml\` \`*.md\` \`SHA256SUMS*\` 强制 \`text eol=lf\`
- \`*.wasm\` 标记为 \`binary\`

\`.gitattributes\` 优先级高于 \`core.autocrlf\`,保证所有平台 checkout 出的发布制品字节一致。当前仓库存储的文件本就是 LF,\`git add --renormalize\` 无变化。

## 验证
修复后需重新发布 prompt 插件验证(配合 #372 的 xtask 修复)。