### PR TITLE
fix(plugin): 修正按需 sidecar 状态误判

### DIFF
--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -329,7 +329,6 @@ pub fn list_plugins(_storage_root: &Path, runtime: RuntimeKind) -> Vec<PluginSta
                 manifest,
                 loaded.enabled,
                 loaded.ui_plugin.is_some(),
-                sidecar_running,
                 loaded.last_error.as_deref(),
             );
             PluginStatus {
@@ -1137,14 +1136,14 @@ fn plugin_state(
     manifest: &PluginManifest,
     enabled: bool,
     has_wasm_ui: bool,
-    sidecar_running: bool,
     last_error: Option<&str>,
 ) -> &'static str {
+    // 未运行的 sidecar 可能仍在等待首次调用，只有已记录的错误才影响插件状态。
     if !enabled {
         "disabled"
     } else if !has_wasm_ui && manifest.wasm_binary().is_some() {
         "error"
-    } else if last_error.is_some() || (manifest.sidecar.is_some() && !sidecar_running) {
+    } else if last_error.is_some() {
         "degraded"
     } else {
         "loaded"
@@ -1168,13 +1167,7 @@ fn list_plugin_status_without_preload(manifest: &PluginManifest) -> Option<Plugi
     let sidecar_running = sidecar
         .as_ref()
         .is_some_and(|connection| connection.has_runtime_endpoint());
-    let state = plugin_state(
-        manifest,
-        enabled,
-        has_ui,
-        sidecar_running,
-        last_error.as_deref(),
-    );
+    let state = plugin_state(manifest, enabled, has_ui, last_error.as_deref());
     let configured = configured_model_capabilities();
     Some(PluginStatus {
         unavailable_reason: if enabled {


### PR DESCRIPTION
## 变更

- 未运行但没有错误的 sidecar 不再使插件进入 degraded 状态
- Command 空闲时保持已加载，由插件管理页显示后台服务按需启动
- 实际加载或启动错误仍通过 last_error 显示异常

## 原因

统一插件架构合并时，公共状态函数把 sidecar 未运行重新纳入异常条件，导致按需启动的 Command 插件稳定误报。

## 验证

- cargo fmt --all -- --check
- cargo check -p tiangong-plugin-runtime
- cargo test -p tiangong-plugin-runtime（65 项通过）
- cargo check -p tiangong-app
- frontend: yarn build
- 推送前检查：cargo check、cargo clippy、cargo nextest 均通过