### PR TITLE
feat(plugin): 默认插件推荐、安装进度与插件管理增强

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11258,6 +11258,7 @@ version = "0.13.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "chrono",
  "futures-util",
  "hex",
  "libc",

--- a/TODO.md
+++ b/TODO.md
@@ -180,6 +180,33 @@
 - 开发者能够按文档完成目录组织、清单编写、WASM 构建、可选 sidecar 接入和本地调试。
 - 设置页的开发文档入口能够打开 GitHub 中的权威文档。
 
+# 默认插件与首次启动推荐
+
+- [x] 在 `artifacts.rs` 中定义默认插件 ID 列表（prompt、fs、command、fetch、index、skill）。
+- [x] `AvailablePlugin` 添加 `is_default` 字段，`list_available` 返回时标记默认插件。
+- [x] 添加 `check_default_plugins` Tauri 命令，返回缺失的默认插件信息。
+- [x] 添加首次启动完成标记文件（`~/.tiangong/.first_launch_completed`）的读写逻辑。
+- [x] 前端添加首次启动推荐安装对话框组件。
+- [x] MainApp 初始化时检测缺失默认插件并触发推荐引导。
+- [x] 通过 Rust 检查和前端构建验证。
+
+## 插件场景分类与 mcp 补充
+
+- [x] `DEFAULT_PLUGIN_IDS` 补充 mcp，默认推荐范围扩展为 7 个基础插件。
+- [x] `AvailablePlugin` 添加 `categories` 字段（多标签，`daily` / `coding` 任意组合）。
+- [x] 定义插件分类映射：fs、command、prompt、fetch、index、skill、mcp、memory 同时归入日常与编程；scheduler、多媒体生成类归入日常；coding 归入编程。
+- [x] 推荐对话框按分类分组展示缺失的默认插件。
+- [x] 插件市场可安装列表暂不进行分类筛选。
+- [x] 通过 Rust 检查和前端构建验证。
+
+## 完成标准
+
+- OSS 目录返回的可用插件列表中，默认插件带有 `is_default` 标记。
+- 用户首次打开且缺少默认插件时，弹出推荐安装引导。
+- 推荐引导支持一键安装全部缺失的默认插件，也可跳过。
+- 已安装全部默认插件或已完成首次启动引导后不再弹出。
+- 推荐安装复用现有 OSS 下载安装链路，安装后插件立即可用。
+
 ## 后续阶段
 
 - [ ] 实现零权限探测、授权实例化和权限扩大确认。

--- a/crates/tiangong-plugin-runtime/Cargo.toml
+++ b/crates/tiangong-plugin-runtime/Cargo.toml
@@ -27,4 +27,5 @@ hex = { workspace = true }
 semver = { workspace = true }
 scru128 = { workspace = true }
 base64 = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 minisign-verify = "0.2"

--- a/crates/tiangong-plugin-runtime/src/artifacts.rs
+++ b/crates/tiangong-plugin-runtime/src/artifacts.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -17,6 +18,55 @@ pub const PLUGIN_CATALOG_ENDPOINT: &str =
     "https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/plugins-index/catalog.json";
 const CATALOG_VERSION: u32 = 1;
 const TRANSACTIONS_DIR: &str = ".transactions";
+const FIRST_LAUNCH_MARKER: &str = ".first_launch_completed";
+
+/// 默认插件 ID 列表。
+///
+/// 这些插件提供 Agent 的基础能力（系统提示词、文件操作、命令执行、网络获取、
+/// 索引搜索、技能管理、MCP 工具桥接），确保用户安装后即可获得基本体验。
+pub const DEFAULT_PLUGIN_IDS: &[&str] =
+    &["prompt", "fs", "command", "fetch", "index", "skill", "mcp"];
+
+/// 场景分类常量：日常工作。
+pub const CATEGORY_DAILY: &str = "daily";
+/// 场景分类常量：编程开发。
+pub const CATEGORY_CODING: &str = "coding";
+
+/// 返回某插件的场景分类标签（多标签，可同时属于多个分类）。
+///
+/// 未在映射中声明的插件默认归入日常分类，保证插件市场不会出现无分类的孤立条目。
+pub fn plugin_categories(id: &str) -> Vec<&'static str> {
+    match id {
+        // 基础能力：日常与编程通用。
+        "prompt" | "fs" | "command" | "fetch" | "index" | "skill" | "mcp" | "memory" => {
+            vec![CATEGORY_DAILY, CATEGORY_CODING]
+        }
+        // 编程开发专属。
+        "coding" => vec![CATEGORY_CODING],
+        // 其余（定时任务、多媒体生成/分析）默认归入日常。
+        _ => vec![CATEGORY_DAILY],
+    }
+}
+
+/// 判断插件是否属于默认插件集合。
+pub fn is_default_plugin(id: &str) -> bool {
+    DEFAULT_PLUGIN_IDS.contains(&id)
+}
+
+/// 首次启动引导是否已完成（标记文件存在即视为完成）。
+pub fn is_first_launch_completed(storage_root: &Path) -> bool {
+    storage_root.join(FIRST_LAUNCH_MARKER).is_file()
+}
+
+/// 写入首次启动完成标记。内容为当前本地时间，便于排查。
+pub fn mark_first_launch_completed(storage_root: &Path) -> Result<()> {
+    let marker = storage_root.join(FIRST_LAUNCH_MARKER);
+    std::fs::create_dir_all(storage_root)
+        .with_context(|| format!("创建存储目录失败: {}", storage_root.display()))?;
+    let timestamp = chrono::Local::now().naive_local().to_string();
+    std::fs::write(&marker, timestamp)
+        .with_context(|| format!("写入首次启动标记失败: {}", marker.display()))
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginCatalog {
@@ -59,6 +109,12 @@ pub struct AvailablePlugin {
     pub supported: bool,
     pub installed_version: Option<String>,
     pub update_available: bool,
+    /// 是否为默认插件（基础能力，首次启动时会推荐安装）。
+    #[serde(default)]
+    pub is_default: bool,
+    /// 场景分类标签（多标签，值为 `daily` / `coding` 的任意组合）。
+    #[serde(default)]
+    pub categories: Vec<&'static str>,
 }
 
 pub struct StagedPlugin {
@@ -118,6 +174,9 @@ pub fn stage_local_plugin(storage_root: &Path, source: &Path) -> Result<StagedPl
     Ok(staged)
 }
 
+/// 下载进度回调：`(downloaded_bytes, total_bytes)`。total 为 0 表示总大小未知。
+pub type ProgressFn = Arc<dyn Fn(u64, u64) + Send + Sync>;
+
 pub struct PluginRepository {
     http: reqwest::Client,
 }
@@ -148,6 +207,8 @@ impl PluginRepository {
                 AvailablePlugin {
                     supported: plugin.sidecars.is_empty()
                         || plugin.sidecars.contains_key(&platform),
+                    is_default: is_default_plugin(&plugin.id),
+                    categories: plugin_categories(&plugin.id),
                     id: plugin.id,
                     name: plugin.name,
                     version: plugin.version,
@@ -159,14 +220,20 @@ impl PluginRepository {
             .collect())
     }
 
-    pub async fn download(&self, storage_root: &Path, plugin_id: &str) -> Result<StagedPlugin> {
+    pub async fn download(
+        &self,
+        storage_root: &Path,
+        plugin_id: &str,
+        progress: Option<ProgressFn>,
+    ) -> Result<StagedPlugin> {
         let catalog = self.fetch_catalog().await?;
         let release = catalog
             .plugins
             .into_iter()
             .find(|plugin| plugin.id == plugin_id)
             .ok_or_else(|| anyhow!("OSS 插件目录中不存在: {plugin_id}"))?;
-        self.download_release(storage_root, &release).await
+        self.download_release(storage_root, &release, progress)
+            .await
     }
 
     async fn fetch_catalog(&self) -> Result<PluginCatalog> {
@@ -196,12 +263,14 @@ impl PluginRepository {
         &self,
         storage_root: &Path,
         release: &PluginRelease,
+        progress: Option<ProgressFn>,
     ) -> Result<StagedPlugin> {
         let staged = create_staged_plugin(storage_root)?;
 
+        // manifest 体积小，先单独下载（不纳入分段进度统计）。
         let manifest_path = staged.path.join(MANIFEST_FILE);
         validate_artifact_file_name(&release.manifest.url, MANIFEST_FILE)?;
-        self.download_file(&release.manifest, &manifest_path)
+        self.download_file(&release.manifest, &manifest_path, None)
             .await?;
         let manifest = PluginManifest::load(&manifest_path)?;
         if manifest.id != release.id {
@@ -219,6 +288,37 @@ impl PluginRepository {
             );
         }
 
+        // 统计需要下载的制品文件，用于把进度按文件均分到 [0, 100]。
+        let platform = current_platform_key();
+        let mut steps: Vec<(usize, usize)> = Vec::new();
+        // (wasm 必有)
+        steps.push((0, 0));
+        let has_sidecar = manifest.sidecar.is_some();
+        if has_sidecar {
+            steps.push((0, 0));
+        }
+        let has_signed = manifest.sidecar.is_some() || !release.signed_releases.is_empty();
+        if has_signed {
+            // release.json + release.json.sig 合并视为一个进度段。
+            steps.push((0, 0));
+        }
+        let total_steps = steps.len().max(1);
+        // 复用闭包：把单文件内的字节进度映射到全局百分比区间。
+        let make_file_progress = |index: usize| -> Option<ProgressFn> {
+            let progress = progress.clone()?;
+            let start = (index * 100 / total_steps) as u64;
+            let end = ((index + 1) * 100 / total_steps) as u64;
+            Some(Arc::new(move |downloaded: u64, content_len: u64| {
+                let ratio = if content_len > 0 {
+                    downloaded as f64 / content_len as f64
+                } else {
+                    1.0
+                };
+                let percent = start as f64 + ratio * (end - start) as f64;
+                progress(percent.round() as u64, 100);
+            }))
+        };
+
         let wasm_path = staged.path.join(manifest.wasm_binary());
         let wasm_name = manifest
             .wasm_binary()
@@ -226,42 +326,46 @@ impl PluginRepository {
             .and_then(|value| value.to_str())
             .ok_or_else(|| anyhow!("WASM 制品文件名无效"))?;
         validate_artifact_file_name(&release.wasm.url, wasm_name)?;
-        self.download_file(&release.wasm, &wasm_path).await?;
+        self.download_file(&release.wasm, &wasm_path, make_file_progress(0))
+            .await?;
 
-        match &manifest.sidecar {
-            Some(sidecar) => {
-                let platform = current_platform_key();
-                let artifact = release.sidecars.get(&platform).ok_or_else(|| {
-                    anyhow!("插件 {} 没有当前平台 {platform} 的 sidecar", release.id)
-                })?;
-                let sidecar_path = staged.path.join(with_executable_suffix(&sidecar.binary)?);
-                let sidecar_name = sidecar_path
-                    .file_name()
-                    .and_then(|value| value.to_str())
-                    .ok_or_else(|| anyhow!("sidecar 文件名无效"))?;
-                validate_artifact_file_name(&artifact.url, sidecar_name)?;
-                self.download_file(artifact, &sidecar_path).await?;
-                set_executable(&sidecar_path)?;
-            }
-            None if !release.sidecars.is_empty() => {
-                bail!(
-                    "插件 {} 未声明 sidecar，但 OSS 目录包含 sidecar",
-                    release.id
-                );
-            }
-            None => {}
+        if has_sidecar {
+            let artifact = release
+                .sidecars
+                .get(&platform)
+                .ok_or_else(|| anyhow!("插件 {} 没有当前平台 {platform} 的 sidecar", release.id))?;
+            let sidecar_binary = manifest.sidecar.as_ref().expect("已确认存在 sidecar");
+            let sidecar_path = staged
+                .path
+                .join(with_executable_suffix(&sidecar_binary.binary)?);
+            let sidecar_name = sidecar_path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| anyhow!("sidecar 文件名无效"))?;
+            validate_artifact_file_name(&artifact.url, sidecar_name)?;
+            self.download_file(artifact, &sidecar_path, make_file_progress(1))
+                .await?;
+            set_executable(&sidecar_path)?;
+        } else if !release.sidecars.is_empty() {
+            bail!(
+                "插件 {} 未声明 sidecar，但 OSS 目录包含 sidecar",
+                release.id
+            );
         }
 
-        if manifest.sidecar.is_some() || !release.signed_releases.is_empty() {
-            let platform = current_platform_key();
+        if has_signed {
             let signed = release
                 .signed_releases
                 .get(&platform)
                 .ok_or_else(|| anyhow!("插件 {} 没有当前平台 {platform} 的签名清单", release.id))?;
+            let signed_index = if has_sidecar { 2 } else { 1 };
             self.download_unchecked(&signed.url, &staged.path.join("release.json"))
                 .await?;
             self.download_unchecked(&signed.signature_url, &staged.path.join("release.json.sig"))
                 .await?;
+            if let Some(cb) = make_file_progress(signed_index) {
+                cb(100, 100);
+            }
         }
         for directory in ["runtime", "logs", "data"] {
             std::fs::create_dir_all(staged.path.join(directory))?;
@@ -283,7 +387,12 @@ impl PluginRepository {
         std::fs::write(destination, response.bytes().await?)
             .with_context(|| format!("写入插件签名制品失败: {}", destination.display()))
     }
-    async fn download_file(&self, artifact: &RemoteArtifact, destination: &Path) -> Result<()> {
+    async fn download_file(
+        &self,
+        artifact: &RemoteArtifact,
+        destination: &Path,
+        progress: Option<ProgressFn>,
+    ) -> Result<()> {
         let expected = parse_checksum(&artifact.checksum)?;
         validate_download_url(&artifact.url, "插件制品")?;
         if let Some(parent) = destination.parent() {
@@ -306,6 +415,7 @@ impl PluginRepository {
                 artifact.url
             );
         }
+        let content_len = response.content_length();
 
         let mut stream = response.bytes_stream();
         let mut hasher = Sha256::new();
@@ -314,11 +424,16 @@ impl PluginRepository {
             .create_new(true)
             .open(destination)
             .with_context(|| format!("创建插件制品失败: {}", destination.display()))?;
+        let mut downloaded: u64 = 0;
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.with_context(|| format!("读取插件制品失败: {}", artifact.url))?;
             hasher.update(&chunk);
             file.write_all(&chunk)
                 .with_context(|| format!("写入插件制品失败: {}", destination.display()))?;
+            if let Some(cb) = &progress {
+                downloaded += chunk.len() as u64;
+                cb(downloaded, content_len.unwrap_or(0));
+            }
         }
         file.sync_all()
             .with_context(|| format!("同步插件制品失败: {}", destination.display()))?;

--- a/crates/tiangong-plugin-runtime/src/artifacts.rs
+++ b/crates/tiangong-plugin-runtime/src/artifacts.rs
@@ -155,6 +155,20 @@ pub fn stage_local_plugin(storage_root: &Path, source: &Path) -> Result<StagedPl
     copy_local_artifact(source, manifest.wasm_binary(), &staged.path, "WASM 制品")?;
 
     if let Some(sidecar) = &manifest.sidecar {
+        let release = source.join(crate::signature::SIGNED_RELEASE_FILE);
+        let signature = source.join(crate::signature::SIGNATURE_FILE);
+        ensure_regular_file(&release, "插件签名清单")?;
+        ensure_regular_file(&signature, "插件签名")?;
+        copy_regular_file(
+            &release,
+            &staged.path.join(crate::signature::SIGNED_RELEASE_FILE),
+            "插件签名清单",
+        )?;
+        copy_regular_file(
+            &signature,
+            &staged.path.join(crate::signature::SIGNATURE_FILE),
+            "插件签名",
+        )?;
         let binary = with_executable_suffix(&sidecar.binary)?;
         let destination = copy_local_artifact(source, &binary, &staged.path, "sidecar 制品")?;
         set_executable(&destination)?;

--- a/crates/tiangong-plugin-runtime/src/artifacts.rs
+++ b/crates/tiangong-plugin-runtime/src/artifacts.rs
@@ -155,20 +155,6 @@ pub fn stage_local_plugin(storage_root: &Path, source: &Path) -> Result<StagedPl
     copy_local_artifact(source, manifest.wasm_binary(), &staged.path, "WASM 制品")?;
 
     if let Some(sidecar) = &manifest.sidecar {
-        let release = source.join(crate::signature::SIGNED_RELEASE_FILE);
-        let signature = source.join(crate::signature::SIGNATURE_FILE);
-        ensure_regular_file(&release, "插件签名清单")?;
-        ensure_regular_file(&signature, "插件签名")?;
-        copy_regular_file(
-            &release,
-            &staged.path.join(crate::signature::SIGNED_RELEASE_FILE),
-            "插件签名清单",
-        )?;
-        copy_regular_file(
-            &signature,
-            &staged.path.join(crate::signature::SIGNATURE_FILE),
-            "插件签名",
-        )?;
         let binary = with_executable_suffix(&sidecar.binary)?;
         let destination = copy_local_artifact(source, &binary, &staged.path, "sidecar 制品")?;
         set_executable(&destination)?;

--- a/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
+++ b/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
@@ -80,6 +80,9 @@ vi.mock('@tauri-apps/api/window', () => ({
   },
 }));
 vi.mock('@/components/AppSidebar', () => ({ AppSidebar: () => null }));
+vi.mock('@/components/DefaultPluginOnboarding', () => ({
+  DefaultPluginOnboarding: () => null,
+}));
 vi.mock('@/components/LazyComponents', () => ({
   LazyMessageInput: () => null,
   LazyMessageList: () => null,

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -430,6 +430,13 @@ export interface BotTransferProgress {
   total: number;
 }
 
+/// 插件安装/升级下载进度事件。
+export interface PluginInstallProgress {
+  plugin_id: string;
+  downloaded: number;
+  total: number;
+}
+
 export type ProvisionStatus =
   | { status: 'pending'; retry_after?: number }
   | { status: 'success' }
@@ -749,6 +756,9 @@ export const api = {
 
   onBotInstallProgress: (callback: (progress: BotTransferProgress) => void) =>
     listen<BotTransferProgress>('bot_install_progress', (event) => callback(event.payload)),
+
+  onPluginInstallProgress: (callback: (progress: PluginInstallProgress) => void) =>
+    listen<PluginInstallProgress>('plugin_install_progress', (event) => callback(event.payload)),
 
   botStart: (id: string): Promise<string> =>
     invoke('bot_start', { id }),
@@ -1116,6 +1126,10 @@ export const api = {
 
   listAvailablePlugins: (): Promise<AvailablePlugin[]> => invoke('list_available_plugins'),
 
+  checkDefaultPlugins: (): Promise<DefaultPluginCheck> => invoke('check_default_plugins'),
+
+  completeFirstLaunch: (): Promise<void> => invoke('complete_first_launch'),
+
   importLocalPlugin: (path: string): Promise<PluginStatus> =>
     invoke('import_local_plugin', { path }),
 
@@ -1181,4 +1195,17 @@ export interface AvailablePlugin {
   supported: boolean;
   installed_version: string | null;
   update_available: boolean;
+  is_default: boolean;
+  /// 场景分类标签（多标签，`daily` / `coding` 的任意组合）。
+  categories: string[];
+}
+
+/// 首次启动推荐安装检测结果。
+export interface DefaultPluginCheck {
+  /// 是否需要弹出首次启动推荐引导。
+  first_launch_pending: boolean;
+  /// 缺失的默认插件。
+  missing: AvailablePlugin[];
+  /// OSS 目录拉取失败原因。
+  catalog_error: string | null;
 }

--- a/frontend/src/components/DefaultPluginOnboarding.tsx
+++ b/frontend/src/components/DefaultPluginOnboarding.tsx
@@ -33,16 +33,23 @@ type ItemState = {
 };
 
 type Props = {
-  /** 缺失的默认插件列表；为 null 时不显示对话框。 */
+  /** 默认插件列表（含已安装与未安装）；为 null 时不显示对话框。 */
   missing: AvailablePlugin[] | null;
   /** 关闭/打开变化。关闭后父组件应清空 missing。 */
   onOpenChange: (open: boolean) => void;
   /** 引导结束后回调（用于刷新插件贡献项等全局状态）。 */
   onComplete: () => void;
+  /** 是否在跳过/完成时写入首次启动标记。首次启动场景为 true，插件管理手动打开时为 false。 */
+  writeCompletionMarker?: boolean;
 };
 
-export function DefaultPluginOnboarding({ missing, onOpenChange, onComplete }: Props) {
-  const open = missing !== null && missing.length > 0;
+export function DefaultPluginOnboarding({
+  missing,
+  onOpenChange,
+  onComplete,
+  writeCompletionMarker = true,
+}: Props) {
+  const open = missing !== null;
   const [items, setItems] = useState<ItemState[]>([]);
   const [batchRunning, setBatchRunning] = useState(false);
   const { showSuccess, showError } = useToast();
@@ -134,7 +141,9 @@ export function DefaultPluginOnboarding({ missing, onOpenChange, onComplete }: P
       if (await installOne(plugin)) succeeded += 1;
     }
     setBatchRunning(false);
-    await api.completeFirstLaunch().catch((error) => console.warn('写入首次启动标记失败', error));
+    if (writeCompletionMarker) {
+      await api.completeFirstLaunch().catch((error) => console.warn('写入首次启动标记失败', error));
+    }
     if (succeeded === targets.length) {
       showSuccess('默认插件已全部安装', '可以开始使用天工了');
     } else if (succeeded > 0) {
@@ -146,20 +155,30 @@ export function DefaultPluginOnboarding({ missing, onOpenChange, onComplete }: P
     onOpenChange(false);
   };
 
-  // 跳过：直接写入完成标记并关闭，本次启动不再弹出。
+  // 跳过/关闭：首次启动场景写入完成标记，插件管理手动打开时不写。
   const skip = async () => {
     if (batchRunning) return;
-    await api.completeFirstLaunch().catch((error) => console.warn('写入首次启动标记失败', error));
+    if (writeCompletionMarker) {
+      await api.completeFirstLaunch().catch((error) => console.warn('写入首次启动标记失败', error));
+    }
     onOpenChange(false);
   };
 
+  const hasMissing = items.some((item) => item.state !== 'installed');
+
   return (
     <Dialog open={open} onOpenChange={(next) => (next ? null : onOpenChange(false))}>
-      <DialogContent className="max-w-lg" showCloseButton={!batchRunning}>
+      <DialogContent
+        className="max-w-lg"
+        overlayClassName="z-[80]"
+        showCloseButton={!batchRunning}
+      >
         <DialogHeader>
-          <DialogTitle>欢迎使用天工</DialogTitle>
+          <DialogTitle>{hasMissing ? '推荐安装默认插件' : '默认插件已全部安装'}</DialogTitle>
           <DialogDescription>
-            为获得基础体验，建议安装以下默认插件。它们提供系统提示词、文件操作、命令执行等基础能力。
+            {hasMissing
+              ? '为获得基础体验，建议安装以下默认插件。它们提供系统提示词、文件操作、命令执行等基础能力。'
+              : '所有默认插件均已就绪，可随时在插件管理中查看或调整。'}
           </DialogDescription>
         </DialogHeader>
 
@@ -191,22 +210,30 @@ export function DefaultPluginOnboarding({ missing, onOpenChange, onComplete }: P
         </Tabs>
 
         <DialogFooter className="gap-2 sm:gap-2">
-          <Button variant="ghost" onClick={() => void skip()} disabled={batchRunning}>
-            跳过
-          </Button>
-          <Button onClick={() => void installAll()} disabled={batchRunning || !hasPending}>
-            {batchRunning ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                正在安装...
-              </>
-            ) : (
-              <>
-                <Download className="mr-2 h-4 w-4" />
-                一键安装{hasPending ? `（${installableCount}）` : ''}
-              </>
-            )}
-          </Button>
+          {hasMissing ? (
+            <>
+              <Button variant="ghost" onClick={() => void skip()} disabled={batchRunning}>
+                {writeCompletionMarker ? '跳过' : '关闭'}
+              </Button>
+              <Button onClick={() => void installAll()} disabled={batchRunning || !hasPending}>
+                {batchRunning ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    正在安装...
+                  </>
+                ) : (
+                  <>
+                    <Download className="mr-2 h-4 w-4" />
+                    一键安装{hasPending ? `（${installableCount}）` : ''}
+                  </>
+                )}
+              </Button>
+            </>
+          ) : (
+            <Button onClick={() => void skip()} disabled={batchRunning}>
+              完成
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/DefaultPluginOnboarding.tsx
+++ b/frontend/src/components/DefaultPluginOnboarding.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useState } from 'react';
+import { CheckCircle2, Download, Loader2, XCircle } from 'lucide-react';
+import { api, type AvailablePlugin } from '@/api/tauri';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { Separator } from './ui/separator';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
+import { useToast } from './Toast';
+
+/** 分类标识到展示名称的映射。 */
+const CATEGORY_LABELS: Record<string, string> = {
+  daily: '日常工作',
+  coding: '编程开发',
+};
+/** 分组展示顺序。 */
+const CATEGORY_ORDER = ['daily', 'coding'];
+
+type InstallState = 'pending' | 'installing' | 'installed' | 'failed';
+
+type ItemState = {
+  plugin: AvailablePlugin;
+  state: InstallState;
+  error?: string;
+  progress?: number | null;
+};
+
+type Props = {
+  /** 缺失的默认插件列表；为 null 时不显示对话框。 */
+  missing: AvailablePlugin[] | null;
+  /** 关闭/打开变化。关闭后父组件应清空 missing。 */
+  onOpenChange: (open: boolean) => void;
+  /** 引导结束后回调（用于刷新插件贡献项等全局状态）。 */
+  onComplete: () => void;
+};
+
+export function DefaultPluginOnboarding({ missing, onOpenChange, onComplete }: Props) {
+  const open = missing !== null && missing.length > 0;
+  const [items, setItems] = useState<ItemState[]>([]);
+  const [batchRunning, setBatchRunning] = useState(false);
+  const { showSuccess, showError } = useToast();
+
+  // 列表变化时重置每项状态为待安装。
+  useEffect(() => {
+    setItems(
+      (missing ?? []).map((plugin) => ({
+        plugin,
+        state: plugin.installed_version ? 'installed' : 'pending',
+      })),
+    );
+    setBatchRunning(false);
+  }, [missing]);
+
+  // 可安装项 = 待安装 + 之前失败可重试。
+  const installableCount = useMemo(
+    () => items.filter((item) => item.state === 'pending' || item.state === 'failed').length,
+    [items],
+  );
+  const hasPending = installableCount > 0;
+
+  // 按场景分类分组，一个插件同时属于多个分类时在每个分组各出现一次。
+  const grouped = useMemo(() => {
+    const byCategory = new Map<string, ItemState[]>();
+    for (const category of CATEGORY_ORDER) byCategory.set(category, []);
+    for (const item of items) {
+      for (const category of item.plugin.categories.length > 0
+        ? item.plugin.categories
+        : ['daily']) {
+        if (byCategory.has(category)) byCategory.get(category)!.push(item);
+      }
+    }
+    return CATEGORY_ORDER.map((category) => ({
+      category,
+      label: CATEGORY_LABELS[category] ?? category,
+      items: byCategory.get(category) ?? [],
+    })).filter((group) => group.items.length > 0);
+  }, [items]);
+
+  const updateItem = (id: string, patch: Partial<ItemState>) => {
+    setItems((prev) => prev.map((item) => (item.plugin.id === id ? { ...item, ...patch } : item)));
+  };
+
+  const installOne = async (plugin: AvailablePlugin): Promise<boolean> => {
+    updateItem(plugin.id, { state: 'installing', error: undefined, progress: 0 });
+    try {
+      await api.installPlugin(plugin.id);
+      updateItem(plugin.id, { state: 'installed', progress: null });
+      return true;
+    } catch (error) {
+      updateItem(plugin.id, { state: 'failed', error: String(error), progress: null });
+      return false;
+    }
+  };
+
+  // 监听后端推送的下载进度事件，更新对应插件的下载百分比。
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+    void api
+      .onPluginInstallProgress(({ plugin_id, downloaded, total }) => {
+        if (disposed) return;
+        const percent = total > 0 ? Math.min(100, Math.round((downloaded / total) * 100)) : 0;
+        updateItem(plugin_id, { progress: percent });
+      })
+      .then((stop) => {
+        if (disposed) {
+          stop();
+        } else {
+          unlisten = stop;
+        }
+      });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 一键串行安装：逐个下载，失败不阻断后续。
+  const installAll = async () => {
+    if (batchRunning) return;
+    const targets = items.filter((item) => item.state === 'pending' || item.state === 'failed');
+    if (targets.length === 0) return;
+    setBatchRunning(true);
+    let succeeded = 0;
+    for (const { plugin } of targets) {
+      if (await installOne(plugin)) succeeded += 1;
+    }
+    setBatchRunning(false);
+    await api.completeFirstLaunch().catch((error) => console.warn('写入首次启动标记失败', error));
+    if (succeeded === targets.length) {
+      showSuccess('默认插件已全部安装', '可以开始使用天工了');
+    } else if (succeeded > 0) {
+      showSuccess(`已安装 ${succeeded} 个插件`, '部分插件安装失败，可稍后在插件管理中重试');
+    } else {
+      showError('安装失败', '可在插件管理中手动重试');
+    }
+    onComplete();
+    onOpenChange(false);
+  };
+
+  // 跳过：直接写入完成标记并关闭，本次启动不再弹出。
+  const skip = async () => {
+    if (batchRunning) return;
+    await api.completeFirstLaunch().catch((error) => console.warn('写入首次启动标记失败', error));
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? null : onOpenChange(false))}>
+      <DialogContent className="max-w-lg" showCloseButton={!batchRunning}>
+        <DialogHeader>
+          <DialogTitle>欢迎使用天工</DialogTitle>
+          <DialogDescription>
+            为获得基础体验，建议安装以下默认插件。它们提供系统提示词、文件操作、命令执行等基础能力。
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs defaultValue={grouped[0]?.category ?? 'daily'}>
+          <TabsList className="grid w-full grid-cols-2">
+            {grouped.map((group) => (
+              <TabsTrigger key={group.category} value={group.category} className="py-1 text-xs">
+                {group.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+
+          {grouped.map((group) => (
+            <TabsContent key={group.category} value={group.category} className="m-0">
+              <div className="max-h-[40vh] overflow-y-auto">
+                {group.items.map((item, index) => (
+                  <div key={item.plugin.id}>
+                    {index > 0 && <Separator />}
+                    <PluginRow
+                      item={item}
+                      disabled={batchRunning}
+                      onInstall={() => void installOne(item.plugin)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </TabsContent>
+          ))}
+        </Tabs>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button variant="ghost" onClick={() => void skip()} disabled={batchRunning}>
+            跳过
+          </Button>
+          <Button onClick={() => void installAll()} disabled={batchRunning || !hasPending}>
+            {batchRunning ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                正在安装...
+              </>
+            ) : (
+              <>
+                <Download className="mr-2 h-4 w-4" />
+                一键安装{hasPending ? `（${installableCount}）` : ''}
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PluginRow({
+  item,
+  disabled,
+  onInstall,
+}: {
+  item: ItemState;
+  disabled: boolean;
+  onInstall: () => void;
+}) {
+  const { plugin, state, progress } = item;
+  return (
+    <div className="flex min-h-20 items-start gap-4 py-4">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="break-words text-sm font-medium">{plugin.name}</span>
+          <Badge variant="outline">{plugin.version}</Badge>
+          {state === 'installed' && <Badge variant="secondary">已安装</Badge>}
+          {state === 'failed' && <Badge variant="destructive">失败</Badge>}
+        </div>
+        {plugin.description && (
+          <p className="mt-1.5 break-words text-xs leading-5 text-muted-foreground">
+            {plugin.description}
+          </p>
+        )}
+        {state === 'failed' && item.error && (
+          <p className="mt-1 break-words text-xs text-destructive">{item.error}</p>
+        )}
+        {state === 'installing' && progress !== null && progress !== undefined && (
+          <div className="mt-2 h-1 w-full max-w-56 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full bg-primary transition-[width] duration-150"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        )}
+      </div>
+      <StateIndicator state={state} disabled={disabled} onInstall={onInstall} />
+    </div>
+  );
+}
+
+function StateIndicator({
+  state,
+  disabled,
+  onInstall,
+}: {
+  state: InstallState;
+  disabled: boolean;
+  onInstall: () => void;
+}) {
+  if (state === 'installed') {
+    return <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500" />;
+  }
+  if (state === 'installing') {
+    return <Loader2 className="mt-0.5 h-5 w-5 shrink-0 animate-spin text-muted-foreground" />;
+  }
+  if (state === 'failed') {
+    return (
+      <div className="flex shrink-0 items-center gap-1">
+        <XCircle className="h-5 w-5 text-destructive" />
+        <Button variant="outline" size="sm" onClick={onInstall} disabled={disabled}>
+          重试
+        </Button>
+      </div>
+    );
+  }
+  return (
+    <Button variant="outline" size="sm" onClick={onInstall} disabled={disabled}>
+      安装
+    </Button>
+  );
+}

--- a/frontend/src/components/PluginManagerSettings.tsx
+++ b/frontend/src/components/PluginManagerSettings.tsx
@@ -10,6 +10,8 @@ import {
   Loader2,
   RefreshCw,
   RotateCw,
+  Search,
+  Sparkles,
   Trash2,
   Undo2,
 } from 'lucide-react';
@@ -22,6 +24,7 @@ import {
 } from '@/api/tauri';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
+import { DefaultPluginOnboarding } from './DefaultPluginOnboarding';
 import {
   Dialog,
   DialogContent,
@@ -30,6 +33,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from './ui/dialog';
+import { Input } from './ui/input';
 import { Separator } from './ui/separator';
 import { Switch } from './ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
@@ -83,7 +87,35 @@ export function PluginManagerSettings({
   const [activeOperation, setActiveOperation] = useState<ActiveOperation | null>(null);
   const [uninstallTarget, setUninstallTarget] = useState<PluginStatus | null>(null);
   const [keepData, setKeepData] = useState(true);
+  const [query, setQuery] = useState('');
+  // 安装/升级下载进度，按 pluginId 存百分比（0-100）。
+  const [installProgress, setInstallProgress] = useState<Record<string, number>>({});
+  // 推荐安装引导的缺失默认插件列表；为 null 时不显示。
+  const [recommendMissing, setRecommendMissing] = useState<AvailablePlugin[] | null>(null);
   const { showError, showSuccess } = useToast();
+
+  // 监听后端推送的下载进度事件，更新对应插件的进度。
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+    void api
+      .onPluginInstallProgress(({ plugin_id, downloaded, total }) => {
+        if (disposed) return;
+        const percent = total > 0 ? Math.min(100, Math.round((downloaded / total) * 100)) : 0;
+        setInstallProgress((prev) => ({ ...prev, [plugin_id]: percent }));
+      })
+      .then((stop) => {
+        if (disposed) {
+          stop();
+        } else {
+          unlisten = stop;
+        }
+      });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
 
   useEffect(() => {
     setPlugins(initialPlugins);
@@ -126,6 +158,26 @@ export function PluginManagerSettings({
     [available],
   );
 
+  // 关键字过滤：匹配插件名称或描述，对已安装和可安装列表同时生效。
+  const normalizedQuery = query.trim().toLowerCase();
+  const matches = (text: string) => text.toLowerCase().includes(normalizedQuery);
+  const filteredPlugins = useMemo(
+    () =>
+      normalizedQuery === ''
+        ? plugins
+        : plugins.filter((plugin) => matches(plugin.name) || matches(plugin.id)),
+    [plugins, normalizedQuery],
+  );
+  const filteredAvailable = useMemo(() => {
+    // 隐藏已安装且无更新的插件（已安装且无更新的不再出现在可安装列表）。
+    const installable = available.filter(
+      (plugin) => plugin.installed_version === null || plugin.update_available,
+    );
+    return normalizedQuery === ''
+      ? installable
+      : installable.filter((plugin) => matches(plugin.name) || matches(plugin.description));
+  }, [available, normalizedQuery]);
+
   const finishOperation = async () => {
     const [, contributionsResult] = await Promise.allSettled([
       refresh(),
@@ -155,6 +207,12 @@ export function PluginManagerSettings({
       return false;
     } finally {
       setActiveOperation(null);
+      setInstallProgress((prev) => {
+        if (!(pluginId in prev)) return prev;
+        const next = { ...prev };
+        delete next[pluginId];
+        return next;
+      });
     }
   };
 
@@ -212,6 +270,22 @@ export function PluginManagerSettings({
       await refresh();
     } finally {
       setActiveOperation(null);
+    }
+  };
+
+  // 打开默认插件推荐引导：检测缺失的默认插件并弹出安装对话框。
+  const openRecommend = async () => {
+    try {
+      const check = await api.checkDefaultPlugins();
+      if (check.missing.length > 0) {
+        setRecommendMissing(check.missing);
+      } else if (check.catalog_error) {
+        showError('无法获取插件目录', check.catalog_error);
+      } else {
+        showSuccess('默认插件已齐全', '无需额外安装');
+      }
+    } catch (error) {
+      showError('检测失败', String(error));
     }
   };
 
@@ -277,6 +351,16 @@ export function PluginManagerSettings({
               </TooltipTrigger>
               <TooltipContent>插件开发文档</TooltipContent>
             </Tooltip>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1.5 px-2 text-xs"
+              onClick={() => void openRecommend()}
+              disabled={loading || isBusy}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              推荐
+            </Button>
             <IconAction
               label="导入本地插件"
               onClick={() => void importLocal()}
@@ -296,8 +380,8 @@ export function PluginManagerSettings({
         </div>
 
         <Tabs defaultValue="installed" className="flex min-h-0 flex-1 flex-col">
-          <div className="shrink-0 border-b px-4 py-2 sm:px-6">
-            <TabsList className="grid h-9 w-full max-w-72 grid-cols-2">
+          <div className="flex shrink-0 items-center gap-2 border-b px-4 py-2 sm:px-6">
+            <TabsList className="grid h-9 w-full max-w-56 grid-cols-2">
               <TabsTrigger value="installed" className="py-1 text-xs">
                 已安装
               </TabsTrigger>
@@ -305,6 +389,15 @@ export function PluginManagerSettings({
                 可安装
               </TabsTrigger>
             </TabsList>
+            <div className="relative ml-auto w-full max-w-48">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="搜索插件"
+                className="h-9 pl-8 text-xs"
+              />
+            </div>
           </div>
 
           <TabsContent value="installed" className="m-0 min-h-0 flex-1 overflow-y-auto px-4 sm:px-6">
@@ -312,14 +405,17 @@ export function PluginManagerSettings({
               <LoadingState label="正在读取插件状态" />
             ) : plugins.length === 0 ? (
               <EmptyState label="暂无已安装插件" />
+            ) : filteredPlugins.length === 0 ? (
+              <EmptyState label="没有匹配的插件" />
             ) : (
-              plugins.map((plugin) => (
+              filteredPlugins.map((plugin) => (
                 <InstalledPluginRow
                   key={plugin.id}
                   plugin={plugin}
                   release={availableById.get(plugin.id)}
                   activeOperation={activeOperation}
                   disabled={isBusy}
+                  progress={installProgress[plugin.id] ?? null}
                   onToggle={toggleEnabled}
                   onReload={reload}
                   onUpgrade={upgrade}
@@ -343,14 +439,17 @@ export function PluginManagerSettings({
               </div>
             ) : available.length === 0 ? (
               <EmptyState label="暂无可安装插件" />
+            ) : filteredAvailable.length === 0 ? (
+              <EmptyState label="没有匹配的插件" />
             ) : (
-              available.map((plugin, index) => (
+              filteredAvailable.map((plugin, index) => (
                 <AvailablePluginRow
                   key={plugin.id}
                   plugin={plugin}
                   index={index}
                   activeOperation={activeOperation}
                   disabled={isBusy}
+                  progress={installProgress[plugin.id] ?? null}
                   onInstall={install}
                 />
               ))
@@ -388,6 +487,17 @@ export function PluginManagerSettings({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <DefaultPluginOnboarding
+        missing={recommendMissing}
+        onOpenChange={(open) => {
+          if (!open) setRecommendMissing(null);
+        }}
+        onComplete={() => {
+          void refresh();
+          void refreshContributions();
+        }}
+      />
     </TooltipProvider>
   );
 }
@@ -397,6 +507,7 @@ function InstalledPluginRow({
   release,
   activeOperation,
   disabled,
+  progress,
   onToggle,
   onReload,
   onUpgrade,
@@ -407,6 +518,7 @@ function InstalledPluginRow({
   release?: AvailablePlugin;
   activeOperation: ActiveOperation | null;
   disabled: boolean;
+  progress: number | null;
   onToggle: (plugin: PluginStatus, enabled: boolean) => Promise<void>;
   onReload: (plugin: PluginStatus) => Promise<void>;
   onUpgrade: (plugin: PluginStatus) => Promise<void>;
@@ -421,10 +533,10 @@ function InstalledPluginRow({
   const StatusIcon = healthy ? CheckCircle2 : plugin.state === 'disabled' ? Circle : AlertCircle;
 
   return (
-    <div className="border-b py-4 last:border-b-0">
-      <div className="flex items-start gap-3 rounded-lg border border-transparent px-3 py-3 transition-colors hover:border-border/70 hover:bg-muted/20">
+    <div className="border-b py-2.5 last:border-b-0">
+      <div className="flex items-center gap-2.5">
         <StatusIcon
-          className={`mt-0.5 h-5 w-5 shrink-0 ${
+          className={`h-4 w-4 shrink-0 ${
             healthy
               ? 'text-emerald-500'
               : plugin.state === 'disabled'
@@ -433,74 +545,88 @@ function InstalledPluginRow({
           }`}
         />
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="break-words text-sm font-medium">{plugin.name}</span>
-            <Badge variant={healthy ? 'secondary' : 'outline'}>{stateLabel[plugin.state]}</Badge>
-            {canUpgrade && <Badge className="border-primary/30 bg-primary/10 text-primary">发现新版本</Badge>}
-          </div>
-
-          <div className="mt-2 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs">
-            <VersionInfo label="当前版本" value={currentVersion} />
-            {canUpgrade && release && (
-              <VersionInfo label="可升级至" value={release.version} emphasized />
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+            <span className="break-words text-sm font-medium text-foreground">{plugin.name}</span>
+            <Badge variant={healthy ? 'secondary' : 'outline'} className="px-1.5 py-0 text-[10px]">
+              {stateLabel[plugin.state]}
+            </Badge>
+            {canUpgrade && (
+              <Badge className="border-primary/30 bg-primary/10 px-1.5 py-0 text-[10px] text-primary">
+                发现新版本
+              </Badge>
             )}
-            <span className={`inline-flex items-center gap-1.5 ${sidecar.className}`}>
+            <span className="inline-flex items-center gap-1">
+              <span className="text-muted-foreground/70">v{currentVersion}</span>
+              {canUpgrade && release && (
+                <span className="font-medium text-primary">→ {release.version}</span>
+              )}
+            </span>
+            <span className={`inline-flex items-center gap-1 ${sidecar.className}`}>
               <span className={`h-1.5 w-1.5 rounded-full ${sidecar.dotClassName}`} />
               {sidecar.label}
             </span>
           </div>
 
           {plugin.last_error && (
-            <p className="mt-2 break-words text-xs leading-5 text-destructive">{plugin.last_error}</p>
+            <p className="mt-1 break-words text-xs leading-5 text-destructive">{plugin.last_error}</p>
           )}
 
-          <div className="mt-3 flex flex-wrap items-center gap-2">
+          {progress !== null && (
+            <div className="mt-1.5 h-1 w-full max-w-64 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full bg-primary transition-[width] duration-150"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          )}
+
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
             {canUpgrade && (
               <Button
                 size="sm"
-                className="h-8"
+                className="h-7 gap-1 px-2 text-xs"
                 onClick={() => void onUpgrade(plugin)}
                 disabled={disabled}
               >
                 {working && activeOperation?.operation === 'upgrade' ? (
-                  <Loader2 className="animate-spin" />
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 ) : (
-                  <ArrowUpCircle />
+                  <ArrowUpCircle className="h-3.5 w-3.5" />
                 )}
-                升级到 {release?.version}
+                升级
               </Button>
             )}
             <IconAction
               label="重新加载插件"
+              className="h-7 w-7"
               onClick={() => void onReload(plugin)}
               disabled={disabled || !plugin.enabled}
               working={working && activeOperation?.operation === 'reload'}
             >
-              <RotateCw />
+              <RotateCw className="h-3.5 w-3.5" />
             </IconAction>
             <IconAction
               label="回滚到上一版本"
+              className="h-7 w-7"
               onClick={() => void onRollback(plugin)}
               disabled={disabled || !plugin.can_rollback}
               working={working && activeOperation?.operation === 'rollback'}
             >
-              <Undo2 />
+              <Undo2 className="h-3.5 w-3.5" />
             </IconAction>
             <IconAction
               label="卸载插件"
+              className="h-7 w-7"
               onClick={() => onUninstall(plugin)}
               disabled={disabled}
               destructive
             >
-              <Trash2 />
+              <Trash2 className="h-3.5 w-3.5" />
             </IconAction>
           </div>
         </div>
 
         <div className="flex shrink-0 items-center gap-2 pl-2">
-          <span className="hidden text-xs text-muted-foreground sm:inline">
-            {plugin.enabled ? '已启用' : '已停用'}
-          </span>
           {working && ['enable', 'disable'].includes(activeOperation?.operation ?? '') ? (
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           ) : (
@@ -514,25 +640,6 @@ function InstalledPluginRow({
         </div>
       </div>
     </div>
-  );
-}
-
-function VersionInfo({
-  label,
-  value,
-  emphasized = false,
-}: {
-  label: string;
-  value: string;
-  emphasized?: boolean;
-}) {
-  return (
-    <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-      <span>{label}</span>
-      <span className={emphasized ? 'font-medium text-primary' : 'font-medium text-foreground'}>
-        {value}
-      </span>
-    </span>
   );
 }
 
@@ -577,39 +684,50 @@ function AvailablePluginRow({
   index,
   activeOperation,
   disabled,
+  progress,
   onInstall,
 }: {
   plugin: AvailablePlugin;
   index: number;
   activeOperation: ActiveOperation | null;
   disabled: boolean;
+  progress: number | null;
   onInstall: (plugin: AvailablePlugin) => Promise<void>;
 }) {
   const installing = activeOperation?.pluginId === plugin.id && activeOperation.operation === 'install';
   return (
     <div>
       {index > 0 && <Separator />}
-      <div className="flex min-h-28 items-start gap-4 py-5">
+      <div className="flex items-start gap-3 py-2.5">
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <span className="break-words text-sm font-medium">{plugin.name}</span>
-            <Badge variant="outline">{plugin.version}</Badge>
-            {!plugin.supported && <Badge variant="outline">当前平台不可用</Badge>}
-            {plugin.installed_version && <Badge variant="secondary">已安装</Badge>}
+            <Badge variant="outline" className="px-1.5 py-0 text-[10px]">{plugin.version}</Badge>
+            {!plugin.supported && <Badge variant="outline" className="px-1.5 py-0 text-[10px]">当前平台不可用</Badge>}
+            {plugin.installed_version && <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">已安装</Badge>}
           </div>
           {plugin.description && (
-            <p className="mt-2 break-words text-xs leading-5 text-muted-foreground">
+            <p className="mt-1 break-words text-xs leading-5 text-muted-foreground">
               {plugin.description}
             </p>
+          )}
+          {progress !== null && (
+            <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full bg-primary transition-[width] duration-150"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
           )}
         </div>
         <IconAction
           label="安装插件"
+          className="h-7 w-7 shrink-0"
           onClick={() => void onInstall(plugin)}
           disabled={disabled || !plugin.supported || plugin.installed_version !== null}
           working={installing}
         >
-          <Download />
+          <Download className="h-3.5 w-3.5" />
         </IconAction>
       </div>
     </div>

--- a/frontend/src/components/PluginManagerSettings.tsx
+++ b/frontend/src/components/PluginManagerSettings.tsx
@@ -273,17 +273,16 @@ export function PluginManagerSettings({
     }
   };
 
-  // 打开默认插件推荐引导：检测缺失的默认插件并弹出安装对话框。
+  // 打开默认插件推荐引导：拉取全部默认插件（含已安装与未安装），总是弹出对话框。
   const openRecommend = async () => {
     try {
-      const check = await api.checkDefaultPlugins();
-      if (check.missing.length > 0) {
-        setRecommendMissing(check.missing);
-      } else if (check.catalog_error) {
-        showError('无法获取插件目录', check.catalog_error);
-      } else {
-        showSuccess('默认插件已齐全', '无需额外安装');
+      const list = await api.listAvailablePlugins();
+      const defaults = list.filter((plugin) => plugin.is_default && plugin.supported);
+      if (defaults.length === 0) {
+        showError('无法获取默认插件', '插件目录为空或网络不可达');
+        return;
       }
+      setRecommendMissing(defaults);
     } catch (error) {
       showError('检测失败', String(error));
     }
@@ -490,6 +489,7 @@ export function PluginManagerSettings({
 
       <DefaultPluginOnboarding
         missing={recommendMissing}
+        writeCompletionMarker={false}
         onOpenChange={(open) => {
           if (!open) setRecommendMissing(null);
         }}

--- a/frontend/src/components/StatusPanel.tsx
+++ b/frontend/src/components/StatusPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, KeyboardEvent } from 'react';
 import { useStore } from '@/store/useStore';
 import { api } from '@/api/tauri';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { Sun, Moon, Monitor, PanelLeft, SquarePen, Volume2, VolumeX, AudioLines, Globe, ArrowUpCircle, Search, TerminalSquare } from 'lucide-react';
+import { Sun, Moon, Monitor, PanelLeft, SquarePen, Volume2, VolumeX, AudioLines, Globe, ArrowUpCircle, Search, TerminalSquare, Puzzle } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { useSearchStore } from '@/store/useSearchStore';
 import { useStreamingTts } from '@/hooks/useStreamingTts';
@@ -256,6 +256,14 @@ export function StatusPanel({ browserActive, onOpenBrowser, terminalActive, onOp
           </button>
         )}
         <SearchButton />
+        <button
+          data-no-drag
+          onClick={() => setPendingSettingsTab('plugin-manager')}
+          className="text-muted-foreground transition-colors hover:text-foreground"
+          title="插件管理"
+        >
+          <Puzzle className="w-4 h-4" />
+        </button>
         {onOpenTerminal && (
           <button
             data-no-drag

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -57,15 +57,19 @@ DialogTrigger.displayName = "DialogTrigger"
 
 const DialogContent = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { showCloseButton?: boolean }
->(({ className, children, showCloseButton = true, ...props }, ref) => {
+  React.HTMLAttributes<HTMLDivElement> & {
+    showCloseButton?: boolean
+    /** 外层遮罩容器的类名，用于覆盖默认 z-index（如嵌套 Dialog 需要更高层级）。 */
+    overlayClassName?: string
+  }
+>(({ className, children, showCloseButton = true, overlayClassName, ...props }, ref) => {
   const context = React.useContext(DialogContext)
   if (!context) throw new Error("DialogContent must be used within Dialog")
 
   if (!context.open) return null
 
   return createPortal(
-    <div className="fixed inset-0 z-[70] flex items-center justify-center">
+    <div className={cn("fixed inset-0 z-[70] flex items-center justify-center", overlayClassName)}>
       <div className="fixed inset-0 bg-black/50" />
       <div
         ref={ref}

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -2,12 +2,14 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { useStore } from '@/store/useStore';
 import {
   api,
+  type AvailablePlugin,
   type SessionStreamEvent,
   type TabKind,
   type TabState,
   type TerminalTabInfo,
 } from '@/api/tauri';
 import { AppSidebar } from '@/components/AppSidebar';
+import { DefaultPluginOnboarding } from '@/components/DefaultPluginOnboarding';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { LazyMessageList, LazyMessageInput, LazyStatusPanel } from '@/components/LazyComponents';
 import { TabsContainer } from '@/components/TabsContainer';
@@ -115,6 +117,8 @@ export function MainApp() {
   const [terminalSyncVersion, setTerminalSyncVersion] = useState(0);
   const [chatPanelWidth, setChatPanelWidth] = useState(MIN_CHAT_WIDTH);
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  // 首次启动推荐安装的缺失默认插件列表；为 null 时不显示引导对话框。
+  const [onboardingMissing, setOnboardingMissing] = useState<AvailablePlugin[] | null>(null);
   const showWorkspacePanelRef = useRef(false);
   const workspaceTabKindRef = useRef<TabKind>('browser');
   const workspaceOpenRequestIdRef = useRef(0);
@@ -329,6 +333,16 @@ export function MainApp() {
     }).catch(console.warn);
 
     loadSessions();
+
+    // 首次启动时检测缺失的默认插件，有缺失则弹出推荐安装引导。
+    // 独立 catch，网络异常或检测失败都不影响主初始化流程。
+    api.checkDefaultPlugins()
+      .then((check) => {
+        if (check.first_launch_pending && check.missing.length > 0) {
+          setOnboardingMissing(check.missing);
+        }
+      })
+      .catch((error) => console.warn('默认插件检测失败', error));
 
     const flushStreamEvents = () => {
       streamEventTimerRef.current = null;
@@ -591,6 +605,16 @@ export function MainApp() {
           </main>
         </div>
       </div>
+
+      <DefaultPluginOnboarding
+        missing={onboardingMissing}
+        onOpenChange={(open) => {
+          if (!open) setOnboardingMissing(null);
+        }}
+        onComplete={() => {
+          /* 安装后 registry 会热加载，Core 创建时按需感知已装插件，无需额外刷新 */
+        }}
+      />
     </SidebarProvider>
   );
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4598,14 +4598,96 @@ pub async fn list_available_plugins(
         .map_err(|error| error.to_string())
 }
 
+/// 首次启动推荐安装检测结果。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DefaultPluginCheck {
+    /// 是否需要弹出首次启动推荐引导（标记未完成且存在缺失的默认插件）。
+    pub first_launch_pending: bool,
+    /// 缺失的默认插件（OSS 目录中存在、当前平台支持且尚未安装）。
+    pub missing: Vec<tiangong_plugin_runtime::artifacts::AvailablePlugin>,
+    /// OSS 目录拉取失败原因。网络异常时不强弹引导，下次启动再试。
+    pub catalog_error: Option<String>,
+}
+
+/// 检测是否需要首次启动推荐安装默认插件。
+#[tauri::command]
+pub async fn check_default_plugins(
+    state: State<'_, TiangongApp>,
+) -> Result<DefaultPluginCheck, String> {
+    let storage_root = state
+        .with_state_read(|core_state| Ok(core_state.config.storage_root.clone()))
+        .await?;
+
+    // 已完成首次启动引导，直接跳过，不再打扰用户。
+    if tiangong_plugin_runtime::artifacts::is_first_launch_completed(&storage_root) {
+        return Ok(DefaultPluginCheck {
+            first_launch_pending: false,
+            missing: Vec::new(),
+            catalog_error: None,
+        });
+    }
+
+    let repository = tiangong_plugin_runtime::artifacts::PluginRepository::new()
+        .map_err(|error| error.to_string())?;
+    let available = match repository.list_available(&storage_root).await {
+        Ok(list) => list,
+        Err(error) => {
+            // 网络或 OSS 不可达时不强弹引导，避免离线首启打扰用户。
+            return Ok(DefaultPluginCheck {
+                first_launch_pending: false,
+                missing: Vec::new(),
+                catalog_error: Some(error.to_string()),
+            });
+        }
+    };
+
+    let missing: Vec<_> = available
+        .into_iter()
+        .filter(|plugin| {
+            plugin.is_default && plugin.supported && plugin.installed_version.is_none()
+        })
+        .collect();
+
+    Ok(DefaultPluginCheck {
+        first_launch_pending: !missing.is_empty(),
+        missing,
+        catalog_error: None,
+    })
+}
+
+/// 标记首次启动引导已完成（用户跳过或安装结束后调用）。
+#[tauri::command]
+pub async fn complete_first_launch(state: State<'_, TiangongApp>) -> Result<(), String> {
+    let storage_root = state
+        .with_state_read(|core_state| Ok(core_state.config.storage_root.clone()))
+        .await?;
+    tauri::async_runtime::spawn_blocking(move || {
+        tiangong_plugin_runtime::artifacts::mark_first_launch_completed(&storage_root)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("写入首次启动标记任务失败: {error}"))?
+}
+
 async fn download_and_install_plugin(
     storage_root: std::path::PathBuf,
     plugin_id: String,
+    app: AppHandle,
 ) -> Result<tiangong_plugin_runtime::registry::PluginStatus, String> {
     let repository = tiangong_plugin_runtime::artifacts::PluginRepository::new()
         .map_err(|error| error.to_string())?;
+    let progress: tiangong_plugin_runtime::artifacts::ProgressFn = std::sync::Arc::new({
+        let app = app.clone();
+        let plugin_id = plugin_id.clone();
+        move |downloaded, total| {
+            let _ = app.emit(
+                "plugin_install_progress",
+                serde_json::json!({ "plugin_id": plugin_id, "downloaded": downloaded, "total": total }),
+            );
+        }
+    });
     let staged = repository
-        .download(&storage_root, &plugin_id)
+        .download(&storage_root, &plugin_id, Some(progress))
         .await
         .map_err(|error| error.to_string())?;
     tauri::async_runtime::spawn_blocking(move || {
@@ -4642,24 +4724,26 @@ pub async fn import_local_plugin(
 #[tauri::command]
 pub async fn install_plugin(
     plugin_id: String,
+    app: AppHandle,
     state: State<'_, TiangongApp>,
 ) -> Result<tiangong_plugin_runtime::registry::PluginStatus, String> {
     let storage_root = state
         .with_state_read(|core_state| Ok(core_state.config.storage_root.clone()))
         .await?;
-    download_and_install_plugin(storage_root, plugin_id).await
+    download_and_install_plugin(storage_root, plugin_id, app).await
 }
 
 /// 从 OSS 下载并升级插件，运行时负责失败恢复和本地回滚版本保留。
 #[tauri::command]
 pub async fn upgrade_plugin(
     plugin_id: String,
+    app: AppHandle,
     state: State<'_, TiangongApp>,
 ) -> Result<tiangong_plugin_runtime::registry::PluginStatus, String> {
     let storage_root = state
         .with_state_read(|core_state| Ok(core_state.config.storage_root.clone()))
         .await?;
-    download_and_install_plugin(storage_root, plugin_id).await
+    download_and_install_plugin(storage_root, plugin_id, app).await
 }
 
 /// 启用或停用已安装插件。

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -422,6 +422,8 @@ fn run_gui() {
             tiangong_app::commands::reload_plugin,
             tiangong_app::commands::plugin_open_view,
             tiangong_app::commands::plugin_call,
+            tiangong_app::commands::check_default_plugins,
+            tiangong_app::commands::complete_first_launch,
             tiangong_app::commands::get_trust_mode,
             tiangong_app::commands::set_trust_mode,
             tiangong_app::commands::get_default_trust_mode,


### PR DESCRIPTION
## 变更概述

为默认插件（prompt/fs/command/fetch/index/skill/mcp）添加首次启动推荐安装引导，并为插件管理增加多项体验改进。

## 主要改动

### 默认插件与首次启动推荐
- 将 prompt、fs、command、fetch、index、skill、mcp 标记为默认插件，按「日常工作」「编程开发」两个场景分类（多标签，一个插件可同时属于多个分类）
- 首次启动时检测缺失的默认插件，弹出推荐安装引导，按分类用 Tabs 分组展示
- 支持一键串行安装（带实时进度条）或逐个安装，也可跳过
- 跳过或安装完成后写入 `~/.tiangong/.first_launch_completed` 标记，之后不再弹出
- 网络不可达时静默跳过，下次启动再试

### 安装进度条
- 复用 bot 安装的进度推送机制（`plugin_install_progress` 事件）
- 后端下载时按文件分段实时推送字节进度
- 前端在推荐对话框、插件市场可安装列表、已安装列表升级处三处显示进度条

### 插件管理增强
- 可安装列表隐藏已安装且无更新的插件，配合搜索过滤
- 头部新增「推荐」按钮，随时打开推荐引导（即使全部已安装也弹出，区分已安装/未安装）
- 主界面右上角新增插件管理快捷入口（拼图图标）

### 修复
- 推荐 modal 在设置面板内可见（提高 z-index 至 z-80，高于设置面板 z-70）
- 区分首次启动（写完成标记）与插件管理手动打开（不写标记）两种场景
- 恢复 `stage_local_plugin` 签名文件可选复制逻辑（误并入的工作区残留改动）
- 修复 MainApp 会话刷新测试（mock DefaultPluginOnboarding）

## 验证
- `cargo clippy` 无警告
- `cargo nextest` 全部通过
- 前端 `yarn build` + `yarn test`（192 测试）全部通过