### PR TITLE
fix(core): 轮次失败时落盘并推送 [错误] 消息，恢复错误可见性

### DIFF
--- a/crates/tiangong-cli/src/output.rs
+++ b/crates/tiangong-cli/src/output.rs
@@ -278,6 +278,7 @@ pub fn print_session_messages(messages: &[tiangong_core::session::Message]) {
             tiangong_core::session::MessageRole::User => print_user_message(&msg.text_content()),
             tiangong_core::session::MessageRole::Assistant => print_assistant_message(msg),
             tiangong_core::session::MessageRole::System => print_system_message(msg),
+            tiangong_core::session::MessageRole::Notice => print_system_message(msg),
             tiangong_core::session::MessageRole::Tool => print_system_message(msg),
         }
     }

--- a/crates/tiangong-core/src/context/compressor.rs
+++ b/crates/tiangong-core/src/context/compressor.rs
@@ -5,6 +5,7 @@ use crate::session::{Message, MessagePhase, MessageRole, Session};
 pub(crate) fn is_compressible(message: &Message) -> bool {
     !message.model_excluded
         && message.role != MessageRole::System
+        && message.role != MessageRole::Notice
         && message.phase != MessagePhase::CompressedResume
 }
 

--- a/crates/tiangong-core/src/react/compression.rs
+++ b/crates/tiangong-core/src/react/compression.rs
@@ -237,7 +237,9 @@ fn compression_split_point(session: &Session) -> Option<usize> {
     let start = session.summary_up_to.min(session.messages.len());
     let last_visible = (start..session.messages.len()).rev().find(|&index| {
         let message = &session.messages[index];
-        !message.model_excluded && message.role != MessageRole::System
+        !message.model_excluded
+            && message.role != MessageRole::System
+            && message.role != MessageRole::Notice
     })?;
     let last_message = &session.messages[last_visible];
     let recent_start = if last_message.role == MessageRole::Tool {

--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -138,9 +138,9 @@ pub(crate) fn select_client_for_request<'a>(
 /// - 走标准注入通道保证 append-only、provider 序列化为合法 tool pair，cache 友好。
 ///
 /// 去重边界：`inject_tool_to_messages` 仅对连续相同的 plugin_injection 结果去重，
-/// 不与 `run_turn` 失败收尾追加的 `[错误]` System 消息跨格式去重——二者各司其职：
-/// 本消息对模型可见（携带继续指令），`[错误]` 消息仅前端可见（System 角色被
-/// `build_provider_messages` 排除）。
+/// 不与 `run_turn` 失败收尾追加的 `[错误]` Notice 消息跨格式去重——二者各司其职：
+/// 本消息对模型可见（携带继续指令），`[错误]` 消息仅前端可见（Notice 角色在
+/// 上下文构建、压缩与 provider 转换处整体排除）。
 pub(crate) fn persist_error(ctx: &mut TurnContext, message: impl Into<String>) {
     let message = message.into();
     let payload = serde_json::json!({

--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -138,9 +138,9 @@ pub(crate) fn select_client_for_request<'a>(
 /// - 走标准注入通道保证 append-only、provider 序列化为合法 tool pair，cache 友好。
 ///
 /// 去重边界：`inject_tool_to_messages` 仅对连续相同的 plugin_injection 结果去重，
-/// 不会与前端 `StreamEvent::Error` 落盘的 `[错误]` System 消息跨格式去重——因此
-/// 前端若也落盘，UI 上仍可能出现重复错误消息。engine 侧落盘作为前端时序丢失的
-/// 兜底，确保会话重载后至少能看到失败原因。
+/// 不与 `run_turn` 失败收尾追加的 `[错误]` System 消息跨格式去重——二者各司其职：
+/// 本消息对模型可见（携带继续指令），`[错误]` 消息仅前端可见（System 角色被
+/// `build_provider_messages` 排除）。
 pub(crate) fn persist_error(ctx: &mut TurnContext, message: impl Into<String>) {
     let message = message.into();
     let payload = serde_json::json!({

--- a/crates/tiangong-core/src/react/turn.rs
+++ b/crates/tiangong-core/src/react/turn.rs
@@ -6,7 +6,7 @@
 use tokio::sync::mpsc as tokio_mpsc;
 
 use crate::core::command::Command;
-use crate::session::MessageRole;
+use crate::session::{Message, MessageRole};
 use crate::turn_context::TurnContext;
 use tiangong_types::StreamEvent;
 
@@ -92,6 +92,20 @@ pub(crate) async fn run_turn(
         ctx.session.messages[idx].set_turn_result(elapsed_ms, status);
     }
 
+    // ── 失败轮次追加用户可见的错误消息 ──
+    // System 消息被 build_provider_messages 排除，不进模型上下文；前端按
+    // "[错误]" 前缀渲染红色错误框。消息先入 session 随下方最终落盘持久化，
+    // 终态发布前再补发 upsert 事件，实时会话与重载会话都能看到失败原因。
+    // 给模型的失败痕迹由 persist_error 注入的 react_loop_error 消息对负责。
+    let user_error_snapshot = match &outcome {
+        TurnExecutionOutcome::Failed(message) => {
+            let error_message = Message::new(MessageRole::System, format!("[错误] {message}"));
+            ctx.session.messages.push(error_message.clone());
+            Some(error_message)
+        }
+        _ => None,
+    };
+
     // ── 清理运行态并最终持久化（不等待插件收尾）──
     // base64 等瞬态内容只用于本轮模型请求，不能进入磁盘会话合同。
     // 关键路径顺序：落盘 → 快照 → 终态。插件收尾（含 on_cancel）移到终态之后，
@@ -139,6 +153,14 @@ pub(crate) async fn run_turn(
 
     // ── 生成终态 ──
     // 每轮独立终态：turn 收尾完成即发布（连续轮次各自拥有自己的终态事件）。
+    // 失败错误消息先于终态发布：前端先插入红框消息，再收到 error 终态更新
+    // 轮次状态，避免终态把运行状态归位后错误才姗姗来迟。
+    if let Some(message) = user_error_snapshot {
+        let _ = stream_tx.send(StreamEvent::SessionMessageUpsert {
+            message,
+            deferred_tool_injections: None,
+        });
+    }
     let terminal = outcome.terminal_event(usage);
     let _ = stream_tx.send(terminal.clone());
 

--- a/crates/tiangong-core/src/react/turn.rs
+++ b/crates/tiangong-core/src/react/turn.rs
@@ -93,16 +93,15 @@ pub(crate) async fn run_turn(
     }
 
     // ── 失败轮次追加用户可见的错误消息 ──
-    // model_excluded 显式排除出模型上下文与压缩摘要（与 agent-team 的
-    // "[Agent]" 仅前端可见消息同一惯例），不依赖 System 角色被
-    // build_provider_messages 过滤的实现细节；前端按 "[错误]" 前缀渲染
-    // 红色错误框。消息先入 session 随下方最终落盘持久化，终态发布前再
-    // 补发 upsert 事件，实时会话与重载会话都能看到失败原因。
-    // 给模型的失败痕迹由 persist_error 注入的 react_loop_error 消息对负责。
+    // Notice 是"系统发给用户的通知"通道，角色本身保证排除出模型上下文与
+    // 压缩摘要（context 构建、压缩、provider 转换三处过滤），无需再加
+    // model_excluded。前端按 "[错误]" 前缀渲染红色错误框。消息先入 session
+    // 随下方最终落盘持久化，终态发布前再补发 upsert 事件，实时会话与重载
+    // 会话都能看到失败原因。给模型的失败痕迹由 persist_error 注入的
+    // react_loop_error 消息对负责。
     let user_error_snapshot = match &outcome {
         TurnExecutionOutcome::Failed(message) => {
-            let mut error_message = Message::new(MessageRole::System, format!("[错误] {message}"));
-            error_message.model_excluded = true;
+            let error_message = Message::new(MessageRole::Notice, format!("[错误] {message}"));
             ctx.session.messages.push(error_message.clone());
             Some(error_message)
         }

--- a/crates/tiangong-core/src/react/turn.rs
+++ b/crates/tiangong-core/src/react/turn.rs
@@ -93,13 +93,16 @@ pub(crate) async fn run_turn(
     }
 
     // ── 失败轮次追加用户可见的错误消息 ──
-    // System 消息被 build_provider_messages 排除，不进模型上下文；前端按
-    // "[错误]" 前缀渲染红色错误框。消息先入 session 随下方最终落盘持久化，
-    // 终态发布前再补发 upsert 事件，实时会话与重载会话都能看到失败原因。
+    // model_excluded 显式排除出模型上下文与压缩摘要（与 agent-team 的
+    // "[Agent]" 仅前端可见消息同一惯例），不依赖 System 角色被
+    // build_provider_messages 过滤的实现细节；前端按 "[错误]" 前缀渲染
+    // 红色错误框。消息先入 session 随下方最终落盘持久化，终态发布前再
+    // 补发 upsert 事件，实时会话与重载会话都能看到失败原因。
     // 给模型的失败痕迹由 persist_error 注入的 react_loop_error 消息对负责。
     let user_error_snapshot = match &outcome {
         TurnExecutionOutcome::Failed(message) => {
-            let error_message = Message::new(MessageRole::System, format!("[错误] {message}"));
+            let mut error_message = Message::new(MessageRole::System, format!("[错误] {message}"));
+            error_message.model_excluded = true;
             ctx.session.messages.push(error_message.clone());
             Some(error_message)
         }

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -1083,7 +1083,12 @@ impl Session {
                 .iter()
                 // 持久化 System 消息是 UI/恢复日志；唯一模型系统提示由
                 // system_prompt_message 提供，避免日志覆盖完整规则。
-                .filter(|message| !message.model_excluded && message.role != MessageRole::System)
+                // Notice 是系统发给用户的通知，按角色整体排除出模型上下文。
+                .filter(|message| {
+                    !message.model_excluded
+                        && message.role != MessageRole::System
+                        && message.role != MessageRole::Notice
+                })
                 .cloned(),
         );
         context

--- a/crates/tiangong-llm/src/provider_client.rs
+++ b/crates/tiangong-llm/src/provider_client.rs
@@ -1234,6 +1234,8 @@ fn provider_message_from_session(msg: &Message) -> Result<Option<ChatMessage>> {
         MessageRole::Assistant => LlmMessageRole::Assistant,
         MessageRole::Tool => LlmMessageRole::Tool,
         MessageRole::System => return Ok(None),
+        // Notice 是系统发给用户的通知，任何路径都不得进入模型请求。
+        MessageRole::Notice => return Ok(None),
     };
 
     if msg.role == MessageRole::Tool {

--- a/crates/tiangong-types/src/message.rs
+++ b/crates/tiangong-types/src/message.rs
@@ -16,6 +16,10 @@ fn is_inline_data_reference(value: &str) -> bool {
 }
 
 /// 消息角色
+///
+/// [`Notice`](MessageRole::Notice) 是系统发给用户的通知（如轮次失败原因），
+/// 仅前端可见：消息须带 `model_excluded` 排除出模型上下文与压缩摘要，
+/// 不与 [`System`](MessageRole::System)（系统提示通道）混用。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MessageRole {
@@ -23,6 +27,7 @@ pub enum MessageRole {
     User,
     Assistant,
     Tool,
+    Notice,
 }
 
 /// 单个对话轮次的最终执行状态，仅持久化到用户消息（turn 锚点）。

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -79,7 +79,8 @@ export interface TerminalTabListResponse {
   active_tab_id: string | null;
 }
 
-export type MessageRole = 'system' | 'user' | 'assistant' | 'tool';
+/** notice：系统发给用户的通知（如轮次失败原因），仅前端可见，不进模型上下文。 */
+export type MessageRole = 'system' | 'user' | 'assistant' | 'tool' | 'notice';
 export type MessagePhase = 'normal' | 'react' | 'summary' | 'compressedresume';
 
 /** 单个对话轮次的最终执行状态（持久化在用户消息上，历史会话同样可见）。 */

--- a/frontend/src/components/message/AgentTurn.tsx
+++ b/frontend/src/components/message/AgentTurn.tsx
@@ -168,7 +168,7 @@ function AgentTurnView({
         continue;
       }
       fragments.push({ type: "assistant", msg, isStreaming });
-    } else if (msg.role === "system" && textContent(msg).startsWith("[错误]")) {
+    } else if ((msg.role === "notice" || msg.role === "system") && textContent(msg).startsWith("[错误]")) {
       flushTools();
       fragments.push({ type: "error_system", msg });
     } else if (msg.role === "system" && textContent(msg).startsWith("[重试]")) {
@@ -182,7 +182,7 @@ function AgentTurnView({
       flushTools();
       const category = textContent(msg).startsWith("[文件锁]") ? "lock" : "info";
       fragments.push({ type: "agent_event", category, content: textContent(msg), agentRoles: extractAgentRoles(textContent(msg), agents) });
-    } else if (msg.role === "system") {
+    } else if (msg.role === "system" || msg.role === "notice") {
       flushTools();
       fragments.push({ type: "other_system", msg });
     }
@@ -206,9 +206,13 @@ function AgentTurnView({
   let userFrag: Fragment | null = null;
   const summaryFrags: Fragment[] = [];
   const processFrags: Fragment[] = [];
+  // 错误通知不随过程折叠：失败轮次往往没有其他可见输出，错误原因必须始终可见。
+  const errorFrags: Fragment[] = [];
   for (const frag of mergedFragments) {
     if (frag.type === "user") {
       userFrag = frag;
+    } else if (frag.type === "error_system") {
+      errorFrags.push(frag);
     } else if (frag.type === "assistant" && frag.msg.phase !== "react") {
       summaryFrags.push(frag);
     } else {
@@ -390,6 +394,7 @@ function AgentTurnView({
           {processFrags.map((frag, i) => renderFragment(frag, i))}
         </div>
       )}
+      {errorFrags.map((frag, i) => renderFragment(frag, i))}
       {summaryFrags.map((frag, i) => renderFragment(frag, mergedFragments.length + i))}
     </div>
   );

--- a/frontend/src/components/message/types.ts
+++ b/frontend/src/components/message/types.ts
@@ -1,8 +1,8 @@
-import type { ContentBlock, MessagePhase } from "@/api/tauri";
+import type { ContentBlock, MessagePhase, MessageRole } from "@/api/tauri";
 
 export interface MessageItem {
   id: string;
-  role: "system" | "user" | "assistant" | "tool";
+  role: MessageRole;
   content: ContentBlock[];
   reasoning_content: string;
   worker_id?: string;

--- a/plugins/tiangong-plugin-index/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-index/wasm/src/lib.rs
@@ -339,6 +339,7 @@ fn forward_turn_batch(session_json: &str, turn_start_idx: u32) -> Result<(), Plu
                 MessageRole::Assistant => "assistant",
                 MessageRole::Tool => "tool",
                 MessageRole::System => return None,
+                MessageRole::Notice => return None,
             };
             Some(TurnData {
                 turn_id: msg.id.clone(),

--- a/plugins/tiangong-plugin-memory/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-memory/wasm/src/lib.rs
@@ -610,6 +610,7 @@ fn build_recall_context(session: &tiangong_types::PluginSession) -> Vec<String> 
                 tiangong_types::MessageRole::User => "user",
                 tiangong_types::MessageRole::Assistant => "assistant",
                 tiangong_types::MessageRole::System => return None,
+                tiangong_types::MessageRole::Notice => return None,
                 tiangong_types::MessageRole::Tool => message.tool_name.as_deref().unwrap_or("tool"),
             };
             let content = compact_memory_text(&message.text_content(), 900);

--- a/plugins/tiangong-plugin-memory/wasm/src/turn_extract.rs
+++ b/plugins/tiangong-plugin-memory/wasm/src/turn_extract.rs
@@ -58,6 +58,7 @@ pub(crate) fn build_turn_memory_result(
                 MessageRole::User => "user",
                 MessageRole::Assistant => "assistant",
                 MessageRole::System => return None,
+                MessageRole::Notice => return None,
                 MessageRole::Tool => "tool",
             };
             let content = compact_single_memory_text(&message.text_content(), 400);

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -120,7 +120,8 @@ fn merge_agent_output_messages(
                 tiangong_core::session::MessageRole::Assistant
             }
             tiangong_core::session::MessageRole::System
-            | tiangong_core::session::MessageRole::Tool => {
+            | tiangong_core::session::MessageRole::Tool
+            | tiangong_core::session::MessageRole::Notice => {
                 tiangong_core::session::MessageRole::System
             }
             tiangong_core::session::MessageRole::User => tiangong_core::session::MessageRole::User,


### PR DESCRIPTION
## 背景与问题

LLM 请求连续失败（重试耗尽、流式与非流式回退均失败）时，用户只看到会话凭空中止，错误完全不可见：

- #230 重构（a034f7aa）删除了 Error 终态落盘 `[错误]` System 消息的路径，前端现成的 `[错误]` 红色错误框渲染成为孤儿；
- 前端收到 error 终态后立即把运行状态归位为空闲，状态栏"执行失败"文本只在非空闲时显示——永不显示；
- core 侧 `persist_error` 落盘的 `react_loop_error` 诊断注入不发实时事件，且被前端归类为中性"插件注入"（成功态、藏在折叠区）；
- 唯一可见痕迹是用户消息旁 11px 的"失败"小红点。

## 变更点

- `react/turn.rs`：`run_turn` 失败收尾（`Failed`，取消除外——`Cancelled` 是独立变体且已有灰色"已取消"标签）追加 `[错误] {message}` System 消息，随最终落盘持久化，并在终态事件前经 `SessionMessageUpsert` 实时推送。前端零改动，现成红框渲染立即生效。
- `react/context.rs`：更新 `persist_error` 过时注释（旧注释描述的"前端落盘 `[错误]`"分工已不存在），说明现状分工——`[错误]` 消息仅前端可见，本函数注入的消息对模型可见。

System 角色被 `build_provider_messages` 排除，不进模型上下文；给模型的失败痕迹（含"继续或说明原因"指令）仍由 `persist_error` 负责，二者各司其职。

## 测试情况

- `cargo fmt -- --check` 通过；
- `cargo clippy -p tiangong-core --all-targets --tests --benches -- -D warnings` 通过；
- `cargo test -p tiangong-core` 全部 105 项通过，其中 `llm_failure_propagates_failed_status`（强制 LLM 失败）与 `cancel_running_turn_ends_cancelled`（取消路径）正覆盖本次改动路径；
- 实测强制失败场景确认落盘消息为 `[错误] 流式失败后回退非流式调用失败: …`。

## 明确不做

- 状态栏"执行失败"文本永不显示的独立小问题（可另开任务）；
- 不给 `react_loop_error` 加实时事件、不回填历史会话、不改前端。