### PR TITLE
chore(memory): 发布 memory 插件 v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11378,7 +11378,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11386,7 +11386,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "tiangong-memory",
@@ -11398,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "scru128",
  "serde",

--- a/plugins/tiangong-plugin-memory/plugin.json
+++ b/plugins/tiangong-plugin-memory/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "memory",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "wasm": {
     "binary": "tiangong_plugin_memory_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-memory/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Memory System 独立 sidecar 进程（承载 SQLite/tantivy/lancedb 原生运行）"

--- a/plugins/tiangong-plugin-memory/wasm/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-wasm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Memory 插件的 WASM 组件"


### PR DESCRIPTION
升级 memory 插件版本 0.1.0 → 0.1.1（plugin.json + protocol/wasm/sidecar 三个 Cargo.toml + Cargo.lock 同步）。本版本携带修复 #389（Windows sidecar 改用 vendored 静态编译 OpenSSL，解决缺 libcrypto-3-x64.dll 无法启动）。validate-plugin 校验通过，pre-push hook（fmt/check/clippy/nextest）均通过。合并后打 tag plugin/memory/v0.1.1 触发发布 CI。