### PR TITLE
fix(plugin): 修复 Windows 下插件删除、升级及终端闪现异常

### DIFF
--- a/crates/tiangong-plugin-runtime/src/adapter.rs
+++ b/crates/tiangong-plugin-runtime/src/adapter.rs
@@ -33,7 +33,7 @@ use crate::loader::WasmPlugin;
 /// 注意：Wasmtime 的 Store 要求 `Send`（Engine 编译产物可跨线程），故
 /// `Arc<Mutex<WasmPlugin>>` 可用于 `spawn_blocking`。
 pub struct WasmPluginAdapter {
-    inner: RwLock<Arc<Mutex<WasmPlugin>>>,
+    inner: RwLock<Option<Arc<Mutex<WasmPlugin>>>>,
     config: PluginRuntimeConfig,
     /// 插件 id，构造期确定后不变。
     id: String,
@@ -69,7 +69,7 @@ impl WasmPluginAdapter {
             .map(|d| d.id)
             .unwrap_or_else(|_| "wasm-unknown".to_string());
         Self {
-            inner: RwLock::new(inner),
+            inner: RwLock::new(Some(inner)),
             id: id_string,
             config,
             feedback_tx: RwLock::new(None),
@@ -88,7 +88,7 @@ impl WasmPluginAdapter {
         sidecar: Option<Arc<dyn SidecarConnection>>,
     ) -> Self {
         Self {
-            inner: RwLock::new(Arc::new(Mutex::new(plugin))),
+            inner: RwLock::new(Some(Arc::new(Mutex::new(plugin)))),
             id,
             config,
             feedback_tx: RwLock::new(None),
@@ -104,11 +104,6 @@ impl WasmPluginAdapter {
 
     pub(crate) fn is_enabled(&self) -> bool {
         self.enabled.load(Ordering::Acquire)
-    }
-
-    /// 返回内部 WasmPlugin 句柄的引用（供全局注册表查询 contributions/config）。
-    pub fn inner_handle(&self) -> Arc<Mutex<WasmPlugin>> {
-        self.current_inner()
     }
 
     pub(crate) fn runtime_config(&self) -> PluginRuntimeConfig {
@@ -148,10 +143,23 @@ impl WasmPluginAdapter {
             .inner
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        *current = replacement;
+        *current = Some(replacement);
     }
 
-    fn current_inner(&self) -> Arc<Mutex<WasmPlugin>> {
+    /// 卸载内部 WASM 实例（drop Store），释放其对插件目录的 WASI preopen 句柄。
+    ///
+    /// Windows 上 cap-std 打开目录不带 FILE_SHARE_DELETE，只要 Store 还持有该目录，
+    /// 安装目录就无法 rename/delete，升级与卸载会失败。在改写目录前调用本方法释放句柄，
+    /// 后续 reload 会重建实例。
+    pub(crate) fn release_inner(&self) {
+        let mut current = self
+            .inner
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *current = None;
+    }
+
+    fn current_inner(&self) -> Option<Arc<Mutex<WasmPlugin>>> {
         self.inner
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -302,7 +310,10 @@ impl WasmPluginAdapter {
     where
         R: Send,
     {
-        call_wasm_off_runtime(self.current_inner(), call)
+        let inner = self
+            .current_inner()
+            .ok_or_else(|| anyhow::anyhow!("wasm 插件实例已卸载"))?;
+        call_wasm_off_runtime(inner, call)
     }
 
     /// 序列化 PluginSession 只读快照，在独立线程调 WASM 钩子。失败仅 warn。
@@ -388,7 +399,9 @@ impl WasmPluginAdapter {
         if !self.is_enabled() {
             return;
         }
-        let inner = self.current_inner();
+        let Some(inner) = self.current_inner() else {
+            return;
+        };
         let plugin_id = self.id.clone();
         let hook_thread_id = plugin_id.clone();
         if let Err(error) = std::thread::Builder::new()
@@ -427,7 +440,9 @@ impl WasmPluginAdapter {
         if !self.is_enabled() {
             return;
         }
-        let inner = self.current_inner();
+        let Some(inner) = self.current_inner() else {
+            return;
+        };
         let plugin_id = self.id.clone();
         let hook_thread_id = plugin_id.clone();
         let idx = turn_start_idx as u32;
@@ -486,7 +501,9 @@ impl ToolOverrideHandler for WasmPluginAdapter {
             name: call.name.clone(),
             arguments,
         };
-        let inner = self.current_inner();
+        let Some(inner) = self.current_inner() else {
+            return Box::pin(async { None });
+        };
         let config = self.config.clone();
         Box::pin(async move {
             let result = task::spawn_blocking(move || {

--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -951,6 +951,7 @@ pub fn uninstall_plugin(storage_root: &Path, plugin_id: &str, keep_data: bool) -
     // 不一并停止会导致 Windows 上二进制文件被占用、卸载删除失败。
     stop_connection_for_directory(&installed.directory)?;
     kill_sidecar_orphans(&installed);
+    unload_plugin_wasm(plugin_id);
 
     let removed = transaction_directory(storage_root, "uninstall")?;
     rename_with_retry(&installed.directory, &removed)?;
@@ -1097,6 +1098,7 @@ fn replace_installed_plugin(
     // 避免 Windows 上旧进程占用导致目录切换或旧文件清理失败。
     stop_connection_for_directory(&current.directory)?;
     kill_sidecar_orphans(current);
+    unload_plugin_wasm(&current.manifest.id);
     let rollback = rollback_directory(&current.directory, &current.manifest.id);
     if let Some(parent) = rollback.parent() {
         std::fs::create_dir_all(parent)?;
@@ -1473,6 +1475,37 @@ fn kill_sidecar_orphans(installed: &InstalledPlugin) {
     let binary = sidecar_binary_path(&installed.directory, &sidecar.binary)
         .unwrap_or_else(|_| installed.directory.join(&sidecar.binary));
     crate::sidecar::kill_sidecar_processes_by_image(&binary);
+}
+
+/// 卸载插件的 WASM 实例（drop Store），释放其对安装目录的 WASI preopen 句柄。
+///
+/// Windows 上 cap-std 打开目录不带 FILE_SHARE_DELETE，已加载实例的 Store 会长期持有
+/// 安装目录句柄，阻止其被 rename/delete，导致升级切换、卸载删除失败（code=32）。
+/// 在改写目录前调用本函数清空实例，让目录可被改写；后续 reload 会重建实例。
+fn unload_plugin_wasm(plugin_id: &str) {
+    let adapters = {
+        let mut plugins = match loaded_plugins().lock() {
+            Ok(plugins) => plugins,
+            Err(error) => {
+                tracing::error!(plugin_id, %error, "插件注册表已损坏，无法卸载 WASM 实例");
+                return;
+            }
+        };
+        let Some(loaded) = plugins.get_mut(plugin_id) else {
+            return;
+        };
+        loaded.ui_plugin = None;
+        loaded.component = None;
+        loaded.wasm_bytes = None;
+        loaded
+            .instances
+            .iter()
+            .filter_map(Weak::upgrade)
+            .collect::<Vec<_>>()
+    };
+    for adapter in adapters {
+        adapter.release_inner();
+    }
 }
 
 fn remove_sidecar_connection(directory: &Path) {

--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -947,6 +947,9 @@ pub fn uninstall_plugin(storage_root: &Path, plugin_id: &str, keep_data: bool) -
         );
     }
     stop_loaded_sidecar(plugin_id)?;
+    // 补齐连接表兜底：插件不在 loaded_plugins 时，仍可能保留在 sidecar 连接表中，
+    // 不一并停止会导致 Windows 上二进制文件被占用、卸载删除失败。
+    stop_connection_for_directory(&installed.directory)?;
 
     let removed = transaction_directory(storage_root, "uninstall")?;
     std::fs::rename(&installed.directory, &removed)
@@ -1090,6 +1093,9 @@ fn replace_installed_plugin(
     manifest: PluginManifest,
 ) -> Result<PluginStatus> {
     stop_loaded_sidecar(&current.manifest.id)?;
+    // 升级同样补齐连接表兜底，确保旧 sidecar 进程被停止后再替换二进制文件，
+    // 避免 Windows 上旧进程占用导致目录切换或旧文件清理失败。
+    stop_connection_for_directory(&current.directory)?;
     let rollback = rollback_directory(&current.directory, &current.manifest.id);
     if let Some(parent) = rollback.parent() {
         std::fs::create_dir_all(parent)?;

--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -950,6 +950,7 @@ pub fn uninstall_plugin(storage_root: &Path, plugin_id: &str, keep_data: bool) -
     // 补齐连接表兜底：插件不在 loaded_plugins 时，仍可能保留在 sidecar 连接表中，
     // 不一并停止会导致 Windows 上二进制文件被占用、卸载删除失败。
     stop_connection_for_directory(&installed.directory)?;
+    kill_sidecar_orphans(&installed);
 
     let removed = transaction_directory(storage_root, "uninstall")?;
     rename_with_retry(&installed.directory, &removed)?;
@@ -1095,6 +1096,7 @@ fn replace_installed_plugin(
     // 升级同样补齐连接表兜底，确保旧 sidecar 进程被停止后再替换二进制文件，
     // 避免 Windows 上旧进程占用导致目录切换或旧文件清理失败。
     stop_connection_for_directory(&current.directory)?;
+    kill_sidecar_orphans(current);
     let rollback = rollback_directory(&current.directory, &current.manifest.id);
     if let Some(parent) = rollback.parent() {
         std::fs::create_dir_all(parent)?;
@@ -1358,14 +1360,21 @@ fn retry_io<F>(mut operation: F) -> Result<()>
 where
     F: FnMut() -> std::io::Result<()>,
 {
-    const MAX_WAIT: Duration = Duration::from_secs(3);
+    const MAX_WAIT: Duration = Duration::from_secs(8);
     const INTERVAL: Duration = Duration::from_millis(100);
     let deadline = Instant::now() + MAX_WAIT;
+    let mut warned = false;
     loop {
         match operation() {
             Ok(()) => return Ok(()),
             Err(error) if is_file_locked(&error) && Instant::now() < deadline => {
-                tracing::debug!(error = %error, "文件操作因占用暂时失败，稍后重试");
+                if !warned {
+                    warned = true;
+                    tracing::warn!(
+                        code = error.raw_os_error(),
+                        "文件被占用，开始等待重试（进程退出后句柄或杀毒扫描释放可能有延迟）"
+                    );
+                }
                 std::thread::sleep(INTERVAL);
             }
             Err(error) => return Err(anyhow::Error::from(error)),
@@ -1450,6 +1459,20 @@ fn stop_connection_for_directory(directory: &Path) -> Result<()> {
     }
     remove_sidecar_connection(directory);
     Ok(())
+}
+
+/// 兜底按二进制 image 名清理该插件的所有残留 sidecar 进程。
+///
+/// 注册表里的连接未必覆盖全部进程——热加载覆盖连接时旧 sidecar 进程可能成为
+/// 孤儿，持续占用二进制文件。升级/卸载改写二进制前按 image 名再清一遍，避免
+/// 目录改名/删除因文件被占用而失败。
+fn kill_sidecar_orphans(installed: &InstalledPlugin) {
+    let Some(sidecar) = installed.manifest.sidecar.as_ref() else {
+        return;
+    };
+    let binary = sidecar_binary_path(&installed.directory, &sidecar.binary)
+        .unwrap_or_else(|_| installed.directory.join(&sidecar.binary));
+    crate::sidecar::kill_sidecar_processes_by_image(&binary);
 }
 
 fn remove_sidecar_connection(directory: &Path) {

--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use semver::Version;
@@ -952,18 +952,17 @@ pub fn uninstall_plugin(storage_root: &Path, plugin_id: &str, keep_data: bool) -
     stop_connection_for_directory(&installed.directory)?;
 
     let removed = transaction_directory(storage_root, "uninstall")?;
-    std::fs::rename(&installed.directory, &removed)
-        .with_context(|| format!("移动待卸载插件目录失败: {}", installed.directory.display()))?;
+    rename_with_retry(&installed.directory, &removed)?;
     let uninstall_result = if keep_data {
         preserve_only_data(&removed, &installed.directory)
     } else {
         remove_directory_if_exists(&removed)
     };
     if let Err(error) = uninstall_result {
+        tracing::error!(plugin_id, %error, "卸载插件删除目录失败，尝试恢复插件");
         let restore_result = (|| {
             remove_directory_if_exists(&installed.directory)?;
-            std::fs::rename(&removed, &installed.directory)
-                .with_context(|| format!("恢复插件目录失败: {}", installed.directory.display()))?;
+            rename_with_retry(&removed, &installed.directory)?;
             reload_plugin_inner(storage_root, &installed)
         })();
         if let Err(restore_error) = restore_result {
@@ -1109,13 +1108,14 @@ fn replace_installed_plugin(
     };
 
     let switch_result = (|| {
-        std::fs::rename(&current.directory, &rollback)?;
+        rename_with_retry(&current.directory, &rollback)?;
         move_preserved_entries(&rollback, staged_path)?;
         set_disabled_marker(staged_path, !current.enabled)?;
-        std::fs::rename(staged_path, &current.directory)?;
+        rename_with_retry(staged_path, &current.directory)?;
         Ok::<_, anyhow::Error>(())
     })();
     if let Err(error) = switch_result {
+        tracing::error!(plugin_id = %current.manifest.id, %error, "切换插件目录失败，尝试恢复旧版本");
         let _ = restore_upgrade_directories(staged_path, &current.directory, &rollback);
         let _ = restore_saved_rollback(&rollback, saved_rollback.as_deref());
         let _ = reload_plugin_inner(storage_root, current);
@@ -1129,6 +1129,7 @@ fn replace_installed_plugin(
         signed_release: verify_signed_release(&current.directory, &manifest)?,
     };
     if let Err(error) = reload_plugin_inner(storage_root, &upgraded) {
+        tracing::error!(plugin_id = %current.manifest.id, %error, "升级后重新加载插件失败，尝试恢复旧版本");
         let _ = stop_connection_for_directory(&current.directory);
         let restore_result =
             restore_upgrade_directories(staged_path, &current.directory, &rollback)
@@ -1154,7 +1155,7 @@ fn replace_installed_plugin(
 
 fn restore_upgrade_directories(staged: &Path, destination: &Path, rollback: &Path) -> Result<()> {
     if destination.exists() {
-        std::fs::rename(destination, staged)?;
+        rename_with_retry(destination, staged)?;
     }
     if PRESERVED_ENTRIES
         .iter()
@@ -1163,7 +1164,7 @@ fn restore_upgrade_directories(staged: &Path, destination: &Path, rollback: &Pat
         move_preserved_entries(staged, rollback)?;
     }
     if rollback.exists() {
-        std::fs::rename(rollback, destination)?;
+        rename_with_retry(rollback, destination)?;
     }
     Ok(())
 }
@@ -1273,17 +1274,11 @@ fn move_preserved_entries(source: &Path, destination: &Path) -> Result<()> {
             continue;
         }
         let destination_entry = destination.join(entry);
-        if let Err(error) = std::fs::rename(&source_entry, &destination_entry) {
+        if let Err(error) = rename_with_retry(&source_entry, &destination_entry) {
             for moved_entry in moved.into_iter().rev() {
                 let _ = std::fs::rename(destination.join(moved_entry), source.join(moved_entry));
             }
-            return Err(error).with_context(|| {
-                format!(
-                    "迁移插件目录失败: {} -> {}",
-                    source_entry.display(),
-                    destination_entry.display()
-                )
-            });
+            return Err(error);
         }
         moved.push(entry);
     }
@@ -1346,12 +1341,50 @@ fn ensure_directory(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// 判断 IO 错误是否源于文件被占用。
+///
+/// Windows 上停止 sidecar 进程后，其二进制 image 的文件锁释放可能滞后于进程退出，
+/// 紧随其后的目录改名/删除会撞上占用。ACCESS_DENIED(5) 与 SHARING_VIOLATION(32)
+/// 即此类暂时性占用；其它平台极少出现，保留判断以备用。
+fn is_file_locked(error: &std::io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(5) | Some(32))
+}
+
+/// 对暂时性文件占用做有限重试的 IO 包装。
+///
+/// 这类占用通常在进程退出后数百毫秒内自行释放，故按固定间隔重试至超时；
+/// 非占用错误立即向上抛出，避免无谓等待。
+fn retry_io<F>(mut operation: F) -> Result<()>
+where
+    F: FnMut() -> std::io::Result<()>,
+{
+    const MAX_WAIT: Duration = Duration::from_secs(3);
+    const INTERVAL: Duration = Duration::from_millis(100);
+    let deadline = Instant::now() + MAX_WAIT;
+    loop {
+        match operation() {
+            Ok(()) => return Ok(()),
+            Err(error) if is_file_locked(&error) && Instant::now() < deadline => {
+                tracing::debug!(error = %error, "文件操作因占用暂时失败，稍后重试");
+                std::thread::sleep(INTERVAL);
+            }
+            Err(error) => return Err(anyhow::Error::from(error)),
+        }
+    }
+}
+
+/// 重命名文件/目录，遇到暂时性占用时重试。
+fn rename_with_retry(from: &Path, to: &Path) -> Result<()> {
+    retry_io(|| std::fs::rename(from, to))
+        .with_context(|| format!("重命名失败: {} -> {}", from.display(), to.display()))
+}
+
 fn remove_directory_if_exists(path: &Path) -> Result<()> {
     match std::fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
             bail!("拒绝删除符号链接目录: {}", path.display())
         }
-        Ok(_) => std::fs::remove_dir_all(path)
+        Ok(_) => retry_io(|| std::fs::remove_dir_all(path))
             .with_context(|| format!("删除目录失败: {}", path.display())),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error).with_context(|| format!("读取目录失败: {}", path.display())),

--- a/crates/tiangong-plugin-runtime/src/sidecar.rs
+++ b/crates/tiangong-plugin-runtime/src/sidecar.rs
@@ -304,7 +304,11 @@ impl ProcessSidecarConnection {
         self.health_check().is_ok()
     }
 
-    /// 停止当前插件对应的 sidecar。插件身份握手失败时不终止进程，避免误伤其他服务。
+    /// 停止当前插件对应的 sidecar。
+    ///
+    /// 握手确认身份后终止进程；握手不可用（连不上）但进程仍存活时同样终止——
+    /// Windows 上进程卡住、IPC 挂掉时常见这种状态，若不杀掉会持续占用二进制文件，
+    /// 导致后续删除/升级失败。仅当身份明确不匹配（防 PID 复用误伤）时才放过。
     pub fn stop(&self) -> Result<()> {
         let endpoint = match load_endpoint(&self.config.endpoint) {
             Ok(endpoint) => endpoint,
@@ -319,29 +323,24 @@ impl ProcessSidecarConnection {
             Err(error) => return Err(error),
         };
 
-        match self.verify_plugin_identity() {
-            Ok(()) => {}
+        let should_terminate = match self.verify_plugin_identity() {
+            Ok(()) => true,
             Err(error)
                 if error
                     .downcast_ref::<SidecarInvokeError>()
                     .is_some_and(|error| matches!(error, SidecarInvokeError::Unavailable(_))) =>
             {
-                let _ = std::fs::remove_file(&self.config.endpoint);
-                return Ok(());
+                // 握手连不上：进程可能已退出，也可能卡住。仅在进程仍存活时终止；
+                // 已退出则视为完成，避免对不存在的进程发起 kill/taskkill。
+                process_alive(endpoint.pid)
             }
+            // 身份不匹配等其它错误：不终止进程，避免误伤其他服务。
             Err(error) => return Err(error),
-        }
+        };
 
-        terminate_process(endpoint.pid)?;
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while Instant::now() < deadline {
-            let same_process = load_endpoint(&self.config.endpoint)
-                .map(|current| current.pid == endpoint.pid)
-                .unwrap_or(false);
-            if !same_process {
-                return Ok(());
-            }
-            std::thread::sleep(Duration::from_millis(50));
+        if should_terminate {
+            terminate_process(endpoint.pid)?;
+            wait_for_process_exit(endpoint.pid, Duration::from_secs(5))?;
         }
         let _ = std::fs::remove_file(&self.config.endpoint);
         Ok(())
@@ -641,6 +640,46 @@ fn write_frame(stream: &mut TcpStream, frame: &IpcFrame) -> Result<()> {
 }
 
 #[cfg(unix)]
+fn process_alive(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    // SAFETY: kill(pid, 0) 仅检测进程是否存在，信号 0 不实际发送信号。
+    let result = unsafe { libc::kill(pid, 0) };
+    if result == 0 {
+        return true;
+    }
+    // ESRCH 表示进程不存在；其它错误（如 EPERM，进程存在但无权限）视为存活。
+    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+#[cfg(windows)]
+fn process_alive(pid: u32) -> bool {
+    let mut command = Command::new("tasklist");
+    suppress_console(&mut command);
+    command
+        .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+        .output()
+        .is_ok_and(|output| String::from_utf8_lossy(&output.stdout).contains(&pid.to_string()))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn process_alive(_pid: u32) -> bool {
+    false
+}
+
+/// 为 taskkill/tasklist 等辅助命令抑制 Windows 控制台窗口。
+///
+/// 与拉起 sidecar 用的 [`configure_detached`] 不同：这里只需 CREATE_NO_WINDOW，
+/// 无需 DETACHED_PROCESS（辅助命令短暂运行即退出）。
+#[cfg(windows)]
+fn suppress_console(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    command.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(unix)]
 fn terminate_process(pid: u32) -> Result<()> {
     let pid = i32::try_from(pid).with_context(|| "sidecar PID 超出系统范围")?;
     // SAFETY: kill 只向已通过握手确认的 sidecar PID 发送 SIGTERM。
@@ -658,7 +697,9 @@ fn terminate_process(pid: u32) -> Result<()> {
 
 #[cfg(windows)]
 fn terminate_process(pid: u32) -> Result<()> {
-    let status = Command::new("taskkill")
+    let mut command = Command::new("taskkill");
+    suppress_console(&mut command);
+    let status = command
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .status()
         .with_context(|| format!("停止 sidecar 进程失败: pid={pid}"))?;
@@ -672,6 +713,25 @@ fn terminate_process(pid: u32) -> Result<()> {
 #[cfg(not(any(unix, windows)))]
 fn terminate_process(_pid: u32) -> Result<()> {
     bail!("当前平台不支持停止 sidecar 进程")
+}
+
+/// 终止 sidecar 后轮询进程是否真正退出。
+///
+/// 不能依赖 endpoint 文件：Windows `taskkill /F` 强杀不触发 sidecar 析构，
+/// endpoint 永不被清理。这里直接轮询进程本身，进程退出后再给文件句柄一点
+/// 释放缓冲，确保后续删除/覆盖二进制不会因句柄占用失败。
+fn wait_for_process_exit(pid: u32, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !process_alive(pid) {
+            // Windows 上进程对象销毁与文件句柄释放可能略滞后于进程退出。
+            #[cfg(windows)]
+            std::thread::sleep(Duration::from_millis(100));
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    bail!("等待 sidecar 进程退出超时: pid={pid}")
 }
 
 #[cfg(unix)]

--- a/crates/tiangong-plugin-runtime/src/sidecar.rs
+++ b/crates/tiangong-plugin-runtime/src/sidecar.rs
@@ -668,6 +668,30 @@ fn process_alive(_pid: u32) -> bool {
     false
 }
 
+/// 按 image 名清理指定 sidecar 二进制的所有残留进程。
+///
+/// 升级/卸载时停掉注册表里的连接未必覆盖全部进程——热加载覆盖连接时，旧 sidecar
+/// 进程可能未被停止而成为孤儿，持续占用二进制文件，导致目录改名/删除失败。此处
+/// 按二进制文件名兜底清理该 image 的全部进程（taskkill /IM 在无匹配进程时直接
+/// 失败，属正常情况，忽略即可）。
+#[cfg(windows)]
+pub fn kill_sidecar_processes_by_image(binary: &Path) {
+    let Some(name) = binary.file_name().and_then(|value| value.to_str()) else {
+        return;
+    };
+    let mut command = Command::new("taskkill");
+    suppress_console(&mut command);
+    let status = command.args(["/IM", name, "/F"]).status();
+    if let Ok(status) = status
+        && status.success()
+    {
+        tracing::info!(image = %name, "已清理残留 sidecar 进程");
+    }
+}
+
+#[cfg(not(windows))]
+pub fn kill_sidecar_processes_by_image(_binary: &Path) {}
+
 /// 为 taskkill/tasklist 等辅助命令抑制 Windows 控制台窗口。
 ///
 /// 与拉起 sidecar 用的 [`configure_detached`] 不同：这里只需 CREATE_NO_WINDOW，


### PR DESCRIPTION
## 背景

Windows 环境下插件管理存在三个问题（Mac/Unix 均正常，仅 Windows 受影响）：

1. 无法正常删除插件（卸载后插件被自动恢复）
2. 无法正常升级插件（版本不换）
3. 启停/升级过程中终端闪现黑色 cmd 窗口

## 根因

经多轮排查，定位到逐层叠加的根因：

- **终端闪现**：`terminate_process` 的 `taskkill` 未设 `CREATE_NO_WINDOW`。
- **exe 占用**：停止 sidecar 后进程未真正退出/句柄未释放；卸载/升级未兜底停连接表里的 sidecar，也未清理热加载遗留的孤儿 sidecar 进程。
- **目录占用（code=32，核心根因）**：天工主程序加载插件时经 WASI `preopened_dir` 打开了插件自身的安装目录，cap-std 在 Windows 打开目录不带 `FILE_SHARE_DELETE`，只要 Store 持有该句柄，目录就无法 rename/delete——占用者正是主程序自身，故重试与杀进程均无效。

## 改动

**sidecar 进程管理（闪现 + exe 占用）**
- `terminate_process` 的 taskkill/tasklist 加 `CREATE_NO_WINDOW`（新增 `suppress_console`）。
- `stop()` 改为基于 `process_alive` 真正等待进程退出；握手不可用但进程仍存活时同样终止。
- 新增 `kill_sidecar_processes_by_image`：按 exe 名兜底清理孤儿 sidecar 进程。
- 卸载/升级补齐 `stop_connection_for_directory` 兜底。

**文件占用重试**
- 新增 `rename_with_retry`/`retry_io`：对 `ACCESS_DENIED`/`SHARING_VIOLATION` 重试（8s），首次占用打 warn 记录错误码。
- 卸载/升级/回滚/保留目录迁移的关键 rename/remove 均改用重试版本，失败路径补 `tracing::error`。

**WASI 句柄释放（核心根因）**
- `WasmPluginAdapter.inner` 改为 `Option`，新增 `release_inner()` 卸载内部 Store。
- registry 新增 `unload_plugin_wasm`：改写目录前清空实例、释放 preopen 句柄。
- `replace_installed_plugin`/`uninstall_plugin` 在 rename/delete 目录前调用 `unload_plugin_wasm`，完成后原有 reload 自动重建实例。

## 验证
- `cargo clippy -p tiangong-plugin-runtime -- -D warnings` 通过；全 workspace `cargo check` 通过。
- Windows 实测：升级、卸载均正常，终端闪现已修复。

## 风险 / 行为变化
- `stop()` 等待逻辑从「看 endpoint 文件」改为「看进程本身」，unix 行为也更可靠。
- 卸载到 reload 的窗口内（几十毫秒）插件调用返回空/错误，升级/卸载时插件处于停用态，影响可忽略。