### PR TITLE
feat(plugin): 插件自动安装与自动升级（含卸载记忆）

### DIFF
--- a/crates/tiangong-plugin-runtime/src/artifacts.rs
+++ b/crates/tiangong-plugin-runtime/src/artifacts.rs
@@ -23,11 +23,37 @@ const FIRST_LAUNCH_MARKER: &str = ".first_launch_completed";
 /// 默认插件 ID 列表。
 ///
 /// 这些插件提供 Agent 的基础能力（系统提示词、文件操作、命令执行、网络获取、
-/// 索引搜索、技能管理、MCP 工具桥接、终端与浏览器），确保用户安装后即可
+/// 索引搜索、技能管理、MCP 工具桥接、审批征询、终端与浏览器），确保用户安装后即可
 /// 获得基本体验。
 pub const DEFAULT_PLUGIN_IDS: &[&str] = &[
-    "prompt", "fs", "command", "fetch", "index", "skill", "mcp", "terminal", "browser",
+    "prompt",
+    "fs",
+    "command",
+    "fetch",
+    "index",
+    "skill",
+    "mcp",
+    "interaction",
+    "terminal",
+    "browser",
 ];
+
+/// 启动时自动安装的核心插件 ID 列表（终端、浏览器、审批征询）。
+///
+/// 属于默认插件集合的子集：未安装且未被用户主动卸载时，宿主启动后台任务
+/// 会自动从 OSS 目录安装，不依赖首启推荐引导。
+pub const AUTO_INSTALL_PLUGIN_IDS: &[&str] = &["terminal", "browser", "interaction"];
+
+/// 用户主动卸载的插件记录文件（位于存储根目录）。
+///
+/// 记录中的插件不会被自动安装或自动升级；用户重新手动安装成功后记录清除。
+const UNINSTALLED_PLUGINS_FILE: &str = "uninstalled_plugins.json";
+
+/// 卸载记录文件结构版本。
+const UNINSTALLED_PLUGINS_VERSION: u32 = 1;
+
+/// 与 `registry::DISABLED_MARKER` 保持一致的禁用标记文件名。
+const DISABLED_MARKER_FILE: &str = ".disabled";
 
 /// 场景分类常量：日常工作。
 pub const CATEGORY_DAILY: &str = "daily";
@@ -41,7 +67,7 @@ pub fn plugin_categories(id: &str) -> Vec<&'static str> {
     match id {
         // 基础能力：日常与编程通用。
         "prompt" | "fs" | "command" | "fetch" | "index" | "skill" | "mcp" | "memory"
-        | "terminal" | "browser" => {
+        | "interaction" | "terminal" | "browser" => {
             vec![CATEGORY_DAILY, CATEGORY_CODING]
         }
         // 编程开发专属。
@@ -117,6 +143,9 @@ pub struct AvailablePlugin {
     pub supported: bool,
     pub installed_version: Option<String>,
     pub update_available: bool,
+    /// 已安装插件的启用状态（未安装时为 false）。
+    #[serde(default)]
+    pub installed_enabled: bool,
     /// 是否为默认插件（基础能力，首次启动时会推荐安装）。
     #[serde(default)]
     pub is_default: bool,
@@ -213,13 +242,14 @@ impl PluginRepository {
 
     pub async fn list_available(&self, storage_root: &Path) -> Result<Vec<AvailablePlugin>> {
         let catalog = self.fetch_catalog().await?;
-        let installed = installed_versions(storage_root);
+        let installed = installed_plugin_states(storage_root);
         let platform = current_platform_key();
         Ok(catalog
             .plugins
             .into_iter()
             .map(|plugin| {
-                let installed_version = installed.get(&plugin.id).cloned();
+                let installed_state = installed.get(&plugin.id);
+                let installed_version = installed_state.map(|state| state.version.clone());
                 let update_available = installed_version
                     .as_deref()
                     .is_some_and(|local| version_is_newer(local, &plugin.version));
@@ -228,6 +258,7 @@ impl PluginRepository {
                         || plugin.sidecars.contains_key(&platform),
                     is_default: is_default_plugin(&plugin.id),
                     categories: plugin_categories(&plugin.id),
+                    installed_enabled: installed_state.is_some_and(|state| state.enabled),
                     id: plugin.id,
                     name: plugin.name,
                     version: plugin.version,
@@ -650,16 +681,142 @@ fn validate_relative_artifact_path(path: &Path, label: &str) -> Result<()> {
     Ok(())
 }
 
-fn installed_versions(storage_root: &Path) -> HashMap<String, String> {
+/// 已安装插件的本地状态快照。
+#[derive(Debug, Clone)]
+struct InstalledPluginState {
+    version: String,
+    enabled: bool,
+}
+
+fn installed_plugin_states(storage_root: &Path) -> HashMap<String, InstalledPluginState> {
     let plugins_dir = storage_root.join("plugins");
     let Ok(entries) = std::fs::read_dir(plugins_dir) else {
         return HashMap::new();
     };
     entries
         .filter_map(Result::ok)
-        .filter_map(|entry| PluginManifest::load(&entry.path().join(MANIFEST_FILE)).ok())
-        .map(|manifest| (manifest.id, manifest.version))
+        .filter_map(|entry| {
+            let manifest = PluginManifest::load(&entry.path().join(MANIFEST_FILE)).ok()?;
+            let enabled = !entry.path().join(DISABLED_MARKER_FILE).is_file();
+            Some((
+                manifest.id,
+                InstalledPluginState {
+                    version: manifest.version,
+                    enabled,
+                },
+            ))
+        })
         .collect()
+}
+
+/// 读取用户主动卸载的插件 ID 集合。
+///
+/// 文件不存在视为空集合；损坏时同样按空集合处理并告警——卸载记录缺失
+/// 最坏结果是多余的自动重装，不应阻断启动维护任务。
+pub fn read_uninstalled_plugins(storage_root: &Path) -> BTreeSet<String> {
+    let path = storage_root.join(UNINSTALLED_PLUGINS_FILE);
+    let Ok(content) = std::fs::read(&path) else {
+        return BTreeSet::new();
+    };
+    #[derive(serde::Deserialize)]
+    struct UninstalledRecord {
+        version: u32,
+        uninstalled: BTreeSet<String>,
+    }
+    match serde_json::from_slice::<UninstalledRecord>(&content) {
+        Ok(record) if record.version == UNINSTALLED_PLUGINS_VERSION => record.uninstalled,
+        Ok(record) => {
+            tracing::warn!(
+                version = record.version,
+                path = %path.display(),
+                "卸载记录版本不兼容，按空集合处理"
+            );
+            BTreeSet::new()
+        }
+        Err(error) => {
+            tracing::warn!(path = %path.display(), %error, "卸载记录损坏，按空集合处理");
+            BTreeSet::new()
+        }
+    }
+}
+
+/// 记录一个用户主动卸载的插件（temp + rename 原子写）。
+pub fn record_uninstalled_plugin(storage_root: &Path, plugin_id: &str) -> Result<()> {
+    let mut uninstalled = read_uninstalled_plugins(storage_root);
+    if !uninstalled.insert(plugin_id.to_string()) {
+        return Ok(());
+    }
+    write_uninstalled_plugins(storage_root, &uninstalled)
+}
+
+/// 清除插件的卸载记录（重新安装成功后调用，用户改主意即失效）。
+pub fn clear_uninstalled_plugin(storage_root: &Path, plugin_id: &str) -> Result<()> {
+    let mut uninstalled = read_uninstalled_plugins(storage_root);
+    if uninstalled.remove(plugin_id) {
+        write_uninstalled_plugins(storage_root, &uninstalled)?;
+    }
+    Ok(())
+}
+
+fn write_uninstalled_plugins(storage_root: &Path, uninstalled: &BTreeSet<String>) -> Result<()> {
+    std::fs::create_dir_all(storage_root)
+        .with_context(|| format!("创建存储目录失败: {}", storage_root.display()))?;
+    let path = storage_root.join(UNINSTALLED_PLUGINS_FILE);
+    let temp = storage_root.join(format!(
+        ".{UNINSTALLED_PLUGINS_FILE}.tmp-{}",
+        std::process::id()
+    ));
+    let content = serde_json::json!({
+        "version": UNINSTALLED_PLUGINS_VERSION,
+        "uninstalled": uninstalled,
+    });
+    std::fs::write(&temp, serde_json::to_vec_pretty(&content)?)?;
+    if let Err(error) = std::fs::rename(&temp, &path)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        let _ = std::fs::remove_file(&temp);
+        return Err(anyhow!(error))
+            .with_context(|| format!("写入卸载记录失败: {}", path.display()));
+    }
+    Ok(())
+}
+
+/// 启动时自动维护决策结果。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AutoMaintenancePlan {
+    /// 需要自动安装的核心插件 ID。
+    pub install: Vec<String>,
+    /// 需要自动升级的已启用插件 ID。
+    pub upgrade: Vec<String>,
+}
+
+/// 计算启动时的自动维护计划。
+///
+/// - 自动安装：核心插件（`AUTO_INSTALL_PLUGIN_IDS`）在目录中存在、平台支持、
+///   未安装且不在卸载记录中；
+/// - 自动升级：已安装、启用、目录声明了更新版本且不在卸载记录中
+///   （禁用插件尊重用户意愿，保持现状，可手动升级）。
+pub fn plan_auto_maintenance(
+    available: &[AvailablePlugin],
+    uninstalled: &BTreeSet<String>,
+) -> AutoMaintenancePlan {
+    let mut install = Vec::new();
+    let mut upgrade = Vec::new();
+    for plugin in available {
+        if uninstalled.contains(&plugin.id) {
+            continue;
+        }
+        let is_core = AUTO_INSTALL_PLUGIN_IDS.contains(&plugin.id.as_str());
+        if is_core && plugin.supported && plugin.installed_version.is_none() {
+            install.push(plugin.id.clone());
+        } else if plugin.installed_version.is_some()
+            && plugin.installed_enabled
+            && plugin.update_available
+        {
+            upgrade.push(plugin.id.clone());
+        }
+    }
+    AutoMaintenancePlan { install, upgrade }
 }
 
 fn version_is_newer(installed: &str, available: &str) -> bool {

--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -1325,6 +1325,17 @@ fn install_staged_plugin_inner(
     // 业务调用（打开终端 / 首次工具执行）上。
     if status.is_ok() {
         prewarm_plugin_sidecar(storage_root, &staged.manifest.id);
+        // 安装成功即解除卸载记录：用户主动重装（或自动维护安装）代表
+        // 该插件回到已安装状态，此前的主动卸载意图失效。
+        if let Err(error) =
+            crate::artifacts::clear_uninstalled_plugin(storage_root, &staged.manifest.id)
+        {
+            tracing::warn!(
+                plugin_id = %staged.manifest.id,
+                %error,
+                "插件安装成功，但清除卸载记录失败"
+            );
+        }
     }
     tracing::info!(
         plugin_id,
@@ -1583,6 +1594,11 @@ pub fn uninstall_plugin(storage_root: &Path, plugin_id: &str, keep_data: bool) -
         {
             adapter.set_enabled(false);
         }
+    }
+    // 卸载成功即记录：自动安装/自动维护跳过用户主动移除的插件，
+    // 用户重新手动安装成功后记录在安装路径中清除。
+    if let Err(error) = crate::artifacts::record_uninstalled_plugin(storage_root, plugin_id) {
+        tracing::warn!(plugin_id, %error, "插件已卸载，但写入卸载记录失败");
     }
     Ok(())
 }

--- a/crates/tiangong-plugin-runtime/tests/auto_maintenance.rs
+++ b/crates/tiangong-plugin-runtime/tests/auto_maintenance.rs
@@ -1,0 +1,208 @@
+//! 插件自动维护验证：
+//! 卸载记录读写往返 → 自动维护计划决策（核心插件自动安装、启用插件自动
+//! 升级、黑名单与禁用跳过）→ 卸载写入记录与重新安装清除记录的 registry 集成。
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use tiangong_plugin_runtime::artifacts::{
+    AvailablePlugin, clear_uninstalled_plugin, plan_auto_maintenance, read_uninstalled_plugins,
+    record_uninstalled_plugin,
+};
+use tiangong_plugin_runtime::registry::{install_staged_plugin, uninstall_plugin};
+
+static REGISTRY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn available_plugin(
+    id: &str,
+    version: &str,
+    supported: bool,
+    installed: Option<(&str, bool)>,
+    update_available: bool,
+) -> AvailablePlugin {
+    AvailablePlugin {
+        id: id.to_string(),
+        name: id.to_string(),
+        version: version.to_string(),
+        description: String::new(),
+        supported,
+        installed_version: installed.map(|(version, _)| version.to_string()),
+        update_available,
+        installed_enabled: installed.is_some_and(|(_, enabled)| enabled),
+        is_default: false,
+        categories: Vec::new(),
+    }
+}
+
+fn uninstalled_set(ids: &[&str]) -> BTreeSet<String> {
+    ids.iter().map(|id| id.to_string()).collect()
+}
+
+/// 写一个最小合法的纯 UI 清单目录（可直接被卸载或加载）。
+fn stage_installed_plugin(root: &Path, id: &str) {
+    let dir = root.join("plugins").join(id);
+    std::fs::create_dir_all(dir.join("dist")).unwrap();
+    std::fs::write(
+        dir.join("plugin.json"),
+        format!(
+            r#"{{
+                "schema_version": 2,
+                "id": "{id}",
+                "version": "0.1.0",
+                "ui": {{
+                    "contributions": [
+                        {{
+                            "slot": "extension.tab",
+                            "id": "{id}",
+                            "title": "{id}",
+                            "entry": "dist/index.html"
+                        }}
+                    ]
+                }}
+            }}"#
+        ),
+    )
+    .unwrap();
+    std::fs::write(dir.join("dist").join("index.html"), "<html></html>").unwrap();
+}
+
+/// 构造受管事务目录中的待安装插件（纯 UI，无 wasm 无 sidecar）。
+fn stage_transaction_plugin(root: &Path, id: &str, version: &str) -> std::path::PathBuf {
+    let staging = root
+        .join("plugins")
+        .join(".transactions")
+        .join("staging-test");
+    std::fs::create_dir_all(staging.join("dist")).unwrap();
+    std::fs::write(
+        staging.join("plugin.json"),
+        format!(
+            r#"{{
+                "schema_version": 2,
+                "id": "{id}",
+                "version": "{version}",
+                "ui": {{
+                    "contributions": [
+                        {{
+                            "slot": "extension.tab",
+                            "id": "{id}",
+                            "title": "{id}",
+                            "entry": "dist/index.html"
+                        }}
+                    ]
+                }}
+            }}"#
+        ),
+    )
+    .unwrap();
+    std::fs::write(staging.join("dist").join("index.html"), "<html></html>").unwrap();
+    staging
+}
+
+#[test]
+fn 卸载记录读写往返与幂等() {
+    let root = tempfile::TempDir::new().unwrap();
+    assert!(read_uninstalled_plugins(root.path()).is_empty(), "初始为空");
+
+    record_uninstalled_plugin(root.path(), "terminal").unwrap();
+    record_uninstalled_plugin(root.path(), "browser").unwrap();
+    record_uninstalled_plugin(root.path(), "terminal").unwrap();
+    assert_eq!(
+        read_uninstalled_plugins(root.path()),
+        uninstalled_set(&["terminal", "browser"]),
+        "重复记录应幂等"
+    );
+
+    clear_uninstalled_plugin(root.path(), "terminal").unwrap();
+    clear_uninstalled_plugin(root.path(), "不存在").unwrap();
+    assert_eq!(
+        read_uninstalled_plugins(root.path()),
+        uninstalled_set(&["browser"]),
+        "清除后仅剩未清除项"
+    );
+}
+
+#[test]
+fn 损坏的卸载记录按空集合处理() {
+    let root = tempfile::TempDir::new().unwrap();
+    std::fs::write(root.path().join("uninstalled_plugins.json"), "not-json").unwrap();
+    assert!(read_uninstalled_plugins(root.path()).is_empty());
+
+    // 空集合之上继续写入应恢复正常。
+    record_uninstalled_plugin(root.path(), "browser").unwrap();
+    assert_eq!(
+        read_uninstalled_plugins(root.path()),
+        uninstalled_set(&["browser"])
+    );
+}
+
+#[test]
+fn 自动维护计划_核心安装_启用升级_黑名单与禁用跳过() {
+    let available = vec![
+        // 核心插件未安装 → 自动安装。
+        available_plugin("terminal", "0.1.0", true, None, false),
+        // 核心插件未安装但在卸载黑名单 → 跳过。
+        available_plugin("browser", "0.1.0", true, None, false),
+        // 核心插件平台不支持 → 跳过。
+        available_plugin("interaction", "0.3.1", false, None, false),
+        // 核心插件已安装且无更新 → 不动。
+        available_plugin("interaction", "0.3.1", true, Some(("0.3.1", true)), false),
+        // 已安装、启用、有更新 → 自动升级。
+        available_plugin("memory", "0.2.0", true, Some(("0.1.0", true)), true),
+        // 已安装、禁用、有更新 → 尊重用户意愿不升级。
+        available_plugin("prompt", "0.2.0", true, Some(("0.1.0", false)), true),
+        // 已安装、启用、无更新 → 不动。
+        available_plugin("fetch", "0.1.0", true, Some(("0.1.0", true)), false),
+        // 非核心未安装 → 不自动安装。
+        available_plugin("skill", "0.1.0", true, None, false),
+        // 已安装、启用、有更新但在黑名单 → 不升级。
+        available_plugin("mcp", "0.2.0", true, Some(("0.1.0", true)), true),
+    ];
+    let uninstalled = uninstalled_set(&["browser", "mcp"]);
+    let plan = plan_auto_maintenance(&available, &uninstalled);
+
+    assert_eq!(plan.install, vec!["terminal".to_string()]);
+    assert_eq!(plan.upgrade, vec!["memory".to_string()]);
+}
+
+#[test]
+fn 空目录或全黑名单时计划为空() {
+    assert!(
+        plan_auto_maintenance(&[], &BTreeSet::new())
+            .install
+            .is_empty()
+    );
+    assert!(
+        plan_auto_maintenance(&[], &BTreeSet::new())
+            .upgrade
+            .is_empty()
+    );
+
+    let available = vec![available_plugin("terminal", "0.1.0", true, None, false)];
+    let uninstalled = uninstalled_set(&["terminal"]);
+    let plan = plan_auto_maintenance(&available, &uninstalled);
+    assert!(plan.install.is_empty() && plan.upgrade.is_empty());
+}
+
+#[test]
+fn 卸载写入记录_重新安装清除记录() {
+    let _guard = REGISTRY_LOCK.lock().unwrap();
+    let root = tempfile::TempDir::new().unwrap();
+    tiangong_config::registry::init_from_dir(root.path());
+    stage_installed_plugin(root.path(), "terminal");
+    assert!(read_uninstalled_plugins(root.path()).is_empty());
+
+    uninstall_plugin(root.path(), "terminal", true).unwrap();
+    assert_eq!(
+        read_uninstalled_plugins(root.path()),
+        uninstalled_set(&["terminal"]),
+        "用户主动卸载后应记录"
+    );
+
+    // 重新手动安装（走受管事务目录的正式安装链路）成功后记录失效。
+    let staging = stage_transaction_plugin(root.path(), "terminal", "0.1.1");
+    install_staged_plugin(root.path(), &staging).unwrap();
+    assert!(
+        read_uninstalled_plugins(root.path()).is_empty(),
+        "重新安装成功后卸载记录应清除"
+    );
+}

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -1192,6 +1192,8 @@ export interface AvailablePlugin {
   supported: boolean;
   installed_version: string | null;
   update_available: boolean;
+  /** 已安装插件的启用状态（未安装时为 false）。 */
+  installed_enabled: boolean;
   is_default: boolean;
   /// 场景分类标签（多标签，`daily` / `coding` 的任意组合）。
   categories: string[];

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -432,6 +432,20 @@ impl TiangongApp {
         });
     }
 
+    /// 启动插件自动维护任务（main.rs setup 阶段调用一次）。
+    ///
+    /// 启动后后台检查一次 OSS 插件目录：自动安装缺失的核心插件
+    /// （终端/浏览器/审批征询），自动升级有新版本的已启用插件；
+    /// 用户主动卸载过的插件跳过。全程无弹窗，离线或失败仅记日志，
+    /// 留待下次启动重试。
+    pub fn start_plugin_auto_maintainer(&self, app_handle: tauri::AppHandle) {
+        tauri::async_runtime::spawn(async move {
+            if let Err(error) = run_plugin_auto_maintenance(app_handle).await {
+                tracing::warn!(%error, "插件自动维护任务异常结束");
+            }
+        });
+    }
+
     /// 同步工具消息注入（供需要同步返回值的场景，如 browser:events 的 ack 判断）。
     ///
     /// core 不存在时返回 false。大多数场景应通过 [`Self::tool_injection_tx`] push 到 channel，
@@ -840,6 +854,66 @@ impl TiangongApp {
         let guard = self.lock_embedded_server();
         guard.is_some()
     }
+}
+
+/// 插件自动维护一轮：拉取 OSS 目录 → 结合卸载记录计算安装/升级计划 →
+/// 串行执行（复用手动安装的事务与回滚链路）→ 成功后广播 plugins_changed。
+async fn run_plugin_auto_maintenance(app_handle: tauri::AppHandle) -> anyhow::Result<()> {
+    use tauri::Emitter;
+    use tiangong_plugin_runtime::artifacts;
+
+    let state = app_handle.state::<TiangongApp>();
+    let storage_root = state
+        .with_state_read(|core_state| Ok(core_state.config.storage_root.clone()))
+        .await
+        .map_err(|error| anyhow::anyhow!("读取存储根目录失败: {error}"))?;
+
+    let repository = artifacts::PluginRepository::new()?;
+    let available = match repository.list_available(&storage_root).await {
+        Ok(list) => list,
+        Err(error) => {
+            // 离线或 OSS 不可达：静默跳过，下次启动再试。
+            tracing::info!(%error, "插件目录拉取失败，跳过本次自动维护");
+            return Ok(());
+        }
+    };
+    let uninstalled = artifacts::read_uninstalled_plugins(&storage_root);
+    let plan = artifacts::plan_auto_maintenance(&available, &uninstalled);
+    if plan.install.is_empty() && plan.upgrade.is_empty() {
+        tracing::debug!("插件无需自动维护");
+        return Ok(());
+    }
+    tracing::info!(
+        install = ?plan.install,
+        upgrade = ?plan.upgrade,
+        "开始插件自动维护"
+    );
+    for plugin_id in plan.install.iter().chain(plan.upgrade.iter()) {
+        match crate::commands::download_and_install_plugin(
+            storage_root.clone(),
+            plugin_id.clone(),
+            app_handle.clone(),
+        )
+        .await
+        {
+            Ok(status) => {
+                tracing::info!(
+                    plugin_id,
+                    version = %status.manifest_version,
+                    "插件自动维护安装/升级完成"
+                );
+                let _ = app_handle.emit("plugins_changed", &());
+            }
+            Err(error) => {
+                tracing::warn!(
+                    plugin_id,
+                    %error,
+                    "插件自动维护安装/升级失败，下次启动重试"
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4467,7 +4467,13 @@ pub async fn check_default_plugins(
     let missing: Vec<_> = available
         .into_iter()
         .filter(|plugin| {
-            plugin.is_default && plugin.supported && plugin.installed_version.is_none()
+            plugin.is_default
+                && plugin.supported
+                && plugin.installed_version.is_none()
+                // 核心插件（终端/浏览器/审批征询）由启动时的自动维护任务
+                // 负责安装，首启推荐引导不再重复推荐。
+                && !tiangong_plugin_runtime::artifacts::AUTO_INSTALL_PLUGIN_IDS
+                    .contains(&plugin.id.as_str())
         })
         .collect();
 
@@ -4497,7 +4503,7 @@ fn notify_plugins_changed(app: &AppHandle) {
     let _ = app.emit("plugins_changed", &());
 }
 
-async fn download_and_install_plugin(
+pub(crate) async fn download_and_install_plugin(
     storage_root: std::path::PathBuf,
     plugin_id: String,
     app: AppHandle,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -557,6 +557,10 @@ fn run_gui() {
             let app_handle = app.handle().clone();
             tauri::async_runtime::spawn(auto_start_server_and_bots(app_handle));
 
+            // 插件自动维护：后台安装缺失的核心插件并升级已启用插件，
+            // 用户主动卸载过的插件跳过；离线或失败仅记日志。
+            state.start_plugin_auto_maintainer(app.handle().clone());
+
             #[cfg(debug_assertions)]
             {
                 let app_handle = app.handle().clone();


### PR DESCRIPTION
## 变更内容

- **自动安装**：启动时后台任务自动安装缺失的核心插件 terminal / browser / interaction（platform 支持且未被用户主动卸载）；interaction 同时并入默认插件集合与日常/编程分类。
- **自动升级**：启动时检查一次 OSS 目录，有新版本的**已启用**插件自动升级（沿用既有事务安装、失败回滚、数据与禁用状态保留链路）；禁用插件不动，可手动升级。
- **卸载记忆**：用户主动卸载的插件记录到 `uninstalled_plugins.json`（原子写，损坏按空集容错），自动安装/升级永久跳过；重新手动安装成功后记录自动清除。
- 首启推荐引导（check_default_plugins）不再重复推荐自动安装的三个核心插件，其余默认插件引导不变。
- `list_available` 补充 `installed_enabled` 字段（读取安装目录 `.disabled` 标记），前端类型同步。

## 验证

- 新增集成测试 `tests/auto_maintenance.rs` 5 项：卸载记录读写往返与幂等、损坏容错、计划决策（核心安装/启用升级/黑名单与禁用跳过/非核心不装）、registry 卸载写入与重装清除。
- `cargo fmt -- --check`、`cargo clippy -p tiangong-plugin-runtime -p tiangong-app --all-targets --tests -- -D warnings` 通过。
- `cargo nextest run -p tiangong-plugin-runtime -p tiangong-app` 130 项全过；前端 `yarn build` + `yarn test` 212 项全过。

## Desktop 验收要点（待用户）

1. 全新环境启动 → 三个核心插件自动装上。
2. 卸载任一核心插件重启 → 不自动重装；手动重装后自动维护恢复；再次卸载后记忆重新生效。
3. 已启用插件有新版本 → 启动后自动升级且数据/禁用状态保留。
4. 断网启动无弹窗无报错，仅日志。