### PR TITLE
fix(frontend): 工具调用完成后不再自动展开结果

### DIFF
--- a/frontend/src/components/message/AgentTurn.tsx
+++ b/frontend/src/components/message/AgentTurn.tsx
@@ -66,7 +66,7 @@ function AgentTurnView({
   const currentMessageId = useSearchStore((s) => s.currentMessageId);
   const currentMatchStart = useSearchStore((s) => s.currentMatchStart);
   const caseSensitive = useSearchStore((s) => s.caseSensitive);
-  const toolGroupExpansion = useExpansionState(isActive);
+  const toolGroupExpansion = useExpansionState();
   const agents = useStore((state) => state.agents);
   const resolvedTheme = useResolvedTheme();
 

--- a/frontend/src/components/message/useExpansionState.ts
+++ b/frontend/src/components/message/useExpansionState.ts
@@ -1,32 +1,21 @@
 import { useState, useCallback } from "react";
 
 /**
- * 展开/收起状态：活跃态默认全展开，用户仍可手动收起（记录到 userCollapsed 覆盖默认）；
- * 非活跃态默认全收起，用户手动展开才进入 expanded。
- * 轮次完成（key 变化）触发组件重挂载，两个集合都会重置。
+ * 展开/收起状态：工具结果默认收起（调用完成后不自动展开），仅用户手动展开的进入 expanded。
+ * 轮次完成（key 变化）触发组件重挂载，expanded 重置。
  */
-export function useExpansionState(isActive: boolean) {
+export function useExpansionState() {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const [userCollapsed, setUserCollapsed] = useState<Set<string>>(new Set());
 
-  const isExpanded = (id: string) =>
-    isActive ? !userCollapsed.has(id) : expanded.has(id);
+  const isExpanded = (id: string) => expanded.has(id);
 
   const toggle = useCallback((id: string) => {
-    if (isActive) {
-      setUserCollapsed((prev) => {
-        const next = new Set(prev);
-        next.has(id) ? next.delete(id) : next.add(id);
-        return next;
-      });
-    } else {
-      setExpanded((prev) => {
-        const next = new Set(prev);
-        next.has(id) ? next.delete(id) : next.add(id);
-        return next;
-      });
-    }
-  }, [isActive]);
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }, []);
 
   return { isExpanded, toggle };
 }


### PR DESCRIPTION
## 变更点

- `useExpansionState` 移除活跃轮次默认全展开逻辑：原先工具结果一到达就在活跃轮次中自动展开，现改为统一默认收起，仅用户点击摘要行手动展开/收起
- `AgentTurn` 调用处同步去掉 `isActive` 参数（hook 不再区分活跃态）
- 运行中工具行（不可展开）与历史轮次（原本默认收起）行为不变
- 本地需求文档（`docs/requirements.md`）与 `TODO.md` 已同步补充该交互规则（两文件不入库）

## 测试情况

- `yarn build`（tsc + vite build）通过
- `yarn test` 192 项全部通过
- 推送时远端 CI 的前端构建与测试均通过