### PR TITLE
优化用户长消息的收缩显示

### DIFF
--- a/frontend/src/components/message/AgentTurn.tsx
+++ b/frontend/src/components/message/AgentTurn.tsx
@@ -29,6 +29,7 @@ import { StreamingMessage } from "./StreamingMessage";
 import { MessageActions } from "./MessageActions";
 import { ContentMedia } from "./ContentMedia";
 import { ToolGroup } from "./ToolGroup";
+import { CollapsibleUserText } from "./CollapsibleUserText";
 
 interface AgentTurnProps {
   messages: MessageItem[];
@@ -218,7 +219,11 @@ function AgentTurnView({
           return (
             <div key={frag.msg.id} className="flex flex-col items-end gap-0.5" title={formatMessageTime(frag.msg.created_at)}>
               <div className="flex justify-end">
-                <div className="max-w-[85%] rounded-2xl bg-primary/10 px-4 py-2.5 text-sm text-foreground whitespace-pre-wrap break-words">{textContent(frag.msg)}</div>
+                <div className="max-w-[85%] rounded-2xl bg-primary/10 px-4 py-2.5 text-foreground">
+                  <CollapsibleUserText messageId={frag.msg.id}>
+                    {textContent(frag.msg)}
+                  </CollapsibleUserText>
+                </div>
               </div>
               {(frag.msg.elapsed_ms != null || statusMeta) && (
                 <div className="flex items-center gap-1.5 pr-1 text-[11px] text-muted-foreground/80 tabular-nums">

--- a/frontend/src/components/message/CollapsibleUserText.tsx
+++ b/frontend/src/components/message/CollapsibleUserText.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+const COLLAPSED_LINES = 4;
+
+interface CollapsibleUserTextProps {
+  children: ReactNode;
+  messageId: string;
+}
+
+export function CollapsibleUserText({ children, messageId }: CollapsibleUserTextProps) {
+  const contentRef = useRef<HTMLParagraphElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  const measureOverflow = useCallback(() => {
+    const element = contentRef.current;
+    if (!element) return;
+
+    const lineHeight = Number.parseFloat(window.getComputedStyle(element).lineHeight);
+    if (!Number.isFinite(lineHeight)) return;
+
+    setIsOverflowing(element.scrollHeight > lineHeight * COLLAPSED_LINES + 1);
+  }, []);
+
+  useLayoutEffect(() => {
+    setExpanded(false);
+  }, [messageId]);
+
+  useLayoutEffect(() => {
+    measureOverflow();
+
+    const element = contentRef.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(measureOverflow);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [children, measureOverflow]);
+
+  return (
+    <div>
+      <p
+        ref={contentRef}
+        className="whitespace-pre-wrap break-words text-sm leading-5"
+        style={!expanded ? {
+          display: "-webkit-box",
+          WebkitBoxOrient: "vertical",
+          WebkitLineClamp: COLLAPSED_LINES,
+          overflow: "hidden",
+        } : undefined}
+      >
+        {children}
+      </p>
+      {isOverflowing && (
+        <button
+          type="button"
+          className="mt-1 inline-flex items-center gap-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+          <span>{expanded ? "收起" : "展开"}</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/message/UserMessageGroup.tsx
+++ b/frontend/src/components/message/UserMessageGroup.tsx
@@ -14,6 +14,7 @@ import type { MessageGroup } from "./types";
 import { VoiceBubble } from "./VoiceBubble";
 import { UserMessageActions } from "./UserMessageActions";
 import { ContentMedia } from "./ContentMedia";
+import { CollapsibleUserText } from "./CollapsibleUserText";
 
 export function UserMessageGroup({ group, runStatus, nonEditableIds, voiceMessages, editingMessageId, editingContent, editingAttachments, editingTextareaRef, onStartEdit, onConfirmEdit, onCancelEdit, onSetEditingContent, onSetEditingAttachments, onAttachFiles, onEditPaste }: {
   group: MessageGroup;
@@ -195,7 +196,11 @@ export function UserMessageGroup({ group, runStatus, nonEditableIds, voiceMessag
               ) : (
                 <div>
                   <ContentMedia message={message} />
-                  {messageText && <p className="whitespace-pre-wrap break-words text-sm">{renderUserText(messageText)}</p>}
+                  {messageText && (
+                    <CollapsibleUserText messageId={message.id}>
+                      {renderUserText(messageText)}
+                    </CollapsibleUserText>
+                  )}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## 变更内容
- 普通用户长文本超过 4 行时默认收缩显示
- 支持手动展开全文并再次收起
- 短文本不显示多余控制
- 保持定时任务、Webhook、语音消息和编辑状态的原有展示

## 验证
- `yarn build`
- `yarn test`（12 个测试文件，192 个测试通过）
- `git diff --check`