### PR TITLE
feat(desktop): 对话自动跟随滚动改为可靠的贴底跟随模式

### DIFF
--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -380,6 +380,12 @@ export function MessageList() {
     const streamingIdChanged = streamingMessageId !== prevStreamingIdRef.current;
     const lastMsg = messages[messages.length - 1];
     const isUserSelfSent = newMessageArrived && lastMsg?.role === 'user';
+    // 用户发起对话（发送或编辑重发）时重新进入自动跟随模式；
+    // 用户翻动页面离开底部后跟随自动关闭，拉回最底部时由滚动事件重新开启
+    if (isUserSelfSent) {
+      isAtBottomRef.current = true;
+      setIsAtBottom(true);
+    }
     // 用户离开底部时，新消息/流式 id 变化不强制拉回；tab 切换与用户主动发送始终跟随
     const shouldScroll =
       tabChanged
@@ -390,14 +396,16 @@ export function MessageList() {
       if (completedGroups.length > 0 && !streamingGroup) {
         // 滚动到虚拟列表最后一项
         requestAnimationFrame(() => {
+          // 跟随滚动用瞬时定位：平滑动画期间内容持续增长会让滚动事件
+          // 误判"离开底部"而中断跟随
           virtualizer.scrollToIndex(completedGroups.length - 1, {
-            behavior: tabChanged ? "auto" : "smooth",
+            behavior: "auto",
             align: "end",
           });
         });
       } else if (streamingGroup) {
         requestAnimationFrame(() => {
-          scrollRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+          scrollRef.current?.scrollIntoView({ behavior: "auto", block: "end" });
         });
       }
     }
@@ -419,7 +427,9 @@ export function MessageList() {
       ticking = true;
       requestAnimationFrame(() => {
         if (isAtBottomRef.current) {
-          el.scrollIntoView({ behavior: "smooth", block: "end" });
+          // 瞬时贴底：流式内容增长期间保持视口贴底，滚动事件判定不受
+          // 平滑动画与内容增长的竞态影响；用户翻离底部后自动停止跟随
+          el.scrollIntoView({ behavior: "auto", block: "end" });
         }
         ticking = false;
       });
@@ -432,11 +442,12 @@ export function MessageList() {
     return () => observer.disconnect();
   }, [streamingMessageId]);
 
-  // 滚动到底部
+  // 滚动到底部：瞬时贴底并重新进入跟随模式。平滑动画期间内容增长
+  // 会让落点偏离底部导致跟随开不上来
   const scrollToBottom = useCallback(() => {
     const el = viewportRef.current;
     if (!el) return;
-    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    el.scrollTo({ top: el.scrollHeight, behavior: 'auto' });
     isAtBottomRef.current = true;
     setIsAtBottom(true);
   }, []);


### PR DESCRIPTION
## 变更内容

调整会话消息列表的自动滚动跟随行为：

- **发起对话自动跟随**：用户发送消息（含编辑重发）时显式重新进入自动跟随模式，即使之前正在翻看历史记录也会回到最新内容。
- **翻动页面停止跟随**：用户翻离底部查看历史时自动停止跟随，新消息和流式输出不再把视口拉回底部。
- **拉回底部恢复跟随**：用户滚动回最底部（含点击"滚动到底部"按钮）时自动恢复跟随。

## 问题原因

原实现的跟随滚动全部使用平滑动画，动画进行期间流式内容持续增长、页面总高度不断变化，滚动事件中途计算的距底距离经常超过 80px 阈值，跟随模式被误判为"用户翻离底部"而悄悄中断——表现为发起对话后自动滚动滚着滚着就不跟了。

## 修复方式

- 跟随性滚动（新消息到达、流式输出贴底、回到底部按钮）改为瞬时定位，滚动完成时位置判定准确，不受平滑动画与内容增长的竞态影响。
- 导航性滚动（跳转到指定提问、搜索定位）保留平滑动画，不影响。

## 验证情况

- yarn build 通过
- yarn test 全部 212 个用例通过
- 桌面端实际滚动体验由用户验证