### PR TITLE
perf(memory): 异步处理反刍并修复测试退出阻塞

### DIFF
--- a/crates/tiangong-memory/src/actor.rs
+++ b/crates/tiangong-memory/src/actor.rs
@@ -11,7 +11,12 @@ use crate::options::MemoryOptions;
 use crate::recall_context;
 use crate::rumination;
 use crate::store::MemoryStore;
-use crate::types::MemoryCandidate;
+use crate::types::{EnhancedTurnResult, MemoryCandidate};
+
+struct RuminationJob {
+    turn_result: EnhancedTurnResult,
+    model: Option<tiangong_llm::LlmEndpointConfig>,
+}
 
 /// Memory Actor（独立运行时）
 pub(crate) struct MemoryActor {
@@ -19,19 +24,22 @@ pub(crate) struct MemoryActor {
     store: MemoryStore,
     options: MemoryOptions,
     pending_candidates: Vec<MemoryCandidate>,
+    rumination_tx: mpsc::Sender<RuminationJob>,
 }
 
 impl MemoryActor {
-    pub(crate) fn new(
+    fn new(
         rx: mpsc::Receiver<MemoryCommand>,
         store: MemoryStore,
         options: MemoryOptions,
+        rumination_tx: mpsc::Sender<RuminationJob>,
     ) -> Self {
         Self {
             rx,
             store,
             options,
             pending_candidates: Vec::new(),
+            rumination_tx,
         }
     }
 
@@ -273,25 +281,63 @@ impl MemoryActor {
                 }
             }
 
-            MemoryCommand::RunEnhancedMicroRumination { turn_result, reply } => {
+            MemoryCommand::EnqueueEnhancedMicroRumination { turn_result, reply } => {
+                let started = std::time::Instant::now();
                 let mut enhanced = *turn_result;
-                if !self.pending_candidates.is_empty() {
-                    enhanced
-                        .memory_candidates
-                        .append(&mut self.pending_candidates);
+                let pending = std::mem::take(&mut self.pending_candidates);
+                enhanced.memory_candidates.extend(pending.iter().cloned());
+                let session_id = enhanced.session_id.clone();
+                let turn_id = enhanced.turn_id.clone();
+                let job = RuminationJob {
+                    turn_result: enhanced,
+                    model: self.options.model.clone(),
+                };
+                let result = self.rumination_tx.try_send(job).map_err(|error| {
+                    self.pending_candidates = pending;
+                    format!("Memory 反刍队列不可用: {error}")
+                });
+                match &result {
+                    Ok(()) => tracing::debug!(
+                        %session_id,
+                        %turn_id,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "Memory 增强反刍已入队"
+                    ),
+                    Err(error) => tracing::warn!(
+                        %session_id,
+                        %turn_id,
+                        %error,
+                        "Memory 增强反刍入队失败"
+                    ),
                 }
+                let _ = reply.send(result);
+            }
+            MemoryCommand::ApplyEnhancedMicroRumination {
+                turn_result,
+                extraction,
+            } => {
+                let started = std::time::Instant::now();
+                let enhanced = *turn_result;
+                let session_id = enhanced.session_id.clone();
+                let turn_id = enhanced.turn_id.clone();
                 let wid = enhanced.workspace_id.as_deref();
-                if let Err(e) = rumination::process_enhanced_micro(
-                    &mut self.store,
-                    &enhanced,
-                    wid,
-                    self.options.model.as_ref(),
-                )
-                .await
+                match rumination::apply_enhanced_micro(&mut self.store, &enhanced, &extraction, wid)
+                    .await
                 {
-                    tracing::warn!("增强版 Micro 反刍失败: {}", e);
+                    Ok(()) => tracing::info!(
+                        %session_id,
+                        %turn_id,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "Memory 增强反刍写入完成"
+                    ),
+                    Err(error) => tracing::warn!(
+                        %session_id,
+                        %turn_id,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        %error,
+                        "Memory 增强反刍写入失败"
+                    ),
                 }
-                let _ = reply.send(());
             }
 
             // Phase C 实现
@@ -367,17 +413,69 @@ pub fn start_memory_with_options(options: MemoryOptions) -> anyhow::Result<Memor
 /// 与进程级全局静态析构产生竞态（Linux 偶发 SIGSEGV）。不需要显式 join
 /// 的调用方（如生产路径）可直接丢弃返回的 JoinHandle，actor 线程会在
 /// handle 全部释放后随通道关闭自行退出。
+fn spawn_rumination_worker(
+    mut rx: mpsc::Receiver<RuminationJob>,
+    actor_tx: mpsc::WeakSender<MemoryCommand>,
+) -> anyhow::Result<std::thread::JoinHandle<()>> {
+    std::thread::Builder::new()
+        .name("tiangong-memory-rumination".into())
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Memory 反刍 runtime 构建失败");
+            runtime.block_on(async move {
+                while let Some(job) = rx.recv().await {
+                    let started = std::time::Instant::now();
+                    let session_id = job.turn_result.session_id.clone();
+                    let turn_id = job.turn_result.turn_id.clone();
+                    let extraction =
+                        rumination::extract_enhanced_micro(&job.turn_result, job.model.as_ref())
+                            .await;
+                    tracing::info!(
+                        %session_id,
+                        %turn_id,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        episode_count = extraction.episodes.len(),
+                        entity_count = extraction.entities.len(),
+                        decision_count = extraction.decisions.len(),
+                        evidence_count = extraction.evidences.len(),
+                        "Memory 增强反刍提取完成"
+                    );
+                    let Some(actor_tx) = actor_tx.upgrade() else {
+                        tracing::debug!("Memory Actor 已关闭，停止反刍 worker");
+                        break;
+                    };
+                    if actor_tx
+                        .send(MemoryCommand::ApplyEnhancedMicroRumination {
+                            turn_result: Box::new(job.turn_result),
+                            extraction: Box::new(extraction),
+                        })
+                        .await
+                        .is_err()
+                    {
+                        tracing::debug!("Memory Actor 已关闭，停止反刍 worker");
+                        break;
+                    }
+                }
+            });
+        })
+        .map_err(Into::into)
+}
+
 pub(crate) fn spawn_memory_actor(
     options: MemoryOptions,
 ) -> anyhow::Result<(MemoryHandle, std::thread::JoinHandle<()>)> {
     let (tx, rx) = mpsc::channel(256);
+    let (rumination_tx, rumination_rx) = mpsc::channel(64);
 
     let store = MemoryStore::open().map_err(|e| {
         tracing::error!("Memory Store 初始化失败: {}", e);
         e
     })?;
 
-    let actor = MemoryActor::new(rx, store, options);
+    let actor = MemoryActor::new(rx, store, options.clone(), rumination_tx);
+    let _rumination_join = spawn_rumination_worker(rumination_rx, tx.downgrade())?;
 
     let join_handle = std::thread::Builder::new()
         .name("tiangong-memory-actor".into())

--- a/crates/tiangong-memory/src/actor.rs
+++ b/crates/tiangong-memory/src/actor.rs
@@ -53,18 +53,22 @@ impl MemoryActor {
             )
             .await;
         tracing::info!("Memory Actor 已启动");
-        loop {
+        let shutdown_reply = loop {
             match self.rx.recv().await {
-                Some(MemoryCommand::Shutdown) => {
+                Some(MemoryCommand::Shutdown { reply }) => {
                     tracing::info!("Memory Actor 收到 Shutdown 命令，正在关闭");
-                    break;
+                    break Some(reply);
                 }
                 Some(cmd) => self.handle(cmd).await,
                 None => {
                     tracing::info!("Memory Actor 通道已关闭，退出");
-                    break;
+                    break None;
                 }
             }
+        };
+        drop(self);
+        if let Some(reply) = shutdown_reply {
+            let _ = reply.send(());
         }
         tracing::info!("Memory Actor 已关闭");
     }
@@ -373,7 +377,7 @@ impl MemoryActor {
             }
 
             // Shutdown 在外层 loop 处理
-            MemoryCommand::Shutdown => {}
+            MemoryCommand::Shutdown { .. } => {}
         }
     }
 

--- a/crates/tiangong-memory/src/command.rs
+++ b/crates/tiangong-memory/src/command.rs
@@ -123,5 +123,7 @@ pub enum MemoryCommand {
         options: Box<MemoryOptions>,
         reply: std::sync::mpsc::Sender<Result<(), String>>,
     },
-    Shutdown,
+    Shutdown {
+        reply: oneshot::Sender<()>,
+    },
 }

--- a/crates/tiangong-memory/src/command.rs
+++ b/crates/tiangong-memory/src/command.rs
@@ -102,9 +102,15 @@ pub enum MemoryCommand {
     RunMicroRumination {
         turn_result: Box<TurnResult>,
     },
-    RunEnhancedMicroRumination {
+    /// 将增强版 Micro 反刍快速投递到独立 worker。
+    EnqueueEnhancedMicroRumination {
         turn_result: Box<EnhancedTurnResult>,
-        reply: oneshot::Sender<()>,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    /// 提交后台 worker 已完成模型提取的增强版 Micro 结果。
+    ApplyEnhancedMicroRumination {
+        turn_result: Box<EnhancedTurnResult>,
+        extraction: Box<crate::types::ExtractionOutput>,
     },
     RunMesoRumination {
         session_id: String,

--- a/crates/tiangong-memory/src/handle.rs
+++ b/crates/tiangong-memory/src/handle.rs
@@ -900,7 +900,14 @@ impl MemoryHandle {
     pub async fn shutdown(&self) {
         match self.inner.as_ref() {
             HandleInner::Local { tx } => {
-                let _ = tx.send(MemoryCommand::Shutdown).await;
+                let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+                if tx
+                    .send(MemoryCommand::Shutdown { reply: reply_tx })
+                    .await
+                    .is_ok()
+                {
+                    let _ = reply_rx.await;
+                }
             }
             HandleInner::Remote { .. } => {
                 let _ = self

--- a/crates/tiangong-memory/src/handle.rs
+++ b/crates/tiangong-memory/src/handle.rs
@@ -284,75 +284,38 @@ impl MemoryHandle {
         }
     }
 
-    /// 增强版 Micro 反刍（等待完成）。
+    /// 将增强版 Micro 反刍快速投递到独立 worker。
     ///
-    /// 合并累积候选与增强轮次结果，执行多类型提取、去重写入和跨类型关联。
-    pub async fn run_enhanced_micro_rumination(&self, turn_result: EnhancedTurnResult) {
+    /// 返回时只保证任务已进入有界队列，不等待模型提取和最终写入。
+    pub async fn run_enhanced_micro_rumination(
+        &self,
+        turn_result: EnhancedTurnResult,
+    ) -> Result<()> {
         match self.inner.as_ref() {
             HandleInner::Local { tx } => {
                 let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-                if tx
-                    .send(MemoryCommand::RunEnhancedMicroRumination {
-                        turn_result: Box::new(turn_result),
-                        reply: reply_tx,
-                    })
+                tx.send(MemoryCommand::EnqueueEnhancedMicroRumination {
+                    turn_result: Box::new(turn_result),
+                    reply: reply_tx,
+                })
+                .await
+                .with_context(|| "发送 Memory 增强反刍入队命令失败")?;
+                reply_rx
                     .await
-                    .is_err()
-                {
-                    tracing::warn!("Memory run_enhanced_micro_rumination 发送失败");
-                    return;
-                }
-                let _ = reply_rx.await;
+                    .with_context(|| "等待 Memory 增强反刍入队确认失败")?
+                    .map_err(|error| anyhow!(error))
             }
-            HandleInner::Remote { .. } => {
-                match self
-                    .send_remote_request(MemoryIpcRequestPayload::RunEnhancedMicroRumination {
-                        turn_result,
-                    })
-                    .await
-                {
-                    Ok(MemoryIpcResponsePayload::Ack) | Err(_) => {}
-                    Ok(other) => {
-                        tracing::warn!(
-                            "Memory IPC run_enhanced_micro_rumination 返回了非预期响应: {:?}",
-                            other
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    /// 增强版 Micro 反刍（同步版）。
-    pub fn run_enhanced_micro_rumination_blocking(&self, turn_result: EnhancedTurnResult) {
-        match self.inner.as_ref() {
-            HandleInner::Local { tx } => {
-                let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-                if tx
-                    .blocking_send(MemoryCommand::RunEnhancedMicroRumination {
-                        turn_result: Box::new(turn_result),
-                        reply: reply_tx,
-                    })
-                    .is_err()
-                {
-                    tracing::warn!("Memory run_enhanced_micro_rumination_blocking 发送失败");
-                    return;
-                }
-                let _ = reply_rx.blocking_recv();
-            }
-            HandleInner::Remote { .. } => {
-                match self.block_on_remote_request(
-                    MemoryIpcRequestPayload::RunEnhancedMicroRumination { turn_result },
-                ) {
-                    Ok(MemoryIpcResponsePayload::Ack) | Err(_) => {}
-                    Ok(other) => {
-                        tracing::warn!(
-                            "Memory IPC run_enhanced_micro_rumination_blocking 返回了非预期响应: {:?}",
-                            other
-                        );
-                    }
-                }
-            }
+            HandleInner::Remote { .. } => match self
+                .send_remote_request(MemoryIpcRequestPayload::RunEnhancedMicroRumination {
+                    turn_result,
+                })
+                .await?
+            {
+                MemoryIpcResponsePayload::Ack => Ok(()),
+                other => Err(anyhow!(
+                    "Memory IPC run_enhanced_micro_rumination 返回了非预期响应: {other:?}"
+                )),
+            },
         }
     }
 

--- a/crates/tiangong-memory/src/ipc/mod.rs
+++ b/crates/tiangong-memory/src/ipc/mod.rs
@@ -878,7 +878,7 @@ pub async fn handle_memory_request(
             Ok(MemoryIpcResponsePayload::Ack)
         }
         MemoryIpcRequestPayload::RunEnhancedMicroRumination { turn_result } => {
-            handle.run_enhanced_micro_rumination(turn_result).await;
+            handle.run_enhanced_micro_rumination(turn_result).await?;
             Ok(MemoryIpcResponsePayload::Ack)
         }
         MemoryIpcRequestPayload::RunMesoRumination {

--- a/crates/tiangong-memory/src/rumination.rs
+++ b/crates/tiangong-memory/src/rumination.rs
@@ -147,41 +147,29 @@ fn build_session_injection(episodes: &[Episode], session_id: &str) -> String {
     format!("# Session Memory ({session_id})\n更新时间: {now}\n\n## 本会话近期活动\n{items}\n")
 }
 
-/// 增强版 Micro 反刍。
-///
-/// 合并累积候选与增强轮次结果，执行多类型提取、去重写入和跨类型关联。
-/// 当候选列表为空时退化为普通 Micro 反刍。
-pub(crate) async fn process_enhanced_micro(
-    store: &mut MemoryStore,
+/// 在独立反刍 worker 中执行增强版 Micro 的耗时模型提取。
+pub(crate) async fn extract_enhanced_micro(
     enhanced: &EnhancedTurnResult,
-    workspace_id: Option<&str>,
     model: Option<&LlmEndpointConfig>,
-) -> Result<()> {
-    // 恢复原有分流：候选为空时走普通 Micro（与原生版本一致）。
-    let turn_result = TurnResult {
-        session_id: enhanced.session_id.clone(),
-        turn_id: enhanced.turn_id.clone(),
-        had_tool_calls: enhanced.had_tool_calls,
-        user_input: enhanced.user_input.clone(),
-        summary: enhanced.summary.clone(),
-        tool_calls: enhanced.tool_calls.clone(),
-        artifacts: enhanced.artifacts.clone(),
-        workspace_id: enhanced.workspace_id.clone(),
-    };
-
-    if enhanced.memory_candidates.is_empty() {
-        return process_micro(store, &turn_result, workspace_id, model).await;
-    }
-
+) -> crate::types::ExtractionOutput {
     tracing::debug!(
         candidate_count = enhanced.memory_candidates.len(),
-        "增强版 Micro 反刍：执行多类型提取"
+        "增强版 Micro 反刍：后台执行多类型提取"
     );
+    writer::extract_multi_type_memories_with_model(enhanced, model).await
+}
 
-    // 1. 多类型提取（由 Memory LLM 判断或规则 fallback）
-    let extraction = writer::extract_multi_type_memories_with_model(enhanced, model).await;
-
-    // 2. 去重写入 Episode
+/// 提交已完成模型提取的增强版 Micro 结果。
+///
+/// Actor 只在这里串行执行去重、写入、关联和 Injection 更新，避免耗时模型调用
+/// 阻塞下一轮 LoadInjection / Recall。
+pub(crate) async fn apply_enhanced_micro(
+    store: &mut MemoryStore,
+    enhanced: &EnhancedTurnResult,
+    extraction: &crate::types::ExtractionOutput,
+    workspace_id: Option<&str>,
+) -> Result<()> {
+    // 1. 去重写入 Episode
     let mut written_episode_ids = Vec::new();
     for episode in &extraction.episodes {
         if let Some(existing_id) = check_episode_dedup(store, &episode.title, &episode.keywords) {
@@ -204,7 +192,7 @@ pub(crate) async fn process_enhanced_micro(
         }
     }
 
-    // 3. 写入 Entity
+    // 2. 写入 Entity
     let mut written_entity_ids = Vec::new();
     for entity in &extraction.entities {
         match store.upsert_entity(entity.clone(), workspace_id) {
@@ -213,7 +201,7 @@ pub(crate) async fn process_enhanced_micro(
         }
     }
 
-    // 4. 写入 Decision
+    // 3. 写入 Decision
     let mut written_decision_ids = Vec::new();
     for decision in &extraction.decisions {
         match store.upsert_decision(decision.clone(), workspace_id) {
@@ -239,7 +227,7 @@ pub(crate) async fn process_enhanced_micro(
         &written_decision_ids,
     );
 
-    // 7. 更新 Session Injection
+    // 6. 更新 Session Injection
     let recent = store.recent_episodes_for_session(workspace_id, &enhanced.session_id, 3);
     if !recent.is_empty() {
         let content = build_session_injection(&recent, &enhanced.session_id);

--- a/crates/tiangong-memory/tests/runtime_integration.rs
+++ b/crates/tiangong-memory/tests/runtime_integration.rs
@@ -9,9 +9,10 @@ use serial_test::serial;
 use tempfile::TempDir;
 use tiangong_llm::{LlmEndpointConfig, ProviderProtocol};
 use tiangong_memory::{
-    Episode, EpisodeOutcome, MemoryKind, MemoryOptions, MemoryRecallRequest, MemoryRelationDraft,
-    MemoryRelationKind, MemoryVectorMode, RecallAnchors, RecallDepth, TurnArtifact,
-    TurnArtifactKind, TurnResult, load_injection_sync, start_with_options, workspace_id_from_path,
+    EnhancedTurnResult, Episode, EpisodeOutcome, MemoryCandidate, MemoryKind, MemoryOptions,
+    MemoryRecallRequest, MemoryRelationDraft, MemoryRelationKind, MemoryVectorMode, RecallAnchors,
+    RecallDepth, TurnArtifact, TurnArtifactKind, TurnResult, load_injection_sync,
+    start_with_options, workspace_id_from_path,
 };
 
 struct EnvGuard {
@@ -122,8 +123,23 @@ impl MockMemoryLlmServer {
 }
 
 /// 处理单个 Mock LLM 请求（在独立线程中运行）。
+fn start_slow_memory_llm(delay: Duration) -> (String, std::thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("绑定慢速 mock Memory LLM 失败");
+    let addr = listener.local_addr().expect("读取慢速 mock 地址失败");
+    let join = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("等待慢速 mock 请求失败");
+        handle_mock_request_with_delay(&mut stream, delay);
+    });
+    (format!("http://{addr}/v1"), join)
+}
 fn handle_mock_request(mut stream: std::net::TcpStream) {
-    let request = read_http_request(&mut stream);
+    handle_mock_request_with_delay(&mut stream, Duration::ZERO);
+}
+fn handle_mock_request_with_delay(stream: &mut std::net::TcpStream, delay: Duration) {
+    let request = read_http_request(stream);
+    if !delay.is_zero() {
+        std::thread::sleep(delay);
+    }
     let body = request
         .as_deref()
         .map(memory_llm_mock_response)
@@ -451,6 +467,62 @@ async fn wait_for_unique_kind_hits(
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
     Vec::new()
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn enhanced_rumination_enqueue_does_not_block_injection_reads() {
+    let (home, _workspace, workspace_path, workspace_id) = setup_workspace();
+    let _guard = EnvGuard::enter(home.path(), &workspace_path);
+    let (base_url, mock_join) = start_slow_memory_llm(Duration::from_secs(2));
+    let mut model = LlmEndpointConfig::new("test-key", &base_url, "memory-test");
+    model.protocol = ProviderProtocol::OpenAiChatCompletions;
+    model.timeout = Duration::from_secs(5);
+    model.max_retries = 0;
+    let handle =
+        start_with_options(MemoryOptions::new().with_model(model)).expect("启动 Memory 失败");
+    let turn_result = EnhancedTurnResult {
+        session_id: "rumination-queue-session".to_string(),
+        turn_id: "rumination-queue-turn".to_string(),
+        had_tool_calls: true,
+        user_input: "记录后台反刍队列优化".to_string(),
+        summary: "已将耗时提取移出 Memory Actor".to_string(),
+        workspace_id: Some(workspace_id.clone()),
+        memory_candidates: vec![MemoryCandidate {
+            tool_name: "coding".to_string(),
+            step_index: 0,
+            hint: "反刍队列优化".to_string(),
+            suggested_kinds: Vec::new(),
+            file_path: None,
+            url: None,
+            result_summary: Some("完成反刍队列优化".to_string()),
+            success: true,
+            tool_source: Some("file_operation".to_string()),
+            is_recalled_context: false,
+        }],
+        ..Default::default()
+    };
+
+    let enqueue_started = std::time::Instant::now();
+    handle
+        .run_enhanced_micro_rumination(turn_result)
+        .await
+        .expect("增强反刍应成功入队");
+    assert!(
+        enqueue_started.elapsed() < Duration::from_secs(1),
+        "增强反刍接口只能等待入队，不能等待模型提取"
+    );
+
+    let injection_started = std::time::Instant::now();
+    let _ = handle
+        .load_injection("rumination-queue-session", Some(&workspace_id))
+        .await;
+    assert!(
+        injection_started.elapsed() < Duration::from_secs(1),
+        "后台反刍执行期间 LoadInjection 不应被模型调用阻塞"
+    );
+    handle.shutdown().await;
+    mock_join.join().expect("慢速 mock Memory LLM 不应异常退出");
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/tiangong-plugin-runtime/src/adapter.rs
+++ b/crates/tiangong-plugin-runtime/src/adapter.rs
@@ -217,13 +217,13 @@ impl Plugin for WasmPluginAdapter {
         );
     }
 
-    /// 轮次结束：序列化 session 转发（WASM 内部触发 micro 反刍）。
+    /// 轮次结束：序列化 session 并有序转发。
     ///
-    /// 采用 fire-and-forget：WASM 调用（含 sidecar 往返）投递到独立 OS 线程，
-    /// 调用方立即返回，避免把 sidecar 建连与往返开销堆在发布终态前的关键路径上。
-    /// 反刍在 sidecar 端本就是后台异步执行，这里只需保证"通知发出"，不阻塞即可。
+    /// Memory 等插件必须在这里完成的只是将后台任务快速入队；真正耗时工作由 sidecar
+    /// 自己处理。同步等待入队确认可保证本轮 on_turn_finished 一定先于下一轮
+    /// on_turn_started，且不会让后台收尾线程继续持有 WASM 实例锁。
     fn on_turn_finished(&self, session: &mut Session, turn_start_idx: usize) {
-        self.forward_session_hook_with_idx_detached(
+        self.forward_session_hook_with_idx(
             "on_turn_finished",
             session,
             turn_start_idx,
@@ -396,46 +396,6 @@ impl WasmPluginAdapter {
             .spawn(move || {
                 if let Err(error) =
                     call_wasm_off_runtime(inner, move |plugin| call(plugin, json))
-                {
-                    tracing::warn!(plugin_id = %hook_thread_id, hook, %error, "wasm 生命周期钩子失败");
-                }
-            })
-        {
-            tracing::warn!(plugin_id = %plugin_id, hook, %error, "启动 wasm 钩子后台线程失败");
-        }
-    }
-
-    /// 同上，但带 turn_start_idx 参数。
-    fn forward_session_hook_with_idx_detached(
-        &self,
-        hook: &'static str,
-        session: &Session,
-        turn_start_idx: usize,
-        call: impl Fn(&mut WasmPlugin, String, u32) -> anyhow::Result<()> + Send + Sync + 'static,
-    ) {
-        let plugin_session = tiangong_types::PluginSession::from(session);
-        let json = match serde_json::to_string(&plugin_session) {
-            Ok(j) => j,
-            Err(e) => {
-                tracing::warn!("序列化 PluginSession 失败，跳过 wasm 钩子: {e}");
-                return;
-            }
-        };
-        if let Ok(mut context) = self.context.lock() {
-            context.session_json = Some(json.clone());
-        }
-        if !self.is_enabled() {
-            return;
-        }
-        let inner = self.current_inner();
-        let plugin_id = self.id.clone();
-        let hook_thread_id = plugin_id.clone();
-        let idx = turn_start_idx as u32;
-        if let Err(error) = std::thread::Builder::new()
-            .name(format!("wasm-hook-{plugin_id}-{hook}"))
-            .spawn(move || {
-                if let Err(error) =
-                    call_wasm_off_runtime(inner, move |plugin| call(plugin, json, idx))
                 {
                     tracing::warn!(plugin_id = %hook_thread_id, hook, %error, "wasm 生命周期钩子失败");
                 }

--- a/crates/tiangong-plugin-runtime/tests/load_and_call.rs
+++ b/crates/tiangong-plugin-runtime/tests/load_and_call.rs
@@ -483,8 +483,7 @@ fn on_turn_finished_with_connection_forwards_rumination() {
     let adapter = WasmPluginAdapter::new(plugin, config);
 
     let mut session = test_session_with_user_message();
-    // 有用户消息时，on_turn_finished 应触发反刍（best-effort）。
-    // 反刍通知以 fire-and-forget 投递，等待模拟 sidecar 实际收到请求后再断言。
+    // 有用户消息时，on_turn_finished 应有序投递反刍任务并等待 sidecar 入队确认。
     <WasmPluginAdapter as Plugin>::on_turn_finished(&adapter, &mut session, 0);
     assert!(sidecar.wait_for_call_count("run_enhanced_micro_rumination", 1));
     assert!(sidecar.called("run_enhanced_micro_rumination"));
@@ -498,8 +497,7 @@ fn on_turn_finished_with_connection_forwards_rumination() {
 }
 
 #[test]
-#[ignore = "耗时故障诊断，仅在手动复测运行中追加消息阻塞时执行"]
-fn detached_turn_finish_releases_caller_but_holds_wasm_instance_lock() {
+fn turn_finish_waits_only_for_sidecar_enqueue_and_releases_wasm_lock() {
     let sidecar = Arc::new(BlockingMemorySidecar::default());
     let Some(wasm) = wasm_or_skip() else {
         return;
@@ -509,71 +507,32 @@ fn detached_turn_finish_releases_caller_but_holds_wasm_instance_lock() {
         WasmPluginLoader::with_sidecar(&config, Some(sidecar.clone())).expect("创建加载器失败");
     let plugin = loader.load(&wasm, &config).expect("加载 wasm 组件失败");
     let adapter = Arc::new(WasmPluginAdapter::new(plugin, config));
-    let mut session = test_session_with_user_message();
-
-    let turn_finish_started = Instant::now();
-    <WasmPluginAdapter as Plugin>::on_turn_finished(&adapter, &mut session, 0);
-    let turn_finish_elapsed = turn_finish_started.elapsed();
-    let rumination_entered =
-        sidecar.wait_for_call("run_enhanced_micro_rumination", Duration::from_secs(1));
-
-    let (config_started_tx, config_started_rx) = std::sync::mpsc::sync_channel(1);
-    let (config_finished_tx, config_finished_rx) = std::sync::mpsc::sync_channel(1);
-    let config_adapter = Arc::clone(&adapter);
-    let config_thread = std::thread::spawn(move || {
-        let started = Instant::now();
-        let _ = config_started_tx.send(());
-        <WasmPluginAdapter as Plugin>::on_config_updated(&config_adapter, &CoreConfig::default());
-        let _ = config_finished_tx.send(started.elapsed());
+    let session = test_session_with_user_message();
+    let (finish_tx, finish_rx) = std::sync::mpsc::sync_channel(1);
+    let finish_adapter = Arc::clone(&adapter);
+    let finish_thread = std::thread::spawn(move || {
+        let mut session = session;
+        <WasmPluginAdapter as Plugin>::on_turn_finished(&finish_adapter, &mut session, 0);
+        let _ = finish_tx.send(());
     });
-    let config_started = config_started_rx
-        .recv_timeout(Duration::from_secs(1))
-        .is_ok();
-    let blocked_result = config_finished_rx.recv_timeout(Duration::from_millis(250));
-    let config_was_blocked = matches!(
-        &blocked_result,
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+    assert!(sidecar.wait_for_call("run_enhanced_micro_rumination", Duration::from_secs(1)));
+    assert!(
+        finish_rx.recv_timeout(Duration::from_millis(250)).is_err(),
+        "sidecar 尚未确认入队时，收尾调用不应虚报完成"
     );
-
     sidecar.release_rumination();
-    let config_elapsed = match blocked_result {
-        Ok(elapsed) => elapsed,
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => config_finished_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("释放慢 sidecar 后配置通知应在 2 秒内完成"),
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            panic!("配置通知线程在返回结果前断开")
-        }
-    };
-    config_thread.join().expect("配置通知线程不应异常退出");
-
+    finish_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("sidecar 确认入队后收尾调用应尽快返回");
+    finish_thread.join().expect("收尾线程不应异常退出");
+    let started = Instant::now();
+    <WasmPluginAdapter as Plugin>::on_config_updated(&adapter, &CoreConfig::default());
     assert!(
-        turn_finish_elapsed < Duration::from_secs(1),
-        "异步轮次收尾应在 1 秒内返回，实际耗时 {turn_finish_elapsed:?}"
+        started.elapsed() < Duration::from_secs(1),
+        "收尾入队完成后不应继续占用 WASM 实例锁"
     );
-    assert!(
-        rumination_entered,
-        "后台轮次收尾应在 1 秒内进入真实 sidecar"
-    );
-    assert!(config_started, "同步配置通知线程应在 1 秒内开始调用");
-    assert!(
-        config_was_blocked,
-        "后台收尾持有 WASM 实例锁时，同步配置通知不应提前完成"
-    );
-    assert!(
-        config_elapsed >= Duration::from_millis(250),
-        "同步配置通知应等待后台收尾释放实例锁，实际耗时 {config_elapsed:?}"
-    );
-    assert!(
-        sidecar.wait_for_call("reconfigure", Duration::from_millis(100)),
-        "释放后台收尾后应完成真实 reconfigure 调用"
-    );
-    assert!(
-        !sidecar.auto_released(),
-        "测试必须由显式释放完成，不能依赖 10 秒自动释放上限"
-    );
+    assert!(!sidecar.auto_released(), "测试不应依赖自动释放上限");
 }
-
 #[test]
 fn every_tenth_turn_forwards_meta_rumination() {
     let sidecar = Arc::new(MockMemorySidecar::default());

--- a/plugins/tiangong-plugin-memory/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-memory/wasm/src/lib.rs
@@ -382,7 +382,7 @@ impl Guest for Component {
 
     fn on_turn_finished(session_json: String, turn_start_idx: u32) -> Result<(), PluginError> {
         // 轮次结束：从 session 只读快照提取本轮信息，转发给 sidecar 做 micro 反刍。
-        let _ = forward_turn_rumination(&session_json, turn_start_idx);
+        forward_turn_rumination(&session_json, turn_start_idx)?;
 
         // 每 10 轮触发 Meta 反刍（与原生版本一致）。
         if state::increment_turn_and_check_meta() {
@@ -548,8 +548,9 @@ fn forward_turn_rumination(session_json: &str, turn_start_idx: u32) -> Result<()
     let turn_result =
         turn_extract::build_turn_memory_result(&session, &messages, &user_input, turn_status);
     let request = RunEnhancedMicroRuminationRequest { turn_result };
-    let _ = sidecar_client::invoke::<RunEnhancedMicroRumination>(&request);
-    Ok(())
+    sidecar_client::invoke::<RunEnhancedMicroRumination>(&request)
+        .map(|_| ())
+        .map_err(|error| PluginError::Message(format!("提交 Memory 增强反刍任务失败: {error}")))
 }
 
 /// 从 session 快照提取 id/cwd，转发给 sidecar 做 meso 反刍。


### PR DESCRIPTION
## 变更内容

- 将 Memory 轮次反刍改为快速入队，避免收尾阶段等待完整模型提取
- 将耗时提取移到独立后台任务，最终结果只在 Memory 内部写入并记录日志
- 保持插件轮次生命周期顺序，入队确认后及时释放 WASM 实例锁
- 使用弱通道引用避免反刍线程阻止 Memory Actor 和测试进程退出
- 增加慢速模型、记忆注入隔离和 WASM 锁释放回归覆盖

## 验证结果

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy -p tiangong-memory -p tiangong-plugin-runtime -p tiangong-plugin-memory-wasm --all-targets -- -D warnings`
- `cargo test -p tiangong-memory --lib`：46 项通过，约 0.6 秒
- `cargo test -p tiangong-plugin-runtime --test load_and_call`：15 项通过
- `cargo test -p tiangong-memory --test election_failover_integration`：3 项通过，约 1.2 秒
- 慢速 Memory 模型期间的注入读取回归测试通过
- 推送前 changed-crates check、clippy、nextest 全部通过