### PR TITLE
fix(ci): Verify platform output 步骤适配纯 WASM 插件

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -173,8 +173,11 @@ jobs:
         run: |
           fragment="target/plugin-dist/plugins-index/fragments/${PLUGIN_ID}-${EXPECTED_PLATFORM}.json"
           test -f "$fragment"
-          test -f "target/plugin-dist/plugins/${PLUGIN_ID}"/*/"${EXPECTED_PLATFORM}/release.json"
-          test -f "target/plugin-dist/plugins/${PLUGIN_ID}"/*/"${EXPECTED_PLATFORM}/release.json.sig"
+          # release.json / release.json.sig 仅对 sidecar 插件生成；
+          # 纯 WASM 插件不产出签名清单，只要求 fragment 存在。
+          if compgen -G "target/plugin-dist/plugins/${PLUGIN_ID}/*/${EXPECTED_PLATFORM}/release.json" > /dev/null; then
+            test -f "target/plugin-dist/plugins/${PLUGIN_ID}"/*/"${EXPECTED_PLATFORM}/release.json.sig"
+          fi
 
       - name: Remove plugin signing key
         if: always() && steps.plugin_signing.outputs.key_path != ''


### PR DESCRIPTION
## 问题
prompt(纯 WASM 插件)发布时,Verify platform output 步骤失败,因为它强制要求 \`release.json\` 和 \`release.json.sig\` 存在。但纯 WASM 插件不生成签名清单(配合 #376 的改动)。

## 修复
Verify platform output 步骤改为:
- fragment 必须存在(所有插件)
- \`release.json.sig\` 只在 \`release.json\` 存在时才要求(即 sidecar 插件)

## 验证
合并后重新发布 prompt。