### PR TITLE
fix(llm): 确定性错误不再回退非流式重发

### DIFF
--- a/crates/tiangong-core/src/core/contract_tests.rs
+++ b/crates/tiangong-core/src/core/contract_tests.rs
@@ -151,6 +151,6 @@ async fn steer_during_manual_compression_cancels_and_starts_turn() {
         "压缩被用户消息取消，未应用任何结果"
     );
     routes["manual-compression"].assert_hits(1);
-    routes["deferred-steer"].assert_hits(2);
+    routes["deferred-steer"].assert_hits(1);
     core.shutdown_join().expect("关闭失败");
 }

--- a/crates/tiangong-core/src/core/integration_tests.rs
+++ b/crates/tiangong-core/src/core/integration_tests.rs
@@ -402,10 +402,9 @@ async fn llm_failure_propagates_failed_status() {
     events.assert_single_failure_terminal("fail");
 
     let requests = server.received_requests().await.unwrap();
-    assert_eq!(requests.len(), 2, "流式失败后应出现一次非流式回退");
+    assert_eq!(requests.len(), 1, "400 确定性失败不回退非流式重发");
     assert!(chat_request_at(&server, 0).await.is_stream());
-    assert!(!chat_request_at(&server, 1).await.is_stream());
-    routes["forced-failure"].assert_hits(2);
+    routes["forced-failure"].assert_hits(1);
     core.shutdown_join().expect("关闭失败");
 }
 

--- a/crates/tiangong-core/src/react/execute_tests.rs
+++ b/crates/tiangong-core/src/react/execute_tests.rs
@@ -529,7 +529,6 @@ async fn compression_persists_summary_and_keeps_recent_interaction() {
 async fn forced_compression_folds_older_history_and_keeps_latest_tool_batch() {
     let server = MockServer::start().await;
     mount_request_error(&server, "context_window_exceeded").await;
-    mount_request_error(&server, "context_window_exceeded").await;
     mount_completion(
         &server,
         "[[CURRENT_TASK]]\n继续处理最近工具结果\n[[SUMMARY]]\n较早历史摘要",
@@ -598,10 +597,10 @@ async fn forced_compression_folds_older_history_and_keeps_latest_tool_batch() {
     }));
 
     let requests = server.received_requests().await.unwrap();
-    assert_eq!(requests.len(), 4);
+    assert_eq!(requests.len(), 3);
     let first_body = String::from_utf8_lossy(&requests[0].body);
-    let compression_body = String::from_utf8_lossy(&requests[2].body);
-    let retry_body = String::from_utf8_lossy(&requests[3].body);
+    let compression_body = String::from_utf8_lossy(&requests[1].body);
+    let retry_body = String::from_utf8_lossy(&requests[2].body);
     assert!(first_body.contains("recent-tool-output"));
     assert!(!compression_body.contains("recent-tool-output"));
     assert!(compression_body.contains("较早回答"));

--- a/crates/tiangong-llm/src/provider_client.rs
+++ b/crates/tiangong-llm/src/provider_client.rs
@@ -708,6 +708,10 @@ impl SingleProviderClient {
         {
             Ok(response) => Ok(response),
             Err(err) => {
+                // 确定性失败（400/401 等）换非流式重发同样失败，直接失败不再回退。
+                if is_deterministic_llm_error(&err) {
+                    return Err(err);
+                }
                 if let Some(on_retry) = &self.on_retry {
                     on_retry(1, MAX_RETRIES, 0, &err.to_string());
                 }
@@ -945,6 +949,7 @@ impl SingleProviderClient {
                 on_delta,
             ) {
                 Ok(resp) => Ok(resp),
+                Err(err) if is_deterministic_llm_error(&err) => Err(err),
                 Err(_) => {
                     // 流式失败，回退到非流式，一次性推送 reasoning + content
                     let resp =
@@ -1888,7 +1893,23 @@ fn block_on_provider_stream(
 }
 
 fn map_llm_error(error: crate::error::LlmError) -> anyhow::Error {
-    anyhow!(error.to_string())
+    anyhow::Error::new(error)
+}
+
+/// 判断错误是否为确定性失败（配置、认证、请求无效类）。
+///
+/// 这类错误与调用方式（流式/非流式）无关，换非流式重发同样失败，
+/// 流式失败后不应回退非流式重试。
+fn is_deterministic_llm_error(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<crate::error::LlmError>()
+        .is_some_and(|error| {
+            matches!(
+                error,
+                crate::error::LlmError::Configuration(_)
+                    | crate::error::LlmError::Authentication(_)
+                    | crate::error::LlmError::InvalidRequest(_)
+            )
+        })
 }
 
 // ── 重试相关 ──────────────────────────────────────────────


### PR DESCRIPTION
## 问题背景

使用 OpenRouter 等聚合服务时，上游供应商可能返回 400 等确定性错误。此前流式请求失败后会对**任何**错误回退非流式重发一次：

- 400/401 等确定性错误重发必然再失败，白白多打一次请求
- 错误提示叠加为「流式失败后回退非流式调用失败: …」双重文本，真实错误被淹没

## 变更点

- `map_llm_error` 改为 `anyhow::Error::new` 保留 `LlmError` 类型信息，回退决策按错误类别判断
- 新增 `is_deterministic_llm_error`：配置错误、认证失败、请求无效（400 类）直接失败，不回退非流式重发；传输、超时、限流等瞬态错误保持原回退行为
- 同步（`complete_with_functions_stream_with_tool_choice`）与异步（`stream_function_calls_attempt`）两条流式路径统一应用
- 更新 tiangong-core 中断言旧回退行为的三个测试：

  | 测试 | 变更 |
  | --- | --- |
  | `llm_failure_propagates_failed_status` | 期望请求数 2 → 1，路由命中 2 → 1 |
  | `steer_during_manual_compression_cancels_and_starts_turn` | 路由命中 2 → 1 |
  | `forced_compression_folds_older_history_and_keeps_latest_tool_batch` | 错误路由挂载 2 → 1，期望请求数 4 → 3 |

行为收益示例：上下文超限（同为 400）时不再先回退重打一次失败请求，直接进入强制压缩流程。

## 测试情况

- `cargo check --workspace` 通过
- `cargo clippy -p tiangong-llm -p tiangong-core` 无警告
- `cargo test -p tiangong-llm`：98 项全部通过
- `cargo test -p tiangong-core`：与改动相关测试单独运行全部通过；并发全量下偶发的随机失败在未改动的主分支同样出现（既有测试不稳定，与本次无关）
- 临时端到端验证（已移除）：模拟 OpenRouter 整数 `code` 的 400 错误体，修复后仅发起 1 次流式请求即失败返回，无回退请求
