### PR TITLE
fix(plugin): 纯 WASM 插件不生成签名清单并放宽 catalog 校验

### DIFF
--- a/crates/tiangong-plugin-runtime/src/artifacts.rs
+++ b/crates/tiangong-plugin-runtime/src/artifacts.rs
@@ -451,13 +451,9 @@ fn validate_catalog(catalog: &PluginCatalog) -> Result<()> {
             validate_download_url(&signed.url, "插件签名清单")?;
             validate_download_url(&signed.signature_url, "插件签名文件")?;
         }
-        for (platform, signed) in &plugin.signed_releases {
-            if !plugin.sidecars.contains_key(platform) {
-                bail!(
-                    "插件 {} 的平台 {platform} 只有签名清单而没有 sidecar",
-                    plugin.id
-                );
-            }
+        // 纯 WASM 插件（如 prompt）没有 sidecar 但同样需要官方签名建立信任，
+        // 因此签名清单不强制要求对应 sidecar，这里只校验签名 URL 合法性。
+        for signed in plugin.signed_releases.values() {
             validate_download_url(&signed.url, "插件签名清单")?;
             validate_download_url(&signed.signature_url, "插件签名文件")?;
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -556,8 +556,12 @@ fn generate_oss_distribution(
     plugin: &Path,
     config: &PluginConfig,
 ) -> io::Result<()> {
-    // 先生成签名发布清单；无签名私钥或验签失败直接终止，避免发布未签名制品。
-    write_signed_release(plugin, config)?;
+    // 只有带 sidecar 的插件才生成签名发布清单：签名用于建立 sidecar 信任边界，
+    // 纯 WASM 插件（如 prompt）不需要 sidecar，运行时不强制要求签名。
+    let has_sidecar = config.sidecar_artifact.is_some();
+    if has_sidecar {
+        write_signed_release(plugin, config)?;
+    }
 
     let manifest_path = plugin.join("plugin.json");
     let manifest: serde_json::Value = serde_json::from_slice(&std::fs::read(&manifest_path)?)
@@ -578,15 +582,17 @@ fn generate_oss_distribution(
     let dist_wasm = release_root.join(config.wasm_artifact);
     std::fs::copy(&manifest_path, &dist_manifest)?;
     std::fs::copy(plugin.join(config.wasm_artifact), &dist_wasm)?;
-    // 签名清单与签名文件复制到分平台目录，供运行时验签。
-    std::fs::copy(
-        plugin.join("release.json"),
-        platform_root.join("release.json"),
-    )?;
-    std::fs::copy(
-        plugin.join("release.json.sig"),
-        platform_root.join("release.json.sig"),
-    )?;
+    // 签名清单与签名文件复制到分平台目录，供运行时验签（仅 sidecar 插件）。
+    if has_sidecar {
+        std::fs::copy(
+            plugin.join("release.json"),
+            platform_root.join("release.json"),
+        )?;
+        std::fs::copy(
+            plugin.join("release.json.sig"),
+            platform_root.join("release.json.sig"),
+        )?;
+    }
 
     let base_url = env_var_or("TIANGONG_PLUGIN_OSS_BASE_URL", DEFAULT_OSS_BASE_URL)
         .trim_end_matches('/')
@@ -628,7 +634,7 @@ fn generate_oss_distribution(
 
     let manifest_checksum = format!("sha256:{}", sha256(&dist_manifest)?);
     let wasm_checksum = format!("sha256:{}", sha256(&dist_wasm)?);
-    let release = serde_json::json!({
+    let mut release = serde_json::json!({
         "id": config.id,
         "name": config.name,
         "version": version,
@@ -637,18 +643,21 @@ fn generate_oss_distribution(
             "url": format!("{release_url}/plugin.json"),
             "checksum": manifest_checksum,
         },
-        "signed_releases": {
-            platform.clone(): {
-                "url": format!("{release_url}/{platform}/release.json"),
-                "signature_url": format!("{release_url}/{platform}/release.json.sig"),
-            }
-        },
         "wasm": {
             "url": format!("{release_url}/{}", config.wasm_artifact),
             "checksum": wasm_checksum,
         },
         "sidecars": sidecar_entry.unwrap_or(serde_json::Value::Null),
     });
+    // 签名清单仅对 sidecar 插件生成，纯 WASM 插件不携带签名。
+    if has_sidecar {
+        release["signed_releases"] = serde_json::json!({
+            platform.clone(): {
+                "url": format!("{release_url}/{platform}/release.json"),
+                "signature_url": format!("{release_url}/{platform}/release.json.sig"),
+            }
+        });
+    }
     write_json(
         &index_root.join("catalog.json"),
         &serde_json::json!({"version": 1, "plugins": [release.clone()]}),


### PR DESCRIPTION
## 问题
所有插件发布后,App 报「解析 OSS 插件目录失败」,看不到任何插件。

## 根因
`validate_catalog` 的第二个循环要求**签名清单的每个平台都必须有对应 sidecar**。prompt 是纯 WASM 插件(无 sidecar)但签名修复后也生成了 `signed_releases`,触发该校验导致**整个 catalog 被拒绝**。

## 修复

**运行时(artifacts.rs)**
`validate_catalog` 第二个循环去掉「签名必须对应 sidecar」的约束,只保留签名 URL 校验。与 `signature.rs` 的 `validate`(L104-113,无 sidecar 插件允许无签名)对齐。保留「有 sidecar 必须有签名」的安全底线不变。

**发布端(xtask)**
纯 WASM 插件(无 sidecar,如 prompt)跳过签名清单生成,不产出 release.json/sig 和 catalog 的 `signed_releases` 字段。签名只用于建立 sidecar 信任边界。

## 验证
合并后重新发布 prompt(去掉签名清单)、coding 和 generate-image(之前并发被取消)。