### PR TITLE
feat(browser): web_fetch 新增 open 参数控制是否弹出浏览器面板

### DIFF
--- a/crates/plugins/tiangong-plugin-browser/src/capability.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/capability.rs
@@ -23,10 +23,14 @@ use crate::types::{
 /// 返回 `None` 表示能力不可用（如浏览器未就绪），调用方应回退或报错。
 pub trait PageFetcher: Send + Sync + 'static {
     /// 获取指定 URL 的页面内容。
+    ///
+    /// `open` 为 true 时表示用户明确要求打开浏览器（前端会弹出面板），
+    /// 为 false 时表示 agent 自主抓取（只亮标记，不弹面板）。
     fn fetch_page(
         &self,
         url: &str,
         max_chars: usize,
+        open: bool,
     ) -> Pin<Box<dyn Future<Output = Option<BrowserResponse>> + Send>>;
 
     /// 获取当前浏览器页面的快照。

--- a/crates/plugins/tiangong-plugin-browser/src/handler.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/handler.rs
@@ -124,6 +124,7 @@ pub async fn browser_command_handler(
                 session_id,
                 url,
                 max_chars,
+                open,
                 response_tx,
             } => {
                 let url_for_error = url.clone();
@@ -132,8 +133,8 @@ pub async fn browser_command_handler(
                 };
                 let manager = BrowserManager::from_state(agent_state);
 
-                let was_open = manager.is_open();
-                if !was_open {
+                if open {
+                    // 用户明确要求打开浏览器：发 browser:open 让前端弹出面板
                     let _ = app.emit(
                         "browser:open",
                         BrowserOpenEvent {
@@ -141,14 +142,15 @@ pub async fn browser_command_handler(
                             url: url.clone(),
                         },
                     );
+                } else {
+                    // agent 自主抓取：只亮标记，不弹面板
+                    let _ = app.emit(
+                        "browser:agent_active",
+                        BrowserAgentActiveEvent {
+                            session_id: session_id.clone(),
+                        },
+                    );
                 }
-                // 始终通知前端 agent 正在使用浏览器（用于图标标记），不再依赖面板是否展开
-                let _ = app.emit(
-                    "browser:agent_active",
-                    BrowserAgentActiveEvent {
-                        session_id: session_id.clone(),
-                    },
-                );
                 let ticket = match manager.navigate_for_agent(&app, &url) {
                     Ok(ticket) => ticket,
                     Err(error) => {

--- a/crates/plugins/tiangong-plugin-browser/src/page_fetcher.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/page_fetcher.rs
@@ -63,6 +63,7 @@ impl PageFetcher for BrowserPageFetcher {
         &self,
         url: &str,
         max_chars: usize,
+        open: bool,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<BrowserResponse>> + Send>> {
         let tx = self.cmd_tx.clone();
         let Some(session_id) = self.session_id() else {
@@ -77,6 +78,7 @@ impl PageFetcher for BrowserPageFetcher {
                     session_id: session_id.clone(),
                     url,
                     max_chars,
+                    open,
                     response_tx
                 },
                 response_rx,
@@ -445,6 +447,12 @@ impl BrowserToolOverride {
             .get("max_chars")
             .and_then(|v| v.as_u64())
             .unwrap_or(12000) as usize;
+        // 用户明确要求打开浏览器时为 true，触发前端弹出面板；默认 false（agent 自主抓取）
+        let open = call
+            .arguments
+            .get("open")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         let fetcher = fetcher.clone();
         let fetch_lock = fetch_lock.clone();
@@ -452,7 +460,7 @@ impl BrowserToolOverride {
             // 串行化 web_fetch：并发调用等待前一个完成后再操作 WebView，
             // 规避 wry 在 WebView 导航中 URL() 返回 nil 的 panic。
             let _guard = fetch_lock.lock().await;
-            let result = match fetcher.fetch_page(&url, max_chars).await {
+            let result = match fetcher.fetch_page(&url, max_chars, open).await {
                 Some(r) => r,
                 None => {
                     return Some(tiangong_core::tool::ToolResult {

--- a/crates/plugins/tiangong-plugin-browser/src/plugin.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/plugin.rs
@@ -123,7 +123,8 @@ impl tiangong_core::tool_override::ToolSpecProvider for BrowserPlugin {
                         "overwrite": { "type": "boolean", "description": "download 模式是否覆盖已有文件，默认 false" },
                         "timeout_ms": { "type": "integer", "description": "请求超时时间，默认 15000，最大 60000", "minimum": 1000, "maximum": 60000 },
                         "follow_redirects": { "type": "boolean", "description": "是否跟随重定向，默认 true" },
-                        "extract_mode": { "type": "string", "enum": ["auto", "text", "raw"], "description": "text 模式提取方式，默认 auto" }
+                        "extract_mode": { "type": "string", "enum": ["auto", "text", "raw"], "description": "text 模式提取方式，默认 auto" },
+                        "open": { "type": "boolean", "description": "是否为用户打开浏览器面板。用户明确要求打开浏览器/网页时设为 true，会弹出浏览器面板供用户查看；agent 自主抓取信息时保持 false（默认），不弹面板。", "default": false }
                     },
                     "required": ["url"]
                 }),

--- a/crates/plugins/tiangong-plugin-browser/src/types.rs
+++ b/crates/plugins/tiangong-plugin-browser/src/types.rs
@@ -117,6 +117,8 @@ pub enum BrowserCommand {
         session_id: String,
         url: String,
         max_chars: usize,
+        /// 用户明确要求打开时为 true，触发前端弹出浏览器面板。
+        open: bool,
         response_tx: oneshot::Sender<BrowserResponse>,
     },
     /// 打开 URL（用于链接点击等场景）

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -478,11 +478,13 @@ export function MainApp() {
         void refreshAgentActiveMarkers(sessionId);
       }));
       guard();
-      // 保留 browser:open 监听：后端首次初始化浏览器窗口时触发，同样刷新标记。
-      track(await listen<{ session_id: string; url: string }>('browser:open', (event) => {
+      // browser:open 仅在用户明确要求打开浏览器时发出（web_fetch open=true），
+      // 此时需要弹出浏览器面板供用户查看。
+      track(await listen<{ session_id: string; url: string }>('browser:open', async (event) => {
         const { session_id } = event.payload;
         if (!session_id || useStore.getState().activeSessionId !== session_id) return;
-        void refreshAgentActiveMarkers(session_id);
+        setBrowserAgentActive(false);
+        await openWorkspacePanel('browser');
       }));
       guard();
       // agent_active 信号：agent 打开/导航页面时发出，刷新标记。


### PR DESCRIPTION
## 背景

agent 默认不主动弹出浏览器面板（#385 已实现：只亮标记）。但用户在对话里明确要求"打开网站"时，agent 应该自动弹出浏览器面板供用户查看。

## 改动

给 `web_fetch` 工具新增 `open` 参数（bool，默认 false）：

| open 值 | 场景 | 行为 |
|---------|------|------|
| `false`（默认） | agent 自主抓取页面内容 | 后端发 `browser:agent_active`，前端只亮标记，**不弹面板** |
| `true` | 用户明确要求打开浏览器/网页 | 后端发 `browser:open`，前端**自动弹出浏览器面板** |

agent 根据 `open` 参数的描述判断传值：用户直接要求"打开网站"时传 true，agent 自己查资料时保持 false。

## 全链路改动

- `plugin.rs`：web_fetch 工具 spec 加 `open` 参数
- `capability.rs`：PageFetcher trait 的 fetch_page 签名加 `open`
- `types.rs`：BrowserCommand::FetchPage 加 `open` 字段
- `page_fetcher.rs`：BrowserPageFetcher 实现 + handle_web_fetch 读取参数
- `handler.rs`：FetchPage 分支按 open 发不同事件
- `MainApp.tsx`：browser:open 事件恢复弹面板（语义已变为"用户要求打开"才发）

## 验证

- \`cargo check -p tiangong-plugin-browser --tests\` 通过
- \`cargo clippy -p tiangong-plugin-browser\` 零警告
- \`yarn build\` 通过