### PR TITLE
fix(ci): 将 Download shared WASM 移到 Cache 之后避免文件被清掉

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -95,15 +95,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: tauri-cli
-      - name: Download shared WASM
-        uses: actions/download-artifact@v4
-        with:
-          name: plugin-wasm-${{ needs.resolve-plugin.outputs.plugin_id }}
-          path: target/shared-wasm
-      - name: Validate plugin from repository configuration
-        env:
-          PLUGIN_ID: ${{ needs.resolve-plugin.outputs.plugin_id }}
-        run: cargo run -p xtask -- validate-plugin "$PLUGIN_ID"
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
@@ -143,6 +134,16 @@ jobs:
           "OPENSSL_LIB_DIR=$($crypto.Directory.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "OPENSSL_INCLUDE_DIR=$include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "OPENSSL_NO_VENDOR=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Download shared WASM
+        uses: actions/download-artifact@v4
+        with:
+          name: plugin-wasm-${{ needs.resolve-plugin.outputs.plugin_id }}
+          path: target/shared-wasm
+      - name: Validate plugin from repository configuration
+        env:
+          PLUGIN_ID: ${{ needs.resolve-plugin.outputs.plugin_id }}
+        run: cargo run -p xtask -- validate-plugin "$PLUGIN_ID"
+
       - name: Prepare plugin signing key
         id: plugin_signing
         env:


### PR DESCRIPTION
## 问题
\`plugin/prompt/v0.1.0\` 发布时,Windows 构建报:
\`\`\`
xtask 失败: 文件不存在: D:\...\target/shared-wasm/prompt.wasm
\`\`\`

## 根因
通过临时调试步骤确认了文件消失的时间点:
- \`02:32:51\` Download shared WASM 之后:\`prompt.wasm\` **存在**(231524 字节)
- \`02:33:57\` Build and sign plugin:\`prompt.wasm\` **不存在**

中间运行的 \`Cache Rust artifacts\`(Swatinem/rust-cache,配置 \`workspaces: . -> target\`)在 Windows 上 restore 时管理整个 \`target/\` 目录,把刚下载的 \`target/shared-wasm/prompt.wasm\` 清掉了。

Linux/mac 没复现是因为 cache 行为在不同平台有差异。

## 修复
调整步骤顺序,把 \`Cache Rust artifacts\` 移到 \`Download shared WASM\` **之前**:
\`\`\`
Checkout → Setup Rust → Install Tauri signer → Cache Rust artifacts
→ (protoc/openssl 安装) → Download shared WASM → Validate → Build
\`\`\`
这样缓存先恢复完毕,之后下载的 wasm 不会被缓存操作影响。

## 验证
合并后重新发布 prompt 插件验证。