### PR TITLE
fix(xtask): 修复插件签名生成与发布清单结构

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -484,11 +484,81 @@ fn build_plugin(config: &PluginConfig) -> io::Result<()> {
     Ok(())
 }
 
+/// 生成插件签名发布清单（release.json）并对它做 minisign 数字签名。
+///
+/// 清单结构与运行时 `signature.rs::SignedPluginRelease` 对齐，覆盖
+/// schema、id、version、publisher、permissions 以及 plugin.json、WASM
+/// 和（若有）sidecar 的 sha256。签名失败直接报错，绝不写空签名文件。
+fn write_signed_release(plugin: &Path, config: &PluginConfig) -> io::Result<()> {
+    let manifest_path = plugin.join("plugin.json");
+    let manifest: serde_json::Value = serde_json::from_slice(&std::fs::read(&manifest_path)?)
+        .map_err(|error| invalid_data(format!("解析 plugin.json 失败: {error}")))?;
+    let version = manifest
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| invalid_data("plugin.json 缺少 version"))?;
+    let permissions = manifest
+        .get("permissions")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!([]));
+
+    let mut release = serde_json::json!({
+        "schema_version": 1,
+        "id": config.id,
+        "version": version,
+        "publisher": "tiangong-official",
+        "permissions": permissions,
+        "manifest": {
+            "path": "plugin.json",
+            "sha256": sha256(&manifest_path)?,
+        },
+        "wasm": {
+            "path": config.wasm_artifact,
+            "sha256": sha256(&plugin.join(config.wasm_artifact))?,
+        },
+    });
+
+    // sidecar 声明（无 sidecar 的插件跳过，保持清单与 plugin.json 一致）。
+    if let Some(sidecar_artifact) = config.sidecar_artifact {
+        let sidecar_name = format!("{sidecar_artifact}{}", std::env::consts::EXE_SUFFIX);
+        release["sidecar"] = serde_json::json!({
+            "path": sidecar_name,
+            "sha256": sha256(&plugin.join(&sidecar_name))?,
+        });
+    }
+
+    let release_path = plugin.join("release.json");
+    write_json(&release_path, &release)?;
+
+    let key_path = std::env::var_os("TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PATH")
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+        .ok_or_else(|| {
+            invalid_input("缺少插件签名私钥，请设置 TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PATH")
+        })?;
+    let password =
+        std::env::var("TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PASSWORD").unwrap_or_default();
+    let status = Command::new("cargo")
+        .args(["tauri", "signer", "sign", "-f"])
+        .arg(&key_path)
+        .args(["-p", &password])
+        .arg(&release_path)
+        .status()?;
+    if !status.success() {
+        return Err(invalid_data("插件发布清单签名失败"));
+    }
+    eprintln!("[xtask] release.json 已签名");
+    Ok(())
+}
+
 fn generate_oss_distribution(
     workspace_root: &Path,
     plugin: &Path,
     config: &PluginConfig,
 ) -> io::Result<()> {
+    // 先生成签名发布清单；无签名私钥或验签失败直接终止，避免发布未签名制品。
+    write_signed_release(plugin, config)?;
+
     let manifest_path = plugin.join("plugin.json");
     let manifest: serde_json::Value = serde_json::from_slice(&std::fs::read(&manifest_path)?)
         .map_err(|error| invalid_data(format!("解析 {} 失败: {error}", manifest_path.display())))?;
@@ -508,6 +578,15 @@ fn generate_oss_distribution(
     let dist_wasm = release_root.join(config.wasm_artifact);
     std::fs::copy(&manifest_path, &dist_manifest)?;
     std::fs::copy(plugin.join(config.wasm_artifact), &dist_wasm)?;
+    // 签名清单与签名文件复制到分平台目录，供运行时验签。
+    std::fs::copy(
+        plugin.join("release.json"),
+        platform_root.join("release.json"),
+    )?;
+    std::fs::copy(
+        plugin.join("release.json.sig"),
+        platform_root.join("release.json.sig"),
+    )?;
 
     let base_url = env_var_or("TIANGONG_PLUGIN_OSS_BASE_URL", DEFAULT_OSS_BASE_URL)
         .trim_end_matches('/')
@@ -558,6 +637,12 @@ fn generate_oss_distribution(
             "url": format!("{release_url}/plugin.json"),
             "checksum": manifest_checksum,
         },
+        "signed_releases": {
+            platform.clone(): {
+                "url": format!("{release_url}/{platform}/release.json"),
+                "signature_url": format!("{release_url}/{platform}/release.json.sig"),
+            }
+        },
         "wasm": {
             "url": format!("{release_url}/{}", config.wasm_artifact),
             "checksum": wasm_checksum,
@@ -598,22 +683,6 @@ fn generate_oss_distribution(
         release_root.join(format!("SHA256SUMS-{platform}")),
         checksums,
     )?;
-    let release_json_path = platform_root.join("release.json");
-    write_json(&release_json_path, &release)?;
-    let sig_path = platform_root.join("release.json.sig");
-    if let Ok(key_path) = std::env::var("TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PATH") {
-        let pwd = std::env::var("TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PASSWORD").unwrap_or_default();
-        let status = Command::new("cargo")
-            .args(["tauri", "signer", "sign", "-k", &key_path, "-p", &pwd])
-            .arg(&release_json_path)
-            .status();
-        match status {
-            Ok(s) if s.success() => eprintln!("[xtask] release.json signed"),
-            _ => std::fs::write(&sig_path, "")?,
-        }
-    } else {
-        std::fs::write(&sig_path, "")?;
-    }
 
     eprintln!("[xtask] OSS 制品已生成: {}", dist_root.display());
     Ok(())
@@ -938,6 +1007,7 @@ fn merge_plugin_distributions(
                 )));
             }
             merge_platform_map(existing, &release, "sidecars", &key)?;
+            merge_platform_map(existing, &release, "signed_releases", &key)?;
         } else {
             releases.insert(key, release);
         }


### PR DESCRIPTION
## 问题
全部 15 个插件发布后,App 显示「未签名」,且报「解析 OSS 插件目录失败」。带 sidecar 的插件无法启动。

## 根因(三个关联缺陷)

**1. 签名命令参数错误(签名从未成功)**
tauri signer 的 \`-k\` 期望**密钥内容**,代码却传了**文件路径**,签名命令必然失败。旧代码吞掉错误并写空 \`.sig\` 文件,导致所有插件 \`release.json.sig\` 为 **0 字节**。
\`\`\`
正确: cargo tauri signer sign -f <密钥路径> ...
错误: cargo tauri signer sign -k <密钥路径> ...  ← 把路径当成了内容
\`\`\`
本地用 \`cargo tauri signer sign -f\` 验证可正常生成 396 字节签名。

**2. release.json 结构错误**
当前复用了 catalog fragment 结构(\`manifest\`/\`wasm\`/\`sidecars\` 用 \`url\`+\`checksum\`),与运行时 \`signature.rs::SignedPluginRelease\` 期望的 schema 不符。运行时要求 \`schema_version\`、\`publisher\`、\`permissions\` 以及 \`path\`+\`sha256\`。

**3. catalog 缺 \`signed_releases\` 字段**
fragment 没有 \`signed_releases\`,导致:
- App 不下载签名文件(\`download_release\` 依赖此字段)
- \`validate_catalog\` 因「声明 sidecar 的平台缺少 \`signed_releases\`」拒绝整个 catalog → 即「解析 OSS 插件目录失败」

## 修复
- 新增 \`write_signed_release\`:生成正确 schema 的 \`release.json\`,签名失败直接报错(不再写空文件)
- 签名参数 \`-k\` → \`-f\`
- \`generate_oss_distribution\` 调用 \`write_signed_release\`,fragment 产出 \`signed_releases\`
- \`merge-plugin-dist\` 恢复对 \`signed_releases\` 的按平台合并
- 适配无 sidecar 插件(prompt 等)

## 验证
本地验证 \`cargo tauri signer sign -f\` 可生成有效 minisign 签名。合并后重新发布全部 15 个插件。