### PR TITLE
fix(memory): Windows sidecar 改用 vendored 静态编译 OpenSSL，修复缺 libcrypto-3-x64.dll

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -115,25 +115,11 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install protoc -y
 
-      - name: Configure OpenSSL on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $openssl = (Get-Command openssl).Source
-          $root = Split-Path (Split-Path $openssl -Parent) -Parent
-          $crypto = Get-ChildItem -Path $root -Recurse -Filter libcrypto.lib |
-            Where-Object { Test-Path (Join-Path $_.Directory.FullName 'libssl.lib') } |
-            Select-Object -First 1
-          if (-not $crypto) {
-            throw "Could not locate matching libcrypto.lib and libssl.lib under $root"
-          }
-          $include = Join-Path $root 'include'
-          if (-not (Test-Path (Join-Path $include 'openssl/ssl.h'))) {
-            throw "Could not locate OpenSSL headers under $include"
-          }
-          "OPENSSL_LIB_DIR=$($crypto.Directory.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_INCLUDE_DIR=$include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_NO_VENDOR=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      # memory sidecar 通过 bundled-sqlcipher-vendored-openssl 由 openssl-sys 从源码
+      # 静态编译 SQLCipher 与 OpenSSL 并链接进 sidecar.exe，产物自包含，运行时不再
+      # 依赖 libcrypto-3-x64.dll。因此 Windows 下既不需要配置系统 OpenSSL 路径，更不能
+      # 设置 OPENSSL_NO_VENDOR=1——那会让 openssl-sys 改用系统动态库，导致用户机器缺 DLL。
+      # GitHub windows-latest runner 预装 Perl/NASM/MSVC，足以完成 vendored 静态编译。
       - name: Download shared WASM
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## 问题

Windows 用户启动 memory sidecar 时弹系统错误：

> 由于找不到 `libcrypto-3-x64.dll`，无法继续执行代码。

## 根因

memory sidecar 依赖 SQLCipher。`crates/tiangong-memory/Cargo.toml` 中 rusqlite 特性为 `bundled-sqlcipher-vendored-openssl`，**特性名本意就是 vendored 静态编译**。

但 `publish-plugins.yml` 在 Windows 构建前额外设置了：

\`\`\`
OPENSSL_NO_VENDOR=1
OPENSSL_LIB_DIR=...      # 指向 GitHub runner 预装的系统 OpenSSL
OPENSSL_INCLUDE_DIR=...
\`\`\`

`OPENSSL_NO_VENDOR=1` 由 openssl-sys 在编译脚本中直接读取，**优先级高于 Cargo 特性**，会推翻 vendored 行为，改用 runner 预装的**系统动态 OpenSSL**。于是编出的 `tiangong-memory-sidecar.exe` 运行时依赖 `libcrypto-3-x64.dll`；而 xtask 打包（`xtask/src/main.rs`）只复制了 `.exe` 本体，未随附该 DLL——普通 Windows 用户机器上没有该库，启动即崩。

> macOS / Linux 未复现：系统库目录通常已含 OpenSSL，动态库查找更宽松。

## 修复

删除 `publish-plugins.yml` 的 \`Configure OpenSSL on Windows\` 步骤，不再设置上述环境变量，让 \`bundled-sqlcipher-vendored-openssl\` 按特性名本意走 vendored 静态编译：openssl-sys 从源码构建静态库并链接进 sidecar.exe，产物自包含，运行时无需任何 OpenSSL DLL。

**可行性佐证**：\`release.yml\` 桌面构建历来不配置任何 OPENSSL_* 环境变量（主程序集成本地记忆时期即如此），同一 windows-latest runner 下 vendored 静态编译已长期验证可正常出包。

## 为什么不改 Cargo.toml

Cargo.toml 一直是正确的：特性名 \`bundled-sqlcipher-vendored-openssl\` 表达的就是静态意图。病因在 CI 环境变量凌驾其上，只拨回上层开关即可，下层依赖声明无需调整。

## 验证

- [x] YAML 语法校验通过
- [x] 改动 diff 干净，仅删除该步骤并补充说明注释
- [x] 全仓库核对无 \`OPENSSL_NO_VENDOR\` 残留配置
- [ ] 端到端：待插件发布 CI 在 Windows runner 实跑确认（本机 macOS 无法验证 Windows 静态编译）

## 代价

Windows 插件发布构建时间会增加数分钟（首次现场编译 OpenSSL 源码，命中 rust-cache 后好转）。换取用户侧零运行时依赖。