### PR TITLE
feat(browser): agent 使用浏览器改为图标标记提示

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,27 @@
 
 | 能力         | 说明                                                                                         |
 | ------------ | -------------------------------------------------------------------------------------------- |
-| 桌面 Agent   | Tauri + React + shadcn/ui 桌面界面，支持会话、工作区、工具过程、模型配置和运行状态展示       |
-| 嵌入式浏览器 | 内置多标签浏览器，Agent 可自主浏览网页、读取页面内容、点击元素、填写表单，用户也可手动操作   |
-| CLI / Server | 同一个 `tiangong` 入口支持命令行、后台 Server、更新检查和安装                                |
-| 多智能体协作 | 主 Agent 可按任务创建 PM、Developer、Tester、Researcher 等 Sub Agent，并通过消息和文件锁协作 |
-| 工具执行     | 支持文件读写、命令执行、代码搜索、补丁应用、网页抓取、时间查询等本地工具                     |
-| MCP 与 Skill | 支持 MCP 工具接入、本地 Skill 安装启停、按任务意图匹配和详情加载                             |
-| 移动端控制   | 通过独立 Bot 制品接入飞书、微信、QQ，支持扫码配置、运行托管、日志查看和图片/文件收发         |
-| 定时与触发   | 内置 Cron 定时任务（简单/Cron 双模式）与 Webhook 触发，定时结果可推送到指定 Bot 通道         |
-| 长期记忆     | 基于 SQLite、Tantivy 和向量索引保存项目事实、偏好、决策、产物和历史问题                      |
-| 多媒体能力   | 支持图片、视频、语音识别、语音合成等能力路由，结果以结构化媒体资源进入会话                   |
-| DeepSeek V4  | 适配 V4 新版接口，支持思考模式分档、结构化与文本协议双通道工具调用解析、流式 KV cache 统计   |
-| 权限治理     | 桌面会话可在监督模式和信任模式之间切换，Server 模式使用受控的远程角色边界                    |
-| 发布更新     | GitHub Release 分发安装包，桌面设置页和 `tiangong update` 共用在线更新链路                   |
+| 桌面 Agent    | Tauri + React + shadcn/ui 桌面界面，支持会话、工作区、工具过程、模型配置和运行状态展示       |
+| 嵌入式浏览器  | 内置多标签浏览器，Agent 可自主浏览网页、读取页面内容、点击元素、填写表单，用户也可手动操作   |
+| CLI / Server  | 同一个 `tiangong` 入口支持命令行、后台 Server、更新检查和安装                                |
+| 多智能体协作  | 主 Agent 可按任务创建 PM、Developer、Tester、Researcher 等 Sub Agent，并通过消息和文件锁协作 |
+| WASM 插件生态 | 工具执行、MCP/Skill、定时任务（Cron/Webhook）、长期记忆、多媒体生成、Coding 工作模式、桌面应用控制等能力均以独立签名发布的 WASM 插件提供，支持默认推荐、安装进度、按需启停和本地导入开发 |
+| 移动端控制    | 通过独立 Bot 制品接入飞书、微信、QQ，支持扫码配置、运行托管、日志查看和图片/文件收发         |
+| DeepSeek V4   | 适配 V4 新版接口，支持思考模式分档、结构化与文本协议双通道工具调用解析、流式 KV cache 统计   |
+| 权限治理      | 桌面会话可在监督模式和信任模式之间切换，Server 模式使用受控的远程角色边界                    |
+| 发布更新      | GitHub Release 分发安装包，桌面设置页和 `tiangong update` 共用在线更新链路                   |
+
+## WASM 插件系统
+
+天工的所有内置能力（文件、命令、网页抓取、MCP、Skill、记忆、调度、索引、媒体、Prompt、Coding、Computer Use 等）均已 WASM 化，运行在独立 sidecar 中，通过 WIT 接口与主程序解耦：
+
+- **独立签名发布**：每个插件单独构建、签名和发布，CI 校验签名清单与目录结构，支持默认插件推荐与安装进度展示。
+- **按需启停**：插件可在桌面设置页或 CLI 中启停、卸载和更新，失败不影响主进程稳定性。
+- **能力声明过滤**：插件通过 WIT 声明自身能力（工具、媒体、记忆等），主程序按能力路由请求。
+- **mention 候选**：插件可通过 Core 接口聚合 mention 候选，统一接入提示补全。
+- **本地开发**：参考 [WASM 插件开发指南](docs/plugin-development.md) 编写清单、构建 sidecar 并本地导入。
+
+插件源码位于根目录 [`plugins/`](plugins/)，尚未 WASM 化的内置插件（多智能体团队、浏览器、终端）位于 [`crates/plugins/`](crates/plugins/)。
 
 ## 多智能体协作
 
@@ -76,9 +84,9 @@ Sub Agent 独立执行、互相发消息、必要时获取文件锁
 
 ## 定时与触发
 
-天工内置独立的调度与触发能力，用于按计划或外部事件驱动 Agent 执行：
+调度与触发能力通过 `scheduler` 插件提供（底层基于 `tiangong-scheduler` crate），用于按计划或外部事件驱动 Agent 执行：
 
-- **定时任务**：基于 `tiangong-scheduler` crate 和 JSON 文件存储（`~/.tiangong/scheduler/`），复用 silent 框架内置 Scheduler，Server 启动时自动恢复已启用的 Cron Job。
+- **定时任务**：JSON 文件存储（`~/.tiangong/scheduler/`），复用 silent 框架内置 Scheduler，Server 启动时自动恢复已启用的 Cron Job。
 - **双模式编辑**：桌面端提供简单模式和 Cron 模式两种编辑器，内置校验和下次触发预览，可关联已有会话复用上下文或自动创建新会话。
 - **Webhook 触发**：Server 内置独立于定时任务的 HTTP 触发能力（`~/.tiangong/webhooks/`），提供无需认证的外部触发端点和需认证的管理端点，支持可选签名验证。
 - **结果推送**：定时任务和 Webhook 触发的结果可推送到指定 Bot 通道，与移动端控制联动。
@@ -101,7 +109,10 @@ crates/
   tiangong-entry/       统一命令入口
   tiangong-server/      HTTP REST + WebSocket Server
   tiangong-media/       图片、视频、语音等多媒体能力
-  plugins/              工具/媒体/记忆等可插拔能力
+  plugins/              已 WASM 化的可插拔能力（fs/command/fetch/mcp/skill/
+                        memory/scheduler/index/media/prompt/coding/computer-use
+                        等，独立签名发布）
+  crates/plugins/       尚未 WASM 化的内置插件（agent-team/browser/terminal）
 frontend/               桌面前端
 src-tauri/              Tauri 桌面壳
 ```

--- a/crates/plugins/tiangong-plugin-browser/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/handler.rs
@@ -20,9 +20,10 @@ fn resolve_agent_state(
 }
 
 use crate::types::{
-    format_browser_events, AnnotationExtractResult, BrowserCommand, BrowserEvent, BrowserOpenEvent,
-    BrowserPageSnapshot, BrowserResponse, ClickElementResult, FillFieldResult, FormExtractResult,
-    LocateElementResult, PageStatus, QueryDomResult, TabHistoryResult,
+    format_browser_events, AnnotationExtractResult, BrowserAgentActiveEvent, BrowserCommand,
+    BrowserEvent, BrowserOpenEvent, BrowserPageSnapshot, BrowserResponse, ClickElementResult,
+    FillFieldResult, FormExtractResult, LocateElementResult, PageStatus, QueryDomResult,
+    TabHistoryResult,
 };
 
 /// 轮询等待页面内容变化并稳定，返回最终的 after-digest。
@@ -141,6 +142,13 @@ pub async fn browser_command_handler(
                         },
                     );
                 }
+                // 始终通知前端 agent 正在使用浏览器（用于图标标记），不再依赖面板是否展开
+                let _ = app.emit(
+                    "browser:agent_active",
+                    BrowserAgentActiveEvent {
+                        session_id: session_id.clone(),
+                    },
+                );
                 let ticket = match manager.navigate_for_agent(&app, &url) {
                     Ok(ticket) => ticket,
                     Err(error) => {
@@ -186,6 +194,13 @@ pub async fn browser_command_handler(
                         },
                     );
                 }
+                // 始终通知前端 agent 正在使用浏览器（用于图标标记）
+                let _ = app.emit(
+                    "browser:agent_active",
+                    BrowserAgentActiveEvent {
+                        session_id: session_id.clone(),
+                    },
+                );
                 if let Err(error) = manager.navigate_for_agent(&app, &url) {
                     warn!(%error, %session_id, %url, "browser open URL failed");
                 }
@@ -527,6 +542,13 @@ pub async fn browser_command_handler(
                         },
                     );
                 }
+                // 始终通知前端 agent 正在使用浏览器（用于图标标记）
+                let _ = app.emit(
+                    "browser:agent_active",
+                    BrowserAgentActiveEvent {
+                        session_id: session_id.clone(),
+                    },
+                );
                 let result = tokio::task::spawn_blocking(move || manager.load_html(&html))
                     .await
                     .unwrap_or(Err("加载 HTML 任务失败".to_string()));

--- a/crates/plugins/tiangong-plugin-browser/src/types.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/types.rs
@@ -46,6 +46,14 @@ pub struct BrowserOpenEvent {
     pub url: String,
 }
 
+/// Agent 正在使用浏览器（打开或导航页面）的信号。
+///
+/// 前端据此在浏览器图标上显示"使用中"标记，而不是自动弹出浏览器面板。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrowserAgentActiveEvent {
+    pub session_id: String,
+}
+
 /// 页面加载事件。所有消费者必须按 `session_id` 路由，不能回退到当前活动会话。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BrowserPageLoadedEvent {

--- a/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
+++ b/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
@@ -285,7 +285,7 @@ describe('MainApp sessions_updated scheduling contract', () => {
     await advance(120);
 
     expect(getSessionsMock).not.toHaveBeenCalled();
-    expect(registeredUnlisteners.length).toBe(6);
+    expect(registeredUnlisteners.length).toBe(8);
     for (const unlisten of registeredUnlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -298,7 +298,9 @@ describe('MainApp StrictMode 异步监听注册竞态', () => {
   const LISTENED_EVENTS = [
     'sessions_updated',
     'desktop_notification_open_session',
+    'browser:tab_updated',
     'browser:open',
+    'browser:agent_active',
     'terminal:tab_updated',
   ] as const;
 

--- a/frontend/src/components/StatusPanel.tsx
+++ b/frontend/src/components/StatusPanel.tsx
@@ -21,6 +21,7 @@ const appWindow = getCurrentWindow();
 
 interface StatusPanelProps {
   browserActive?: boolean;
+  browserAgentActive?: boolean;
   onOpenBrowser?: () => void;
   terminalActive?: boolean;
   onOpenTerminal?: () => void;
@@ -47,7 +48,7 @@ function SearchButton() {
   );
 }
 
-export function StatusPanel({ browserActive, onOpenBrowser, terminalActive, onOpenTerminal }: StatusPanelProps) {
+export function StatusPanel({ browserActive, browserAgentActive, onOpenBrowser, terminalActive, onOpenTerminal }: StatusPanelProps) {
   const { activeSessionId, isNewConversation, sessions, startNewConversation, updateAvailable, setPendingSettingsTab } = useStore();
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
@@ -287,7 +288,7 @@ export function StatusPanel({ browserActive, onOpenBrowser, terminalActive, onOp
         <button
           data-no-drag
           onClick={onOpenBrowser}
-          className={`transition-colors ${
+          className={`relative transition-colors ${
             browserActive
               ? 'text-primary'
               : 'text-muted-foreground hover:text-foreground'
@@ -295,6 +296,13 @@ export function StatusPanel({ browserActive, onOpenBrowser, terminalActive, onOp
           title={browserActive ? '浏览器已打开' : '打开浏览器'}
         >
           <Globe className="w-4 h-4" />
+          {browserAgentActive && !browserActive && (
+            <span
+              className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-emerald-500"
+              title="Agent 正在使用浏览器"
+              aria-label="Agent 正在使用浏览器"
+            />
+          )}
         </button>
         <button
           data-no-drag

--- a/frontend/src/components/StatusPanel.tsx
+++ b/frontend/src/components/StatusPanel.tsx
@@ -6,7 +6,6 @@ import { Sun, Moon, Monitor, PanelLeft, SquarePen, Volume2, VolumeX, AudioLines,
 import { useTheme } from '@/hooks/useTheme';
 import { useSearchStore } from '@/store/useSearchStore';
 import { useStreamingTts } from '@/hooks/useStreamingTts';
-import { useToast } from './Toast';
 import { Separator } from './ui/separator';
 import { useSidebar } from './ui/sidebar';
 import { Button } from './ui/button';
@@ -24,6 +23,7 @@ interface StatusPanelProps {
   browserAgentActive?: boolean;
   onOpenBrowser?: () => void;
   terminalActive?: boolean;
+  terminalAgentActive?: boolean;
   onOpenTerminal?: () => void;
 }
 
@@ -48,7 +48,7 @@ function SearchButton() {
   );
 }
 
-export function StatusPanel({ browserActive, browserAgentActive, onOpenBrowser, terminalActive, onOpenTerminal }: StatusPanelProps) {
+export function StatusPanel({ browserActive, browserAgentActive, onOpenBrowser, terminalActive, terminalAgentActive, onOpenTerminal }: StatusPanelProps) {
   const { activeSessionId, isNewConversation, sessions, startNewConversation, updateAvailable, setPendingSettingsTab } = useStore();
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
@@ -59,42 +59,10 @@ export function StatusPanel({ browserActive, browserAgentActive, onOpenBrowser, 
   const { toggleSidebar, open: sidebarOpen } = useSidebar();
   const streamingTts = useStreamingTts();
   const [hasTts, setHasTts] = useState(false);
-  // 终端绿点：有任意会话 PTY 处于 Interactive/Running 时点亮
-  const [terminalBusy, setTerminalBusy] = useState(false);
-  const toast = useToast();
-  const lastBusyRef = useRef(false);
 
   useEffect(() => {
     api.hasTtsCapability().then(setHasTts).catch(() => setHasTts(false));
   }, []);
-
-  // 轮询终端状态（每 1.5s）→ 绿点 + toast 提示后台命令
-  useEffect(() => {
-    let cancelled = false;
-    const poll = async () => {
-      try {
-        const statuses = await api.terminalListStatuses();
-        if (cancelled) return;
-        const busy = statuses.some(
-          (s) => s.alive && s.phase === 'Running',
-        );
-        setTerminalBusy(busy);
-        // 从空闲变忙时弹一次 toast（且当前面板未开）
-        if (busy && !lastBusyRef.current && !terminalActive) {
-          toast.showInfo('命令在终端执行中', '点击终端按钮查看输出', 2500);
-        }
-        lastBusyRef.current = busy;
-      } catch {
-        // plugin 未注册时静默
-      }
-    };
-    poll();
-    const id = window.setInterval(poll, 1500);
-    return () => {
-      cancelled = true;
-      window.clearInterval(id);
-    };
-  }, [terminalActive, toast]);
 
   const activeSession = isNewConversation ? null : sessions.find((s) => s.id === activeSessionId);
   const currentTitle = isNewConversation ? '新对话' : (activeSession?.title || '新对话');
@@ -277,10 +245,11 @@ export function StatusPanel({ browserActive, browserAgentActive, onOpenBrowser, 
             title={terminalActive ? '终端已打开' : '打开终端'}
           >
             <TerminalSquare className="w-4 h-4" />
-            {terminalBusy && !terminalActive && (
+            {terminalAgentActive && !terminalActive && (
               <span
-                className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-emerald-500 animate-pulse"
-                title="有命令在终端执行中"
+                className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-emerald-500"
+                title="终端在使用中"
+                aria-label="终端在使用中"
               />
             )}
           </button>

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -211,27 +211,25 @@ export function MainApp() {
     }
   }, [lockResize, setSidebarOpenByLayout, unlockResize]);
 
-  // 查询指定会话的浏览器 tab 数量，决定是否在浏览器图标上显示"使用中"标记。
-  // 标记语义：当前会话浏览器存在 tab（即浏览器在使用中）。
-  // 圆点是否可见由 StatusPanel 按 `browserAgentActive && !browserActive` 控制，
-  // 因此用户已打开浏览器面板时圆点会自动隐藏，无需在此判断面板状态。
-  const refreshBrowserAgentActive = useCallback(async (sessionId: string) => {
+  // 刷新浏览器/终端的"使用中"标记。
+  // 数据源用持久化的 getSessionTabs（而非各插件的 runtime tab_list）：
+  // 历史会话切回来时 runtime state 尚未重建，runtime 查询会返回空，
+  // 而持久化数据真实记录了该会话拥有的 browser/terminal tab。
+  // 圆点是否可见由 StatusPanel 按 `<kind>AgentActive && !<kind>Active` 控制，
+  // 用户已打开对应面板时圆点自动隐藏，无需在此判断面板状态。
+  const refreshAgentActiveMarkers = useCallback(async (sessionId: string) => {
     try {
-      const result = await api.browserTabList(sessionId);
-      setBrowserAgentActive(result.tabs.length > 0);
+      const result = await api.getSessionTabs(sessionId);
+      let hasBrowser = false;
+      let hasTerminal = false;
+      for (const tab of result.tabs) {
+        if (tab.kind === 'browser') hasBrowser = true;
+        else if (tab.kind === 'terminal') hasTerminal = true;
+      }
+      setBrowserAgentActive(hasBrowser);
+      setTerminalAgentActive(hasTerminal);
     } catch {
-      // 浏览器插件未就绪或会话无浏览器状态时静默
-    }
-  }, []);
-
-  // 查询指定会话的终端 tab 数量，决定是否在终端图标上显示"使用中"标记。
-  // 标记语义与浏览器一致：当前会话存在终端 tab 即亮标记。
-  const refreshTerminalAgentActive = useCallback(async (sessionId: string) => {
-    try {
-      const result = await api.terminalTabList(sessionId);
-      setTerminalAgentActive(result.tabs.length > 0);
-    } catch {
-      // 终端插件未就绪或会话无终端状态时静默
+      // 会话 tabs 未就绪时静默
     }
   }, []);
 
@@ -262,10 +260,9 @@ export function MainApp() {
     // 面板关闭后浏览器/终端 tab 仍然存活（仅隐藏），刷新"使用中"标记让圆点重新亮起
     const sessionId = useStore.getState().activeSessionId ?? useStore.getState().newConversationId;
     if (sessionId) {
-      void refreshBrowserAgentActive(sessionId);
-      void refreshTerminalAgentActive(sessionId);
+      void refreshAgentActiveMarkers(sessionId);
     }
-  }, [lockResize, refreshBrowserAgentActive, refreshTerminalAgentActive, setSidebarOpenByLayout, unlockResize]);
+  }, [lockResize, refreshAgentActiveMarkers, setSidebarOpenByLayout, unlockResize]);
 
   // 浏览器面板挂载后，显式触达后端以渲染浏览器表面。
   // 与 `browser:open` / `tiangong:open-browser` 入口保持一致，
@@ -370,9 +367,8 @@ export function MainApp() {
       setTerminalAgentActive(false);
       return;
     }
-    void refreshBrowserAgentActive(activeSessionId);
-    void refreshTerminalAgentActive(activeSessionId);
-  }, [activeSessionId, refreshBrowserAgentActive, refreshTerminalAgentActive]);
+    void refreshAgentActiveMarkers(activeSessionId);
+  }, [activeSessionId, refreshAgentActiveMarkers]);
 
   useEffect(() => {
     ensureDesktopNotificationPermission().catch(console.warn);
@@ -479,21 +475,21 @@ export function MainApp() {
       track(await listen<{ session_id?: string }>('browser:tab_updated', (event) => {
         const sessionId = event.payload?.session_id;
         if (!sessionId || useStore.getState().activeSessionId !== sessionId) return;
-        void refreshBrowserAgentActive(sessionId);
+        void refreshAgentActiveMarkers(sessionId);
       }));
       guard();
       // 保留 browser:open 监听：后端首次初始化浏览器窗口时触发，同样刷新标记。
       track(await listen<{ session_id: string; url: string }>('browser:open', (event) => {
         const { session_id } = event.payload;
         if (!session_id || useStore.getState().activeSessionId !== session_id) return;
-        void refreshBrowserAgentActive(session_id);
+        void refreshAgentActiveMarkers(session_id);
       }));
       guard();
       // agent_active 信号：agent 打开/导航页面时发出，刷新标记。
       track(await listen<{ session_id: string }>('browser:agent_active', (event) => {
         const { session_id } = event.payload;
         if (!session_id || useStore.getState().activeSessionId !== session_id) return;
-        void refreshBrowserAgentActive(session_id);
+        void refreshAgentActiveMarkers(session_id);
       }));
       guard();
       track(await listen<{
@@ -520,7 +516,7 @@ export function MainApp() {
         }
         // 当前会话的终端 tab 发生变化时刷新"使用中"标记
         if (isCurrentTerminalSession) {
-          void refreshTerminalAgentActive(session_id);
+          void refreshAgentActiveMarkers(session_id);
         }
         if (!isCurrentTerminalSession) {
           return;
@@ -622,8 +618,7 @@ export function MainApp() {
     closeWorkspacePanel,
     lockResize,
     unlockResize,
-    refreshBrowserAgentActive,
-    refreshTerminalAgentActive,
+    refreshAgentActiveMarkers,
     syncTerminalRuntimeTabsToSession,
   ]);
 

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -108,6 +108,7 @@ function terminalRuntimeTabToState(tab: TerminalTabInfo): TabState {
 
 export function MainApp() {
   const { applyStreamEvents, loadSessions } = useStore();
+  const activeSessionId = useStore((state) => state.activeSessionId);
   useUpdateCheck();
   const [workspacePanelMounted, setWorkspacePanelMounted] = useState(false);
   const [showWorkspacePanel, setShowWorkspacePanel] = useState(false);
@@ -117,6 +118,9 @@ export function MainApp() {
   const [terminalSyncVersion, setTerminalSyncVersion] = useState(0);
   const [chatPanelWidth, setChatPanelWidth] = useState(MIN_CHAT_WIDTH);
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  // Agent 正在使用浏览器（打开/导航页面）时置位，用户点开浏览器面板后清除。
+  // 用于在右上角浏览器图标上显示"使用中"标记，而不是自动弹出面板。
+  const [browserAgentActive, setBrowserAgentActive] = useState(false);
   // 首次启动推荐安装的缺失默认插件列表；为 null 时不显示引导对话框。
   const [onboardingMissing, setOnboardingMissing] = useState<AvailablePlugin[] | null>(null);
   const showWorkspacePanelRef = useRef(false);
@@ -204,6 +208,19 @@ export function MainApp() {
     }
   }, [lockResize, setSidebarOpenByLayout, unlockResize]);
 
+  // 查询指定会话的浏览器 tab 数量，决定是否在浏览器图标上显示"使用中"标记。
+  // 标记语义：当前会话浏览器存在 tab（即浏览器在使用中）。
+  // 圆点是否可见由 StatusPanel 按 `browserAgentActive && !browserActive` 控制，
+  // 因此用户已打开浏览器面板时圆点会自动隐藏，无需在此判断面板状态。
+  const refreshBrowserAgentActive = useCallback(async (sessionId: string) => {
+    try {
+      const result = await api.browserTabList(sessionId);
+      setBrowserAgentActive(result.tabs.length > 0);
+    } catch {
+      // 浏览器插件未就绪或会话无浏览器状态时静默
+    }
+  }, []);
+
   const closeWorkspacePanel = useCallback(async (restoreSize = true) => {
     if (!showWorkspacePanelRef.current) return;
     workspaceOpenRequestIdRef.current += 1;
@@ -228,7 +245,12 @@ export function MainApp() {
       setSidebarOpenByLayout(true);
     }
     workspaceExpandedForBrowserRef.current = false;
-  }, [lockResize, setSidebarOpenByLayout, unlockResize]);
+    // 面板关闭后浏览器 tab 仍然存活（仅隐藏 webview），刷新"使用中"标记让圆点重新亮起
+    const sessionId = useStore.getState().activeSessionId ?? useStore.getState().newConversationId;
+    if (sessionId) {
+      void refreshBrowserAgentActive(sessionId);
+    }
+  }, [lockResize, refreshBrowserAgentActive, setSidebarOpenByLayout, unlockResize]);
 
   // 浏览器面板挂载后，显式触达后端以渲染浏览器表面。
   // 与 `browser:open` / `tiangong:open-browser` 入口保持一致，
@@ -237,6 +259,8 @@ export function MainApp() {
   const handleToggleBrowser = useCallback(async () => {
     // 标题栏按钮只表达"打开 browser 意图"——Tab 的查找/切换/创建统一由
     // TabsContainer.activateOrCreateTab 执行（不再调 ensureBrowserVisible）
+    // 用户主动查看浏览器面板后，清除"agent 使用中"标记
+    setBrowserAgentActive(false);
     await openWorkspacePanel('browser');
   }, [openWorkspacePanel]);
 
@@ -321,6 +345,15 @@ export function MainApp() {
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
   }, [closeWorkspacePanel]);
+
+  // 会话切换时刷新浏览器"使用中"标记：新切到的会话可能已有浏览器 tab。
+  useEffect(() => {
+    if (!activeSessionId) {
+      setBrowserAgentActive(false);
+      return;
+    }
+    void refreshBrowserAgentActive(activeSessionId);
+  }, [activeSessionId, refreshBrowserAgentActive]);
 
   useEffect(() => {
     ensureDesktopNotificationPermission().catch(console.warn);
@@ -422,12 +455,26 @@ export function MainApp() {
       }));
       guard();
 
-      track(await listen<{ session_id: string; url: string }>('browser:open', async (event) => {
+      // 浏览器 tab 增删/更新时刷新"使用中"标记。
+      // 标记语义：当前会话浏览器存在 tab（即浏览器在使用），且用户尚未打开浏览器面板。
+      track(await listen<{ session_id?: string }>('browser:tab_updated', (event) => {
+        const sessionId = event.payload?.session_id;
+        if (!sessionId || useStore.getState().activeSessionId !== sessionId) return;
+        void refreshBrowserAgentActive(sessionId);
+      }));
+      guard();
+      // 保留 browser:open 监听：后端首次初始化浏览器窗口时触发，同样刷新标记。
+      track(await listen<{ session_id: string; url: string }>('browser:open', (event) => {
         const { session_id } = event.payload;
         if (!session_id || useStore.getState().activeSessionId !== session_id) return;
-        await openWorkspacePanel('browser');
-        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
-        // browser:open 已在后端完成导航，前端不再重复 navigate
+        void refreshBrowserAgentActive(session_id);
+      }));
+      guard();
+      // agent_active 信号：agent 打开/导航页面时发出，刷新标记。
+      track(await listen<{ session_id: string }>('browser:agent_active', (event) => {
+        const { session_id } = event.payload;
+        if (!session_id || useStore.getState().activeSessionId !== session_id) return;
+        void refreshBrowserAgentActive(session_id);
       }));
       guard();
       track(await listen<{
@@ -552,6 +599,7 @@ export function MainApp() {
     closeWorkspacePanel,
     lockResize,
     unlockResize,
+    refreshBrowserAgentActive,
     syncTerminalRuntimeTabsToSession,
   ]);
 
@@ -560,6 +608,7 @@ export function MainApp() {
       <div className="flex flex-col h-screen w-full overflow-hidden">
         <LazyStatusPanel
           browserActive={showWorkspacePanel && workspaceTabKind === 'browser'}
+          browserAgentActive={browserAgentActive}
           onOpenBrowser={handleToggleBrowser}
           terminalActive={showWorkspacePanel && workspaceTabKind === 'terminal'}
           onOpenTerminal={handleToggleTerminal}

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -121,6 +121,9 @@ export function MainApp() {
   // Agent 正在使用浏览器（打开/导航页面）时置位，用户点开浏览器面板后清除。
   // 用于在右上角浏览器图标上显示"使用中"标记，而不是自动弹出面板。
   const [browserAgentActive, setBrowserAgentActive] = useState(false);
+  // 当前会话存在终端 tab 时置位，用户点开终端面板后清除。
+  // 与浏览器标记策略一致：有 tab 即常亮。
+  const [terminalAgentActive, setTerminalAgentActive] = useState(false);
   // 首次启动推荐安装的缺失默认插件列表；为 null 时不显示引导对话框。
   const [onboardingMissing, setOnboardingMissing] = useState<AvailablePlugin[] | null>(null);
   const showWorkspacePanelRef = useRef(false);
@@ -221,6 +224,17 @@ export function MainApp() {
     }
   }, []);
 
+  // 查询指定会话的终端 tab 数量，决定是否在终端图标上显示"使用中"标记。
+  // 标记语义与浏览器一致：当前会话存在终端 tab 即亮标记。
+  const refreshTerminalAgentActive = useCallback(async (sessionId: string) => {
+    try {
+      const result = await api.terminalTabList(sessionId);
+      setTerminalAgentActive(result.tabs.length > 0);
+    } catch {
+      // 终端插件未就绪或会话无终端状态时静默
+    }
+  }, []);
+
   const closeWorkspacePanel = useCallback(async (restoreSize = true) => {
     if (!showWorkspacePanelRef.current) return;
     workspaceOpenRequestIdRef.current += 1;
@@ -245,12 +259,13 @@ export function MainApp() {
       setSidebarOpenByLayout(true);
     }
     workspaceExpandedForBrowserRef.current = false;
-    // 面板关闭后浏览器 tab 仍然存活（仅隐藏 webview），刷新"使用中"标记让圆点重新亮起
+    // 面板关闭后浏览器/终端 tab 仍然存活（仅隐藏），刷新"使用中"标记让圆点重新亮起
     const sessionId = useStore.getState().activeSessionId ?? useStore.getState().newConversationId;
     if (sessionId) {
       void refreshBrowserAgentActive(sessionId);
+      void refreshTerminalAgentActive(sessionId);
     }
-  }, [lockResize, refreshBrowserAgentActive, setSidebarOpenByLayout, unlockResize]);
+  }, [lockResize, refreshBrowserAgentActive, refreshTerminalAgentActive, setSidebarOpenByLayout, unlockResize]);
 
   // 浏览器面板挂载后，显式触达后端以渲染浏览器表面。
   // 与 `browser:open` / `tiangong:open-browser` 入口保持一致，
@@ -265,6 +280,8 @@ export function MainApp() {
   }, [openWorkspacePanel]);
 
   const handleToggleTerminal = useCallback(() => {
+    // 用户主动查看终端面板后，清除"使用中"标记
+    setTerminalAgentActive(false);
     void openWorkspacePanel('terminal');
   }, [openWorkspacePanel]);
 
@@ -350,10 +367,12 @@ export function MainApp() {
   useEffect(() => {
     if (!activeSessionId) {
       setBrowserAgentActive(false);
+      setTerminalAgentActive(false);
       return;
     }
     void refreshBrowserAgentActive(activeSessionId);
-  }, [activeSessionId, refreshBrowserAgentActive]);
+    void refreshTerminalAgentActive(activeSessionId);
+  }, [activeSessionId, refreshBrowserAgentActive, refreshTerminalAgentActive]);
 
   useEffect(() => {
     ensureDesktopNotificationPermission().catch(console.warn);
@@ -499,6 +518,10 @@ export function MainApp() {
           setWorkspacePanelMounted(true);
           setTerminalSyncVersion((version) => version + 1);
         }
+        // 当前会话的终端 tab 发生变化时刷新"使用中"标记
+        if (isCurrentTerminalSession) {
+          void refreshTerminalAgentActive(session_id);
+        }
         if (!isCurrentTerminalSession) {
           return;
         }
@@ -600,6 +623,7 @@ export function MainApp() {
     lockResize,
     unlockResize,
     refreshBrowserAgentActive,
+    refreshTerminalAgentActive,
     syncTerminalRuntimeTabsToSession,
   ]);
 
@@ -611,6 +635,7 @@ export function MainApp() {
           browserAgentActive={browserAgentActive}
           onOpenBrowser={handleToggleBrowser}
           terminalActive={showWorkspacePanel && workspaceTabKind === 'terminal'}
+          terminalAgentActive={terminalAgentActive}
           onOpenTerminal={handleToggleTerminal}
         />
 


### PR DESCRIPTION
## 改动概述

Agent 打开浏览器页面时不再自动展开浏览器面板，改为在右上角浏览器图标上显示"使用中"常亮绿点，点击图标才打开面板查看。终端图标同步采用相同策略。

## 变更点

### 后端（浏览器插件）
- `types.rs` 新增 `BrowserAgentActiveEvent`
- `handler.rs`：agent 经 FetchPage / OpenUrl / LoadHtml 打开页面时始终发出 `browser:agent_active` 事件（原先仅在浏览器未初始化时发 `browser:open`）

### 前端
- `MainApp.tsx`：
  - 不再监听 `browser:open` 自动展开面板，改为刷新浏览器/终端"使用中"标记
  - 新增 `refreshAgentActiveMarkers`：基于持久化 `getSessionTabs` 判断当前会话是否存在 browser/terminal tab
  - 会话切换 / tab 增删 / 面板关闭时刷新标记；用户点开对应面板时清除标记
- `StatusPanel.tsx`：
  - 浏览器图标新增 `browserAgentActive` 常亮绿点（`!browserActive` 时显示）
  - 终端图标从原轮询脉冲改为 `terminalAgentActive` 常亮绿点，策略与浏览器一致
  - 移除原终端轮询与 toast 提示
- 测试同步更新 listener 计数与事件清单

### 数据源选择
标记判断使用持久化 `getSessionTabs`（而非 runtime `browserTabList`/`terminalTabList`）：历史会话切回时 runtime state 尚未重建，runtime 查询返回空会导致标记不亮；持久化数据真实记录会话拥有的 tab，切换即可立即显示标记。

## 不受影响的部分
- 用户点链接打开浏览器（`tiangong:open-browser`）走原流程，不受影响
- 终端独立 tab 内的命令运行中黄点（基于 phase）保持不变

## 验证
- 后端 \`cargo check -p tiangong-plugin-browser\` 通过
- 前端 \`yarn build\` 与 \`yarn test\`（192 passed）通过