### PR TITLE
fix(desktop): 修复设置页打开时消息通知不可见

### DIFF
--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -103,7 +103,7 @@ function ToastContainer({
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 max-w-md w-full">
+    <div className="fixed top-4 right-4 z-[110] flex flex-col gap-2 max-w-md w-full">
       {toasts.map((toast) => (
         <ToastItem key={toast.id} toast={toast} onRemove={onRemove} />
       ))}


### PR DESCRIPTION
## 变更内容

- 设置页打开时，全屏遮罩层级（z-[70]）高于消息通知 Toast 容器（z-50），导致设置页内所有消息通知被遮挡不可见。
- 将 Toast 容器层级提升至 z-[110]，高于设置对话框（z-[70]）及设置页内部插件刷新遮罩（z-[100]），保证任何浮层打开时消息通知均可见。

## 验证情况

- yarn build 通过
- yarn test 全部 212 个用例通过
- 桌面端实际显示效果由用户验证