### PR TITLE
fix(llm): 禁用 Responses 后台流式模式

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,4 +17,5 @@
 - [x] 完成前端构建验证
 
 - [x] 修复交互式配置向导对 OpenAI Responses 协议的支持
-- [x] 为 OpenAI Responses 增加后台流式与服务端取消能力
+- [x] 验证 OpenAI Responses 后台流式与服务端取消能力（因上游兼容性问题已回退）
+- [x] 将 OpenAI Responses 改为普通流式模式，并通过关闭连接取消请求

--- a/crates/tiangong-llm/src/providers/openai/client.rs
+++ b/crates/tiangong-llm/src/providers/openai/client.rs
@@ -52,18 +52,6 @@ impl ResponsesClient {
         .await
     }
 
-    pub async fn cancel(&self, response_id: &str) -> Result<(), LlmError> {
-        let client = self.build_client();
-        timeout(
-            self.config.timeout,
-            client.responses().cancel_byot::<_, Value>(response_id),
-        )
-        .await
-        .map_err(|_| LlmError::Timeout(self.config.timeout.as_millis() as u64))?
-        .map(|_| ())
-        .map_err(|err| map_responses_error(&err))
-    }
-
     pub async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
         // Responses 与 Chat 共用 /models 端点，复用 Chat Completions 的实现。
         crate::providers::openai_chatcompletions::client::list_models_via_config(

--- a/crates/tiangong-llm/src/providers/openai/mapping.rs
+++ b/crates/tiangong-llm/src/providers/openai/mapping.rs
@@ -40,8 +40,6 @@ pub fn build_request_json(req: &ProviderRequest, stream: bool) -> Result<Value> 
 
     if stream {
         payload.insert("stream".to_string(), json!(true));
-        // 后台流式 Response 可在连接中断或用户取消时通过 response ID 请求服务端停止。
-        payload.insert("background".to_string(), json!(true));
     }
 
     if req.max_tokens > 0 {
@@ -496,7 +494,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn streaming_request_enables_background_mode() {
+    fn streaming_request_uses_regular_mode() {
         let req = ProviderRequest {
             model: "gpt-5.6-sol".to_string(),
             system: None,
@@ -514,7 +512,7 @@ mod tests {
         };
         let payload = build_request_json(&req, true).unwrap();
         assert_eq!(payload["stream"], true);
-        assert_eq!(payload["background"], true);
+        assert!(!payload.as_object().unwrap().contains_key("background"));
     }
 
     #[test]

--- a/crates/tiangong-llm/src/providers/openai/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai/provider.rs
@@ -1,12 +1,5 @@
-use std::pin::Pin;
-use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicBool, Ordering},
-};
-use std::task::{Context, Poll};
-
 use async_trait::async_trait;
-use futures_util::{Stream, StreamExt, stream};
+use futures_util::{StreamExt, stream};
 use serde_json::Value;
 
 use crate::error::LlmError;
@@ -21,49 +14,6 @@ use super::config::OpenAiResponsesConfig;
 use super::error::map_responses_error;
 use super::mapping::{build_request_json, parse_complete_response};
 use super::stream::{ResponsesStreamParser, extract_completed_reasoning};
-
-struct BackgroundResponsesStream {
-    inner: ProviderStream,
-    client: ResponsesClient,
-    response_id: Arc<Mutex<Option<String>>>,
-    terminal: Arc<AtomicBool>,
-}
-
-impl Stream for BackgroundResponsesStream {
-    type Item = Result<ProviderStreamEvent, LlmError>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.inner.as_mut().poll_next(cx)
-    }
-}
-
-impl Drop for BackgroundResponsesStream {
-    fn drop(&mut self) {
-        if self.terminal.load(Ordering::Acquire) {
-            return;
-        }
-        let response_id = self
-            .response_id
-            .lock()
-            .ok()
-            .and_then(|response_id| response_id.clone());
-        let Some(response_id) = response_id else {
-            return;
-        };
-        let client = self.client.clone();
-        let Ok(handle) = tokio::runtime::Handle::try_current() else {
-            tracing::warn!(%response_id, "无法取得异步运行时，跳过 Responses 服务端取消");
-            return;
-        };
-        handle.spawn(async move {
-            if let Err(error) = client.cancel(&response_id).await {
-                tracing::warn!(%response_id, %error, "Responses 服务端取消失败");
-            } else {
-                tracing::info!(%response_id, "Responses 服务端取消成功");
-            }
-        });
-    }
-}
 
 #[derive(Clone)]
 pub struct OpenAiResponsesProvider {
@@ -124,10 +74,6 @@ impl LlmProvider for OpenAiResponsesProvider {
         let payload = build_request_json(&req, true)
             .map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
         let stream = self.client.stream(&model, payload).await?;
-        let response_id = Arc::new(Mutex::new(None));
-        let terminal = Arc::new(AtomicBool::new(false));
-        let stream_response_id = Arc::clone(&response_id);
-        let stream_terminal = Arc::clone(&terminal);
 
         // 维护流式状态：记录是否收到过 reasoning delta 增量。
         // 流式增量一律保留；仅在全程无 delta 时，从 completed 兜底补发 reasoning。
@@ -140,26 +86,6 @@ impl LlmProvider for OpenAiResponsesProvider {
                     return stream::iter(vec![Err(map_responses_error(&err))]);
                 }
             };
-
-            let event_type = raw_payload
-                .get("type")
-                .and_then(Value::as_str)
-                .unwrap_or("");
-            if event_type == "response.created"
-                && let Some(id) = raw_payload
-                    .get("response")
-                    .and_then(|response| response.get("id"))
-                    .and_then(Value::as_str)
-                && let Ok(mut stored_id) = stream_response_id.lock()
-            {
-                *stored_id = Some(id.to_string());
-            }
-            if matches!(
-                event_type,
-                "response.completed" | "response.failed" | "response.incomplete"
-            ) {
-                stream_terminal.store(true, Ordering::Release);
-            }
 
             // 记录本条事件是否产生 reasoning delta（用于 completed 兜底判断）。
             let is_completed = raw_payload
@@ -186,13 +112,7 @@ impl LlmProvider for OpenAiResponsesProvider {
 
             stream::iter(events)
         });
-        let inner: ProviderStream = Box::pin(mapped);
-        Ok(Box::pin(BackgroundResponsesStream {
-            inner,
-            client: self.client.clone(),
-            response_id,
-            terminal,
-        }))
+        Ok(Box::pin(mapped))
     }
 
     async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {
@@ -205,7 +125,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn dropping_background_stream_cancels_response_on_server() {
+    async fn streaming_request_does_not_enable_background_mode() {
         use wiremock::matchers::{body_json, method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -216,22 +136,12 @@ mod tests {
                 "model": "gpt-5.6-sol",
                 "input": [{"type": "message", "role": "user", "content": "你好"}],
                 "stream": true,
-                "background": true,
                 "max_output_tokens": 1024
             })))
             .respond_with(ResponseTemplate::new(200).set_body_raw(
                 "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_test\"}}\n\n",
                 "text/event-stream",
             ))
-            .expect(1)
-            .mount(&server)
-            .await;
-        Mock::given(method("POST"))
-            .and(path("/responses/resp_test/cancel"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "id": "resp_test",
-                "status": "cancelled"
-            })))
             .expect(1)
             .mount(&server)
             .await;
@@ -265,8 +175,6 @@ mod tests {
             Some(Ok(ProviderStreamEvent::MessageStart))
         ));
         drop(response_stream);
-
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         server.verify().await;
     }
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -12,7 +12,7 @@
 - Responses 原始结构不得泄漏到 Core、Session 或前端消息模型。
 - Chat Completions、Anthropic 和 DeepSeek 的已有行为不得回退。
 - 前端供应商配置必须提供 OpenAI Responses 选项，并明确区分 Responses 与 Chat Completions，保存值分别为 `openai` 和 `openai_chatcompletions`。
-- OpenAI Responses 流式请求必须使用后台流式模式；本地取消或流异常结束时，如已获得 Response ID，必须调用服务端取消接口，并始终保留本地任务终止作为兜底。
+- OpenAI Responses 流式请求必须使用普通流式模式，不得启用 `background`；本地取消时必须终止模型任务并关闭流式连接。
 
 ### 完成标准
 


### PR DESCRIPTION
## 变更内容

- Responses 流式请求不再发送 `background: true`
- 删除后台响应编号跟踪和服务端取消请求
- 保留本地任务终止，通过关闭流式连接取消普通流
- 同步需求与任务记录

## 原因

部分上游兼容端点对 Responses 普通流式请求可正常处理，但对后台流式组合持续返回上游错误。普通流式模式也符合官方取消方式：终止连接。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p tiangong-llm`（96 项通过）
- `cargo clippy -p tiangong-llm --all-targets --all-features -- -D warnings`
- `cargo check -p tiangong-core -p tiangong-entry -p tiangong-core-manager`
- `cargo test -p tiangong-core react::execute::tests::returns_cancelled_on_cancel_command -- --exact`
- 推送前检查：changed crates check、clippy、nextest 全部通过
