### PR TITLE
fix(browser): 修复复杂页面导致桌面端卡死

### DIFF
--- a/crates/plugins/tiangong-plugin-browser/js/bridge.js
+++ b/crates/plugins/tiangong-plugin-browser/js/bridge.js
@@ -2833,7 +2833,7 @@
                     subtree: true,
                     attributes: true,
                     attributeFilter: [
-                        'class', 'style', 'disabled', 'readonly',
+                        'class', 'disabled', 'readonly',
                         'aria-busy', 'aria-hidden', 'aria-disabled',
                         'aria-expanded', 'aria-selected'
                     ]

--- a/crates/plugins/tiangong-plugin-browser/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/handler.rs
@@ -5,7 +5,7 @@ use tauri::{AppHandle, Emitter, Wry};
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
-use crate::manager::{default_browser_rect, BrowserManager};
+use crate::manager::{default_browser_rect, BrowserManager, POLL_EVAL_TIMEOUT};
 
 /// Agent 命令严格按 session_id 解析：空 session_id 返回 None（调用方应跳过/报错）。
 /// 不 fallback active/bootstrap——空 session_id 是调用方错误。
@@ -250,12 +250,33 @@ pub async fn browser_command_handler(
                         }
                     }
                     let events = manager.drain_events();
-                    manager
-                        .eval_with_result(
-                            "(function(){try{var t=window.__tiangong_bridge.getFullText(12000);var a=window.__tiangong_bridge.annotation.getAnnotations();if(a&&a.count>0){t.text+='\\n\\n[页面批注] '+JSON.stringify(a.annotations);}return t;}catch(e){return {title:'',url:'',text:'',error:e.message};}})()"
-                        )
+                    let tab_id = manager
+                        .clone_state()
+                        .lock()
+                        .ok()
+                        .and_then(|s| s.active_tab_id.clone());
+                    let raw = tab_id
+                        .as_deref()
+                        .and_then(|id| manager.eval_full_text_cached(id, 12000));
+                    raw
                         .and_then(|raw| {
-                            let data = serde_json::from_str::<serde_json::Value>(&raw).ok()?;
+                            let mut data = serde_json::from_str::<serde_json::Value>(&raw).ok()?;
+                            // 追加页面批注（仅在存在批注时取，大多数页面无批注可省一次 eval）
+                            let annotations = manager.eval_with_result_timeout(
+                                "(function(){try{var a=window.__tiangong_bridge.annotation.getAnnotations();return a&&a.count>0?JSON.stringify(a.annotations):''}catch(e){return ''}})()",
+                                POLL_EVAL_TIMEOUT,
+                            );
+                            if let Some(annotations) = annotations {
+                                if !annotations.is_empty() && !annotations.starts_with('"') {
+                                    if let Some(text) =
+                                        data.get("text").and_then(|t| t.as_str()).map(str::to_string)
+                                    {
+                                        data["text"] = serde_json::Value::String(format!(
+                                            "{text}\n\n[页面批注] {annotations}"
+                                        ));
+                                    }
+                                }
+                            }
                             Some(BrowserPageSnapshot {
                                 title: data["title"].as_str().unwrap_or("").to_string(),
                                 url: data["url"].as_str().unwrap_or("").to_string(),

--- a/crates/plugins/tiangong-plugin-browser/src/manager.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/manager.rs
@@ -3,7 +3,7 @@ use tracing::{debug, warn};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Condvar, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tauri::{
     AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Url, Webview, WebviewBuilder,
@@ -45,6 +45,19 @@ const MAX_ZOOM: f64 = 5.0;
 /// 天工统一判定页面加载异常的固定截止时间。
 const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const PAGE_LOAD_ERROR_MESSAGE: &str = "页面未能在 30 秒内完成加载";
+/// 后台轮询（url_poll / event_poll / ObservePage）执行 eval 的超时上限。
+///
+/// 复杂页面上单个 eval 可能耗时数秒；此前统一沿用 15 秒，导致多轮询线程
+/// 同时挂起多个重量级 eval，webview 渲染线程饱和、桌面端冻结。缩短到 4 秒，
+/// 超时后直接跳过本轮（下一轮 tick 会补），从源头避免 eval 堆积。
+pub(crate) const POLL_EVAL_TIMEOUT: Duration = Duration::from_secs(4);
+/// url_poll 后台线程的 tick 间隔（URL 变化检测延迟）。
+const URL_POLL_TICK: Duration = Duration::from_millis(1000);
+/// url_poll 内容变化检测的 tick 周期（URL_POLL_TICK 的倍数）。
+const URL_POLL_CONTENT_TICKS: u32 = 8;
+/// full_text 缓存的有效期：TTL 内多个轮询线程的 getFullText 请求复用同一结果，
+/// 避免并发遍历 DOM。
+const FULL_TEXT_CACHE_TTL: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NavigationPhase {
@@ -257,6 +270,12 @@ pub struct BrowserState {
     pub session_id: String,
     /// 当前浏览器运行时绑定的对话会话 ID（兼容旧字段，T5 后由 registry.active_session_id 取代）
     pub active_session_id: Option<String>,
+    /// 最近一次 `getFullText` 的结果与时间戳，用于跨线程去重。
+    ///
+    /// url_poll、event_poll、watcher(ObservePage) 都可能调用 getFullText，
+    /// 复杂页面上单次执行耗时数秒。TTL 内的重复请求直接返回缓存，
+    /// 避免多线程并发遍历 DOM 导致渲染线程饱和。
+    pub(crate) full_text_cache: Mutex<Option<(Instant, String)>>,
 }
 
 /// 浏览器进程级共享状态。所有 session 通过同一个实例读写，避免磁盘共享但内存分叉。
@@ -298,6 +317,7 @@ impl BrowserState {
             tab_history_indices: HashMap::new(),
             session_id,
             active_session_id: None,
+            full_text_cache: Mutex::new(None),
         }
     }
 
@@ -340,6 +360,7 @@ impl BrowserManager {
                 tab_history_indices: HashMap::new(),
                 session_id: String::new(),
                 active_session_id: None,
+                full_text_cache: Mutex::new(None),
             })),
         }
     }
@@ -1191,7 +1212,7 @@ impl BrowserManager {
                 let mut tick: u32 = 0;
                 let mut no_webview_ticks: u32 = 0;
                 while !stop.load(std::sync::atomic::Ordering::Relaxed) {
-                    std::thread::sleep(Duration::from_millis(500));
+                    std::thread::sleep(URL_POLL_TICK);
                     tick += 1;
                     if stop.load(std::sync::atomic::Ordering::Relaxed) {
                         break;
@@ -1222,8 +1243,8 @@ impl BrowserManager {
                             }
                             None => {
                                 no_webview_ticks += 1;
-                                // 无 WebView 时等待最多 30 秒（60 个 tick），超时退出
-                                if no_webview_ticks > 60 {
+                                // 无 WebView 时等待最多 30 秒（30 个 tick × 1000ms），超时退出
+                                if no_webview_ticks > 30 {
                                     break;
                                 }
                                 continue;
@@ -1275,15 +1296,15 @@ impl BrowserManager {
                         );
                     }
 
-                    // 每 3 秒检测页面内容变化
-                    if tick.is_multiple_of(6) {
+                    // 每 URL_POLL_CONTENT_TICKS 个 tick 检测页面内容变化
+                    if tick.is_multiple_of(URL_POLL_CONTENT_TICKS) {
                         let mgr = BrowserManager {
                             state: state.clone(),
                         };
                         if let Some(sig) = mgr.eval_tab_with_result_timeout(
                             &active_tab_id,
                             "(function(){try{return(document.body.innerText||'').substring(0,500).trim()}catch(e){return''}})()",
-                            Duration::from_secs(15),
+                            POLL_EVAL_TIMEOUT,
                         ) {
                             let content_changed = {
                                 let mut s = match state.lock() {
@@ -1302,11 +1323,7 @@ impl BrowserManager {
                                 let mgr2 = BrowserManager {
                                     state: state.clone(),
                                 };
-                                if let Some(raw) = mgr2.eval_tab_with_result_timeout(
-                                    &active_tab_id,
-                                    "(function(){try{var t=window.__tiangong_bridge.getFullText(12000);return JSON.stringify(t)}catch(e){return '{}'}})()",
-                                    Duration::from_secs(15),
-                                ) {
+                                if let Some(raw) = mgr2.eval_full_text_cached(&active_tab_id, 12000) {
                                     if let Ok(data) = serde_json::from_str::<serde_json::Value>(&raw) {
                                         let still_loaded = {
                                             let state = match state.lock() {
@@ -1501,8 +1518,20 @@ impl BrowserManager {
                     let mgr = BrowserManager {
                         state: state.clone(),
                     };
-                    if let Some(raw) = mgr.eval_with_result(
+                    let active_tab_id_for_events = {
+                        let state = match state.lock() {
+                            Ok(state) => state,
+                            Err(error) => error.into_inner(),
+                        };
+                        match state.active_tab_id.clone() {
+                            Some(id) => id,
+                            None => continue,
+                        }
+                    };
+                    if let Some(raw) = mgr.eval_tab_with_result_timeout(
+                        &active_tab_id_for_events,
                         "(function(){try{return window.__tiangong_bridge.observer.drainAllEvents()}catch(e){return[]}})()",
+                        POLL_EVAL_TIMEOUT,
                     ) {
                         if raw == "[]" || raw.is_empty() {
                             continue;
@@ -1789,7 +1818,7 @@ impl BrowserManager {
         self.eval_with_result_timeout(js, Duration::from_secs(15))
     }
 
-    fn eval_with_result_timeout(&self, js: &str, timeout: Duration) -> Option<String> {
+    pub(crate) fn eval_with_result_timeout(&self, js: &str, timeout: Duration) -> Option<String> {
         let tab_id = self.state.lock().ok()?.active_tab_id.clone()?;
         self.eval_tab_with_result_timeout(&tab_id, js, timeout)
     }
@@ -1818,6 +1847,40 @@ impl BrowserManager {
         rx.recv_timeout(timeout).ok()
     }
 
+    /// 执行 `getFullText(max_chars)` 并带 TTL 缓存去重。
+    ///
+    /// url_poll / ObservePage 等多个轮询线程都会读取页面全文，复杂页面上单次
+    /// getFullText 耗时数秒。`FULL_TEXT_CACHE_TTL` 内的重复请求直接返回缓存，
+    /// 避免多线程并发遍历 DOM 导致渲染线程饱和。
+    pub(crate) fn eval_full_text_cached(&self, tab_id: &str, max_chars: usize) -> Option<String> {
+        let now = Instant::now();
+        // 先查缓存：TTL 内直接返回，避免并发遍历 DOM
+        let cached: Option<(Instant, String)> = {
+            let state = self.state.lock().ok()?;
+            state
+                .full_text_cache
+                .lock()
+                .ok()
+                .and_then(|guard| guard.as_ref().map(|(ts, raw)| (*ts, raw.clone())))
+        };
+        if let Some((ts, raw)) = cached {
+            if now.duration_since(ts) < FULL_TEXT_CACHE_TTL {
+                return Some(raw);
+            }
+        }
+        let js = format!(
+            "(function(){{try{{var t=window.__tiangong_bridge.getFullText({max_chars});return JSON.stringify(t)}}catch(e){{return '{{}}'}}}})()"
+        );
+        let raw = self.eval_tab_with_result_timeout(tab_id, &js, POLL_EVAL_TIMEOUT)?;
+        if let Ok(state) = self.state.lock() {
+            *state
+                .full_text_cache
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = Some((now, raw.clone()));
+        }
+        Some(raw)
+    }
+
     pub(crate) fn drain_events(&self) -> Vec<BrowserEvent> {
         let mut live_count = 0usize;
         let mut events = {
@@ -1829,8 +1892,9 @@ impl BrowserManager {
         };
         let cached_count = events.len();
 
-        if let Some(raw) = self.eval_with_result(
+        if let Some(raw) = self.eval_with_result_timeout(
             "(function(){try{return window.__tiangong_bridge.observer.drainAllEvents()}catch(e){return[]}})()",
+            POLL_EVAL_TIMEOUT,
         ) {
             if raw != "[]" && !raw.is_empty() {
                 if let Ok(mut current) = serde_json::from_str::<Vec<BrowserEvent>>(&raw) {

--- a/crates/plugins/tiangong-plugin-browser/src/watcher.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/watcher.rs
@@ -37,6 +37,11 @@ const OBSERVE_TIMEOUT: Duration = Duration::from_secs(3);
 const TEXT_DIFF_THRESHOLD: u64 = 500;
 /// 后台轮询的 tick 间隔（实际 observe 仍受 MIN_OBSERVE_INTERVAL 节流）。
 const POLL_TICK: Duration = Duration::from_secs(2);
+/// observe 连续超时/失败的最大允许次数；超过后进入退避，拉长 tick 间隔，
+/// 避免复杂页面持续触发 eval 堆积加剧卡顿。
+const MAX_CONSECUTIVE_FAILURES: u32 = 2;
+/// 退避倍数：连续失败达到阈值后，本轮 tick 间隔乘以该倍数。
+const BACKOFF_MULTIPLIER: u64 = 4;
 
 /// 浏览器页面观察器：持有 fetcher 与当前 session 的 feedback 通道，后台周期性观察，
 /// 变化时只向自己的通道投递 `browser_data`。
@@ -58,6 +63,8 @@ pub struct BrowserWatcher {
     /// 暂停标志：turn 被取消时置位，watcher 停止 observe/inject；
     /// 新 turn 开始时清除，恢复推送。
     paused: AtomicBool,
+    /// 连续 observe 失败/超时次数；超过阈值后退避，减少对卡顿页面的轮询压力。
+    consecutive_failures: std::sync::atomic::AtomicU32,
 }
 
 impl BrowserWatcher {
@@ -69,6 +76,7 @@ impl BrowserWatcher {
             last_snapshot: RwLock::new(None),
             last_check: RwLock::new(None),
             paused: AtomicBool::new(false),
+            consecutive_failures: std::sync::atomic::AtomicU32::new(0),
         }
     }
 
@@ -112,7 +120,15 @@ impl BrowserWatcher {
     async fn run_loop(&self) {
         tracing::debug!("browser watcher started");
         loop {
-            sleep(POLL_TICK).await;
+            // 连续失败时退避：拉长 tick 间隔，减轻卡顿页面的轮询压力。
+            // 正常情况下连续失败为 0，按标准 POLL_TICK 间隔运行。
+            let failures = self.consecutive_failures.load(Ordering::Acquire);
+            let tick = if failures >= MAX_CONSECUTIVE_FAILURES {
+                POLL_TICK * BACKOFF_MULTIPLIER as u32
+            } else {
+                POLL_TICK
+            };
+            sleep(tick).await;
             // feedback channel 关闭时退出，避免 session 结束后 task 泄漏
             let closed = self
                 .feedback_tx
@@ -174,13 +190,21 @@ impl BrowserWatcher {
                 Ok(Some(s)) => s,
                 Ok(None) => return,
                 Err(_) => {
-                    tracing::warn!("browser watcher: observe timeout");
+                    self.consecutive_failures.fetch_add(1, Ordering::AcqRel);
+                    tracing::warn!(
+                        timeouts = self.consecutive_failures.load(Ordering::Acquire),
+                        "browser watcher: observe timeout"
+                    );
                     return;
                 }
             };
         if matches!(&snapshot.status, PageStatus::Loading | PageStatus::Error(_)) {
+            // 浏览器不可见时 handler 返回 Error status，计入失败用于触发退避
+            self.consecutive_failures.fetch_add(1, Ordering::AcqRel);
             return;
         }
+        // 成功拿到有效快照，重置连续失败计数
+        self.consecutive_failures.store(0, Ordering::Release);
         if snapshot.url.is_empty() {
             return;
         }


### PR DESCRIPTION
## 问题

打开复杂页面（大量 DOM / 高频 re-render 的 SPA）时，桌面端 UI 冻结，但 agent 后端和终端正常运行。日志中持续出现：

\`\`\`
WARN tiangong_plugin_browser::watcher: browser watcher: observe timeout
\`\`\`

## 根因

三个后台轮询线程（url_poll / event_poll / watcher）同时对同一个 webview 发起重量级 eval（getFullText / drainAllEvents），复杂页面上单个 JS 执行耗时数秒。多个 eval 在 webview 渲染线程串行排队，饱和后桌面端冻结。

最坏情况同时挂起 4-5 个 **15 秒超时**的 eval（url_poll 2 次 + event_poll 1 次 + watcher 2 次），互相叠加导致雪崩。

## 修复（浏览器插件内部，不动 webview 架构）

| # | 改动 | 文件 |
|---|------|------|
| 1 | 缩短 polling eval 超时 **15s→4s**（POLL_EVAL_TIMEOUT），超时跳过本轮不堆积 | manager.rs / handler.rs |
| 2 | 引入 full_text_cache（TTL 3s），getFullText 结果跨线程去重 | manager.rs |
| 3 | watcher 连续失败/超时退避：连续 2 次失败后 tick 间隔 ×4（2s→8s） | watcher.rs |
| 4 | url_poll 降频：tick 500ms→1000ms，内容检测 3s→8s | manager.rs |
| 5 | 收窄 MutationObserver：去掉 style 属性监听 | bridge.js |

## 验证

- \`cargo check -p tiangong-plugin-browser --tests\` 通过
- \`cargo clippy -p tiangong-plugin-browser\` 零警告
- 需人工验证：复杂页面下卡死是否消失、observe timeout 警告是否减少