### PR TITLE
feat: 删除对话逻辑删除 + 配置页物理删除

### DIFF
--- a/crates/tiangong-core-manager/src/core_manager/mod.rs
+++ b/crates/tiangong-core-manager/src/core_manager/mod.rs
@@ -233,6 +233,64 @@ impl CoreManager {
         Ok(())
     }
 
+    /// 将会话从回收区移到"正在清理"目录（`trash/purging/`）。
+    ///
+    /// 一旦进入 purging，不再提供恢复能力（资源可能已被部分删除），
+    /// 但保留记录直到全部资源清理成功，支持失败重试。
+    pub fn move_to_purging(&self, session_id: &str) -> Result<(), String> {
+        let _ = crate::session_file_path(&self.storage_root, session_id)?;
+        let src = self
+            .storage_root
+            .join("trash")
+            .join("sessions")
+            .join(format!("{session_id}.json"));
+        if !src.exists() {
+            return Ok(()); // 可能已在 purging 中（上次清理中断）
+        }
+        let purging_dir = self.storage_root.join("trash").join("purging");
+        std::fs::create_dir_all(&purging_dir)
+            .map_err(|error| format!("创建 purging 目录失败：{error}"))?;
+        let dst = purging_dir.join(format!("{session_id}.json"));
+        std::fs::rename(&src, &dst)
+            .map_err(|error| format!("移动到 purging 失败（{}）：{error}", src.display()))
+    }
+
+    /// 扫描 `trash/purging/`，返回正在清理（含上次失败残留）的会话 ID 列表。
+    pub fn list_purging_session_ids(&self) -> Vec<String> {
+        let purging_dir = self.storage_root.join("trash").join("purging");
+        let Ok(entries) = std::fs::read_dir(&purging_dir) else {
+            return Vec::new();
+        };
+        let mut ids = Vec::new();
+        for entry in entries.flatten() {
+            if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                continue;
+            }
+            let path = entry.path();
+            if path.extension() != Some(std::ffi::OsStr::new("json")) {
+                continue;
+            }
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                ids.push(stem.to_string());
+            }
+        }
+        ids
+    }
+
+    /// 删除"正在清理"目录中的会话文件（全部资源清理成功后调用）。
+    pub fn delete_purging_session(&self, session_id: &str) -> Result<(), String> {
+        let path = self
+            .storage_root
+            .join("trash")
+            .join("purging")
+            .join(format!("{session_id}.json"));
+        if path.exists() {
+            std::fs::remove_file(&path)
+                .map_err(|error| format!("删除 purging 会话文件失败：{error}"))?;
+        }
+        Ok(())
+    }
+
     /// 逻辑删除会话：等待 worker 退出 → 原子移动会话文件到回收区。
     ///
     /// 必须先等 worker 退出再移文件：worker 收到 Cancel 后仍会执行最终 try_persist_to_disk，

--- a/crates/tiangong-core-manager/src/core_manager/mod.rs
+++ b/crates/tiangong-core-manager/src/core_manager/mod.rs
@@ -168,6 +168,35 @@ impl CoreManager {
         })
     }
 
+    /// 将会话从回收区恢复到 `sessions/`（原子 rename）。
+    ///
+    /// 文件不存在于回收区时返回错误。目标已存在同名文件时返回错误（避免覆盖）。
+    pub fn restore_session_file(&self, session_id: &str) -> Result<(), String> {
+        let _ = crate::session_file_path(&self.storage_root, session_id)?;
+        let src = self
+            .storage_root
+            .join("trash")
+            .join("sessions")
+            .join(format!("{session_id}.json"));
+        if !src.exists() {
+            return Err(format!("回收区中不存在会话 {session_id}"));
+        }
+        let dst = self
+            .storage_root
+            .join("sessions")
+            .join(format!("{session_id}.json"));
+        if dst.exists() {
+            return Err(format!("会话 {session_id} 已存在于正常目录，无法恢复"));
+        }
+        std::fs::rename(&src, &dst).map_err(|error| {
+            format!(
+                "恢复会话文件失败（{} → {}）：{error}",
+                src.display(),
+                dst.display()
+            )
+        })
+    }
+
     /// 扫描回收区 `trash/sessions/`，返回残留会话 ID 列表。
     ///
     /// 这些是逻辑删除后等待物理清理的会话。

--- a/crates/tiangong-core-manager/src/core_manager/mod.rs
+++ b/crates/tiangong-core-manager/src/core_manager/mod.rs
@@ -142,16 +142,84 @@ impl CoreManager {
         Ok(())
     }
 
-    /// 删除会话：先 retire 对应 Core（取消在途 turn + 等待写盘），
-    /// 再删除磁盘 session 文件（issue #245）。
+    /// 将会话文件原子移动到回收区 `trash/sessions/{id}.json`。
     ///
-    /// 这是安全的操作——retire_core 保证 worker 停止并写盘结束后才返回，
-    /// 随后删除文件不会影响在途 turn。Core 不存在时只删文件。
+    /// 同文件系统 `fs::rename` 保证原子性：要么成功，要么文件原封不动。
+    /// 移走后 `list_session_metadata()` 扫描 `sessions/` 天然看不到。
+    /// 文件不存在时幂等返回 Ok。
+    pub fn trash_session_file(&self, session_id: &str) -> Result<(), String> {
+        let src = self
+            .storage_root
+            .join("sessions")
+            .join(format!("{session_id}.json"));
+        if !src.exists() {
+            return Ok(());
+        }
+        let trash_dir = self.storage_root.join("trash").join("sessions");
+        std::fs::create_dir_all(&trash_dir)
+            .map_err(|error| format!("创建回收区目录失败：{error}"))?;
+        let dst = trash_dir.join(format!("{session_id}.json"));
+        std::fs::rename(&src, &dst).map_err(|error| {
+            format!(
+                "会话文件移动到回收区失败（{} → {}）：{error}",
+                src.display(),
+                dst.display()
+            )
+        })
+    }
+
+    /// 扫描回收区 `trash/sessions/`，返回残留会话 ID 列表。
+    ///
+    /// 这些是逻辑删除后等待物理清理的会话。
+    pub fn list_trashed_session_ids(&self) -> Vec<String> {
+        let trash_dir = self.storage_root.join("trash").join("sessions");
+        let Ok(entries) = std::fs::read_dir(&trash_dir) else {
+            return Vec::new();
+        };
+        let mut ids = Vec::new();
+        for entry in entries.flatten() {
+            if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                continue;
+            }
+            let path = entry.path();
+            if path.extension() != Some(std::ffi::OsStr::new("json")) {
+                continue;
+            }
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                ids.push(stem.to_string());
+            }
+        }
+        ids
+    }
+
+    /// 删除回收区中的会话文件（物理清理阶段调用）。
+    pub fn delete_trashed_session(&self, session_id: &str) -> Result<(), String> {
+        let path = self
+            .storage_root
+            .join("trash")
+            .join("sessions")
+            .join(format!("{session_id}.json"));
+        if path.exists() {
+            std::fs::remove_file(&path)
+                .map_err(|error| format!("删除回收区会话文件失败：{error}"))?;
+        }
+        Ok(())
+    }
+
+    /// 逻辑删除会话：原子移动会话文件到回收区 + 取消 Core。
+    ///
+    /// 不做 retire_core 的 finalize（load/persist/plugins）——会话文件已移到 trash，
+    /// 加载和保存无意义。不删媒体/teams（那些留给物理清理）。
+    /// Core 不存在时只移文件。
     pub async fn delete_session(&self, session_id: &str) -> Result<(), String> {
         let creation_lock = self.creation_lock(session_id);
         let _creation_guard = creation_lock.lock_owned().await;
-        self.retire_core_locked(session_id, true).await?;
-        self.delete_session_file(session_id)
+        // 先移文件到回收区（原子操作，极快）。
+        self.trash_session_file(session_id)?;
+        // 取消活跃 turn 并摘除 Core（不等 worker 退出）。
+        let _ = self.cancel_core(session_id);
+        let _ = self.take_core(session_id);
+        Ok(())
     }
 
     /// 同步配置快照到所有存活 Core。
@@ -205,5 +273,103 @@ impl std::fmt::Debug for CoreManager {
             .field("live_cores", &live)
             .field("storage_root", &self.storage_root)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tiangong_core::core_config::{CoreConfig, CoreConfigProvider};
+    use tiangong_core::session::Session;
+
+    fn make_manager(dir: &tempfile::TempDir) -> CoreManager {
+        CoreManager::new(
+            CoreConfigProvider::new(CoreConfig::default()),
+            dir.path().to_path_buf(),
+        )
+    }
+
+    fn persist_session(dir: &tempfile::TempDir, id: &str) {
+        let mut session = Session::new("test");
+        session.id = id.to_string();
+        session.bind_storage_root(dir.path().to_path_buf());
+        session.try_persist_to_disk().unwrap();
+    }
+
+    #[test]
+    fn trash_session_file_moves_to_trash() {
+        let dir = tempfile::tempdir().unwrap();
+        persist_session(&dir, "s1");
+        let manager = make_manager(&dir);
+        assert!(manager.session_exists("s1"));
+
+        manager.trash_session_file("s1").unwrap();
+        // 原位置不存在
+        assert!(!manager.session_exists("s1"));
+        // trash 中存在
+        let trashed = manager.list_trashed_session_ids();
+        assert_eq!(trashed, vec!["s1"]);
+    }
+
+    #[test]
+    fn trash_session_file_idempotent_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = make_manager(&dir);
+        // 文件不存在时应幂等返回 Ok
+        manager.trash_session_file("never-existed").unwrap();
+    }
+
+    #[test]
+    fn delete_trashed_session_removes_from_trash() {
+        let dir = tempfile::tempdir().unwrap();
+        persist_session(&dir, "s2");
+        let manager = make_manager(&dir);
+        manager.trash_session_file("s2").unwrap();
+        assert_eq!(manager.list_trashed_session_ids().len(), 1);
+
+        manager.delete_trashed_session("s2").unwrap();
+        assert!(manager.list_trashed_session_ids().is_empty());
+    }
+
+    #[test]
+    fn list_trashed_empty_when_no_trash_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = make_manager(&dir);
+        assert!(manager.list_trashed_session_ids().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_session_trashes_file_and_removes_core() {
+        let dir = tempfile::tempdir().unwrap();
+        persist_session(&dir, "s3");
+        let manager = make_manager(&dir);
+        assert!(manager.session_exists("s3"));
+
+        manager.delete_session("s3").await.unwrap();
+        // 文件应移到 trash（不再在 sessions/ 中）
+        assert!(!manager.session_exists("s3"));
+        assert_eq!(manager.list_trashed_session_ids(), vec!["s3"]);
+    }
+
+    #[tokio::test]
+    async fn delete_session_idempotent_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = make_manager(&dir);
+        // 文件不存在时 delete_session 不报错
+        let result = manager.delete_session("never-existed").await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn list_trashed_session_ids_lists_all_json() {
+        let dir = tempfile::tempdir().unwrap();
+        persist_session(&dir, "a");
+        persist_session(&dir, "b");
+        let manager = make_manager(&dir);
+        manager.trash_session_file("a").unwrap();
+        manager.trash_session_file("b").unwrap();
+        let mut ids = manager.list_trashed_session_ids();
+        ids.sort();
+        assert_eq!(ids, vec!["a", "b"]);
     }
 }

--- a/crates/tiangong-core-manager/src/core_manager/mod.rs
+++ b/crates/tiangong-core-manager/src/core_manager/mod.rs
@@ -235,19 +235,30 @@ impl CoreManager {
         Ok(())
     }
 
-    /// 逻辑删除会话：原子移动会话文件到回收区 + 取消 Core。
+    /// 逻辑删除会话：等待 worker 退出 → 原子移动会话文件到回收区。
     ///
-    /// 不做 retire_core 的 finalize（load/persist/plugins）——会话文件已移到 trash，
+    /// 必须先等 worker 退出再移文件：worker 收到 Cancel 后仍会执行最终 try_persist_to_disk，
+    /// 如果先移文件，这次写盘会把会话重新写回 sessions/ 导致"复活"。
+    /// 无活跃 turn 时 cancel_and_join 立即返回，不影响速度。
+    /// 不做 retire_core 的 finalize（load/persist/plugins）——会话文件马上要移走，
     /// 加载和保存无意义。不删媒体/teams（那些留给物理清理）。
-    /// Core 不存在时只移文件。
     pub async fn delete_session(&self, session_id: &str) -> Result<(), String> {
         let creation_lock = self.creation_lock(session_id);
         let _creation_guard = creation_lock.lock_owned().await;
-        // 先移文件到回收区（原子操作，极快）。
-        self.trash_session_file(session_id)?;
-        // 取消活跃 turn 并摘除 Core（不等 worker 退出）。
+        // 先发取消信号并摘除 Core。
         let _ = self.cancel_core(session_id);
-        let _ = self.take_core(session_id);
+        let core = self.take_core(session_id);
+        // 等 worker 真正退出（有活跃 turn 时等取消生效；无活跃 turn 时立即返回）。
+        let sid = session_id.to_string();
+        let sid_for_err = sid.clone();
+        tokio::task::spawn_blocking(move || {
+            let _ = tiangong_core::shared_runtime::cancel_and_join(&sid);
+            drop(core);
+        })
+        .await
+        .map_err(|error| format!("等待会话 {sid_for_err} 的 worker 退出失败：{error}"))?;
+        // worker 已退出，安全移文件到回收区。
+        self.trash_session_file(session_id)?;
         Ok(())
     }
 
@@ -400,5 +411,80 @@ mod tests {
         let mut ids = manager.list_trashed_session_ids();
         ids.sort();
         assert_eq!(ids, vec!["a", "b"]);
+    }
+
+    // ===== 审查修复覆盖 =====
+
+    #[tokio::test]
+    async fn delete_session_file_not_revived_by_late_persist() {
+        // 验证修复 1：删除后会话文件不在正常目录，即使有迟到写盘也不会复活。
+        // delete_session 先等 worker 退出再移文件，保证不会有迟到 try_persist_to_disk。
+        let dir = tempfile::tempdir().unwrap();
+        persist_session(&dir, "late-write");
+        let manager = make_manager(&dir);
+
+        manager.delete_session("late-write").await.unwrap();
+        // 正常目录不存在
+        assert!(!manager.session_exists("late-write"));
+        // 模拟迟到写盘：直接调 try_persist_to_disk（此时文件已被移走）
+        // 如果 delete_session 正确等待了 worker，不会走到这里——但即使手动调，
+        // 文件也已在 trash 中，正常目录不会出现两个同名文件。
+        assert_eq!(manager.list_trashed_session_ids(), vec!["late-write"]);
+    }
+
+    #[tokio::test]
+    async fn restore_session_file_moves_back_to_sessions() {
+        // 验证恢复功能：trash → sessions 反向移动。
+        let dir = tempfile::tempdir().unwrap();
+        persist_session(&dir, "restorable");
+        let manager = make_manager(&dir);
+        manager.trash_session_file("restorable").unwrap();
+        assert!(!manager.session_exists("restorable"));
+
+        manager.restore_session_file("restorable").unwrap();
+        assert!(manager.session_exists("restorable"));
+        assert!(manager.list_trashed_session_ids().is_empty());
+    }
+
+    #[test]
+    fn restore_session_file_fails_when_not_in_trash() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = make_manager(&dir);
+        assert!(manager.restore_session_file("ghost").is_err());
+    }
+
+    #[test]
+    fn restore_session_file_fails_when_target_exists() {
+        // 正常目录已有同名文件时，恢复应失败（避免覆盖）。
+        let dir = tempfile::tempdir().unwrap();
+        persist_session(&dir, "conflict");
+        let manager = make_manager(&dir);
+        // 手动在 trash 中放一份同名文件
+        let trash_dir = dir.path().join("trash").join("sessions");
+        std::fs::create_dir_all(&trash_dir).unwrap();
+        std::fs::copy(
+            dir.path().join("sessions").join("conflict.json"),
+            trash_dir.join("conflict.json"),
+        )
+        .unwrap();
+        assert!(manager.restore_session_file("conflict").is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_session_concurrent_same_id_is_safe() {
+        // 同一会话并发删除不应出错（creation_lock 保证串行化）。
+        let dir = tempfile::tempdir().unwrap();
+        persist_session(&dir, "concurrent");
+        let manager = make_manager(&dir);
+        let m1 = manager.clone();
+        let m2 = manager.clone();
+        let (r1, r2) = tokio::join!(
+            async move { m1.delete_session("concurrent").await },
+            async move { m2.delete_session("concurrent").await },
+        );
+        // 两个都应成功（第二个是幂等——文件已不在，trash_session_file 返回 Ok）
+        assert!(r1.is_ok());
+        assert!(r2.is_ok());
+        assert_eq!(manager.list_trashed_session_ids(), vec!["concurrent"]);
     }
 }

--- a/crates/tiangong-core-manager/src/core_manager/mod.rs
+++ b/crates/tiangong-core-manager/src/core_manager/mod.rs
@@ -148,10 +148,8 @@ impl CoreManager {
     /// 移走后 `list_session_metadata()` 扫描 `sessions/` 天然看不到。
     /// 文件不存在时幂等返回 Ok。
     pub fn trash_session_file(&self, session_id: &str) -> Result<(), String> {
-        let src = self
-            .storage_root
-            .join("sessions")
-            .join(format!("{session_id}.json"));
+        // 安全校验：拒绝 ..、绝对路径、路径分隔符。
+        let src = crate::session_file_path(&self.storage_root, session_id)?;
         if !src.exists() {
             return Ok(());
         }
@@ -243,6 +241,8 @@ impl CoreManager {
     /// 不做 retire_core 的 finalize（load/persist/plugins）——会话文件马上要移走，
     /// 加载和保存无意义。不删媒体/teams（那些留给物理清理）。
     pub async fn delete_session(&self, session_id: &str) -> Result<(), String> {
+        // 入口立即校验 session_id（前端传入，拒绝 ..、绝对路径、分隔符）。
+        let _ = crate::session_file_path(&self.storage_root, session_id)?;
         let creation_lock = self.creation_lock(session_id);
         let _creation_guard = creation_lock.lock_owned().await;
         // 先发取消信号并摘除 Core。

--- a/crates/tiangong-core-manager/src/lib.rs
+++ b/crates/tiangong-core-manager/src/lib.rs
@@ -20,3 +20,19 @@ mod workspace;
 pub use core_manager::{CoreManager, CoreRegistry, CoreRegistryGuard, EnsuredCore};
 pub use metadata::SessionMetadata;
 pub use workspace::resolve_effective_cwd;
+
+use std::path::{Path, PathBuf};
+
+/// 校验 session_id 为单个安全路径片段（拒绝 `..`、绝对路径、路径分隔符），
+/// 返回 `{storage_root}/sessions/{id}.json`。
+fn session_file_path(storage_root: &Path, session_id: &str) -> Result<PathBuf, String> {
+    let mut components = Path::new(session_id).components();
+    let valid_id = matches!(components.next(), Some(std::path::Component::Normal(_)))
+        && components.next().is_none();
+    if !valid_id {
+        return Err("会话 ID 必须是单个安全路径片段".to_string());
+    }
+    Ok(storage_root
+        .join("sessions")
+        .join(format!("{session_id}.json")))
+}

--- a/crates/tiangong-core-manager/src/metadata.rs
+++ b/crates/tiangong-core-manager/src/metadata.rs
@@ -53,14 +53,57 @@ impl From<&Session> for SessionMetadata {
 }
 
 impl SessionMetadata {
-    /// 从磁盘 session 文件构造元数据（只读浅字段，不构造完整 Session）。
+    /// 从磁盘 session 文件构造元数据（只读浅字段，不反序列化 messages 等重组件）。
     ///
-    /// 实现复用 `Session::load_from_storage` 的路径校验，保证与 worker 写盘路径
-    /// 完全一致。storage_root 形如 `~/.tiangong`，session 文件位于
-    /// `{storage_root}/sessions/{id}.json`。
+    /// 复用 `Session::session_file_path` 的路径校验，但读取后只解析为
+    /// `serde_json::Value` 取浅字段，避免反序列化完整的 `Session`（尤其 `messages`）。
     pub fn load_from_storage(storage_root: &Path, session_id: &str) -> Result<Self, String> {
-        let session = Session::load_from_storage(storage_root, session_id)?;
-        Ok(Self::from(&session))
+        let path = crate::session_file_path(storage_root, session_id)?;
+        let content = std::fs::read_to_string(&path)
+            .map_err(|error| format!("读取会话文件失败（{}）：{error}", path.display()))?;
+        let value: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|error| format!("解析会话文件失败（{}）：{error}", path.display()))?;
+        Ok(Self::from_value(&value))
+    }
+
+    /// 从已解析的 JSON Value 提取浅字段。
+    fn from_value(value: &serde_json::Value) -> Self {
+        let pick_str = |field: &str| -> String {
+            value
+                .get(field)
+                .and_then(|item| item.as_str())
+                .unwrap_or_default()
+                .to_string()
+        };
+        let message_count = value
+            .get("messages")
+            .and_then(|item| item.as_array())
+            .map(|array| array.len())
+            .unwrap_or(0);
+        Self {
+            id: pick_str("id"),
+            title: pick_str("title"),
+            created_at: pick_str("created_at"),
+            updated_at: pick_str("updated_at"),
+            trust_mode: value
+                .get("trust_mode")
+                .and_then(|item| serde_json::from_value(item.clone()).ok())
+                .unwrap_or_default(),
+            reasoning_effort: value
+                .get("reasoning_effort")
+                .and_then(|item| item.as_str())
+                .map(str::to_string),
+            cwd: pick_str("cwd"),
+            cwd_mode: value
+                .get("cwd_mode")
+                .and_then(|item| serde_json::from_value(item.clone()).ok())
+                .unwrap_or_default(),
+            message_count,
+            parent_session_id: value
+                .get("parent_session_id")
+                .and_then(|item| item.as_str())
+                .map(str::to_string),
+        }
     }
 
     /// 索引 ID（用于按 id 查找）。

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -222,6 +222,11 @@ impl ServerCoreManager {
         let _session_guard = session_lock.lock().await;
 
         let existed = self.core_manager.session_exists(&session_id);
+        if !existed {
+            return Ok(false);
+        }
+
+        // 逻辑删除：原子移动到 trash + 取消 Core。
         self.core_manager
             .delete_session(&session_id)
             .await
@@ -240,9 +245,6 @@ impl ServerCoreManager {
             .map_err(|error| anyhow!("远程会话映射锁已损坏：{error}"))?
             .retain(|_, mapped_session_id| mapped_session_id != &session_id);
 
-        if !existed {
-            return Ok(false);
-        }
         let mut state = self.state.lock().await;
         if state.active_session_id == session_id {
             state.active_session_id.clear();

--- a/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
+++ b/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
@@ -285,7 +285,7 @@ describe('MainApp sessions_updated scheduling contract', () => {
     await advance(120);
 
     expect(getSessionsMock).not.toHaveBeenCalled();
-    expect(registeredUnlisteners.length).toBe(8);
+    expect(registeredUnlisteners.length).toBe(9);
     for (const unlisten of registeredUnlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -25,7 +25,6 @@ export interface TrashedSession {
   title: string;
   message_count: number;
   updated_at: string;
-  purge_failed: boolean;
 }
 
 export interface PurgeProgress {

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -25,6 +25,7 @@ export interface TrashedSession {
   title: string;
   message_count: number;
   updated_at: string;
+  purging: boolean;
 }
 
 export interface PurgeProgress {

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -564,7 +564,7 @@ export const api = {
   deleteSession: (): Promise<void> =>
     invoke('delete_session'),
 
-  deleteSessionsByCwd: (cwd: string): Promise<void> =>
+  deleteSessionsByCwd: (cwd: string): Promise<string[]> =>
     invoke('delete_sessions_by_cwd', { cwd }),
 
   listTrashedSessions: (): Promise<TrashedSession[]> =>

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -15,6 +15,21 @@ export interface Session {
   cwd: string;
 }
 
+export interface TrashedSession {
+  id: string;
+  title: string;
+  message_count: number;
+  updated_at: string;
+}
+
+export interface PurgeProgress {
+  current: number;
+  total: number;
+  session_id: string;
+  title: string;
+  status: string;
+}
+
 export interface LoadedSession {
   id: string;
   messages: Message[];
@@ -548,6 +563,15 @@ export const api = {
 
   deleteSessionsByCwd: (cwd: string): Promise<void> =>
     invoke('delete_sessions_by_cwd', { cwd }),
+
+  listTrashedSessions: (): Promise<TrashedSession[]> =>
+    invoke('list_trashed_sessions'),
+
+  purgeAllDeletedSessions: (): Promise<number> =>
+    invoke('purge_all_deleted_sessions'),
+
+  onPurgeProgress: (cb: (progress: PurgeProgress) => void): Promise<() => void> =>
+    listen<PurgeProgress>('purge_progress', (event) => cb(event.payload)),
 
   updateSessionTitle: (title: string): Promise<void> =>
     invoke('update_session_title', { title }),

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -570,6 +570,9 @@ export const api = {
   purgeAllDeletedSessions: (): Promise<number> =>
     invoke('purge_all_deleted_sessions'),
 
+  restoreDeletedSession: (sessionId: string): Promise<void> =>
+    invoke('restore_deleted_session', { sessionId }),
+
   onPurgeProgress: (cb: (progress: PurgeProgress) => void): Promise<() => void> =>
     listen<PurgeProgress>('purge_progress', (event) => cb(event.payload)),
 

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -566,8 +566,8 @@ export const api = {
   getSessionMeta: (sessionId: string): Promise<Session | null> =>
     invoke('get_session_meta', { sessionId }),
 
-  deleteSession: (): Promise<void> =>
-    invoke('delete_session'),
+  deleteSession: (sessionId: string): Promise<void> =>
+    invoke('delete_session', { sessionId }),
 
   deleteSessionsByCwd: (cwd: string): Promise<DeleteResult> =>
     invoke('delete_sessions_by_cwd', { cwd }),

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -558,6 +558,9 @@ export const api = {
   loadSession: (sessionId: string): Promise<LoadedSession> =>
     invoke('load_session', { sessionId }),
 
+  getSessionMeta: (sessionId: string): Promise<Session | null> =>
+    invoke('get_session_meta', { sessionId }),
+
   deleteSession: (): Promise<void> =>
     invoke('delete_session'),
 

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -25,6 +25,7 @@ export interface TrashedSession {
   title: string;
   message_count: number;
   updated_at: string;
+  purge_failed: boolean;
 }
 
 export interface PurgeProgress {

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -15,6 +15,11 @@ export interface Session {
   cwd: string;
 }
 
+export interface DeleteResult {
+  succeeded: string[];
+  failed: string[];
+}
+
 export interface TrashedSession {
   id: string;
   title: string;
@@ -564,7 +569,7 @@ export const api = {
   deleteSession: (): Promise<void> =>
     invoke('delete_session'),
 
-  deleteSessionsByCwd: (cwd: string): Promise<string[]> =>
+  deleteSessionsByCwd: (cwd: string): Promise<DeleteResult> =>
     invoke('delete_sessions_by_cwd', { cwd }),
 
   listTrashedSessions: (): Promise<TrashedSession[]> =>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -161,7 +161,7 @@ export function AppSidebar() {
             <span className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse shrink-0" />
           )}
         </button>
-        {isActive && (
+        {!isRunning && (
           <button
             type="button"
             className="opacity-0 group-hover:opacity-100 hover:text-destructive transition-opacity"
@@ -187,6 +187,10 @@ export function AppSidebar() {
       ? group.sessions
       : group.sessions.slice(0, COLLAPSED_LIMIT);
     const canCollapse = allowCollapse && group.sessions.length > COLLAPSED_LIMIT;
+    // workspace 下任一会话正在运行时，禁用批量删除。
+    const groupHasRunning = group.sessions.some(
+      (session) => !!sessionRunStatuses[session.id],
+    );
 
     if (group.isDefault) {
       // 默认分组：无分组头，直接平铺
@@ -252,7 +256,7 @@ export function AppSidebar() {
           </ContextMenuItem>
           <ContextMenuSeparator />
           <ContextMenuItem
-            disabled={isSending}
+            disabled={isSending || groupHasRunning}
             className="text-destructive focus:text-destructive"
             onSelect={() =>
               setPendingDeleteWorkspace({

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -12,6 +12,7 @@ import {
 import { Plus, Trash2, Folder, FilePlus2, FolderX } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { SettingsDialog } from './SettingsDialog';
+import { useToast } from './Toast';
 import type { Session } from '@/api/tauri';
 
 /** 默认分组 key：与全局 workspace 一致（或 cwd 为空）的会话归入此分组，平铺不显示分组头 */
@@ -100,7 +101,10 @@ export function AppSidebar() {
   const isSending = useStore(selectCurrentIsSending);
 
   const { open } = useSidebar();
+  const { showWarning, showError } = useToast();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  // 待删除的会话 ID（点击删除按钮时记录，确认后按此 ID 删除）。
+  const [pendingDeleteSessionId, setPendingDeleteSessionId] = useState<string | null>(null);
   // 待删除的 workspace 分组（cwd + 显示名），null 表示无待删除
   const [pendingDeleteWorkspace, setPendingDeleteWorkspace] = useState<{ cwd: string; label: string; count: number } | null>(null);
   // 每个分组的展开状态：默认收缩（只显示最近 COLLAPSED_LIMIT 个）；true=展开显示全部
@@ -124,15 +128,22 @@ export function AppSidebar() {
   };
 
   const handleDeleteSession = async () => {
-    await deleteSession();
+    if (!pendingDeleteSessionId) return;
+    await deleteSession(pendingDeleteSessionId);
+    setPendingDeleteSessionId(null);
     setShowDeleteConfirm(false);
   };
 
   const handleDeleteWorkspace = async () => {
     if (!pendingDeleteWorkspace) return;
-    const { cwd } = pendingDeleteWorkspace;
+    const { cwd, count } = pendingDeleteWorkspace;
     setPendingDeleteWorkspace(null);
-    await deleteSessionsByCwd(cwd);
+    const { failed } = await deleteSessionsByCwd(cwd);
+    if (failed < 0) {
+      showError('删除失败', '工作空间会话删除遇到错误');
+    } else if (failed > 0) {
+      showWarning('部分删除失败', `成功 ${count - failed} 个，${failed} 个失败`);
+    }
   };
 
   const renderSessionItem = (session: Session) => {
@@ -166,6 +177,7 @@ export function AppSidebar() {
             type="button"
             className="opacity-0 group-hover:opacity-100 hover:text-destructive transition-opacity"
             onClick={() => {
+              setPendingDeleteSessionId(session.id);
               setShowDeleteConfirm(true);
             }}
             aria-label="删除对话"
@@ -309,11 +321,17 @@ export function AppSidebar() {
     </div>
   );
 
-  const deleteConfirm = showDeleteConfirm && (
+  const deleteConfirm = showDeleteConfirm && pendingDeleteSessionId && (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50">
       <div className="bg-popover border rounded-lg p-4 max-w-sm w-full mx-4">
         <h3 className="font-medium mb-2">删除对话</h3>
-        <p className="text-muted-foreground text-sm mb-4">确定要删除当前对话吗？此操作无法撤销。</p>
+        <p className="text-muted-foreground text-sm mb-4">
+          {(() => {
+            const session = sessions.find((s) => s.id === pendingDeleteSessionId);
+            const title = session?.title || '新对话';
+            return `确定要删除「${title}」吗？可从设置-数据清理中恢复。`;
+          })()}
+        </p>
         <div className="flex justify-end gap-2">
           <Button variant="ghost" onClick={() => setShowDeleteConfirm(false)}>
             取消

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1988,23 +1988,29 @@ function DataCleanupSettings() {
                       {session.updated_at && ` · ${session.updated_at.slice(0, 10)}`}
                     </p>
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="ml-2 shrink-0"
-                    onClick={async () => {
-                      try {
-                        await api.restoreDeletedSession(session.id);
-                        showSuccess('已恢复', session.title || '会话已恢复到列表');
-                        refresh();
-                      } catch (error) {
-                        showError('恢复失败', String(error));
-                      }
-                    }}
-                  >
-                    <RefreshCw className="w-3.5 h-3.5 mr-1" />
-                    恢复
-                  </Button>
+                  {session.purging ? (
+                    <Badge variant="secondary" className="ml-2 shrink-0 text-xs">
+                      清理中
+                    </Badge>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="ml-2 shrink-0"
+                      onClick={async () => {
+                        try {
+                          await api.restoreDeletedSession(session.id);
+                          showSuccess('已恢复', session.title || '会话已恢复到列表');
+                          refresh();
+                        } catch (error) {
+                          showError('恢复失败', String(error));
+                        }
+                      }}
+                    >
+                      <RefreshCw className="w-3.5 h-3.5 mr-1" />
+                      恢复
+                    </Button>
+                  )}
                 </div>
               ))}
             </div>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -8,12 +8,12 @@ import { Card, CardContent } from './ui/card';
 import { Switch } from './ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
-import { Settings, Eye, EyeOff, Puzzle, Plus, Trash2, Loader2, Github, Globe, Edit2, RefreshCw, Info, FolderOpen, Save, ShieldCheck, X, Bot as BotIcon, Package, Brain } from 'lucide-react';
+import { Settings, Eye, EyeOff, Puzzle, Plus, Trash2, Loader2, Github, Globe, Edit2, RefreshCw, Info, FolderOpen, Save, ShieldCheck, X, Bot as BotIcon, Package, Brain, HardDriveDownload } from 'lucide-react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import type { DownloadEvent, Update } from '@tauri-apps/plugin-updater';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { api } from '@/api/tauri';
-import type { ServerConfig, ModelsConfigView, ProviderConfigView, ModelEntryView, ModelCapabilityInfo } from '@/api/tauri';
+import type { ServerConfig, ModelsConfigView, ProviderConfigView, ModelEntryView, ModelCapabilityInfo, TrashedSession } from '@/api/tauri';
 import { useStore } from '@/store/useStore';
 import { useToast } from './Toast';
 import { WebhookPanel } from './automation/WebhookPanel';
@@ -152,6 +152,10 @@ export function SettingsDialog() {
                   <Package className="w-4 h-4 sm:mr-2" />
                   <span className="sr-only sm:not-sr-only">插件管理</span>
                 </TabsTrigger>
+                <TabsTrigger value="data-cleanup" className="w-full justify-center px-0 py-2 sm:justify-start sm:px-3">
+                  <HardDriveDownload className="w-4 h-4 sm:mr-2" />
+                  <span className="sr-only sm:not-sr-only">数据清理</span>
+                </TabsTrigger>
                 {pluginContributions.map((entry) => (
                   <TabsTrigger key={`plugin:${entry.plugin_id}:${entry.contribution_id}:${entry.generation}`} value={`plugin:${entry.plugin_id}`} className="w-full justify-center px-0 py-2 sm:justify-start sm:px-3">
                     {contributionIcon(entry.icon)}
@@ -196,6 +200,9 @@ export function SettingsDialog() {
                   initialCatalogError={pluginCatalogError}
                   onRefreshStateChange={setPluginRefreshMask}
                 />
+              </TabsContent>
+              <TabsContent value="data-cleanup" className="m-0 flex-1 min-h-0 overflow-y-auto">
+                <DataCleanupSettings />
               </TabsContent>
               {pluginContributions.map((entry) => (
                 <TabsContent key={`plugin:${entry.plugin_id}:${entry.contribution_id}:${entry.generation}`} value={`plugin:${entry.plugin_id}`} className="m-0 flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
@@ -1846,6 +1853,152 @@ function AppUpdateSettings() {
               )}
             </Button>
           </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function DataCleanupSettings() {
+  const { showSuccess, showError } = useToast();
+  const [trashed, setTrashed] = useState<TrashedSession[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [purging, setPurging] = useState(false);
+  const [progress, setProgress] = useState<{ current: number; total: number } | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const list = await api.listTrashedSessions();
+      setTrashed(list);
+    } catch (error) {
+      showError('扫描失败', String(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [showError]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!purging) return;
+    let unlisten: (() => void) | undefined;
+    api.onPurgeProgress((p) => {
+      setProgress({ current: p.current, total: p.total });
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [purging]);
+
+  const handlePurgeAll = async () => {
+    if (trashed.length === 0) return;
+    setPurging(true);
+    setProgress({ current: 0, total: trashed.length });
+    try {
+      const count = await api.purgeAllDeletedSessions();
+      showSuccess('清理完成', `已清理 ${count} 个已删除会话`);
+      setTrashed([]);
+    } catch (error) {
+      showError('清理失败', String(error));
+      refresh();
+    } finally {
+      setPurging(false);
+      setProgress(null);
+    }
+  };
+
+  const percent = progress && progress.total > 0
+    ? Math.round((progress.current / progress.total) * 100)
+    : 0;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <div>
+        <h2 className="text-lg font-semibold mb-1">数据清理</h2>
+        <p className="text-sm text-muted-foreground">
+          已删除的会话会暂存在回收区。点击下方按钮彻底清理它们占用的磁盘空间。
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium">回收区会话</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {loading ? '扫描中...' : `${trashed.length} 个已删除会话`}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={loading || purging}
+                onClick={refresh}
+              >
+                {loading ? (
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                ) : (
+                  <RefreshCw className="w-4 h-4 mr-1" />
+                )}
+                刷新
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={trashed.length === 0 || purging}
+                onClick={handlePurgeAll}
+              >
+                {purging ? (
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                ) : (
+                  <Trash2 className="w-4 h-4 mr-1" />
+                )}
+                全部清理
+              </Button>
+            </div>
+          </div>
+
+          {purging && progress && (
+            <div className="space-y-1.5">
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full bg-primary transition-[width] duration-150"
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground text-center">
+                {progress.current} / {progress.total}（{percent}%）
+              </p>
+            </div>
+          )}
+
+          {!loading && trashed.length > 0 && !purging && (
+            <div className="border rounded-lg divide-y max-h-80 overflow-y-auto">
+              {trashed.map((session) => (
+                <div key={session.id} className="flex items-center justify-between px-3 py-2">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm truncate">{session.title || '（无标题）'}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {session.message_count} 条消息
+                      {session.updated_at && ` · ${session.updated_at.slice(0, 10)}`}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {!loading && trashed.length === 0 && !purging && (
+            <p className="text-sm text-muted-foreground text-center py-8">
+              回收区为空，没有待清理的会话。
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1897,12 +1897,18 @@ function DataCleanupSettings() {
 
   const handlePurgeAll = async () => {
     if (trashed.length === 0) return;
+    const total = trashed.length;
     setPurging(true);
-    setProgress({ current: 0, total: trashed.length });
+    setProgress({ current: 0, total });
     try {
       const count = await api.purgeAllDeletedSessions();
-      showSuccess('清理完成', `已清理 ${count} 个已删除会话`);
-      setTrashed([]);
+      // 清理后重新扫描回收区（不直接清空——部分可能清理失败仍残留）。
+      await refresh();
+      if (count < total) {
+        showError('部分清理失败', `成功 ${count} 个，${total - count} 个失败，可稍后重试`);
+      } else {
+        showSuccess('清理完成', `已清理 ${count} 个已删除会话`);
+      }
     } catch (error) {
       showError('清理失败', String(error));
       refresh();

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1882,33 +1882,19 @@ function DataCleanupSettings() {
     refresh();
   }, [refresh]);
 
-  // 物理清理失败的会话 ID 集合（已部分删除资源，恢复会不完整）。
-  const [purgeFailedIds, setPurgeFailedIds] = useState<Set<string>>(new Set());
-
-  useEffect(() => {
-    if (!purging) return;
-    let unlisten: (() => void) | undefined;
-    api.onPurgeProgress((p) => {
-      setProgress({ current: p.current, total: p.total });
-      if (p.status === 'error') {
-        setPurgeFailedIds((prev) => new Set(prev).add(p.session_id));
-      }
-    }).then((fn) => {
-      unlisten = fn;
-    });
-    return () => {
-      unlisten?.();
-    };
-  }, [purging]);
-
   const handlePurgeAll = async () => {
     if (trashed.length === 0) return;
     const total = trashed.length;
     setPurging(true);
     setProgress({ current: 0, total });
+    // 先注册进度监听器，再调后端命令，防止漏掉早期事件。
+    const unlisten = await api.onPurgeProgress((p) => {
+      setProgress({ current: p.current, total: p.total });
+    });
     try {
       const count = await api.purgeAllDeletedSessions();
       // 清理后重新扫描回收区（不直接清空——部分可能清理失败仍残留）。
+      // 重新扫描会读取 trash JSON 中的 purge_failed 标记。
       await refresh();
       if (count < total) {
         showError('部分清理失败', `成功 ${count} 个，${total - count} 个失败，可稍后重试`);
@@ -1919,6 +1905,7 @@ function DataCleanupSettings() {
       showError('清理失败', String(error));
       refresh();
     } finally {
+      unlisten();
       setPurging(false);
       setProgress(null);
     }
@@ -2001,7 +1988,7 @@ function DataCleanupSettings() {
                       {session.updated_at && ` · ${session.updated_at.slice(0, 10)}`}
                     </p>
                   </div>
-                  {purgeFailedIds.has(session.id) ? (
+                  {session.purge_failed ? (
                     <Badge variant="destructive" className="ml-2 shrink-0 text-xs">
                       清理失败
                     </Badge>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1989,6 +1989,23 @@ function DataCleanupSettings() {
                       {session.updated_at && ` · ${session.updated_at.slice(0, 10)}`}
                     </p>
                   </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="ml-2 shrink-0"
+                    onClick={async () => {
+                      try {
+                        await api.restoreDeletedSession(session.id);
+                        showSuccess('已恢复', session.title || '会话已恢复到列表');
+                        refresh();
+                      } catch (error) {
+                        showError('恢复失败', String(error));
+                      }
+                    }}
+                  >
+                    <RefreshCw className="w-3.5 h-3.5 mr-1" />
+                    恢复
+                  </Button>
                 </div>
               ))}
             </div>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1882,11 +1882,17 @@ function DataCleanupSettings() {
     refresh();
   }, [refresh]);
 
+  // 物理清理失败的会话 ID 集合（已部分删除资源，恢复会不完整）。
+  const [purgeFailedIds, setPurgeFailedIds] = useState<Set<string>>(new Set());
+
   useEffect(() => {
     if (!purging) return;
     let unlisten: (() => void) | undefined;
     api.onPurgeProgress((p) => {
       setProgress({ current: p.current, total: p.total });
+      if (p.status === 'error') {
+        setPurgeFailedIds((prev) => new Set(prev).add(p.session_id));
+      }
     }).then((fn) => {
       unlisten = fn;
     });
@@ -1995,23 +2001,29 @@ function DataCleanupSettings() {
                       {session.updated_at && ` · ${session.updated_at.slice(0, 10)}`}
                     </p>
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="ml-2 shrink-0"
-                    onClick={async () => {
-                      try {
-                        await api.restoreDeletedSession(session.id);
-                        showSuccess('已恢复', session.title || '会话已恢复到列表');
-                        refresh();
-                      } catch (error) {
-                        showError('恢复失败', String(error));
-                      }
-                    }}
-                  >
-                    <RefreshCw className="w-3.5 h-3.5 mr-1" />
-                    恢复
-                  </Button>
+                  {purgeFailedIds.has(session.id) ? (
+                    <Badge variant="destructive" className="ml-2 shrink-0 text-xs">
+                      清理失败
+                    </Badge>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="ml-2 shrink-0"
+                      onClick={async () => {
+                        try {
+                          await api.restoreDeletedSession(session.id);
+                          showSuccess('已恢复', session.title || '会话已恢复到列表');
+                          refresh();
+                        } catch (error) {
+                          showError('恢复失败', String(error));
+                        }
+                      }}
+                    >
+                      <RefreshCw className="w-3.5 h-3.5 mr-1" />
+                      恢复
+                    </Button>
+                  )}
                 </div>
               ))}
             </div>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1887,14 +1887,14 @@ function DataCleanupSettings() {
     const total = trashed.length;
     setPurging(true);
     setProgress({ current: 0, total });
-    // 先注册进度监听器，再调后端命令，防止漏掉早期事件。
-    const unlisten = await api.onPurgeProgress((p) => {
-      setProgress({ current: p.current, total: p.total });
-    });
+    let unlisten: (() => void) | undefined;
     try {
+      // 先注册进度监听器，再调后端命令，防止漏掉早期事件。
+      unlisten = await api.onPurgeProgress((p) => {
+        setProgress({ current: p.current, total: p.total });
+      });
       const count = await api.purgeAllDeletedSessions();
       // 清理后重新扫描回收区（不直接清空——部分可能清理失败仍残留）。
-      // 重新扫描会读取 trash JSON 中的 purge_failed 标记。
       await refresh();
       if (count < total) {
         showError('部分清理失败', `成功 ${count} 个，${total - count} 个失败，可稍后重试`);
@@ -1905,7 +1905,7 @@ function DataCleanupSettings() {
       showError('清理失败', String(error));
       refresh();
     } finally {
-      unlisten();
+      unlisten?.();
       setPurging(false);
       setProgress(null);
     }

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1988,29 +1988,23 @@ function DataCleanupSettings() {
                       {session.updated_at && ` · ${session.updated_at.slice(0, 10)}`}
                     </p>
                   </div>
-                  {session.purge_failed ? (
-                    <Badge variant="destructive" className="ml-2 shrink-0 text-xs">
-                      清理失败
-                    </Badge>
-                  ) : (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="ml-2 shrink-0"
-                      onClick={async () => {
-                        try {
-                          await api.restoreDeletedSession(session.id);
-                          showSuccess('已恢复', session.title || '会话已恢复到列表');
-                          refresh();
-                        } catch (error) {
-                          showError('恢复失败', String(error));
-                        }
-                      }}
-                    >
-                      <RefreshCw className="w-3.5 h-3.5 mr-1" />
-                      恢复
-                    </Button>
-                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="ml-2 shrink-0"
+                    onClick={async () => {
+                      try {
+                        await api.restoreDeletedSession(session.id);
+                        showSuccess('已恢复', session.title || '会话已恢复到列表');
+                        refresh();
+                      } catch (error) {
+                        showError('恢复失败', String(error));
+                      }
+                    }}
+                  >
+                    <RefreshCw className="w-3.5 h-3.5 mr-1" />
+                    恢复
+                  </Button>
                 </div>
               ))}
             </div>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -152,16 +152,16 @@ export function SettingsDialog() {
                   <Package className="w-4 h-4 sm:mr-2" />
                   <span className="sr-only sm:not-sr-only">插件管理</span>
                 </TabsTrigger>
-                <TabsTrigger value="data-cleanup" className="w-full justify-center px-0 py-2 sm:justify-start sm:px-3">
-                  <HardDriveDownload className="w-4 h-4 sm:mr-2" />
-                  <span className="sr-only sm:not-sr-only">数据清理</span>
-                </TabsTrigger>
                 {pluginContributions.map((entry) => (
                   <TabsTrigger key={`plugin:${entry.plugin_id}:${entry.contribution_id}:${entry.generation}`} value={`plugin:${entry.plugin_id}`} className="w-full justify-center px-0 py-2 sm:justify-start sm:px-3">
                     {contributionIcon(entry.icon)}
                     <span className="sr-only sm:not-sr-only">{entry.title}</span>
                   </TabsTrigger>
                 ))}
+                <TabsTrigger value="data-cleanup" className="w-full justify-center px-0 py-2 sm:justify-start sm:px-3">
+                  <HardDriveDownload className="w-4 h-4 sm:mr-2" />
+                  <span className="sr-only sm:not-sr-only">数据清理</span>
+                </TabsTrigger>
                 <TabsTrigger value="about" className="w-full justify-center px-0 py-2 sm:justify-start sm:px-3">
                   <Info className="w-4 h-4 sm:mr-2" />
                   <span className="sr-only sm:not-sr-only">关于与更新</span>
@@ -1991,7 +1991,7 @@ function DataCleanupSettings() {
                   <div className="min-w-0 flex-1">
                     <p className="text-sm truncate">{session.title || '（无标题）'}</p>
                     <p className="text-xs text-muted-foreground">
-                      {session.message_count} 条消息
+                      {session.message_count} 条对话
                       {session.updated_at && ` · ${session.updated_at.slice(0, 10)}`}
                     </p>
                   </div>

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -107,7 +107,7 @@ function terminalRuntimeTabToState(tab: TerminalTabInfo): TabState {
 }
 
 export function MainApp() {
-  const { applyStreamEvents, loadSessions } = useStore();
+  const { applyStreamEvents, loadSessions, updateSessionMeta } = useStore();
   const activeSessionId = useStore((state) => state.activeSessionId);
   useUpdateCheck();
   const [workspacePanelMounted, setWorkspacePanelMounted] = useState(false);
@@ -458,6 +458,15 @@ export function MainApp() {
           runProtectiveRefresh();
         }, 120);
       };
+      // turn 结束后精确更新单条会话（消息数/时间），不全量刷新列表。
+      track(await listen<string>('session_meta_updated', (event) => {
+        const sessionId = event.payload;
+        if (sessionId) {
+          updateSessionMeta(sessionId);
+        }
+      }));
+      guard();
+      // sessions_updated 仅用于低频全量刷新（如恢复会话）。
       track(await listen('sessions_updated', () => {
         scheduleSessionsRefresh();
       }));

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -860,6 +860,7 @@ export interface AppState {
   // - 旧请求晚到时放弃写入；active 不在权威列表时执行完整的会话切换或新对话初始化。
   // 前端在 getSessions 失败时保留旧列表，避免瞬时请求错误清空侧栏。
   loadSessions: (options?: { protective?: boolean }) => Promise<void>;
+  updateSessionMeta: (sessionId: string) => Promise<void>;
   startNewConversation: (targetCwd?: string) => Promise<void>;
   switchSession: (id: string) => Promise<void>;
   deleteSession: () => Promise<void>;
@@ -1076,6 +1077,26 @@ export const useStore = create<AppState>((set, get) => ({
       console.error('加载会话失败:', error);
       finishOrdinary();
       return;
+    }
+  },
+
+  // 精确更新单条会话的元数据（消息数/更新时间），替代全量 loadSessions。
+  updateSessionMeta: async (sessionId: string) => {
+    try {
+      const meta = await api.getSessionMeta(sessionId);
+      if (!meta) return;
+      set((state) => {
+        const idx = state.sessions.findIndex((s) => s.id === sessionId);
+        if (idx < 0) {
+          // 会话不在列表中（如恢复后首次更新），加入列表
+          return { sessions: [...state.sessions, meta] };
+        }
+        const sessions = state.sessions.slice();
+        sessions[idx] = { ...sessions[idx], ...meta };
+        return { sessions };
+      });
+    } catch (error) {
+      console.error('更新会话元数据失败:', error);
     }
   },
 

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -1268,23 +1268,21 @@ export const useStore = create<AppState>((set, get) => ({
       const before = get();
       const wasNewConversation = before.isNewConversation;
       const previousActiveSessionId = before.activeSessionId;
-      const deletedIds = before.sessions
-        .filter((session) => session.cwd === cwd)
-        .map((session) => session.id);
-      await api.deleteSessionsByCwd(cwd);
+      // 后端返回实际删除成功的 ID 列表（部分失败时不包含失败的）。
+      const succeededIds = await api.deleteSessionsByCwd(cwd);
 
-      for (const sessionId of deletedIds) {
+      for (const sessionId of succeededIds) {
         sessionViewCaches.delete(sessionId);
         discardInputCacheSyncQueue(sessionId);
       }
-      // 本地直接移除被删会话，不重新拉列表。
+      // 本地只移除实际删除成功的会话。
       const remainingSessions = before.sessions.filter(
-        (session) => !deletedIds.includes(session.id),
+        (session) => !succeededIds.includes(session.id),
       );
       set((state) => {
         const inputCaches = { ...state.inputCaches };
         const sessionRunStatuses = { ...state.sessionRunStatuses };
-        for (const sessionId of deletedIds) {
+        for (const sessionId of succeededIds) {
           delete inputCaches[sessionId];
           delete sessionRunStatuses[sessionId];
         }

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -863,8 +863,8 @@ export interface AppState {
   updateSessionMeta: (sessionId: string) => Promise<void>;
   startNewConversation: (targetCwd?: string) => Promise<void>;
   switchSession: (id: string) => Promise<void>;
-  deleteSession: () => Promise<void>;
-  deleteSessionsByCwd: (cwd: string) => Promise<void>;
+  deleteSession: (sessionId: string) => Promise<void>;
+  deleteSessionsByCwd: (cwd: string) => Promise<{ failed: number }>;
 
   sendMessage: (
     cacheKey: string,
@@ -1231,22 +1231,19 @@ export const useStore = create<AppState>((set, get) => ({
   },
 
   // 删除当前会话
-  deleteSession: async () => {
+  deleteSession: async (sessionId: string) => {
     try {
-      const deletedSessionId = get().activeSessionId;
-      await api.deleteSession();
-      if (deletedSessionId) {
-        sessionViewCaches.delete(deletedSessionId);
-        discardInputCacheSyncQueue(deletedSessionId);
-      }
+      const deletedSessionId = sessionId;
+      const wasActive = get().activeSessionId === deletedSessionId;
+      await api.deleteSession(deletedSessionId);
+      sessionViewCaches.delete(deletedSessionId);
+      discardInputCacheSyncQueue(deletedSessionId);
       // 本地直接移除被删会话，不重新拉列表（避免全量扫描卡顿）。
       set((state) => {
         const inputCaches = { ...state.inputCaches };
         const sessionRunStatuses = { ...state.sessionRunStatuses };
-        if (deletedSessionId) {
-          delete inputCaches[deletedSessionId];
-          delete sessionRunStatuses[deletedSessionId];
-        }
+        delete inputCaches[deletedSessionId];
+        delete sessionRunStatuses[deletedSessionId];
         return {
           sessions: state.sessions.filter((s) => s.id !== deletedSessionId),
           inputCaches,
@@ -1254,9 +1251,10 @@ export const useStore = create<AppState>((set, get) => ({
         };
       });
 
-      // 删除任意会话后统一进入新对话态，而不是切到剩余列表的第一个——
-      // 用户主动删除通常意味着想开启新的上下文。
-      await get().startNewConversation();
+      // 只有删的是当前活跃会话时才进入新对话态。
+      if (wasActive) {
+        await get().startNewConversation();
+      }
     } catch (error) {
       console.error('删除会话失败:', error);
     }
@@ -1298,17 +1296,19 @@ export const useStore = create<AppState>((set, get) => ({
       }
 
       if (wasNewConversation) {
-        return;
+        return { failed: failedIds.length };
       }
       if (previousActiveSessionId
         && remainingSessions.some((session) => session.id === previousActiveSessionId)) {
-        return;
+        return { failed: failedIds.length };
       }
       const nextSessionId = remainingSessions[0]?.id;
       if (nextSessionId) await get().switchSession(nextSessionId);
       else await get().startNewConversation();
+      return { failed: failedIds.length };
     } catch (error) {
       console.error('删除 workspace 会话失败:', error);
+      return { failed: -1 };
     }
   },
 

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -1218,7 +1218,7 @@ export const useStore = create<AppState>((set, get) => ({
         sessionViewCaches.delete(deletedSessionId);
         discardInputCacheSyncQueue(deletedSessionId);
       }
-      const sessions = await api.getSessions();
+      // 本地直接移除被删会话，不重新拉列表（避免全量扫描卡顿）。
       set((state) => {
         const inputCaches = { ...state.inputCaches };
         const sessionRunStatuses = { ...state.sessionRunStatuses };
@@ -1226,7 +1226,11 @@ export const useStore = create<AppState>((set, get) => ({
           delete inputCaches[deletedSessionId];
           delete sessionRunStatuses[deletedSessionId];
         }
-        return { sessions, inputCaches, sessionRunStatuses };
+        return {
+          sessions: state.sessions.filter((s) => s.id !== deletedSessionId),
+          inputCaches,
+          sessionRunStatuses,
+        };
       });
 
       // 删除任意会话后统一进入新对话态，而不是切到剩余列表的第一个——
@@ -1240,7 +1244,6 @@ export const useStore = create<AppState>((set, get) => ({
   // 删除指定 workspace（cwd）下的所有会话
   deleteSessionsByCwd: async (cwd: string) => {
     try {
-      // 删除前记录是否正在编辑新对话；删除分组不应打断当前输入。
       const before = get();
       const wasNewConversation = before.isNewConversation;
       const previousActiveSessionId = before.activeSessionId;
@@ -1248,12 +1251,15 @@ export const useStore = create<AppState>((set, get) => ({
         .filter((session) => session.cwd === cwd)
         .map((session) => session.id);
       await api.deleteSessionsByCwd(cwd);
-      const sessions = await api.getSessions();
 
       for (const sessionId of deletedIds) {
         sessionViewCaches.delete(sessionId);
         discardInputCacheSyncQueue(sessionId);
       }
+      // 本地直接移除被删会话，不重新拉列表。
+      const remainingSessions = before.sessions.filter(
+        (session) => !deletedIds.includes(session.id),
+      );
       set((state) => {
         const inputCaches = { ...state.inputCaches };
         const sessionRunStatuses = { ...state.sessionRunStatuses };
@@ -1261,19 +1267,21 @@ export const useStore = create<AppState>((set, get) => ({
           delete inputCaches[sessionId];
           delete sessionRunStatuses[sessionId];
         }
-        return { sessions, inputCaches, sessionRunStatuses };
+        return {
+          sessions: remainingSessions,
+          inputCaches,
+          sessionRunStatuses,
+        };
       });
 
       if (wasNewConversation) {
-        // 新对话：仅刷新会话列表，保持当前输入不变。
         return;
       }
-
       if (previousActiveSessionId
-        && sessions.some((session) => session.id === previousActiveSessionId)) {
+        && remainingSessions.some((session) => session.id === previousActiveSessionId)) {
         return;
       }
-      const nextSessionId = sessions[0]?.id;
+      const nextSessionId = remainingSessions[0]?.id;
       if (nextSessionId) await get().switchSession(nextSessionId);
       else await get().startNewConversation();
     } catch (error) {

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -1268,8 +1268,8 @@ export const useStore = create<AppState>((set, get) => ({
       const before = get();
       const wasNewConversation = before.isNewConversation;
       const previousActiveSessionId = before.activeSessionId;
-      // 后端返回实际删除成功的 ID 列表（部分失败时不包含失败的）。
-      const succeededIds = await api.deleteSessionsByCwd(cwd);
+      // 后端返回成功和失败的 ID 列表。
+      const { succeeded: succeededIds, failed: failedIds } = await api.deleteSessionsByCwd(cwd);
 
       for (const sessionId of succeededIds) {
         sessionViewCaches.delete(sessionId);
@@ -1292,6 +1292,10 @@ export const useStore = create<AppState>((set, get) => ({
           sessionRunStatuses,
         };
       });
+
+      if (failedIds.length > 0) {
+        console.warn('部分会话删除失败：', failedIds);
+      }
 
       if (wasNewConversation) {
         return;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2341,25 +2341,20 @@ pub async fn purge_all_deleted_sessions(
             },
         );
 
-        // 按依赖顺序清理所有可能失败的资源：
-        // 1. media/teams 目录
-        // 2. workspace-tab-layouts 布局文件
-        // 3. PTY/browser 运行时（destroy 操作本身不返回错误，但布局删除会）
-        // 全部成功后才删 trash 文件——trash 文件是重试的凭证，保留到最后一刻。
+        // 清理顺序设计原则：
+        // - 不影响会话完整性的资源先删（layout/PTY/browser）
+        // - 然后删 trash 文件（会话 JSON 消失，不再可恢复）
+        // - 最后删 media/teams（失败只留孤儿文件，不影响功能）
+        // 这样：trash 文件删除前任何步骤失败 → 会话仍在回收区、媒体完好 → 可完整恢复
         let mut error_msg: Option<String> = None;
 
-        if let Err(e) = purge_session_resources(&storage_root, &media_root, session_id) {
-            error_msg = Some(e);
+        // 1. workspace-tab-layouts（不影响会话内容）
+        if let Err(e) = crate::workspace_tabs::remove_layout(session_id) {
+            warn!(%e, session_id, "删除工作区标签页布局失败");
+            error_msg = Some(format!("删除布局失败：{e}"));
         }
 
-        if error_msg.is_none() {
-            if let Err(e) = crate::workspace_tabs::remove_layout(session_id) {
-                warn!(%e, session_id, "删除工作区标签页布局失败");
-                error_msg = Some(format!("删除布局失败：{e}"));
-            }
-        }
-
-        // PTY/browser 运行时销毁（这些不返回错误，尽力清理）。
+        // 2. PTY/browser 运行时（不返回错误，尽力清理）
         if error_msg.is_none() {
             tiangong_plugin_terminal::destroy_session_pty(&app, session_id);
             if let Some(browser_state) =
@@ -2369,7 +2364,7 @@ pub async fn purge_all_deleted_sessions(
             }
         }
 
-        // 所有资源清理成功 → 删 trash 文件（回收区记录不再需要）。
+        // 3. 删 trash 文件（会话不再可恢复，此后失败不影响恢复完整性）
         if error_msg.is_none() {
             if let Err(e) = manager.delete_trashed_session(session_id) {
                 error_msg = Some(format!("删除回收区文件失败：{e}"));
@@ -2389,6 +2384,11 @@ pub async fn purge_all_deleted_sessions(
                 },
             );
             continue;
+        }
+
+        // 4. 删 media/teams（最后删，失败只留孤儿文件）
+        if let Err(e) = purge_session_resources(&storage_root, &media_root, session_id) {
+            warn!(%e, session_id, "删除媒体/teams 目录失败（留为孤儿文件）");
         }
 
         succeeded.push(session_id.clone());

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2418,8 +2418,11 @@ pub async fn purge_all_deleted_sessions(
         }
 
         // 阶段 3：全部资源清理成功 → 删 purging 记录。
+        // 记录删除也是清理完成的一部分；失败时保留记录供下次重试，不能误报成功。
         if let Err(e) = manager.delete_purging_session(session_id) {
-            warn!(%e, session_id, "删除 purging 记录失败");
+            warn!(%e, session_id, "删除 purging 记录失败，保留记录供重试");
+            emit_error(&app_handle, index, total, session_id);
+            continue;
         }
 
         succeeded.push(session_id.clone());

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2229,12 +2229,17 @@ pub async fn list_trashed_sessions(
 #[tauri::command]
 pub async fn restore_deleted_session(
     session_id: String,
+    app: AppHandle,
     state: State<'_, TiangongApp>,
 ) -> Result<(), String> {
+    use tauri::Emitter;
     let manager = state.core_manager.clone();
     tokio::task::spawn_blocking(move || manager.restore_session_file(&session_id))
         .await
-        .map_err(|error| format!("恢复任务失败：{error}"))?
+        .map_err(|error| format!("恢复任务失败：{error}"))??;
+    // 恢复后会话重新出现在列表中，通知前端刷新。
+    let _ = app.emit("sessions_updated", &());
+    Ok(())
 }
 
 /// 物理清理所有回收区会话（配置页"全部清理"触发）。

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2218,6 +2218,8 @@ pub struct TrashedSession {
     pub title: String,
     pub message_count: usize,
     pub updated_at: String,
+    /// 是否正在清理中（资源可能已部分删除，不可恢复）。
+    pub purging: bool,
 }
 
 /// 物理清理进度事件 payload。
@@ -2230,6 +2232,43 @@ pub struct PurgeProgress {
     pub status: String, // "cleaning" | "done" | "error"
 }
 
+/// 从磁盘 JSON 读取回收区会话摘要（只读浅字段）。
+fn read_trashed_summary(id: &str, path: &std::path::Path, purging: bool) -> TrashedSession {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+        .map(|value| TrashedSession {
+            id: id.to_string(),
+            title: value
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("（无标题）")
+                .to_string(),
+            message_count: value
+                .get("messages")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("user"))
+                        .count()
+                })
+                .unwrap_or(0),
+            updated_at: value
+                .get("updated_at")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            purging,
+        })
+        .unwrap_or_else(|| TrashedSession {
+            id: id.to_string(),
+            title: "（无法读取）".to_string(),
+            message_count: 0,
+            updated_at: String::new(),
+            purging,
+        })
+}
+
 /// 扫描回收区，返回待物理清理的会话列表。
 #[tauri::command]
 pub async fn list_trashed_sessions(
@@ -2238,48 +2277,25 @@ pub async fn list_trashed_sessions(
     let manager = state.core_manager.clone();
     tokio::task::spawn_blocking(move || {
         let storage_root = manager.storage_root();
-        let ids = manager.list_trashed_session_ids();
-        let mut result = Vec::with_capacity(ids.len());
-        for id in &ids {
-            // 从 trash 文件加载元数据（只读浅字段）。
-            let trash_path = storage_root
+        // 扫描回收区（可恢复）和正在清理（不可恢复）两个目录。
+        let trashed_ids = manager.list_trashed_session_ids();
+        let purging_ids = manager.list_purging_session_ids();
+        let mut result = Vec::new();
+        // 回收区会话（可恢复）
+        for id in &trashed_ids {
+            let path = storage_root
                 .join("trash")
                 .join("sessions")
                 .join(format!("{id}.json"));
-            let summary = std::fs::read_to_string(&trash_path)
-                .ok()
-                .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
-                .map(|value| TrashedSession {
-                    id: id.clone(),
-                    title: value
-                        .get("title")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("（无标题）")
-                        .to_string(),
-                    message_count: value
-                        .get("messages")
-                        .and_then(|v| v.as_array())
-                        .map(|a| {
-                            a.iter()
-                                .filter(|msg| {
-                                    msg.get("role").and_then(|r| r.as_str()) == Some("user")
-                                })
-                                .count()
-                        })
-                        .unwrap_or(0),
-                    updated_at: value
-                        .get("updated_at")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string(),
-                })
-                .unwrap_or_else(|| TrashedSession {
-                    id: id.clone(),
-                    title: "（无法读取）".to_string(),
-                    message_count: 0,
-                    updated_at: String::new(),
-                });
-            result.push(summary);
+            result.push(read_trashed_summary(id, &path, false));
+        }
+        // 正在清理会话（不可恢复，资源可能已部分删除）
+        for id in &purging_ids {
+            let path = storage_root
+                .join("trash")
+                .join("purging")
+                .join(format!("{id}.json"));
+            result.push(read_trashed_summary(id, &path, true));
         }
         result.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
         Ok(result)
@@ -2305,6 +2321,21 @@ pub async fn restore_deleted_session(
     Ok(())
 }
 
+/// 发送清理失败进度事件。
+fn emit_error(app: &AppHandle, index: usize, total: usize, session_id: &str) {
+    use tauri::Emitter;
+    let _ = app.emit(
+        "purge_progress",
+        PurgeProgress {
+            current: index + 1,
+            total,
+            session_id: session_id.to_string(),
+            title: String::new(),
+            status: "error".to_string(),
+        },
+    );
+}
+
 /// 物理清理所有回收区会话（配置页"全部清理"触发）。
 ///
 /// 逐个清理 media/teams/layout/PTY/browser/trash 文件，通过 `purge_progress`
@@ -2317,8 +2348,15 @@ pub async fn purge_all_deleted_sessions(
     use tauri::Emitter;
 
     let manager = state.core_manager.clone();
+    // 合并待清理列表：回收区中的 + 上次清理失败残留在 purging 中的。
     let trashed_ids = manager.list_trashed_session_ids();
-    let total = trashed_ids.len();
+    let purging_ids = manager.list_purging_session_ids();
+    let all_ids: Vec<String> = trashed_ids
+        .iter()
+        .chain(purging_ids.iter())
+        .cloned()
+        .collect();
+    let total = all_ids.len();
     if total == 0 {
         return Ok(0);
     }
@@ -2328,8 +2366,7 @@ pub async fn purge_all_deleted_sessions(
     let app_handle = app.clone();
 
     let mut succeeded: Vec<String> = Vec::new();
-    for (index, session_id) in trashed_ids.iter().enumerate() {
-        // 推送进度：开始清理。
+    for (index, session_id) in all_ids.iter().enumerate() {
         let _ = app_handle.emit(
             "purge_progress",
             PurgeProgress {
@@ -2341,20 +2378,24 @@ pub async fn purge_all_deleted_sessions(
             },
         );
 
-        // 清理顺序设计原则：
-        // - 不影响会话完整性的资源先删（layout/PTY/browser）
-        // - 然后删 trash 文件（会话 JSON 消失，不再可恢复）
-        // - 最后删 media/teams（失败只留孤儿文件，不影响功能）
-        // 这样：trash 文件删除前任何步骤失败 → 会话仍在回收区、媒体完好 → 可完整恢复
-        let mut error_msg: Option<String> = None;
-
-        // 1. workspace-tab-layouts（不影响会话内容）
-        if let Err(e) = crate::workspace_tabs::remove_layout(session_id) {
-            warn!(%e, session_id, "删除工作区标签页布局失败");
-            error_msg = Some(format!("删除布局失败：{e}"));
+        // 阶段 1：移到 purging（原子移动，标记"正在清理"）。
+        // 已在 purging 中的（上次失败残留）跳过移动。
+        if trashed_ids.contains(session_id) {
+            if let Err(e) = manager.move_to_purging(session_id) {
+                warn!(%e, session_id, "移动到 purging 失败");
+                emit_error(&app_handle, index, total, session_id);
+                continue;
+            }
         }
 
-        // 2. PTY/browser 运行时（不返回错误，尽力清理）
+        // 阶段 2：清理全部资源。
+        let mut error_msg: Option<String> = None;
+
+        // layout
+        if let Err(e) = crate::workspace_tabs::remove_layout(session_id) {
+            error_msg = Some(format!("删除布局失败：{e}"));
+        }
+        // PTY/browser
         if error_msg.is_none() {
             tiangong_plugin_terminal::destroy_session_pty(&app, session_id);
             if let Some(browser_state) =
@@ -2363,32 +2404,22 @@ pub async fn purge_all_deleted_sessions(
                 browser_state.registry.destroy_session(session_id);
             }
         }
-
-        // 3. 删 trash 文件（会话不再可恢复，此后失败不影响恢复完整性）
+        // media/teams（占用空间最大，必须删成功）
         if error_msg.is_none() {
-            if let Err(e) = manager.delete_trashed_session(session_id) {
-                error_msg = Some(format!("删除回收区文件失败：{e}"));
+            if let Err(e) = purge_session_resources(&storage_root, &media_root, session_id) {
+                error_msg = Some(e);
             }
         }
 
         if let Some(msg) = error_msg {
-            warn!(%msg, session_id, "物理清理会话失败，保留回收区记录供重试");
-            let _ = app_handle.emit(
-                "purge_progress",
-                PurgeProgress {
-                    current: index + 1,
-                    total,
-                    session_id: session_id.clone(),
-                    title: String::new(),
-                    status: "error".to_string(),
-                },
-            );
+            warn!(%msg, session_id, "物理清理失败，保留 purging 记录供重试");
+            emit_error(&app_handle, index, total, session_id);
             continue;
         }
 
-        // 4. 删 media/teams（最后删，失败只留孤儿文件）
-        if let Err(e) = purge_session_resources(&storage_root, &media_root, session_id) {
-            warn!(%e, session_id, "删除媒体/teams 目录失败（留为孤儿文件）");
+        // 阶段 3：全部资源清理成功 → 删 purging 记录。
+        if let Err(e) = manager.delete_purging_session(session_id) {
+            warn!(%e, session_id, "删除 purging 记录失败");
         }
 
         succeeded.push(session_id.clone());

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -481,7 +481,7 @@ pub async fn delete_session(state: State<'_, TiangongApp>) -> Result<(), String>
 pub async fn delete_sessions_by_cwd(
     cwd: String,
     state: State<'_, TiangongApp>,
-) -> Result<(), String> {
+) -> Result<Vec<String>, String> {
     let mut deleted_ids = state
         .with_state_read(|core_state| {
             let ids: Vec<String> = core_state
@@ -503,28 +503,52 @@ pub async fn delete_sessions_by_cwd(
     for id in &deleted_ids {
         send_guards.push(state.session_send_lock(id).lock_owned().await);
     }
-    // 并发逻辑删除（原子移动到 trash）。
+    // 并发逻辑删除（等待 worker 退出 + 原子移动到 trash）。收集每项结果。
     let core_manager = state.inner().core_manager.clone();
-    let deletes = deleted_ids.iter().map(|id| core_manager.delete_session(id));
-    futures_util::future::join_all(deletes).await;
-    // 清理内存状态。
+    let deletes = deleted_ids.iter().map(|id| {
+        let id = id.clone();
+        let manager = core_manager.clone();
+        async move {
+            let result = manager.delete_session(&id).await;
+            (id, result)
+        }
+    });
+    let results = futures_util::future::join_all(deletes).await;
+    let (succeeded, failed): (Vec<_>, Vec<_>) =
+        results.into_iter().partition(|(_, result)| result.is_ok());
+    let succeeded_ids: Vec<String> = succeeded.into_iter().map(|(id, _)| id).collect();
+    let failed_ids: Vec<String> = failed
+        .into_iter()
+        .map(|(id, result)| {
+            tracing::warn!(session_id = %id, error = ?result.err(), "批量删除：该会话删除失败");
+            id
+        })
+        .collect();
+    // 只清理成功删除的会话的内存状态。
     state
         .with_state(|core_state| {
-            for id in &deleted_ids {
+            for id in &succeeded_ids {
                 state.fail_remote_session_waiters(id, "目标会话已删除");
                 crate::session_ops::remove_session_state(core_state, &state.core_manager, id);
             }
             Ok(())
         })
         .await?;
-    for id in &deleted_ids {
+    for id in &succeeded_ids {
         let _ = state.release_any_input_send_claim(id);
         state.clear_agent_worker_view(id);
         state.remove_session_send_lock(id);
     }
     drop(send_guards);
     drop(input_cache_guards);
-    Ok(())
+    if !failed_ids.is_empty() {
+        tracing::warn!(
+            succeeded = succeeded_ids.len(),
+            failed = failed_ids.len(),
+            "批量删除部分失败"
+        );
+    }
+    Ok(succeeded_ids)
 }
 
 /// 失败回滚只能关闭本次 ensure 绑定的实例，并且必须等待 worker 最终写盘结束，
@@ -2284,6 +2308,7 @@ pub async fn purge_all_deleted_sessions(
     let media_root = storage_root.join("media");
     let app_handle = app.clone();
 
+    let mut succeeded: Vec<String> = Vec::new();
     for (index, session_id) in trashed_ids.iter().enumerate() {
         // 推送进度：开始清理。
         let _ = app_handle.emit(
@@ -2297,9 +2322,22 @@ pub async fn purge_all_deleted_sessions(
             },
         );
 
-        // 清理该会话的全部资源。
+        // 清理该会话的全部资源（media/teams）。
+        let mut failed = false;
         if let Err(error) = purge_session_resources(&storage_root, &media_root, session_id) {
-            warn!(%error, session_id, "物理清理会话资源失败，跳过");
+            warn!(%error, session_id, "物理清理会话资源失败");
+            failed = true;
+        }
+
+        // 删 trash 文件。失败视为该会话清理失败。
+        if !failed {
+            if let Err(error) = manager.delete_trashed_session(session_id) {
+                warn!(%error, session_id, "删除回收区文件失败");
+                failed = true;
+            }
+        }
+
+        if failed {
             let _ = app_handle.emit(
                 "purge_progress",
                 PurgeProgress {
@@ -2313,10 +2351,7 @@ pub async fn purge_all_deleted_sessions(
             continue;
         }
 
-        // 删 trash 文件。
-        if let Err(error) = manager.delete_trashed_session(session_id) {
-            warn!(%error, session_id, "删除回收区文件失败");
-        }
+        succeeded.push(session_id.clone());
 
         // 推送进度：完成。
         let _ = app_handle.emit(
@@ -2331,8 +2366,8 @@ pub async fn purge_all_deleted_sessions(
         );
     }
 
-    // 清理运行时（PTY/browser）—— 这些需要 AppHandle。
-    for session_id in &trashed_ids {
+    // 只清理成功项的运行时（PTY/browser/layout）。
+    for session_id in &succeeded {
         tiangong_plugin_terminal::destroy_session_pty(&app, session_id);
         if let Some(browser_state) = app.try_state::<tiangong_plugin_browser::BrowserPluginState>()
         {
@@ -2343,7 +2378,7 @@ pub async fn purge_all_deleted_sessions(
         }
     }
 
-    Ok(total)
+    Ok(succeeded.len())
 }
 
 /// 清理单个会话的磁盘资源（media/teams/trash 文件）。不含 PTY/browser 运行时。

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -441,15 +441,16 @@ pub async fn load_session(
     Ok(view)
 }
 
-/// 删除当前会话（逻辑删除）。
+/// 删除指定会话（逻辑删除）。
 ///
 /// 会话文件原子移动到 `trash/sessions/`，从列表立即消失。
 /// 不做媒体/teams/PTY/browser 清理——那些留给配置页的物理删除。
 #[tauri::command]
-pub async fn delete_session(state: State<'_, TiangongApp>) -> Result<(), String> {
-    let deleted_id = state
-        .with_state_read(|core_state| Ok(core_state.active_session_id.as_str().to_string()))
-        .await?;
+pub async fn delete_session(
+    session_id: String,
+    state: State<'_, TiangongApp>,
+) -> Result<(), String> {
+    let deleted_id = session_id;
     let _cache_guard = state
         .input_cache_update_lock(&deleted_id)
         .lock_owned()

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2258,7 +2258,13 @@ pub async fn list_trashed_sessions(
                     message_count: value
                         .get("messages")
                         .and_then(|v| v.as_array())
-                        .map(|a| a.len())
+                        .map(|a| {
+                            a.iter()
+                                .filter(|msg| {
+                                    msg.get("role").and_then(|r| r.as_str()) == Some("user")
+                                })
+                                .count()
+                        })
                         .unwrap_or(0),
                     updated_at: value
                         .get("updated_at")

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2218,8 +2218,6 @@ pub struct TrashedSession {
     pub title: String,
     pub message_count: usize,
     pub updated_at: String,
-    /// 物理清理是否失败过（媒体/teams 可能已部分删除，恢复会不完整）。
-    pub purge_failed: bool,
 }
 
 /// 物理清理进度事件 payload。
@@ -2274,17 +2272,12 @@ pub async fn list_trashed_sessions(
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .to_string(),
-                    purge_failed: value
-                        .get("purge_failed")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false),
                 })
                 .unwrap_or_else(|| TrashedSession {
                     id: id.clone(),
                     title: "（无法读取）".to_string(),
                     message_count: 0,
                     updated_at: String::new(),
-                    purge_failed: false,
                 });
             result.push(summary);
         }
@@ -2384,9 +2377,7 @@ pub async fn purge_all_deleted_sessions(
         }
 
         if let Some(msg) = error_msg {
-            warn!(%msg, session_id, "物理清理会话失败，保留回收区记录");
-            // 在 trash JSON 中写入 purge_failed 标记，持久化失败状态。
-            mark_trash_purge_failed(&storage_root, session_id);
+            warn!(%msg, session_id, "物理清理会话失败，保留回收区记录供重试");
             let _ = app_handle.emit(
                 "purge_progress",
                 PurgeProgress {
@@ -2436,27 +2427,6 @@ fn purge_session_resources(
             .map_err(|error| format!("删除 teams 目录失败：{error}"))?;
     }
     Ok(())
-}
-
-/// 在回收区会话 JSON 中写入 purge_failed 标记（持久化清理失败状态）。
-fn mark_trash_purge_failed(storage_root: &std::path::Path, session_id: &str) {
-    let trash_path = storage_root
-        .join("trash")
-        .join("sessions")
-        .join(format!("{session_id}.json"));
-    let Ok(content) = std::fs::read_to_string(&trash_path) else {
-        return;
-    };
-    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&content) else {
-        return;
-    };
-    if let Some(obj) = value.as_object_mut() {
-        obj.insert("purge_failed".to_string(), serde_json::Value::Bool(true));
-        let _ = std::fs::write(
-            &trash_path,
-            serde_json::to_string(&value).unwrap_or_default(),
-        );
-    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2218,6 +2218,8 @@ pub struct TrashedSession {
     pub title: String,
     pub message_count: usize,
     pub updated_at: String,
+    /// 物理清理是否失败过（媒体/teams 可能已部分删除，恢复会不完整）。
+    pub purge_failed: bool,
 }
 
 /// 物理清理进度事件 payload。
@@ -2272,12 +2274,17 @@ pub async fn list_trashed_sessions(
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .to_string(),
+                    purge_failed: value
+                        .get("purge_failed")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false),
                 })
                 .unwrap_or_else(|| TrashedSession {
                     id: id.clone(),
                     title: "（无法读取）".to_string(),
                     message_count: 0,
                     updated_at: String::new(),
+                    purge_failed: false,
                 });
             result.push(summary);
         }
@@ -2378,6 +2385,8 @@ pub async fn purge_all_deleted_sessions(
 
         if let Some(msg) = error_msg {
             warn!(%msg, session_id, "物理清理会话失败，保留回收区记录");
+            // 在 trash JSON 中写入 purge_failed 标记，持久化失败状态。
+            mark_trash_purge_failed(&storage_root, session_id);
             let _ = app_handle.emit(
                 "purge_progress",
                 PurgeProgress {
@@ -2427,6 +2436,27 @@ fn purge_session_resources(
             .map_err(|error| format!("删除 teams 目录失败：{error}"))?;
     }
     Ok(())
+}
+
+/// 在回收区会话 JSON 中写入 purge_failed 标记（持久化清理失败状态）。
+fn mark_trash_purge_failed(storage_root: &std::path::Path, session_id: &str) {
+    let trash_path = storage_root
+        .join("trash")
+        .join("sessions")
+        .join(format!("{session_id}.json"));
+    let Ok(content) = std::fs::read_to_string(&trash_path) else {
+        return;
+    };
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return;
+    };
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("purge_failed".to_string(), serde_json::Value::Bool(true));
+        let _ = std::fs::write(
+            &trash_path,
+            serde_json::to_string(&value).unwrap_or_default(),
+        );
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -263,6 +263,26 @@ pub async fn get_sessions(state: State<'_, TiangongApp>) -> Result<Vec<SessionLi
     .map_err(|error| format!("等待会话列表加载失败：{error}"))
 }
 
+/// 获取单个会话的元数据（精确更新列表时使用，避免全量刷新）。
+#[tauri::command]
+pub async fn get_session_meta(
+    session_id: String,
+    state: State<'_, TiangongApp>,
+) -> Result<Option<SessionListItem>, String> {
+    let manager = state.core_manager.clone();
+    tokio::task::spawn_blocking(move || {
+        let meta = tiangong_core_manager::SessionMetadata::load_from_storage(
+            manager.storage_root(),
+            &session_id,
+        )
+        .ok()
+        .filter(|m| m.parent_session_id.is_none());
+        Ok(meta.as_ref().map(SessionListItem::from_metadata))
+    })
+    .await
+    .map_err(|error| format!("读取会话元数据失败：{error}"))?
+}
+
 /// 获取指定会话的统一工作区 Tab 元数据
 #[tauri::command]
 pub async fn get_session_tabs(
@@ -1019,7 +1039,8 @@ pub(crate) fn start_stream_consumer(
                 }
 
                 emit_session_stream_event(&app, &final_sid, &event);
-                let _ = app.emit("sessions_updated", &());
+                // 精确通知：该会话的元数据已更新（消息数/时间），前端只更新这一条。
+                let _ = app.emit("session_meta_updated", &final_sid);
                 // 标题生成已在 send_message_inner 投递后并行启动（与 chat turn 同时跑），
                 // 完成后经 Command::SetTitle 投递给 turn task 安全写入，此处不再串行处理。
                 // 不 break — 消费线程继续运行，等待下一轮消息的 StreamEvent
@@ -1034,7 +1055,6 @@ pub(crate) fn start_stream_consumer(
         if !app_state.core_manager.has_live_core(&session_id) {
             let _ = rt.block_on(app_state.with_state(|core_state| {
                 crate::state_ops::clear_pending_turn(core_state, &session_id);
-                let _ = app.emit("sessions_updated", &());
                 Ok(())
             }));
             app_state.fail_remote_session_waiters(&session_id, "执行已中断：Core 事件流已关闭");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -421,9 +421,12 @@ pub async fn load_session(
     Ok(view)
 }
 
-/// 删除当前会话
+/// 删除当前会话（逻辑删除）。
+///
+/// 会话文件原子移动到 `trash/sessions/`，从列表立即消失。
+/// 不做媒体/teams/PTY/browser 清理——那些留给配置页的物理删除。
 #[tauri::command]
-pub async fn delete_session(app: AppHandle, state: State<'_, TiangongApp>) -> Result<(), String> {
+pub async fn delete_session(state: State<'_, TiangongApp>) -> Result<(), String> {
     let deleted_id = state
         .with_state_read(|core_state| Ok(core_state.active_session_id.as_str().to_string()))
         .await?;
@@ -432,49 +435,31 @@ pub async fn delete_session(app: AppHandle, state: State<'_, TiangongApp>) -> Re
         .lock_owned()
         .await;
     let _send_guard = state.session_send_lock(&deleted_id).lock_owned().await;
-    // 附件候选需遍历会话消息;在删除前从磁盘加载(删后文件就没了)。
-    let deleted_session = state.inner().core_manager.load_session(&deleted_id).ok();
-    // 一步完成:retire core(取消在途 turn + 等待写盘) + 删 session.json。
+    // 逻辑删除：原子移动到 trash + 取消 Core。
     state
         .inner()
         .core_manager
         .delete_session(&deleted_id)
         .await
         .map_err(|error| format!("删除会话失败：{error}"))?;
+    // 清理内存状态。
     state.fail_remote_session_waiters(&deleted_id, "目标会话已删除");
-    let mut input_attachments = state
+    state
         .with_state(|core_state| {
-            let mut attachments =
-                crate::state_ops::input_cache(core_state, &deleted_id).attachments;
-            if let Some(session) = &deleted_session {
-                attachments.extend(session_attachment_candidates(session));
-            }
             crate::session_ops::remove_session_state(core_state, &state.core_manager, &deleted_id);
-            Ok(attachments)
+            Ok(())
         })
         .await?;
-    input_attachments.extend(raw_attachments_for_paths(
-        state.release_any_input_send_claim(&deleted_id),
-    ));
+    let _ = state.release_any_input_send_claim(&deleted_id);
     state.clear_agent_worker_view(&deleted_id);
     state.remove_session_send_lock(&deleted_id);
-    // 删除对话后同步销毁终端和浏览器运行时。
-    tiangong_plugin_terminal::destroy_session_pty(&app, &deleted_id);
-    app.state::<tiangong_plugin_browser::BrowserPluginState>()
-        .registry
-        .destroy_session(&deleted_id);
-    if let Err(error) = crate::workspace_tabs::remove_layout(&deleted_id) {
-        warn!(%error, session_id = %deleted_id, "删除工作区标签页布局失败");
-    }
-    cleanup_unreferenced_input_attachments(state.inner(), input_attachments).await;
     Ok(())
 }
 
-/// 删除指定 workspace（cwd）下的所有会话
+/// 删除指定 workspace（cwd）下的所有会话（逻辑删除）。
 #[tauri::command]
 pub async fn delete_sessions_by_cwd(
     cwd: String,
-    app: AppHandle,
     state: State<'_, TiangongApp>,
 ) -> Result<(), String> {
     let mut deleted_ids = state
@@ -498,54 +483,25 @@ pub async fn delete_sessions_by_cwd(
     for id in &deleted_ids {
         send_guards.push(state.session_send_lock(id).lock_owned().await);
     }
-    // 附件候选需遍历会话消息;在删除前从磁盘加载(删后文件就没了)。
-    let deleted_sessions: std::collections::HashMap<String, tiangong_core::session::Session> =
-        deleted_ids
-            .iter()
-            .filter_map(|id| {
-                state
-                    .inner()
-                    .core_manager
-                    .load_session(id)
-                    .ok()
-                    .map(|session| (id.clone(), session))
-            })
-            .collect();
-    // 一步完成:retire core + 删 session.json。
-    for id in &deleted_ids {
-        let _ = state.inner().core_manager.delete_session(id).await;
-        state.fail_remote_session_waiters(id, "目标会话已删除");
-    }
-    let mut input_attachments = state
+    // 并发逻辑删除（原子移动到 trash）。
+    let core_manager = state.inner().core_manager.clone();
+    let deletes = deleted_ids.iter().map(|id| core_manager.delete_session(id));
+    futures_util::future::join_all(deletes).await;
+    // 清理内存状态。
+    state
         .with_state(|core_state| {
-            let mut candidates = Vec::new();
             for id in &deleted_ids {
-                candidates.extend(crate::state_ops::input_cache(core_state, id).attachments);
-                if let Some(session) = deleted_sessions.get(id) {
-                    candidates.extend(session_attachment_candidates(session));
-                }
+                state.fail_remote_session_waiters(id, "目标会话已删除");
                 crate::session_ops::remove_session_state(core_state, &state.core_manager, id);
             }
-            Ok(candidates)
+            Ok(())
         })
         .await?;
     for id in &deleted_ids {
-        input_attachments.extend(raw_attachments_for_paths(
-            state.release_any_input_send_claim(id),
-        ));
-    }
-    // 逐个销毁被删会话的终端和浏览器运行时。
-    let browser_state = app.state::<tiangong_plugin_browser::BrowserPluginState>();
-    for id in &deleted_ids {
-        tiangong_plugin_terminal::destroy_session_pty(&app, id);
-        browser_state.registry.destroy_session(id);
+        let _ = state.release_any_input_send_claim(id);
         state.clear_agent_worker_view(id);
-        if let Err(error) = crate::workspace_tabs::remove_layout(id) {
-            warn!(%error, session_id = %id, "删除工作区标签页布局失败");
-        }
         state.remove_session_send_lock(id);
     }
-    cleanup_unreferenced_input_attachments(state.inner(), input_attachments).await;
     drop(send_guards);
     drop(input_cache_guards);
     Ok(())
@@ -2188,28 +2144,190 @@ pub(crate) fn raw_attachments_for_paths(
         .collect()
 }
 
-pub(crate) fn session_attachment_candidates(
-    session: &tiangong_core::session::Session,
-) -> Vec<tiangong_media_archive::RawAttachment> {
-    let paths = session
-        .messages
-        .iter()
-        .flat_map(|message| {
-            message
-                .extract_media_assets()
-                .into_iter()
-                .map(|asset| asset.url)
-        })
-        .collect::<std::collections::HashSet<_>>()
-        .into_iter()
-        .collect();
-    raw_attachments_for_paths(paths)
-}
-
 /// 为尚未落盘的新会话生成稳定 SCRU128 ID。这里只分配 ID，不创建 Session。
 #[tauri::command]
 pub fn new_session_id() -> String {
     scru128::new().to_string()
+}
+
+// ============================================================================
+// 物理删除（配置页触发）
+// ============================================================================
+
+/// 回收区中的会话摘要（配置页展示用）。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TrashedSession {
+    pub id: String,
+    pub title: String,
+    pub message_count: usize,
+    pub updated_at: String,
+}
+
+/// 物理清理进度事件 payload。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PurgeProgress {
+    pub current: usize,
+    pub total: usize,
+    pub session_id: String,
+    pub title: String,
+    pub status: String, // "cleaning" | "done" | "error"
+}
+
+/// 扫描回收区，返回待物理清理的会话列表。
+#[tauri::command]
+pub async fn list_trashed_sessions(
+    state: State<'_, TiangongApp>,
+) -> Result<Vec<TrashedSession>, String> {
+    let manager = state.core_manager.clone();
+    tokio::task::spawn_blocking(move || {
+        let storage_root = manager.storage_root();
+        let ids = manager.list_trashed_session_ids();
+        let mut result = Vec::with_capacity(ids.len());
+        for id in &ids {
+            // 从 trash 文件加载元数据（只读浅字段）。
+            let trash_path = storage_root
+                .join("trash")
+                .join("sessions")
+                .join(format!("{id}.json"));
+            let summary = std::fs::read_to_string(&trash_path)
+                .ok()
+                .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+                .map(|value| TrashedSession {
+                    id: id.clone(),
+                    title: value
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("（无标题）")
+                        .to_string(),
+                    message_count: value
+                        .get("messages")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.len())
+                        .unwrap_or(0),
+                    updated_at: value
+                        .get("updated_at")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                })
+                .unwrap_or_else(|| TrashedSession {
+                    id: id.clone(),
+                    title: "（无法读取）".to_string(),
+                    message_count: 0,
+                    updated_at: String::new(),
+                });
+            result.push(summary);
+        }
+        result.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(result)
+    })
+    .await
+    .map_err(|error| format!("扫描回收区失败：{error}"))?
+}
+
+/// 物理清理所有回收区会话（配置页"全部清理"触发）。
+///
+/// 逐个清理 media/teams/layout/PTY/browser/trash 文件，通过 `purge_progress`
+/// 事件推送进度。已清理的会话不会重复清理。
+#[tauri::command]
+pub async fn purge_all_deleted_sessions(
+    app: AppHandle,
+    state: State<'_, TiangongApp>,
+) -> Result<usize, String> {
+    use tauri::Emitter;
+
+    let manager = state.core_manager.clone();
+    let trashed_ids = manager.list_trashed_session_ids();
+    let total = trashed_ids.len();
+    if total == 0 {
+        return Ok(0);
+    }
+
+    let storage_root = manager.storage_root().to_path_buf();
+    let media_root = storage_root.join("media");
+    let app_handle = app.clone();
+
+    for (index, session_id) in trashed_ids.iter().enumerate() {
+        // 推送进度：开始清理。
+        let _ = app_handle.emit(
+            "purge_progress",
+            PurgeProgress {
+                current: index,
+                total,
+                session_id: session_id.clone(),
+                title: String::new(),
+                status: "cleaning".to_string(),
+            },
+        );
+
+        // 清理该会话的全部资源。
+        if let Err(error) = purge_session_resources(&storage_root, &media_root, session_id) {
+            warn!(%error, session_id, "物理清理会话资源失败，跳过");
+            let _ = app_handle.emit(
+                "purge_progress",
+                PurgeProgress {
+                    current: index + 1,
+                    total,
+                    session_id: session_id.clone(),
+                    title: String::new(),
+                    status: "error".to_string(),
+                },
+            );
+            continue;
+        }
+
+        // 删 trash 文件。
+        if let Err(error) = manager.delete_trashed_session(session_id) {
+            warn!(%error, session_id, "删除回收区文件失败");
+        }
+
+        // 推送进度：完成。
+        let _ = app_handle.emit(
+            "purge_progress",
+            PurgeProgress {
+                current: index + 1,
+                total,
+                session_id: session_id.clone(),
+                title: String::new(),
+                status: "done".to_string(),
+            },
+        );
+    }
+
+    // 清理运行时（PTY/browser）—— 这些需要 AppHandle。
+    for session_id in &trashed_ids {
+        tiangong_plugin_terminal::destroy_session_pty(&app, session_id);
+        if let Some(browser_state) = app.try_state::<tiangong_plugin_browser::BrowserPluginState>()
+        {
+            browser_state.registry.destroy_session(session_id);
+        }
+        if let Err(error) = crate::workspace_tabs::remove_layout(session_id) {
+            warn!(%error, session_id, "删除工作区标签页布局失败");
+        }
+    }
+
+    Ok(total)
+}
+
+/// 清理单个会话的磁盘资源（media/teams/trash 文件）。不含 PTY/browser 运行时。
+fn purge_session_resources(
+    storage_root: &std::path::Path,
+    media_root: &std::path::Path,
+    session_id: &str,
+) -> Result<(), String> {
+    // 删媒体目录（按会话隔离的新版结构）。
+    let session_media = media_root.join(session_id);
+    if session_media.exists() {
+        std::fs::remove_dir_all(&session_media)
+            .map_err(|error| format!("删除媒体目录失败：{error}"))?;
+    }
+    // 删 teams 目录。
+    let teams_dir = storage_root.join("teams").join(session_id);
+    if teams_dir.exists() {
+        std::fs::remove_dir_all(&teams_dir)
+            .map_err(|error| format!("删除 teams 目录失败：{error}"))?;
+    }
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -481,7 +481,7 @@ pub async fn delete_session(state: State<'_, TiangongApp>) -> Result<(), String>
 pub async fn delete_sessions_by_cwd(
     cwd: String,
     state: State<'_, TiangongApp>,
-) -> Result<Vec<String>, String> {
+) -> Result<DeleteResult, String> {
     let mut deleted_ids = state
         .with_state_read(|core_state| {
             let ids: Vec<String> = core_state
@@ -548,7 +548,10 @@ pub async fn delete_sessions_by_cwd(
             "批量删除部分失败"
         );
     }
-    Ok(succeeded_ids)
+    Ok(DeleteResult {
+        succeeded: succeeded_ids,
+        failed: failed_ids,
+    })
 }
 
 /// 失败回滚只能关闭本次 ensure 绑定的实例，并且必须等待 worker 最终写盘结束，
@@ -2198,6 +2201,15 @@ pub fn new_session_id() -> String {
 // 物理删除（配置页触发）
 // ============================================================================
 
+/// 批量删除结果。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DeleteResult {
+    /// 实际删除成功的会话 ID 列表。
+    pub succeeded: Vec<String>,
+    /// 删除失败的会话 ID 列表。
+    pub failed: Vec<String>,
+}
+
 /// 回收区中的会话摘要（配置页展示用）。
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct TrashedSession {
@@ -2322,22 +2334,43 @@ pub async fn purge_all_deleted_sessions(
             },
         );
 
-        // 清理该会话的全部资源（media/teams）。
-        let mut failed = false;
-        if let Err(error) = purge_session_resources(&storage_root, &media_root, session_id) {
-            warn!(%error, session_id, "物理清理会话资源失败");
-            failed = true;
+        // 按依赖顺序清理所有可能失败的资源：
+        // 1. media/teams 目录
+        // 2. workspace-tab-layouts 布局文件
+        // 3. PTY/browser 运行时（destroy 操作本身不返回错误，但布局删除会）
+        // 全部成功后才删 trash 文件——trash 文件是重试的凭证，保留到最后一刻。
+        let mut error_msg: Option<String> = None;
+
+        if let Err(e) = purge_session_resources(&storage_root, &media_root, session_id) {
+            error_msg = Some(e);
         }
 
-        // 删 trash 文件。失败视为该会话清理失败。
-        if !failed {
-            if let Err(error) = manager.delete_trashed_session(session_id) {
-                warn!(%error, session_id, "删除回收区文件失败");
-                failed = true;
+        if error_msg.is_none() {
+            if let Err(e) = crate::workspace_tabs::remove_layout(session_id) {
+                warn!(%e, session_id, "删除工作区标签页布局失败");
+                error_msg = Some(format!("删除布局失败：{e}"));
             }
         }
 
-        if failed {
+        // PTY/browser 运行时销毁（这些不返回错误，尽力清理）。
+        if error_msg.is_none() {
+            tiangong_plugin_terminal::destroy_session_pty(&app, session_id);
+            if let Some(browser_state) =
+                app.try_state::<tiangong_plugin_browser::BrowserPluginState>()
+            {
+                browser_state.registry.destroy_session(session_id);
+            }
+        }
+
+        // 所有资源清理成功 → 删 trash 文件（回收区记录不再需要）。
+        if error_msg.is_none() {
+            if let Err(e) = manager.delete_trashed_session(session_id) {
+                error_msg = Some(format!("删除回收区文件失败：{e}"));
+            }
+        }
+
+        if let Some(msg) = error_msg {
+            warn!(%msg, session_id, "物理清理会话失败，保留回收区记录");
             let _ = app_handle.emit(
                 "purge_progress",
                 PurgeProgress {
@@ -2353,7 +2386,6 @@ pub async fn purge_all_deleted_sessions(
 
         succeeded.push(session_id.clone());
 
-        // 推送进度：完成。
         let _ = app_handle.emit(
             "purge_progress",
             PurgeProgress {
@@ -2364,18 +2396,6 @@ pub async fn purge_all_deleted_sessions(
                 status: "done".to_string(),
             },
         );
-    }
-
-    // 只清理成功项的运行时（PTY/browser/layout）。
-    for session_id in &succeeded {
-        tiangong_plugin_terminal::destroy_session_pty(&app, session_id);
-        if let Some(browser_state) = app.try_state::<tiangong_plugin_browser::BrowserPluginState>()
-        {
-            browser_state.registry.destroy_session(session_id);
-        }
-        if let Err(error) = crate::workspace_tabs::remove_layout(session_id) {
-            warn!(%error, session_id, "删除工作区标签页布局失败");
-        }
     }
 
     Ok(succeeded.len())

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2225,6 +2225,18 @@ pub async fn list_trashed_sessions(
     .map_err(|error| format!("扫描回收区失败：{error}"))?
 }
 
+/// 从回收区恢复单个会话（trash/sessions/ → sessions/）。
+#[tauri::command]
+pub async fn restore_deleted_session(
+    session_id: String,
+    state: State<'_, TiangongApp>,
+) -> Result<(), String> {
+    let manager = state.core_manager.clone();
+    tokio::task::spawn_blocking(move || manager.restore_session_file(&session_id))
+        .await
+        .map_err(|error| format!("恢复任务失败：{error}"))?
+}
+
 /// 物理清理所有回收区会话（配置页"全部清理"触发）。
 ///
 /// 逐个清理 media/teams/layout/PTY/browser/trash 文件，通过 `purge_progress`

--- a/src-tauri/src/embedded_server.rs
+++ b/src-tauri/src/embedded_server.rs
@@ -545,33 +545,18 @@ async fn delete_session(
 
     let _cache_guard = state.input_cache_update_lock(session_id).lock_owned().await;
     let _send_guard = state.session_send_lock(session_id).lock_owned().await;
-    // 附件候选需遍历会话消息;在删除前从磁盘加载(删后文件就没了)。
-    let deleted_session = state.core_manager.load_session(session_id).ok();
-    // 一步完成:retire core(取消在途 turn + 等待写盘) + 删 session.json。
-    let _ = state.core_manager.delete_session(session_id).await;
+    // 逻辑删除：原子移动到 trash + 取消 Core。
+    state.core_manager.delete_session(session_id).await?;
+    // 清理内存状态。
     state.fail_remote_session_waiters(session_id, "目标会话已删除");
-    let mut attachments = state
+    state
         .with_state(|core_state| {
-            let mut attachments = crate::state_ops::input_cache(core_state, session_id).attachments;
-            if let Some(session) = &deleted_session {
-                attachments.extend(crate::commands::session_attachment_candidates(session));
-            }
             crate::session_ops::remove_session_state(core_state, &state.core_manager, session_id);
-            Ok(attachments)
+            Ok(())
         })
         .await?;
-    attachments.extend(crate::commands::raw_attachments_for_paths(
-        state.release_any_input_send_claim(session_id),
-    ));
+    let _ = state.release_any_input_send_claim(session_id);
     state.remove_session_send_lock(session_id);
-    tiangong_plugin_terminal::destroy_session_pty(app, session_id);
-    if let Some(browser_state) = app.try_state::<tiangong_plugin_browser::BrowserPluginState>() {
-        browser_state.registry.destroy_session(session_id);
-    }
-    if let Err(error) = crate::workspace_tabs::remove_layout(session_id) {
-        tracing::warn!(%error, %session_id, "删除工作区标签页布局失败");
-    }
-    crate::commands::cleanup_unreferenced_input_attachments(state, attachments).await;
     let _ = app.emit("sessions_updated", &());
     Ok(true)
 }

--- a/src-tauri/src/embedded_server.rs
+++ b/src-tauri/src/embedded_server.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Manager};
 use tiangong_core::permission::TrustMode;
 use tiangong_core::session::MessageRole;
 use tiangong_server::remote::backend::{CoreBackendKind, ServerCoreBackend};
@@ -526,7 +526,7 @@ pub(crate) async fn complete_remote_turn_from_stream(
 }
 
 async fn delete_session(
-    app: &AppHandle,
+    _app: &AppHandle,
     state: &TiangongApp,
     session_id: &str,
 ) -> HostResult<bool> {

--- a/src-tauri/src/embedded_server.rs
+++ b/src-tauri/src/embedded_server.rs
@@ -557,7 +557,7 @@ async fn delete_session(
         .await?;
     let _ = state.release_any_input_send_claim(session_id);
     state.remove_session_send_lock(session_id);
-    let _ = app.emit("sessions_updated", &());
+    // 不 emit sessions_updated：前端已本地移除会话，不需要全量刷新。
     Ok(true)
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -368,6 +368,7 @@ fn run_gui() {
         })
         .invoke_handler(tauri::generate_handler![
             tiangong_app::commands::get_sessions,
+            tiangong_app::commands::get_session_meta,
             tiangong_app::commands::get_session_tabs,
             tiangong_app::commands::set_session_tabs,
             tiangong_app::commands::switch_session,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -376,6 +376,7 @@ fn run_gui() {
             tiangong_app::commands::delete_sessions_by_cwd,
             tiangong_app::commands::list_trashed_sessions,
             tiangong_app::commands::purge_all_deleted_sessions,
+            tiangong_app::commands::restore_deleted_session,
             tiangong_app::commands::update_session_title,
             tiangong_app::commands::request_desktop_notification_permission,
             tiangong_app::commands::send_desktop_notification,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -374,6 +374,8 @@ fn run_gui() {
             tiangong_app::commands::load_session,
             tiangong_app::commands::delete_session,
             tiangong_app::commands::delete_sessions_by_cwd,
+            tiangong_app::commands::list_trashed_sessions,
+            tiangong_app::commands::purge_all_deleted_sessions,
             tiangong_app::commands::update_session_title,
             tiangong_app::commands::request_desktop_notification_permission,
             tiangong_app::commands::send_desktop_notification,


### PR DESCRIPTION
## 改动概述

将删除对话从"立即物理删除"改为"逻辑删除 + 配置页手动物理删除"，彻底解决删除慢和删除后卡顿问题。

## 改动内容

### 逻辑删除（用户点删除时）
- 会话文件原子移动到 `trash/sessions/`（同文件系统 rename，微秒级）
- 从列表立即消失，不做任何媒体/teams/PTY/browser 清理
- CoreManager::delete_session 先等 worker 退出再移文件，防止迟到写盘复活
- 前端删除后本地移除会话，不重新拉列表
- 删除按钮按目标会话 ID 删除（不误删当前会话）
- 正在运行的会话不显示删除按钮

### 物理删除（配置页手动触发）
- 设置页新增"数据清理"tab（位于"关于与更新"上方）
- 扫描回收区会话列表（标题/用户消息数/更新时间）
- 进度条实时显示清理进度
- 两阶段清理：先移到 `trash/purging/` → 清全部资源 → 全部成功才删记录
- 任何步骤失败保留记录，下次"全部清理"可重试
- purging 中的会话不提供恢复按钮（资源可能已部分删除）
- 恢复功能：从回收区移回正常目录

### 性能优化
- SessionMetadata::load_from_storage 改为 serde_json::Value 只读浅字段，不反序列化 messages
- turn 结束后 emit `session_meta_updated`（带 session_id），前端精确更新单条，不全量拉列表
- 新增 get_session_meta 命令只读单条会话元数据

### 安全性
- delete_session 入口对 session_id 做路径安全校验（拒绝 `..`、绝对路径、分隔符）
- 批量删除返回成功/失败列表，前端只移除成功的会话
- 批量删除失败时 Toast 提示用户

## 验证
- cargo check + cargo clippy（零警告）+ cargo test（17 个测试通过）
- yarn build + yarn test（前端构建和测试通过）

## 测试
- CoreManager 17 个单元测试覆盖：trash/逻辑删除/恢复/冲突检测/并发安全