### PR TITLE
fix(memory): Windows vendored OpenSSL 编译前置 Strawberry Perl

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -119,7 +119,18 @@ jobs:
       # 静态编译 SQLCipher 与 OpenSSL 并链接进 sidecar.exe，产物自包含，运行时不再
       # 依赖 libcrypto-3-x64.dll。因此 Windows 下既不需要配置系统 OpenSSL 路径，更不能
       # 设置 OPENSSL_NO_VENDOR=1——那会让 openssl-sys 改用系统动态库，导致用户机器缺 DLL。
-      # GitHub windows-latest runner 预装 Perl/NASM/MSVC，足以完成 vendored 静态编译。
+      # 注意：vendored 编译需要完整 Perl 驱动 OpenSSL 的 Configure；windows-latest 虽预装
+      # Strawberry Perl，但 PATH 中 Git 自带的精简 MSYS2 Perl 优先，缺
+      # Locale::Maketext::Simple 等模块会导致 Configure 启动即失败，故需显式前置 Strawberry Perl。
+      - name: Put Strawberry Perl first on PATH (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "C:\Strawberry\perl\bin" >> "$GITHUB_PATH"
+          # 当前 step 立即验证 Strawberry Perl 可加载 OpenSSL Configure 所需模块；
+          # 路径有误时在此秒级失败，避免白白等待数十分钟的 OpenSSL 编译。
+          export PATH="/c/Strawberry/perl/bin:$PATH"
+          perl -e 'use Locale::Maketext::Simple; print "perl OK: $^X\n"'
       - name: Download shared WASM
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## 问题

\`plugin/memory/v0.1.1\` 发布 CI 在 \`windows-x86_64\` 失败（macOS/Linux 成功）。错误：

\`\`\`
Can't locate Locale/Maketext::Simple.pm in @INC
Error configuring OpenSSL build: 'perl' reported failure with exit code: 2
Command failed: "perl" "./Configure" ... "VC-WIN64A"
\`\`\`

## 根因

memory sidecar 的 \`bundled-sqlcipher-vendored-openssl\` 在 Windows 上 vendored 编译时，openssl-src 调用 \`perl\` 驱动 OpenSSL 的 \`Configure\`。windows-latest runner 虽预装完整的 Strawberry Perl，但 PATH 中 Git 自带的精简 MSYS2 Perl 优先，后者缺 \`Locale::Maketext::Simple\` 等模块，导致 \`Configure\` 启动即失败。

## 修复

在 Windows 构建前新增一步：

- 将 \`C:\\Strawberry\\perl\\bin\` 写入 \`$GITHUB_PATH\`（对后续 build step 生效）；
- 当前 step 立即 \`use Locale::Maketext::Simple\` 验证，路径有误时秒级失败，避免再白等数十分钟的 OpenSSL 编译。

## 验证

- [x] YAML 语法校验通过
- [ ] 端到端：待合并后重发 \`plugin/memory/v0.1.1\`，确认 Windows vendored 静态编译成功

## 合并后重发计划

复用 0.1.1 版本号（上次产物未成功上传）：删除失败的 \`plugin/memory/v0.1.1\` 标签，在本 PR 合并后的 main 提交上重打同名标签，触发发布 CI。