### PR TITLE
refactor(llm): 思考控制统一为 ReasoningEffort 单参数

### DIFF
--- a/crates/plugins/tiangong-plugin-agent-team/src/coordinator.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/coordinator.rs
@@ -238,7 +238,7 @@ impl Coordinator {
             let mut child = Session::new(&label);
             let agent_id = child.id.clone();
             child.cwd = parent.cwd.clone();
-            child.reasoning_effort = parent.reasoning_effort.clone();
+            child.reasoning_effort = parent.reasoning_effort;
             child.trust_mode = TrustMode::FullTrust;
             child.parent_session_id = Some(parent.id.clone());
             let record = AgentRecord {
@@ -924,7 +924,7 @@ fn load_or_create_child_session(
     let mut child = Session::new(&record.descriptor.label);
     child.id = record.descriptor.agent_id.clone();
     child.cwd = parent.cwd.clone();
-    child.reasoning_effort = parent.reasoning_effort.clone();
+    child.reasoning_effort = parent.reasoning_effort;
     child.trust_mode = TrustMode::FullTrust;
     child.parent_session_id = Some(parent.id.clone());
     child.bind_storage_root(root);

--- a/crates/tiangong-anthropic/src/client.rs
+++ b/crates/tiangong-anthropic/src/client.rs
@@ -7,8 +7,15 @@ use crate::config::AnthropicConfig;
 use crate::error::AnthropicError;
 use crate::types::{
     ContentBlockDeltaData, ContentBlockStartData, EventStream, MessageDeltaData, MessageStartData,
-    MessagesCreateRequest, MessagesCreateResponse, ModelsListResponse, StreamEvent,
+    MessagesCreateRequest, MessagesCreateResponse, ModelsListResponse, StreamEvent, ThinkingConfig,
 };
+
+/// 官方 Anthropic API 域名。
+const OFFICIAL_API_HOST: &str = "api.anthropic.com";
+/// 默认思考预算下，为正文（含工具调用）保留的输出空间。
+const DEFAULT_BUDGET_TEXT_RESERVE_TOKENS: u32 = 8_192;
+/// 官方协议要求的思考预算下限（官方拒绝小于 1024 的值）。
+const MIN_THINKING_BUDGET_TOKENS: u32 = 1_024;
 
 #[derive(Clone)]
 pub struct AnthropicClient {
@@ -35,8 +42,9 @@ impl AnthropicClient {
 
     pub async fn create(
         &self,
-        request: MessagesCreateRequest,
+        mut request: MessagesCreateRequest,
     ) -> Result<MessagesCreateResponse, AnthropicError> {
+        self.apply_official_thinking_budget(&mut request);
         let response = self
             .request_builder("/v1/messages")
             .json(&request)
@@ -50,6 +58,7 @@ impl AnthropicClient {
         &self,
         mut request: MessagesCreateRequest,
     ) -> Result<EventStream, AnthropicError> {
+        self.apply_official_thinking_budget(&mut request);
         request.stream = Some(true);
         let response = self
             .stream_request_builder("/v1/messages")
@@ -88,6 +97,37 @@ impl AnthropicClient {
 
     fn request_builder(&self, path: &str) -> reqwest::RequestBuilder {
         self.request_builder_with_client(&self.http_client, path)
+    }
+
+    /// 官方 Anthropic 端点要求 thinking.enabled 必须携带 budget_tokens
+    /// （≥1024 且严格小于 max_tokens）。DeepSeek/GLM 等兼容实现可省略预算，
+    /// 且部分实现（实测 GLM）会执行预算并在思考超限时截断输出，因此仅对
+    /// 官方端点填充默认推荐预算：max_tokens 保留正文空间后全部交给思考。
+    fn apply_official_thinking_budget(&self, request: &mut MessagesCreateRequest) {
+        if !matches!(
+            request.thinking,
+            Some(ThinkingConfig::Enabled {
+                budget_tokens: None
+            })
+        ) || !self.is_official_endpoint()
+        {
+            return;
+        }
+        let budget = request
+            .max_tokens
+            .saturating_sub(DEFAULT_BUDGET_TEXT_RESERVE_TOKENS)
+            .max(MIN_THINKING_BUDGET_TOKENS)
+            .min(request.max_tokens.saturating_sub(1));
+        request.thinking = Some(ThinkingConfig::Enabled {
+            budget_tokens: Some(budget),
+        });
+    }
+
+    /// 判断端点是否为官方 Anthropic API（DeepSeek/GLM 等兼容端点返回 false）。
+    fn is_official_endpoint(&self) -> bool {
+        let base = self.config.base_url.trim_end_matches('/');
+        let host = base.split("://").nth(1).unwrap_or(base);
+        host.eq_ignore_ascii_case(OFFICIAL_API_HOST)
     }
 
     fn stream_request_builder(&self, path: &str) -> reqwest::RequestBuilder {
@@ -258,5 +298,103 @@ fn parse_sse_event(event_type: &str, data: &str) -> Result<StreamEvent, Anthropi
         }),
         "message_stop" => Ok(StreamEvent::MessageStop),
         _other => Ok(StreamEvent::Unknown),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AnthropicConfig;
+    use std::time::Duration;
+
+    fn client_with_base_url(base_url: &str) -> AnthropicClient {
+        AnthropicClient::from_config(AnthropicConfig {
+            api_key: "test-key".to_string(),
+            base_url: base_url.to_string(),
+            timeout: Duration::from_secs(1),
+            api_version: "2023-06-01".to_string(),
+            beta: None,
+        })
+        .unwrap()
+    }
+
+    fn request_with(max_tokens: u32, thinking: Option<ThinkingConfig>) -> MessagesCreateRequest {
+        MessagesCreateRequest {
+            model: "claude-sonnet-4-5".to_string(),
+            max_tokens,
+            system: None,
+            messages: Vec::new(),
+            temperature: None,
+            stop_sequences: None,
+            top_p: None,
+            metadata: None,
+            tools: None,
+            tool_choice: None,
+            stream: None,
+            thinking,
+        }
+    }
+
+    #[test]
+    fn official_endpoint_fills_default_budget() {
+        let client = client_with_base_url("https://api.anthropic.com");
+        let mut request = request_with(32_768, Some(ThinkingConfig::enabled()));
+        client.apply_official_thinking_budget(&mut request);
+        assert_eq!(
+            request.thinking,
+            Some(ThinkingConfig::Enabled {
+                budget_tokens: Some(24_576)
+            })
+        );
+    }
+
+    #[test]
+    fn official_endpoint_keeps_explicit_budget() {
+        let client = client_with_base_url("https://api.anthropic.com");
+        let mut request = request_with(32_768, Some(ThinkingConfig::with_budget(2_048)));
+        client.apply_official_thinking_budget(&mut request);
+        assert_eq!(
+            request.thinking,
+            Some(ThinkingConfig::Enabled {
+                budget_tokens: Some(2_048)
+            })
+        );
+    }
+
+    #[test]
+    fn compatible_endpoint_leaves_budget_unset() {
+        // DeepSeek/GLM 等兼容端点：实测会执行预算并在思考超限时截断，
+        // 不下发预算，思考量由上游决定。
+        for base_url in [
+            "https://open.bigmodel.cn/api/anthropic",
+            "http://127.0.0.1:3456/v1",
+        ] {
+            let client = client_with_base_url(base_url);
+            let mut request = request_with(32_768, Some(ThinkingConfig::enabled()));
+            client.apply_official_thinking_budget(&mut request);
+            assert_eq!(request.thinking, Some(ThinkingConfig::enabled()));
+        }
+    }
+
+    #[test]
+    fn small_max_tokens_clamps_budget() {
+        let client = client_with_base_url("https://api.anthropic.com");
+        // max_tokens 小于正文预留时：取下限 1024，并保证严格小于 max_tokens。
+        let mut request = request_with(1_500, Some(ThinkingConfig::enabled()));
+        client.apply_official_thinking_budget(&mut request);
+        assert_eq!(
+            request.thinking,
+            Some(ThinkingConfig::Enabled {
+                budget_tokens: Some(1_024)
+            })
+        );
+    }
+
+    #[test]
+    fn disabled_thinking_is_untouched() {
+        let client = client_with_base_url("https://api.anthropic.com");
+        let mut request = request_with(32_768, Some(ThinkingConfig::Disabled));
+        client.apply_official_thinking_budget(&mut request);
+        assert_eq!(request.thinking, Some(ThinkingConfig::Disabled));
     }
 }

--- a/crates/tiangong-anthropic/src/types.rs
+++ b/crates/tiangong-anthropic/src/types.rs
@@ -122,8 +122,31 @@ pub struct Tool {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ThinkingConfig {
-    Enabled { budget_tokens: u32 },
+    Enabled {
+        /// 思考预算。Anthropic 官方端点要求必填且须小于 max_tokens；
+        /// DeepSeek/GLM 等兼容实现可省略——省略时思考量由上游决定，
+        /// 且该字段不会序列化进请求。
+        #[serde(skip_serializing_if = "Option::is_none")]
+        budget_tokens: Option<u32>,
+    },
     Disabled,
+}
+
+impl ThinkingConfig {
+    /// 开启思考且不限制预算：兼容 DeepSeek/GLM 等 Anthropic 兼容实现。
+    /// 接入官方 Anthropic 端点时改用 [`ThinkingConfig::with_budget`]。
+    pub fn enabled() -> Self {
+        Self::Enabled {
+            budget_tokens: None,
+        }
+    }
+
+    /// 开启思考并显式指定预算（官方 Anthropic 端点使用）。
+    pub fn with_budget(budget_tokens: u32) -> Self {
+        Self::Enabled {
+            budget_tokens: Some(budget_tokens),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/tiangong-config/src/config.rs
+++ b/crates/tiangong-config/src/config.rs
@@ -199,7 +199,7 @@ impl TiangongConfig {
             trust_mode: self.default_trust_mode,
             default_trust_mode: self.default_trust_mode,
             custom_system_prompt: self.custom_system_prompt.clone(),
-            reasoning_effort: "medium".to_string(),
+            reasoning_effort: tiangong_llm::request::ReasoningEffort::Medium,
             context_limit,
         }
     }

--- a/crates/tiangong-core-manager/src/core_manager/ensure.rs
+++ b/crates/tiangong-core-manager/src/core_manager/ensure.rs
@@ -137,7 +137,11 @@ impl CoreManager {
     }
 
     /// 设置指定会话 Core 的思考强度（下一次尚未发出的模型请求生效）。
-    pub fn set_core_reasoning_effort(&self, session_id: &str, effort: String) {
+    pub fn set_core_reasoning_effort(
+        &self,
+        session_id: &str,
+        effort: tiangong_llm::request::ReasoningEffort,
+    ) {
         let registry = self.registry();
         if let Some(core) = registry.get(session_id) {
             core.set_reasoning_effort(effort);

--- a/crates/tiangong-core-manager/src/core_manager/ensure.rs
+++ b/crates/tiangong-core-manager/src/core_manager/ensure.rs
@@ -49,7 +49,7 @@ impl CoreManager {
             if let Some(core) = registry.get(session_id) {
                 let _ = core.replace_config(session_config.clone());
                 core.set_trust_mode(session_config.trust_mode);
-                core.set_reasoning_effort(session_config.reasoning_effort.clone());
+                core.set_reasoning_effort(session_config.reasoning_effort);
                 return Ok(EnsuredCore {
                     session_id: session_id.to_string(),
                     is_new: false,

--- a/crates/tiangong-core-manager/src/core_manager/mod.rs
+++ b/crates/tiangong-core-manager/src/core_manager/mod.rs
@@ -333,7 +333,7 @@ impl CoreManager {
             if let Some(config) = session_configs.get(session_id) {
                 let _ = core.replace_config(config.clone());
                 core.set_trust_mode(config.trust_mode);
-                core.set_reasoning_effort(config.reasoning_effort.clone());
+                core.set_reasoning_effort(config.reasoning_effort);
             }
         }
     }

--- a/crates/tiangong-core-manager/src/metadata.rs
+++ b/crates/tiangong-core-manager/src/metadata.rs
@@ -20,7 +20,7 @@ pub struct SessionMetadata {
     pub trust_mode: TrustMode,
     /// 会话级思考强度；为空时使用应用级默认值。
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reasoning_effort: Option<String>,
+    pub reasoning_effort: Option<tiangong_llm::request::ReasoningEffort>,
     /// 会话级工作目录（工具执行时的根目录）。
     #[serde(default)]
     pub cwd: String,
@@ -92,7 +92,7 @@ impl SessionMetadata {
             reasoning_effort: value
                 .get("reasoning_effort")
                 .and_then(|item| item.as_str())
-                .map(str::to_string),
+                .map(tiangong_llm::request::ReasoningEffort::parse_flexible),
             cwd: pick_str("cwd"),
             cwd_mode: value
                 .get("cwd_mode")
@@ -124,7 +124,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-02T00:00:00Z".into(),
             trust_mode: TrustMode::FullTrust,
-            reasoning_effort: Some("high".into()),
+            reasoning_effort: Some(tiangong_llm::request::ReasoningEffort::High),
             cwd: "/tmp".into(),
             cwd_mode: SessionCwdMode::Inherit,
             message_count: 3,

--- a/crates/tiangong-core-manager/src/metadata.rs
+++ b/crates/tiangong-core-manager/src/metadata.rs
@@ -43,7 +43,7 @@ impl From<&Session> for SessionMetadata {
             created_at: session.created_at.clone(),
             updated_at: session.updated_at.clone(),
             trust_mode: session.trust_mode,
-            reasoning_effort: session.reasoning_effort.clone(),
+            reasoning_effort: session.reasoning_effort,
             cwd: session.cwd.clone(),
             cwd_mode: session.cwd_mode.clone(),
             message_count: session.messages.len(),

--- a/crates/tiangong-core/src/agent_config.rs
+++ b/crates/tiangong-core/src/agent_config.rs
@@ -15,11 +15,12 @@ pub struct AgentConfig {
     /// 用户自定义特色 Prompt，会注入到 system prompt。
     #[serde(default)]
     pub custom_system_prompt: String,
-    /// 思考强度设置：none/low/medium/high/max，默认 medium
+    /// 思考强度设置：None 关闭思考，默认 Medium
     #[serde(default = "default_reasoning_effort")]
-    pub reasoning_effort: String,
+    #[serde(deserialize_with = "crate::model::deserialize_reasoning_effort_flexible")]
+    pub reasoning_effort: crate::model::ReasoningEffort,
 }
 
-fn default_reasoning_effort() -> String {
-    "medium".to_string()
+fn default_reasoning_effort() -> crate::model::ReasoningEffort {
+    crate::model::ReasoningEffort::Medium
 }

--- a/crates/tiangong-core/src/context/compressor.rs
+++ b/crates/tiangong-core/src/context/compressor.rs
@@ -139,9 +139,7 @@ impl ContextCompressor {
         ModelRequest {
             user_input: String::new(),
             context,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: crate::model::ReasoningEffort::None,
             max_output_tokens: Some(max_output_tokens),
         }
     }

--- a/crates/tiangong-core/src/core/command.rs
+++ b/crates/tiangong-core/src/core/command.rs
@@ -7,7 +7,7 @@ pub enum Command {
     /// 运行时切换信任模式(即时生效到活跃 turn task)
     SetTrustMode(crate::permission::TrustMode),
     /// 运行时切换思考强度（下一次尚未发出的模型请求生效）。
-    SetReasoningEffort(String),
+    SetReasoningEffort(crate::model::ReasoningEffort),
     /// 更新会话标题。
     SetTitle {
         title: String,

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -118,9 +118,9 @@ impl TiangongCore {
     /// 设置会话思考强度。
     ///
     /// 已经发出的模型请求不变；活跃 turn 会在下一次构建模型请求时使用新值。
-    pub fn set_reasoning_effort(&self, effort: String) {
+    pub fn set_reasoning_effort(&self, effort: crate::model::ReasoningEffort) {
         self.config
-            .update(|config| config.reasoning_effort = effort.clone());
+            .update(|config| config.reasoning_effort = effort);
         if self.is_busy() {
             let _ = crate::shared_runtime::send_command(
                 &self.session_id,
@@ -199,7 +199,7 @@ impl TiangongCore {
                     .trust_mode
                     .lock()
                     .unwrap_or_else(|poison| poison.into_inner());
-                session.reasoning_effort = Some(config.reasoning_effort.clone());
+                session.reasoning_effort = Some(config.reasoning_effort);
                 session.cwd = self.workspace_dir.clone();
                 session.cwd_mode = crate::session::SessionCwdMode::Custom;
                 session.bind_storage_root(self.storage_root.clone());
@@ -275,7 +275,7 @@ impl TiangongCore {
                 trust_mode,
                 default_trust_mode: config.default_trust_mode,
                 custom_system_prompt: config.custom_system_prompt.clone(),
-                reasoning_effort: config.reasoning_effort.clone(),
+                reasoning_effort: config.reasoning_effort,
             })
             .trust_mode(trust_mode)
             .observer(crate::observe::Observer::new(self.storage_root.clone()))

--- a/crates/tiangong-core/src/core_config.rs
+++ b/crates/tiangong-core/src/core_config.rs
@@ -83,7 +83,9 @@ pub struct CoreConfig {
     /// 用户自定义 system prompt
     pub custom_system_prompt: String,
     /// 思考强度设置
-    pub reasoning_effort: String,
+    #[serde(default = "default_reasoning_effort")]
+    #[serde(deserialize_with = "crate::model::deserialize_reasoning_effort_flexible")]
+    pub reasoning_effort: crate::model::ReasoningEffort,
     /// 上下文窗口大小（token 数）
     pub context_limit: usize,
 }
@@ -95,7 +97,7 @@ impl Default for CoreConfig {
             trust_mode: TrustMode::default(),
             default_trust_mode: TrustMode::default(),
             custom_system_prompt: String::new(),
-            reasoning_effort: "medium".to_string(),
+            reasoning_effort: crate::model::ReasoningEffort::Medium,
             context_limit: DEFAULT_CONTEXT_LIMIT,
         }
     }
@@ -296,4 +298,8 @@ mod tests {
         let llm = LlmConfig::from_models_config(&models);
         assert_eq!(llm.chat.protocol, ProviderProtocol::Anthropic);
     }
+}
+
+fn default_reasoning_effort() -> crate::model::ReasoningEffort {
+    crate::model::ReasoningEffort::Medium
 }

--- a/crates/tiangong-core/src/core_config.rs
+++ b/crates/tiangong-core/src/core_config.rs
@@ -218,6 +218,10 @@ impl std::fmt::Debug for CoreConfigProvider {
     }
 }
 
+fn default_reasoning_effort() -> crate::model::ReasoningEffort {
+    crate::model::ReasoningEffort::Medium
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -298,8 +302,4 @@ mod tests {
         let llm = LlmConfig::from_models_config(&models);
         assert_eq!(llm.chat.protocol, ProviderProtocol::Anthropic);
     }
-}
-
-fn default_reasoning_effort() -> crate::model::ReasoningEffort {
-    crate::model::ReasoningEffort::Medium
 }

--- a/crates/tiangong-core/src/model.rs
+++ b/crates/tiangong-core/src/model.rs
@@ -10,6 +10,9 @@ pub use tiangong_llm::provider_client::{
     InvalidToolCall, ModelClient, ModelFunctionResponse, ModelRequest, ModelResponse,
     ModelStreamChunk, OnRetryCallback, SingleProviderClient,
 };
-pub use tiangong_llm::request::{ReasoningEffort, ThinkingConfig};
+pub use tiangong_llm::request::{
+    ReasoningEffort, deserialize_reasoning_effort_flexible,
+    deserialize_reasoning_effort_option_flexible,
+};
 pub use tiangong_llm::tool::{ToolCall, ToolChoice, ToolSpec};
 pub use tiangong_types::TokenUsage;

--- a/crates/tiangong-core/src/react/command.rs
+++ b/crates/tiangong-core/src/react/command.rs
@@ -128,8 +128,8 @@ pub(super) async fn handle_command(
             CommandEffect::KeepCurrent
         }
         Deferred::Command(Command::SetReasoningEffort(effort)) => {
-            ctx.agent_config.reasoning_effort = effort.clone();
-            ctx.session.reasoning_effort = Some(effort);
+            ctx.agent_config.reasoning_effort = effort;
+            ctx.session.reasoning_effort = Some(ctx.agent_config.reasoning_effort);
             CommandEffect::KeepCurrent
         }
         Deferred::Command(Command::InjectTool { tool_name, payload }) => {

--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -25,52 +25,10 @@ pub(crate) fn rebuild_system_prompt_for_session(
     session.rebuild_system_prompt(&config);
 }
 
-pub(crate) fn build_thinking_config(
-    ctx: &TurnContext,
-) -> (
-    Option<crate::model::ThinkingConfig>,
-    Option<crate::model::ReasoningEffort>,
-    bool,
-) {
-    let effort = ctx.agent_config.reasoning_effort.trim().to_lowercase();
-    match effort.as_str() {
-        "none" | "" => (None, None, true),
-        "low" => (
-            Some(crate::model::ThinkingConfig {
-                budget_tokens: 4096,
-            }),
-            Some(crate::model::ReasoningEffort::Low),
-            false,
-        ),
-        "medium" => (
-            Some(crate::model::ThinkingConfig {
-                budget_tokens: 4096,
-            }),
-            Some(crate::model::ReasoningEffort::Medium),
-            false,
-        ),
-        "high" => (
-            Some(crate::model::ThinkingConfig {
-                budget_tokens: 8192,
-            }),
-            Some(crate::model::ReasoningEffort::High),
-            false,
-        ),
-        "max" => (
-            Some(crate::model::ThinkingConfig {
-                budget_tokens: 16384,
-            }),
-            Some(crate::model::ReasoningEffort::Max),
-            false,
-        ),
-        _ => (
-            Some(crate::model::ThinkingConfig {
-                budget_tokens: 4096,
-            }),
-            Some(crate::model::ReasoningEffort::Medium),
-            false,
-        ),
-    }
+/// 思考控制：直接采用 AgentConfig 的思考强度档位（None 关闭思考）。
+/// 思考量/预算由各 provider 按自身协议决定，天工层不限制。
+pub(crate) fn build_thinking_config(ctx: &TurnContext) -> crate::model::ReasoningEffort {
+    ctx.agent_config.reasoning_effort
 }
 
 pub(crate) fn compression_threshold_tokens(context_limit: usize) -> usize {

--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -25,16 +25,6 @@ pub(crate) fn rebuild_system_prompt_for_session(
     session.rebuild_system_prompt(&config);
 }
 
-/// 思考控制：直接采用 AgentConfig 的思考强度档位（None 关闭思考）。
-/// 思考量/预算由各 provider 按自身协议决定，天工层不限制。
-pub(crate) fn build_thinking_config(ctx: &TurnContext) -> crate::model::ReasoningEffort {
-    ctx.agent_config.reasoning_effort
-}
-
-pub(crate) fn compression_threshold_tokens(context_limit: usize) -> usize {
-    ContextOrganizer::new(context_limit).token_threshold()
-}
-
 pub(crate) fn emit_token_usage(
     stream_tx: &StdSender<StreamEvent>,
     usage: &TokenUsage,
@@ -73,7 +63,7 @@ pub(crate) fn emit_token_usage(
     let _ = stream_tx.send(StreamEvent::TokenUsage {
         usage: usage.clone(),
         current_tokens,
-        compression_threshold_tokens: Some(compression_threshold_tokens(context_limit)),
+        compression_threshold_tokens: Some(ContextOrganizer::new(context_limit).token_threshold()),
         context_limit_tokens: Some(context_limit),
         source,
         agent_id: agent_id.map(|s| s.to_string()),

--- a/crates/tiangong-core/src/react/execute.rs
+++ b/crates/tiangong-core/src/react/execute.rs
@@ -17,9 +17,7 @@ use crate::model::{
     ToolSpec,
 };
 use crate::permission::TrustMode;
-use crate::react::context::{
-    build_thinking_config, emit_token_usage, persist_error, select_client_for_request,
-};
+use crate::react::context::{emit_token_usage, persist_error, select_client_for_request};
 use crate::react::message::*;
 use crate::runtime::LlmOutputRecord;
 use crate::session::{Message, MessagePhase, MessageRole};
@@ -542,7 +540,7 @@ fn build_react_request(ctx: &TurnContext) -> ModelRequest {
     ModelRequest {
         user_input: String::new(),
         context: ctx.session.context(),
-        reasoning_effort: build_thinking_config(ctx),
+        reasoning_effort: ctx.agent_config.reasoning_effort,
         max_output_tokens: None,
     }
 }

--- a/crates/tiangong-core/src/react/execute.rs
+++ b/crates/tiangong-core/src/react/execute.rs
@@ -539,13 +539,10 @@ impl AgentLoopState {
 // 阶段数据类型统一定义在 super::phase。
 
 fn build_react_request(ctx: &TurnContext) -> ModelRequest {
-    let (thinking, reasoning_effort, thinking_disabled) = build_thinking_config(ctx);
     ModelRequest {
         user_input: String::new(),
         context: ctx.session.context(),
-        thinking,
-        reasoning_effort,
-        thinking_disabled,
+        reasoning_effort: build_thinking_config(ctx),
         max_output_tokens: None,
     }
 }
@@ -966,7 +963,7 @@ pub(super) async fn execute_turn(
     // 运行配置即时生效，Session 在本轮唯一出口接收最终值。
     ctx.trust_mode = trust_mode;
     ctx.session.trust_mode = trust_mode;
-    ctx.session.reasoning_effort = Some(ctx.agent_config.reasoning_effort.clone());
+    ctx.session.reasoning_effort = Some(ctx.agent_config.reasoning_effort);
     injections.commit(ctx);
     result
 }

--- a/crates/tiangong-core/src/react/execute_tests.rs
+++ b/crates/tiangong-core/src/react/execute_tests.rs
@@ -367,7 +367,7 @@ impl TestHarness {
         std::mem::forget(root);
 
         let agent_config = AgentConfig {
-            reasoning_effort: "none".to_string(),
+            reasoning_effort: crate::model::ReasoningEffort::None,
             ..Default::default()
         };
         let (stream_tx, stream_rx) = std::sync::mpsc::channel::<StreamEvent>();
@@ -870,7 +870,9 @@ async fn returns_cancelled_on_cancel_command() {
     tokio::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         let _ = cmd_tx.send(Command::SetTrustMode(TrustMode::Supervised));
-        let _ = cmd_tx.send(Command::SetReasoningEffort("max".to_string()));
+        let _ = cmd_tx.send(Command::SetReasoningEffort(
+            crate::model::ReasoningEffort::Max,
+        ));
         let _ = cmd_tx.send(Command::InjectTool {
             tool_name: "cancelled_probe".to_string(),
             payload: serde_json::json!({"value": 1}),
@@ -888,8 +890,14 @@ async fn returns_cancelled_on_cancel_command() {
     assert_eq!(*trust_modes.lock().unwrap(), vec![TrustMode::Supervised]);
     assert_eq!(harness.ctx.trust_mode, TrustMode::Supervised);
     assert_eq!(harness.ctx.session.trust_mode, TrustMode::Supervised);
-    assert_eq!(harness.ctx.agent_config.reasoning_effort, "max");
-    assert_eq!(harness.ctx.session.reasoning_effort.as_deref(), Some("max"));
+    assert_eq!(
+        harness.ctx.agent_config.reasoning_effort,
+        crate::model::ReasoningEffort::Max
+    );
+    assert_eq!(
+        harness.ctx.session.reasoning_effort,
+        Some(crate::model::ReasoningEffort::Max)
+    );
     assert!(harness.ctx.session.deferred_tool_injections.is_empty());
     assert!(harness.ctx.session.messages.iter().any(|message| {
         message.role == MessageRole::Tool && message.text_content().contains("cancelled_probe")
@@ -1829,8 +1837,10 @@ async fn command_storm_is_processed_in_order_without_panicking() {
             payload: serde_json::json!({"k": 1}),
         })
         .unwrap();
-        tx.send(Command::SetReasoningEffort("high".to_string()))
-            .unwrap();
+        tx.send(Command::SetReasoningEffort(
+            crate::model::ReasoningEffort::High,
+        ))
+        .unwrap();
         tx.send(Command::EmitStreamEvent(Box::new(
             StreamEvent::TitleChanged {
                 title: "不应直接出现的标题".to_string(),
@@ -1853,8 +1863,8 @@ async fn command_storm_is_processed_in_order_without_panicking() {
     );
     assert_eq!(ctx.session.title, "风暴标题", "标题命令应已生效");
     assert_eq!(
-        ctx.session.reasoning_effort.as_deref(),
-        Some("high"),
+        ctx.session.reasoning_effort,
+        Some(crate::model::ReasoningEffort::High),
         "思考强度命令应已生效"
     );
     assert!(
@@ -1905,7 +1915,9 @@ async fn reasoning_effort_update_applies_to_next_model_request() {
             .await
             .expect("工具应在期限内开始执行");
         cmd_tx
-            .send(Command::SetReasoningEffort("max".to_string()))
+            .send(Command::SetReasoningEffort(
+                crate::model::ReasoningEffort::Max,
+            ))
             .expect("运行中的 turn 应接收思考强度更新");
         release.notify_one();
     });
@@ -1914,8 +1926,14 @@ async fn reasoning_effort_update_applies_to_next_model_request() {
     update_task.await.unwrap();
 
     assert!(matches!(result.outcome, TurnExecutionOutcome::Success));
-    assert_eq!(harness.ctx.agent_config.reasoning_effort, "max");
-    assert_eq!(harness.ctx.session.reasoning_effort.as_deref(), Some("max"));
+    assert_eq!(
+        harness.ctx.agent_config.reasoning_effort,
+        crate::model::ReasoningEffort::Max
+    );
+    assert_eq!(
+        harness.ctx.session.reasoning_effort,
+        Some(crate::model::ReasoningEffort::Max)
+    );
 
     let requests = server.received_requests().await.unwrap();
     assert_eq!(requests.len(), 2);

--- a/crates/tiangong-core/src/react/tools.rs
+++ b/crates/tiangong-core/src/react/tools.rs
@@ -231,8 +231,8 @@ fn handle_ambient_command(
             set_runtime_trust_mode(trust_mode, plugins, mode);
         }
         Command::SetReasoningEffort(effort) => {
-            ctx.agent_config.reasoning_effort = effort.clone();
-            ctx.session.reasoning_effort = Some(effort);
+            ctx.agent_config.reasoning_effort = effort;
+            ctx.session.reasoning_effort = Some(ctx.agent_config.reasoning_effort);
         }
         Command::SetTitle {
             title,

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -97,8 +97,12 @@ pub struct Session {
     #[serde(default)]
     pub trust_mode: TrustMode,
     /// 会话级思考强度；为空时使用应用级默认值。
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reasoning_effort: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::model::deserialize_reasoning_effort_option_flexible"
+    )]
+    pub reasoning_effort: Option<crate::model::ReasoningEffort>,
     /// 早期对话的滚动摘要（用于无限上下文压缩）
     ///
     /// 当对话历史超过模型上下文阈值时，早期消息被 LLM 压缩为摘要存储在此。
@@ -1374,7 +1378,9 @@ impl From<&Session> for tiangong_types::PluginSession {
             cwd: session.cwd.clone(),
             workspace_id,
             parent_session_id: session.parent_session_id.clone(),
-            reasoning_effort: session.reasoning_effort.clone(),
+            reasoning_effort: session
+                .reasoning_effort
+                .map(|effort| effort.as_str().to_string()),
             messages: session.messages.clone(),
             context_summary: session.context_summary.clone(),
             created_at: session.created_at.clone(),

--- a/crates/tiangong-llm/src/provider_client.rs
+++ b/crates/tiangong-llm/src/provider_client.rs
@@ -40,7 +40,7 @@ use crate::usage::TokenUsageData;
 use tiangong_types::TokenUsage;
 use tokio::runtime::Builder as TokioRuntimeBuilder;
 
-pub use crate::request::{ReasoningEffort, ThinkingConfig};
+pub use crate::request::ReasoningEffort;
 
 fn merge_stream_usage(current: &mut TokenUsageData, next: TokenUsageData) {
     current.prompt_tokens = current.prompt_tokens.max(next.prompt_tokens);
@@ -103,9 +103,8 @@ fn append_stream_tool_call_arguments(raw_args: &mut String, partial_json: &str) 
 pub struct ModelRequest {
     pub user_input: String,
     pub context: Vec<Message>,
-    pub thinking: Option<ThinkingConfig>,
-    pub reasoning_effort: Option<ReasoningEffort>,
-    pub thinking_disabled: bool,
+    /// 思考强度：None 关闭思考，其余档位开启。
+    pub reasoning_effort: ReasoningEffort,
     /// 该请求允许的最大输出 token 数。
     ///
     /// `None` 时由 llm 层用默认上限（`MAX_TOKENS_MAIN`）。压缩等空间敏感请求
@@ -115,11 +114,6 @@ pub struct ModelRequest {
 }
 
 impl ModelRequest {
-    pub fn with_thinking_budget(mut self, budget_tokens: u32) -> Self {
-        self.thinking = Some(ThinkingConfig { budget_tokens });
-        self
-    }
-
     pub fn with_max_output_tokens(mut self, max_tokens: u32) -> Self {
         self.max_output_tokens = Some(max_tokens);
         self
@@ -535,9 +529,7 @@ impl SingleProviderClient {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let response = self.block_on_llm(provider.complete(request))?;
         let text = strip_think_tags(&collect_provider_text(&response))
@@ -635,9 +627,7 @@ impl SingleProviderClient {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let response = self.block_on_llm(provider.complete(request))?;
         Ok(collect_provider_text(&response).trim().to_string())
@@ -663,9 +653,7 @@ impl SingleProviderClient {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         if self.protocol() == ProviderProtocol::Anthropic {
             let provider = self.build_anthropic_provider(timeout_ms)?;
@@ -1155,7 +1143,6 @@ fn build_provider_request(
     tool_choice: Option<ToolChoice>,
 ) -> Result<ProviderRequest> {
     let (system, messages) = build_provider_messages(req)?;
-    let thinking = req.thinking.clone();
     Ok(ProviderRequest {
         model: model.to_string(),
         system: (!system.trim().is_empty()).then_some(system),
@@ -1167,9 +1154,7 @@ fn build_provider_request(
         top_p: None,
         stop_sequences: Vec::new(),
         metadata: None,
-        thinking,
         reasoning_effort: req.reasoning_effort,
-        thinking_disabled: req.thinking_disabled,
     })
 }
 
@@ -2038,9 +2023,7 @@ mod tests {
         let req = ModelRequest {
             user_input: String::new(),
             context: vec![user_msg],
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
             max_output_tokens: None,
         };
 
@@ -2319,9 +2302,7 @@ mod tests {
         let request = ModelRequest {
             user_input: "检查项目".to_string(),
             context: vec![Message::new(MessageRole::System, "system")],
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
             max_output_tokens: None,
         };
         let functions = vec![schema_tool("read_file"), schema_tool("other_tool")];
@@ -2702,9 +2683,7 @@ mod tests {
         let req = ModelRequest {
             user_input: String::new(),
             context: vec![system_msg, user_msg],
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
             max_output_tokens: None,
         };
 

--- a/crates/tiangong-llm/src/providers/anthropic/mapping.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/mapping.rs
@@ -72,12 +72,12 @@ pub(super) fn to_anthropic_request(
 }
 
 fn map_thinking_config(request: &ProviderRequest) -> Option<ThinkingConfig> {
+    // reasoning_effort 有值即开启思考；预算是 Anthropic 协议自身细节，
+    // 由 tiangong-anthropic 库的 ThinkingConfig 决定（默认不限制）。
     request
-        .thinking
-        .as_ref()
-        .map(|thinking| ThinkingConfig::Enabled {
-            budget_tokens: thinking.budget_tokens,
-        })
+        .reasoning_effort
+        .is_thinking_enabled()
+        .then(ThinkingConfig::enabled)
 }
 
 fn map_message(message: &ChatMessage) -> Option<Result<AnthropicMessage, LlmError>> {

--- a/crates/tiangong-llm/src/providers/anthropic/tests.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/tests.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use crate::request::ReasoningEffort;
+
 use async_trait::async_trait;
 use futures_util::stream;
 use serde_json::json;
@@ -13,7 +15,7 @@ use crate::provider::LlmProvider;
 use crate::providers::anthropic::client::{AnthropicClient, AnthropicTransport};
 use crate::providers::anthropic::config::AnthropicConfig;
 use crate::providers::anthropic::provider::AnthropicProvider;
-use crate::request::{ProviderRequest, ThinkingConfig};
+use crate::request::ProviderRequest;
 use crate::stream::ProviderStreamEvent;
 use crate::tool::{ToolChoice, ToolResult, ToolResultContent, ToolSpec};
 
@@ -97,11 +99,7 @@ fn sample_request() -> ProviderRequest {
         top_p: None,
         stop_sequences: vec!["STOP".to_string()],
         metadata: None,
-        thinking: Some(ThinkingConfig {
-            budget_tokens: 4096,
-        }),
-        reasoning_effort: None,
-        thinking_disabled: false,
+        reasoning_effort: ReasoningEffort::High,
     }
 }
 
@@ -115,7 +113,7 @@ fn test_request_mapping_with_system_and_tools() {
     assert!(matches!(
         mapped.thinking,
         Some(tiangong_anthropic::types::ThinkingConfig::Enabled {
-            budget_tokens: 4096
+            budget_tokens: None
         })
     ));
     assert!(matches!(

--- a/crates/tiangong-llm/src/providers/deepseek/mapping.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/mapping.rs
@@ -99,7 +99,7 @@ fn build_messages(req: &ProviderRequest) -> Result<Vec<tiangong_deepseek::types:
                 let reasoning_content = extract_thinking(message).or_else(|| {
                     fallback_reasoning_content_for_internal_tool_calls(
                         &tool_calls,
-                        req.thinking_disabled,
+                        !req.reasoning_effort.is_thinking_enabled(),
                     )
                 });
                 if !text.is_empty() || reasoning_content.is_some() || !tool_calls.is_empty() {
@@ -278,18 +278,15 @@ fn build_tool_choice(choice: Option<&ToolChoice>) -> Option<Value> {
 
 fn build_thinking(req: &ProviderRequest) -> Option<tiangong_deepseek::types::ThinkingConfig> {
     // 官方文档：思考模式由 thinking.type（enabled/disabled）+ reasoning_effort 控制，
-    // 不再使用 budget_tokens 字段。
-    if req.thinking_disabled {
-        Some(tiangong_deepseek::types::ThinkingConfig {
-            thinking_type: "disabled".to_string(),
-        })
-    } else {
-        req.thinking
-            .as_ref()
-            .map(|_| tiangong_deepseek::types::ThinkingConfig {
-                thinking_type: "enabled".to_string(),
-            })
-    }
+    // 不使用 budget_tokens 字段。reasoning_effort 有值即开启思考，无值即关闭。
+    Some(tiangong_deepseek::types::ThinkingConfig {
+        thinking_type: if req.reasoning_effort.is_thinking_enabled() {
+            "enabled"
+        } else {
+            "disabled"
+        }
+        .to_string(),
+    })
 }
 
 fn build_reasoning_effort(
@@ -297,13 +294,16 @@ fn build_reasoning_effort(
 ) -> Option<tiangong_deepseek::types::ReasoningEffort> {
     // 官方 reasoning_effort 取值：low / high / max。
     // 内部 Medium 无对应档位，统一映射到 high（官方默认档）。
-    req.reasoning_effort.map(|effort| match effort {
-        ReasoningEffort::Low => tiangong_deepseek::types::ReasoningEffort::Low,
-        ReasoningEffort::Medium | ReasoningEffort::High => {
-            tiangong_deepseek::types::ReasoningEffort::High
-        }
-        ReasoningEffort::Max => tiangong_deepseek::types::ReasoningEffort::Max,
-    })
+    req.reasoning_effort
+        .is_thinking_enabled()
+        .then(|| match req.reasoning_effort {
+            ReasoningEffort::Low => tiangong_deepseek::types::ReasoningEffort::Low,
+            ReasoningEffort::Medium | ReasoningEffort::High => {
+                tiangong_deepseek::types::ReasoningEffort::High
+            }
+            ReasoningEffort::Max => tiangong_deepseek::types::ReasoningEffort::Max,
+            ReasoningEffort::None => unreachable!("None 已被 is_thinking_enabled 过滤"),
+        })
 }
 
 fn extract_text(message: &ChatMessage) -> String {
@@ -438,7 +438,6 @@ mod tests {
     use super::*;
     use crate::message::ThinkingContent;
     use crate::message::{ImageContent, MessageContent};
-    use crate::request::ThinkingConfig;
     use crate::tool::ToolCall;
 
     #[test]
@@ -538,9 +537,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
 
         let request = to_deepseek_request(&req).expect("request");
@@ -590,9 +587,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::Medium,
         };
 
         let request = to_deepseek_request(&req).expect("request");
@@ -636,9 +631,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: true,
+            reasoning_effort: ReasoningEffort::None,
         };
 
         let request = to_deepseek_request(&req).expect("request");
@@ -717,9 +710,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let request = to_deepseek_request(&req).expect("request");
         let assistant = request
@@ -790,9 +781,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: Some(ReasoningEffort::Low),
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::Low,
         };
         let request = to_deepseek_request(&req).expect("request");
         assert_eq!(
@@ -815,9 +804,7 @@ mod tests {
                 top_p: None,
                 stop_sequences: Vec::new(),
                 metadata: None,
-                thinking: None,
-                reasoning_effort: Some(effort),
-                thinking_disabled: false,
+                reasoning_effort: effort,
             };
             let request = to_deepseek_request(&req).expect("request");
             request.reasoning_effort.expect("应产出 effort")
@@ -841,11 +828,7 @@ mod tests {
             top_p: Some(0.9),
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: Some(ThinkingConfig {
-                budget_tokens: 4096,
-            }),
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::High,
         };
         let request = to_deepseek_request(&req).expect("request");
         assert_eq!(request.temperature, None, "思考模式不应发送 temperature");
@@ -865,9 +848,7 @@ mod tests {
             top_p: Some(0.9),
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: true,
+            reasoning_effort: ReasoningEffort::None,
         };
         let request = to_deepseek_request(&req).expect("request");
         assert_eq!(request.temperature, Some(0.7));
@@ -892,9 +873,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: Some(metadata),
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let request = to_deepseek_request(&req).expect("request");
         assert_eq!(
@@ -916,9 +895,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let request = to_deepseek_request(&req).expect("request");
         assert_eq!(request.response_format, None);

--- a/crates/tiangong-llm/src/providers/openai/mapping.rs
+++ b/crates/tiangong-llm/src/providers/openai/mapping.rs
@@ -64,19 +64,14 @@ pub fn build_request_json(req: &ProviderRequest, stream: bool) -> Result<Value> 
     // 思考/推理配置：优先 reasoning_effort，其次 thinking。
     // 注意：Responses API 的 reasoning summary 必须显式请求（summary: "auto"），
     // 否则服务端不会返回可展示的思考摘要，前端 thinking 链路将无内容。
-    if let Some(effort) = &req.reasoning_effort {
+    if req.reasoning_effort.is_thinking_enabled() {
         payload.insert(
             "reasoning".to_string(),
-            build_reasoning(effort_to_str(effort)),
-        );
-    } else if req.thinking_disabled {
-        // Responses API 没有 disabled 语义，省略 reasoning 字段即不强制思考。
-    } else if let Some(thinking) = &req.thinking {
-        payload.insert(
-            "reasoning".to_string(),
-            build_reasoning(budget_to_effort(thinking.budget_tokens)),
+            build_reasoning(effort_to_str(req.reasoning_effort)),
         );
     }
+    // ReasoningEffort::None 关闭思考：Responses API 没有 disabled 语义，
+    // 省略 reasoning 字段即不强制思考。
 
     Ok(Value::Object(payload))
 }
@@ -89,25 +84,15 @@ fn build_reasoning(effort: &str) -> Value {
     json!({ "effort": effort, "summary": "auto" })
 }
 
-fn effort_to_str(effort: &ReasoningEffort) -> &'static str {
+fn effort_to_str(effort: ReasoningEffort) -> &'static str {
     match effort {
+        ReasoningEffort::None => "medium",
         ReasoningEffort::Low => "low",
         ReasoningEffort::Medium => "medium",
         ReasoningEffort::High => "high",
         // Responses API 的 reasoning.effort 目前仅支持 low/medium/high，
         // Max 暂降级为 high；若 OpenAI 后续开放 "max" 级别需同步更新此处。
         ReasoningEffort::Max => "high",
-    }
-}
-
-/// 根据 thinking budget_tokens 粗略映射到 reasoning effort。
-fn budget_to_effort(budget_tokens: u32) -> &'static str {
-    if budget_tokens >= 16_384 {
-        "high"
-    } else if budget_tokens >= 4_096 {
-        "medium"
-    } else {
-        "low"
     }
 }
 
@@ -506,9 +491,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let payload = build_request_json(&req, true).unwrap();
         assert_eq!(payload["stream"], true);
@@ -634,9 +617,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let payload = build_request_json(&req, false).unwrap();
         let input = payload["input"].as_array().unwrap();
@@ -668,9 +649,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let payload = build_request_json(&req, false).unwrap();
         let input = payload["input"].as_array().unwrap();
@@ -693,9 +672,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let payload = build_request_json(&req, false).unwrap();
         assert_eq!(payload["model"], "gpt-4o");
@@ -725,9 +702,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let payload = build_request_json(&req, false).unwrap();
         let instructions = payload["instructions"].as_str().unwrap();
@@ -756,9 +731,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
         let payload = build_request_json(&req, true).unwrap();
         assert_eq!(payload["tools"][0]["type"], "function");
@@ -781,9 +754,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: Some(ReasoningEffort::High),
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::High,
         };
         let payload = build_request_json(&req, false).unwrap();
         assert_eq!(payload["reasoning"]["effort"], "high");
@@ -792,7 +763,7 @@ mod tests {
 
     #[test]
     fn thinking_budget_requests_summary_auto() {
-        // thinking 分支（通过 budget_tokens 映射 effort）同样必须带上 summary。
+        // thinking 分支（默认 medium effort）同样必须带上 summary。
         let req = ProviderRequest {
             model: "o3".to_string(),
             system: None,
@@ -804,11 +775,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: Some(crate::request::ThinkingConfig {
-                budget_tokens: 8_192,
-            }),
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::Medium,
         };
         let payload = build_request_json(&req, false).unwrap();
         assert_eq!(payload["reasoning"]["effort"], "medium");
@@ -828,9 +795,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: true,
+            reasoning_effort: ReasoningEffort::None,
         };
         let payload = build_request_json(&req, false).unwrap();
         assert!(payload.get("reasoning").is_none());

--- a/crates/tiangong-llm/src/providers/openai/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai/provider.rs
@@ -6,7 +6,6 @@ use crate::error::LlmError;
 use crate::model::ProviderModelInfo;
 use crate::provider::{LlmProvider, ProviderCapabilities};
 use crate::request::ProviderRequest;
-use crate::request::ReasoningEffort;
 use crate::response::ProviderResponse;
 use crate::stream::{ProviderStream, ProviderStreamEvent};
 
@@ -165,7 +164,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            reasoning_effort: ReasoningEffort::None,
+            reasoning_effort: crate::request::ReasoningEffort::None,
         };
 
         let mut response_stream = provider.stream(request).await.unwrap();

--- a/crates/tiangong-llm/src/providers/openai/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai/provider.rs
@@ -6,6 +6,7 @@ use crate::error::LlmError;
 use crate::model::ProviderModelInfo;
 use crate::provider::{LlmProvider, ProviderCapabilities};
 use crate::request::ProviderRequest;
+use crate::request::ReasoningEffort;
 use crate::response::ProviderResponse;
 use crate::stream::{ProviderStream, ProviderStreamEvent};
 
@@ -164,9 +165,7 @@ mod tests {
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
-            thinking: None,
-            reasoning_effort: None,
-            thinking_disabled: false,
+            reasoning_effort: ReasoningEffort::None,
         };
 
         let mut response_stream = provider.stream(request).await.unwrap();

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/mapping.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/mapping.rs
@@ -46,13 +46,12 @@ pub fn build_request_json(req: &ProviderRequest, stream: bool) -> Result<Value> 
     if !req.tools.is_empty() {
         inject_function_tools(&mut payload, &req.tools, req.tool_choice.as_ref());
     }
-    if let Some(effort) = &req.reasoning_effort {
-        inject_reasoning_effort(&mut payload, effort);
-    }
-    if req.thinking_disabled {
-        inject_thinking_disabled(&mut payload);
-    } else if let Some(thinking) = &req.thinking {
-        inject_thinking_enabled(&mut payload, thinking.budget_tokens);
+    match req.reasoning_effort.is_thinking_enabled() {
+        true => {
+            inject_reasoning_effort(&mut payload, req.reasoning_effort);
+            inject_thinking_enabled(&mut payload);
+        }
+        false => inject_thinking_disabled(&mut payload),
     }
     Ok(payload)
 }
@@ -395,7 +394,7 @@ fn inject_function_tools(
     }
 }
 
-fn inject_reasoning_effort(payload: &mut Value, effort: &ReasoningEffort) {
+fn inject_reasoning_effort(payload: &mut Value, effort: ReasoningEffort) {
     let Some(obj) = payload.as_object_mut() else {
         return;
     };
@@ -404,6 +403,7 @@ fn inject_reasoning_effort(payload: &mut Value, effort: &ReasoningEffort) {
         ReasoningEffort::Medium => "medium",
         ReasoningEffort::High => "high",
         ReasoningEffort::Max => "max",
+        ReasoningEffort::None => return,
     };
     obj.insert("reasoning_effort".to_string(), json!(effort_str));
 }
@@ -415,14 +415,12 @@ fn inject_thinking_disabled(payload: &mut Value) {
     obj.insert("thinking".to_string(), json!({"type": "disabled"}));
 }
 
-fn inject_thinking_enabled(payload: &mut Value, budget_tokens: u32) {
+fn inject_thinking_enabled(payload: &mut Value) {
     let Some(obj) = payload.as_object_mut() else {
         return;
     };
-    obj.insert(
-        "thinking".to_string(),
-        json!({"type": "enabled", "budget_tokens": budget_tokens}),
-    );
+    // 只表达"开启思考"，不带预算——思考强度由上游模型自行决定。
+    obj.insert("thinking".to_string(), json!({"type": "enabled"}));
 }
 
 pub fn strip_think_tags(text: &str) -> String {

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/stream.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/stream.rs
@@ -192,7 +192,9 @@ mod tests {
         );
 
         let calls = finished
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|events| match (&events[0], &events[1]) {
                 (
                     ProviderStreamEvent::ToolCallStart(call),

--- a/crates/tiangong-llm/src/request.rs
+++ b/crates/tiangong-llm/src/request.rs
@@ -4,23 +4,78 @@ use serde_json::{Map, Value};
 use crate::message::ChatMessage;
 use crate::tool::{ToolChoice, ToolSpec};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ThinkingConfig {
-    #[serde(default = "default_thinking_budget_tokens")]
-    pub budget_tokens: u32,
-}
-
-fn default_thinking_budget_tokens() -> u32 {
-    2048
-}
-
+/// 思考强度：请求中唯一的思考控制参数。
+/// `None` 表示关闭思考；其余档位表示开启思考并表达强度。
+/// 各 provider 按自身协议映射（如 Anthropic 的 thinking 开关与预算、
+/// DeepSeek 的 thinking.type、OpenAI 的 reasoning.effort）。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffort {
+    None,
     Low,
     Medium,
     High,
     Max,
+}
+
+impl Default for ReasoningEffort {
+    fn default() -> Self {
+        Self::Medium
+    }
+}
+
+impl ReasoningEffort {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Max => "max",
+        }
+    }
+
+    /// 解析持久化/用户输入字符串：空串与未知值回退 Medium（历史默认档），
+    /// 保证旧数据可加载。
+    pub fn parse_flexible(value: &str) -> Self {
+        match value.trim().to_lowercase().as_str() {
+            "none" => Self::None,
+            "low" => Self::Low,
+            "high" => Self::High,
+            "max" => Self::Max,
+            _ => Self::Medium,
+        }
+    }
+
+    pub fn is_thinking_enabled(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+/// serde 反序列化适配：字符串经 [`ReasoningEffort::parse_flexible`] 容错解析，
+/// 旧数据中的空串/未知值不会导致加载失败。
+pub fn deserialize_reasoning_effort_flexible<'de, D>(
+    deserializer: D,
+) -> Result<ReasoningEffort, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    Ok(ReasoningEffort::parse_flexible(&value))
+}
+
+/// [`deserialize_reasoning_effort_flexible`] 的 Option 版：null/空串 → None，
+/// 未知值回退 Medium。
+pub fn deserialize_reasoning_effort_option_flexible<'de, D>(
+    deserializer: D,
+) -> Result<Option<ReasoningEffort>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<String> = Option::deserialize(deserializer)?;
+    Ok(value
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| ReasoningEffort::parse_flexible(&value)))
 }
 
 /// 统一 provider 请求。
@@ -42,11 +97,11 @@ pub struct ProviderRequest {
     pub stop_sequences: Vec<String>,
     #[serde(default)]
     pub metadata: Option<Map<String, Value>>,
-    #[serde(default)]
-    pub thinking: Option<ThinkingConfig>,
-    #[serde(default)]
-    pub reasoning_effort: Option<ReasoningEffort>,
-    /// 显式禁用思考模式（如 DeepSeek 的 thinking: {"type": "disabled"}）
-    #[serde(default)]
-    pub thinking_disabled: bool,
+    /// 思考强度：None 关闭思考，其余档位开启。
+    #[serde(default = "default_reasoning_effort_disabled")]
+    pub reasoning_effort: ReasoningEffort,
+}
+
+fn default_reasoning_effort_disabled() -> ReasoningEffort {
+    ReasoningEffort::None
 }

--- a/crates/tiangong-llm/src/request.rs
+++ b/crates/tiangong-llm/src/request.rs
@@ -18,6 +18,9 @@ pub enum ReasoningEffort {
     Max,
 }
 
+// derive(Default) 会取第一个变体 None，语义是"关闭思考"，与期望的
+// 默认档位 Medium 不符，因此手写实现。
+#[allow(clippy::derivable_impls)]
 impl Default for ReasoningEffort {
     fn default() -> Self {
         Self::Medium

--- a/crates/tiangong-llm/src/text.rs
+++ b/crates/tiangong-llm/src/text.rs
@@ -14,6 +14,7 @@ use crate::providers::deepseek::{DeepSeekConfig, DeepSeekProvider};
 use crate::providers::openai::{OpenAiResponsesConfig, OpenAiResponsesProvider};
 use crate::providers::openai_chatcompletions::{OpenAiChatCompletionsProvider, OpenAiChatConfig};
 use crate::request::ProviderRequest;
+use crate::request::ReasoningEffort;
 
 #[derive(Debug, Clone)]
 pub struct LlmEndpointConfig {
@@ -81,9 +82,7 @@ pub async fn complete_text_with_usage(
         top_p: None,
         stop_sequences: Vec::new(),
         metadata: None,
-        thinking: None,
-        reasoning_effort: None,
-        thinking_disabled: false,
+        reasoning_effort: ReasoningEffort::None,
     };
     let response = provider.complete(request).await?;
     Ok((message_text(&response.assistant_message), response.usage))

--- a/plugins/tiangong-plugin-analyze-attachment/sidecar/src/service.rs
+++ b/plugins/tiangong-plugin-analyze-attachment/sidecar/src/service.rs
@@ -135,9 +135,7 @@ async fn analyze(req: AnalyzeRequest) -> Result<AnalyzeResponse> {
     let request = ModelRequest {
         user_input: String::new(),
         context,
-        thinking: None,
-        reasoning_effort: None,
-        thinking_disabled: false,
+        reasoning_effort: tiangong_llm::request::ReasoningEffort::None,
         max_output_tokens: None,
     };
 

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -664,7 +664,7 @@ impl TiangongApp {
         let mut template = app_config.to_core_config();
         template.trust_mode = app_config.default_trust_mode;
         template.default_trust_mode = app_config.default_trust_mode;
-        template.reasoning_effort = agent_config.reasoning_effort.clone();
+        template.reasoning_effort = agent_config.reasoning_effort;
         let session_configs = self
             .core_manager
             .list_session_metadata()
@@ -674,11 +674,7 @@ impl TiangongApp {
                 config.trust_mode = metadata.trust_mode;
                 config.reasoning_effort = metadata
                     .reasoning_effort
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|effort| !effort.is_empty())
-                    .unwrap_or(&agent_config.reasoning_effort)
-                    .to_string();
+                    .unwrap_or(agent_config.reasoning_effort);
                 (metadata.id.clone(), config)
             })
             .collect::<HashMap<_, _>>();
@@ -720,7 +716,7 @@ impl TiangongApp {
         session_id: &str,
         workspace_dir: Option<String>,
         initial_trust_mode: Option<tiangong_types::TrustMode>,
-        initial_reasoning_effort: Option<String>,
+        initial_reasoning_effort: Option<tiangong_llm::request::ReasoningEffort>,
         stream_tx: std::sync::mpsc::Sender<tiangong_types::StreamEvent>,
     ) -> EnsuredCore {
         let (app_config, agent_config, default_workspace_dir) = self
@@ -743,16 +739,11 @@ impl TiangongApp {
             session_config.trust_mode = session.trust_mode;
             session_config.reasoning_effort = session
                 .reasoning_effort
-                .as_deref()
-                .map(str::trim)
-                .filter(|effort| !effort.is_empty())
-                .unwrap_or(&agent_config.reasoning_effort)
-                .to_string();
+                .unwrap_or(agent_config.reasoning_effort);
         } else {
             session_config.trust_mode = initial_trust_mode.unwrap_or(app_config.default_trust_mode);
-            session_config.reasoning_effort = initial_reasoning_effort
-                .filter(|effort| !effort.trim().is_empty())
-                .unwrap_or(agent_config.reasoning_effort);
+            session_config.reasoning_effort =
+                initial_reasoning_effort.unwrap_or(agent_config.reasoning_effort);
         }
         // 桌面插件集合由 DesktopCoreFactory 构造（host 专属）。
         // 改为按需回调：只有 Core 不存在（需新建）时才会调用 build_plugins，

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -344,7 +344,7 @@ pub async fn load_session(
     } else {
         config.context_limit
     };
-    let default_reasoning_effort = config.reasoning_effort.clone();
+    let default_reasoning_effort = config.reasoning_effort;
     let manager = state.core_manager.clone();
     let session_id_for_load = session_id.clone();
     let session = tokio::task::spawn_blocking(move || manager.load_session(&session_id_for_load))
@@ -1505,7 +1505,7 @@ pub async fn set_reasoning_effort(
     let session_lock = state.session_send_lock(&session_id);
     let _send_guard = session_lock.lock_owned().await;
 
-    let next_effort = effort.clone();
+    let next_effort = effort;
     let previous_override =
         crate::session_ops::update_reasoning_effort(&state.core_manager, &session_id, Some(effort))
             .map_err(|error| error.to_string())?;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -531,7 +531,7 @@ struct UserMessageDeliveryRequest {
     revision: u64,
     workspace_dir: Option<String>,
     initial_trust_mode: Option<tiangong_types::TrustMode>,
-    initial_reasoning_effort: Option<String>,
+    initial_reasoning_effort: Option<tiangong_llm::request::ReasoningEffort>,
     delivery_kind: UserMessageDeliveryKind,
     requires_input_claim: bool,
 }
@@ -559,7 +559,9 @@ pub async fn send_message(
             revision,
             workspace_dir: cwd,
             initial_trust_mode: trust_mode,
-            initial_reasoning_effort: reasoning_effort,
+            initial_reasoning_effort: reasoning_effort
+                .as_deref()
+                .map(tiangong_llm::request::ReasoningEffort::parse_flexible),
             delivery_kind: UserMessageDeliveryKind::NewTurn,
             requires_input_claim: true,
         },
@@ -1470,7 +1472,7 @@ pub async fn get_reasoning_effort(
         .with_state_read(|core_state| {
             Ok((
                 session_id.unwrap_or_else(|| core_state.active_session_id.clone()),
-                core_state.agent_config.reasoning_effort.clone(),
+                core_state.agent_config.reasoning_effort,
             ))
         })
         .await?;
@@ -1480,9 +1482,9 @@ pub async fn get_reasoning_effort(
         .load_session(&target_id)
         .ok()
         .and_then(|session| session.reasoning_effort)
-        .map(|effort| effort.trim().to_string())
-        .filter(|effort| !effort.is_empty())
-        .unwrap_or(default_effort))
+        .unwrap_or(default_effort)
+        .as_str()
+        .to_string())
 }
 
 #[tauri::command]
@@ -1491,13 +1493,7 @@ pub async fn set_reasoning_effort(
     session_id: Option<String>,
     state: State<'_, TiangongApp>,
 ) -> Result<(), String> {
-    let valid = ["none", "low", "medium", "high", "max"];
-    if !valid.contains(&effort.as_str()) {
-        return Err(format!(
-            "无效的思考强度: {effort}，可选值: {}",
-            valid.join("/")
-        ));
-    }
+    let effort = tiangong_llm::request::ReasoningEffort::parse_flexible(&effort);
     let session_id = match session_id {
         Some(session_id) => session_id,
         None => {
@@ -1529,7 +1525,7 @@ pub async fn set_reasoning_effort(
 async fn rollback_session_reasoning_effort(
     state: &TiangongApp,
     session_id: &str,
-    previous_override: Option<String>,
+    previous_override: Option<tiangong_llm::request::ReasoningEffort>,
 ) {
     if let Err(error) = crate::session_ops::update_reasoning_effort(
         &state.core_manager,

--- a/src-tauri/src/session_ops.rs
+++ b/src-tauri/src/session_ops.rs
@@ -98,8 +98,8 @@ pub(crate) fn update_trust_mode(
 pub(crate) fn update_reasoning_effort(
     manager: &CoreManager,
     session_id: &str,
-    reasoning_effort: Option<String>,
-) -> Result<Option<String>> {
+    reasoning_effort: Option<tiangong_llm::request::ReasoningEffort>,
+) -> Result<Option<tiangong_llm::request::ReasoningEffort>> {
     let mut session = manager
         .load_session(session_id)
         .map_err(|error| anyhow!("加载会话失败：{error}"))?;

--- a/src-tauri/src/view.rs
+++ b/src-tauri/src/view.rs
@@ -61,7 +61,7 @@ impl LoadedSessionView {
     pub fn from_session(
         session: &tiangong_core::session::Session,
         context_limit_tokens: usize,
-        default_reasoning_effort: &str,
+        default_reasoning_effort: &tiangong_llm::request::ReasoningEffort,
     ) -> Self {
         let usage = session.total_usage();
         Self {
@@ -81,10 +81,8 @@ impl LoadedSessionView {
             cwd: session.cwd.clone(),
             reasoning_effort: session
                 .reasoning_effort
-                .as_deref()
-                .map(str::trim)
-                .filter(|effort| !effort.is_empty())
-                .unwrap_or(default_reasoning_effort)
+                .unwrap_or(*default_reasoning_effort)
+                .as_str()
                 .to_string(),
         }
     }


### PR DESCRIPTION
## 变更内容

### 背景问题
使用 DeepSeek 模型时，思考预算（8192）被规划中的长思考耗尽导致流截断、正文为空，被误判为"模型未产生有效回复"并终止 Agent 循环。

### 改动
- **思考控制收敛为单一参数 `ReasoningEffort`**（新增 `None` 变体表示关闭思考），移除 `thinking`/`thinking_disabled` 冗余参数与 `ThinkingConfig` 请求类型
- **配置/会话持久化改用枚举类型**：`AgentConfig`/`CoreConfig`/`Session`/`SessionMetadata` 的 `reasoning_effort` 从 String 改为枚举；旧数据容错解析（空串/未知值回退默认档），存储格式与前端传值不变
- **Anthropic 协议思考预算下沉到 tiangong-anthropic 库**：官方端点（api.anthropic.com）按官方规范自动填充推荐预算（max_tokens − 8192 正文预留，下限 1024）；DeepSeek/GLM 兼容端点不下发预算（实测 GLM 会执行预算并在思考超限时截断）
- 移除 Tauri 层思考强度白名单校验、`build_thinking_config` 等单行转发函数

### 实测验证
- DeepSeek 本地代理与智谱 GLM 的 Anthropic 兼容端点：无预算思考请求均正常
- 智谱端点 budget=1024 时思考被实际截断（验证了兼容端点不下发预算的必要性）

### 测试
- tiangong-anthropic 新增 5 个预算填充单测（官方填充/显式不覆盖/兼容跳过/小上限钳制/关闭不动）
- tiangong-llm（98）、tiangong-core、tiangong-core-manager 全部单测通过；clippy/fmt 零警告

### 已知遗留
设置接口对无效思考强度由报错改为静默回退 medium（review 指出，待后续单独处理）