### PR TITLE
chore(memory): 发布 memory 插件 v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11378,7 +11378,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -11386,7 +11386,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "tiangong-memory",
@@ -11398,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-wasm"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "scru128",
  "serde",

--- a/plugins/tiangong-plugin-memory/plugin.json
+++ b/plugins/tiangong-plugin-memory/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "memory",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "wasm": {
     "binary": "tiangong_plugin_memory_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-memory/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Memory System 独立 sidecar 进程（承载 SQLite/tantivy/lancedb 原生运行）"

--- a/plugins/tiangong-plugin-memory/wasm/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-wasm"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Memory 插件的 WASM 组件"


### PR DESCRIPTION
## 变更点
- 升级 memory 插件版本 0.1.1 → 0.1.2：plugin.json 与 protocol/wasm/sidecar 三个 Cargo.toml + Cargo.lock
- xtask validate-plugin 校验通过

## 本版本携带修复（#407，issue #404 后续）
- 反刍整理（meso/meta）移出 Actor 主循环并并发 LLM 提取：micro 入队确认恒毫秒级，收尾不再长时间持有 WASM 实例锁，连续对话的新消息响应与记忆注入不再被整理任务阻塞

## 发布计划
合并后打标签 `plugin/memory/v0.1.2` 触发 publish-plugins 工作流发布到 OSS。

transport_protocol / business_protocol 属协议版本，不在本次升级范围。