### PR TITLE
feat(desktop): 输入框支持消息队列与 Cmd+Enter 立即引导

### DIFF
--- a/frontend/src/components/InputQueueBar.tsx
+++ b/frontend/src/components/InputQueueBar.tsx
@@ -1,0 +1,60 @@
+import { CornerUpLeft, ListOrdered, Paperclip, X } from 'lucide-react';
+import { useStore } from '@/store/useStore';
+
+const EMPTY_QUEUE: never[] = [];
+
+interface InputQueueBarProps {
+  cacheKey: string | null;
+  isIdle: boolean;
+}
+
+/** 输入框上方的待投递队列：逐条展示、可单独引导/发送或移除。 */
+export function InputQueueBar({ cacheKey, isIdle }: InputQueueBarProps) {
+  const queue = useStore((state) => (cacheKey ? state.inputQueues[cacheKey] : undefined)) ?? EMPTY_QUEUE;
+  const removeQueuedInputMessage = useStore((state) => state.removeQueuedInputMessage);
+  const steerQueuedInputMessage = useStore((state) => state.steerQueuedInputMessage);
+  if (!cacheKey || queue.length === 0) return null;
+  return (
+    <div className="mb-2 flex flex-col gap-1">
+      {queue.map((message, index) => (
+        <div
+          key={message.id}
+          className="flex items-center gap-2 rounded-md border bg-muted/30 px-2 py-1.5 text-xs"
+        >
+          <span className="flex shrink-0 items-center gap-1 text-muted-foreground/70 tabular-nums">
+            <ListOrdered className="h-3 w-3" />
+            {index + 1}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-muted-foreground" title={message.text}>
+            {message.text.trim() || '（仅附件）'}
+          </span>
+          {message.attachments.length > 0 && (
+            <span
+              className="flex shrink-0 items-center gap-0.5 text-muted-foreground/70"
+              title={message.attachments.map((item) => item.original_name ?? item.source).join('\n')}
+            >
+              <Paperclip className="h-3 w-3" />
+              {message.attachments.length}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => { void steerQueuedInputMessage(cacheKey, message.id); }}
+            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+            title={isIdle ? '立即发送' : '立即引导（打断当前执行）'}
+          >
+            <CornerUpLeft className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => removeQueuedInputMessage(cacheKey, message.id)}
+            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+            title="从队列移除"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/InputQueueBar.tsx
+++ b/frontend/src/components/InputQueueBar.tsx
@@ -1,4 +1,5 @@
-import { CornerUpLeft, ListOrdered, Paperclip, X } from 'lucide-react';
+import { useState } from 'react';
+import { CornerUpLeft, GripVertical, ListOrdered, Paperclip, Pencil, X } from 'lucide-react';
 import { useStore } from '@/store/useStore';
 
 const EMPTY_QUEUE: never[] = [];
@@ -8,19 +9,55 @@ interface InputQueueBarProps {
   isIdle: boolean;
 }
 
-/** 输入框上方的待投递队列：逐条展示、可单独引导/发送或移除。 */
+/** 输入框上方的待投递队列：逐条展示，支持拖拽排序、单独引导/发送、编辑回填与移除。 */
 export function InputQueueBar({ cacheKey, isIdle }: InputQueueBarProps) {
   const queue = useStore((state) => (cacheKey ? state.inputQueues[cacheKey] : undefined)) ?? EMPTY_QUEUE;
   const removeQueuedInputMessage = useStore((state) => state.removeQueuedInputMessage);
   const steerQueuedInputMessage = useStore((state) => state.steerQueuedInputMessage);
+  const moveQueuedInputMessage = useStore((state) => state.moveQueuedInputMessage);
+  const editQueuedInputMessage = useStore((state) => state.editQueuedInputMessage);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dropIndex, setDropIndex] = useState<number | null>(null);
   if (!cacheKey || queue.length === 0) return null;
+
+  const finishDrag = () => {
+    setDragIndex(null);
+    setDropIndex(null);
+  };
+
   return (
     <div className="mb-2 flex flex-col gap-1">
       {queue.map((message, index) => (
         <div
           key={message.id}
-          className="flex items-center gap-2 rounded-md border bg-muted/30 px-2 py-1.5 text-xs"
+          draggable
+          onDragStart={(e) => {
+            setDragIndex(index);
+            e.dataTransfer.effectAllowed = 'move';
+          }}
+          onDragOver={(e) => {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'move';
+            setDropIndex(index);
+          }}
+          onDrop={(e) => {
+            e.preventDefault();
+            if (dragIndex != null && dragIndex !== index) {
+              moveQueuedInputMessage(cacheKey, dragIndex, index);
+            }
+            finishDrag();
+          }}
+          onDragEnd={finishDrag}
+          className={`flex cursor-grab items-center gap-2 rounded-md border bg-muted/30 px-2 py-1.5 text-xs transition-colors ${
+            dragIndex === index ? 'opacity-40' : ''
+          } ${
+            dropIndex === index && dragIndex != null && dragIndex !== index
+              ? 'border-primary bg-primary/5'
+              : ''
+          }`}
+          title="拖拽调整投递顺序"
         >
+          <GripVertical className="h-3 w-3 shrink-0 text-muted-foreground/50" />
           <span className="flex shrink-0 items-center gap-1 text-muted-foreground/70 tabular-nums">
             <ListOrdered className="h-3 w-3" />
             {index + 1}
@@ -44,6 +81,14 @@ export function InputQueueBar({ cacheKey, isIdle }: InputQueueBarProps) {
             title={isIdle ? '立即发送' : '立即引导（打断当前执行）'}
           >
             <CornerUpLeft className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => editQueuedInputMessage(cacheKey, message.id)}
+            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+            title="编辑：回填到输入框"
+          >
+            <Pencil className="h-3.5 w-3.5" />
           </button>
           <button
             type="button"

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -24,6 +24,9 @@ import {
 import { replaceMentionCompletion } from '@/utils/mentionEditorModel';
 import { formatDuration } from './message/utils';
 import { SessionInputPluginHost } from './SessionInputPluginHost';
+import { InputQueueBar } from './InputQueueBar';
+
+const MOD_KEY_LABEL = navigator.platform.toUpperCase().includes('MAC') ? 'Cmd+Enter' : 'Ctrl+Enter';
 
 interface MentionCandidate {
   value: string;
@@ -65,6 +68,7 @@ export function MessageInput({
   const setInputCacheAttachments = useStore((state) => state.setInputCacheAttachments);
   const sendMessage = useStore((state) => state.sendMessage);
   const appendMessage = useStore((state) => state.appendMessage);
+  const enqueueInputMessage = useStore((state) => state.enqueueInputMessage);
   const cancelTurn = useStore((state) => state.cancelTurn);
   const beginContextManagement = useStore((state) => state.beginContextManagement);
   const endContextManagement = useStore((state) => state.endContextManagement);
@@ -595,7 +599,12 @@ export function MessageInput({
     }
     if (e.key === 'Enter' && !e.shiftKey && !isComposingRef.current && !e.nativeEvent.isComposing && e.keyCode !== 229) {
       e.preventDefault();
-      handleSend();
+      // Cmd/Ctrl+Enter 立即投递（空闲发送、执行中引导）；执行中普通 Enter 排入队列。
+      if ((e.metaKey || e.ctrlKey) || isIdle) {
+        handleSend();
+      } else {
+        void handleEnqueue();
+      }
     }
   };
 
@@ -641,6 +650,19 @@ export function MessageInput({
   };
 
   const handleCancel = () => { cancelTurn(); };
+
+  // 执行中普通 Enter：当前输入（含附件）排入会话队列并清空草稿，等空闲后自动放行。
+  const handleEnqueue = async () => {
+    if (!canSend) return;
+    setMentionOpen(false);
+    const targetCacheKey = cacheKey;
+    if (!targetCacheKey) return;
+    // slash 命令不入队，直接执行（与发送行为一致）。
+    if (await executeSlashCommand(inputContent.trim())) {
+      return;
+    }
+    enqueueInputMessage(targetCacheKey);
+  };
 
   const handleAttachFiles = async () => {
     try {
@@ -957,6 +979,7 @@ export function MessageInput({
               </div>
             </div>
             <SessionInputPluginHost slot="session.before-input" />
+            <InputQueueBar cacheKey={cacheKey} isIdle={isIdle} />
             <div
               ref={inputAreaRef}
               className="relative"
@@ -1055,7 +1078,7 @@ export function MessageInput({
                     ? agents.length > 0
                       ? '输入消息... (Enter 发送，@ 引用 Agent/Skill/MCP)'
                       : '输入消息... (Enter 发送，@ 引用 Skill/MCP)'
-                    : '追加指示... (Enter 发送)'
+                    : `追加指示... (Enter 排队，${MOD_KEY_LABEL} 立即引导)`
                 }
                 className="min-h-[60px] max-h-[200px] resize-none pr-32 bg-muted/50 focus-visible:ring-ring"
               />
@@ -1110,7 +1133,7 @@ export function MessageInput({
                         : 'bg-blue-600 hover:bg-blue-700 text-white'
                       : 'bg-muted text-muted-foreground'
                   }`}
-                  title={isIdle ? '发送消息' : '追加指示'}
+                  title={isIdle ? '发送消息' : `立即引导 (${MOD_KEY_LABEL})`}
                 >
                   {isIdle ? (
                     <Send className="w-4 h-4" />
@@ -1184,7 +1207,11 @@ export function MessageInput({
                     <><ShieldOff className="w-3 h-3" /><span>信任</span></>
                   )}
                 </button>
-                <span>Enter 发送 · Shift+Enter 换行</span>
+                <span>
+                  {isIdle
+                    ? 'Enter 发送 · Shift+Enter 换行'
+                    : `Enter 排队 · ${MOD_KEY_LABEL} 立即引导 · Shift+Enter 换行`}
+                </span>
               </div>
               </div>
             </div>

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -69,6 +69,16 @@ function newQueuedMessageId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+/** 把当前草稿快照为一条队列消息（不修改草稿）。 */
+function queuedMessageFromCache(cache: InputCache): QueuedInputMessage {
+  return {
+    id: newQueuedMessageId(),
+    text: cache.text,
+    attachments: cache.attachments.map((attachment) => ({ ...attachment })),
+    queuedAt: Date.now(),
+  };
+}
+
 function commitSessionSwitch(sessionId: string, requestVersion: number): Promise<boolean> {
   const commit = switchCommitQueue.then(async () => {
     if (requestVersion !== switchRequestVersion) return false;
@@ -849,6 +859,10 @@ export interface AppState {
   /** 执行中 Enter：把当前草稿（文本+附件快照）排入会话队列并清空草稿。 */
   enqueueInputMessage: (cacheKey: string) => void;
   removeQueuedInputMessage: (cacheKey: string, messageId: string) => void;
+  /** 拖拽调整队列顺序；自动放行按调整后的顺序投递。 */
+  moveQueuedInputMessage: (cacheKey: string, fromIndex: number, toIndex: number) => void;
+  /** 编辑：消息内容（文本+附件）回填草稿并从队列移除；草稿非空时先转入队首。 */
+  editQueuedInputMessage: (cacheKey: string, messageId: string) => void;
   /** 立即投递指定队列消息：空闲走 sendMessage 开新轮，执行中走 appendMessage 引导。 */
   steerQueuedInputMessage: (cacheKey: string, messageId: string) => Promise<boolean>;
   /** turn 结束（runStatus 回 idle）且草稿为空时自动放行队首；失败不自动重试。 */
@@ -1627,12 +1641,7 @@ export const useStore = create<AppState>((set, get) => ({
   enqueueInputMessage: (cacheKey) => {
     const cache = get().inputCaches[cacheKey];
     if (!cache || (cache.text.trim().length === 0 && cache.attachments.length === 0)) return;
-    const message: QueuedInputMessage = {
-      id: newQueuedMessageId(),
-      text: cache.text,
-      attachments: cache.attachments.map((attachment) => ({ ...attachment })),
-      queuedAt: Date.now(),
-    };
+    const message = queuedMessageFromCache(cache);
     set((state) => ({
       inputQueues: {
         ...state.inputQueues,
@@ -1656,6 +1665,46 @@ export const useStore = create<AppState>((set, get) => ({
     });
   },
 
+  moveQueuedInputMessage: (cacheKey, fromIndex, toIndex) => {
+    set((state) => {
+      const queue = state.inputQueues[cacheKey];
+      if (
+        !queue
+        || fromIndex === toIndex
+        || fromIndex < 0 || fromIndex >= queue.length
+        || toIndex < 0 || toIndex >= queue.length
+      ) {
+        return state;
+      }
+      const next = queue.slice();
+      const [moved] = next.splice(fromIndex, 1);
+      next.splice(toIndex, 0, moved);
+      return { inputQueues: { ...state.inputQueues, [cacheKey]: next } };
+    });
+  },
+
+  editQueuedInputMessage: (cacheKey, messageId) => {
+    const state = get();
+    const message = (state.inputQueues[cacheKey] ?? []).find((item) => item.id === messageId);
+    if (!message) return;
+    // 草稿非空时先转入队首，避免回填覆盖丢失。
+    const cache = state.inputCaches[cacheKey];
+    const draftMessage = cache && (cache.text.trim().length > 0 || cache.attachments.length > 0)
+      ? queuedMessageFromCache(cache)
+      : null;
+    set((current) => {
+      const remaining = (current.inputQueues[cacheKey] ?? []).filter((item) => item.id !== messageId);
+      return {
+        inputQueues: {
+          ...current.inputQueues,
+          [cacheKey]: draftMessage ? [draftMessage, ...remaining] : remaining,
+        },
+      };
+    });
+    get().setInputCacheText(cacheKey, message.text);
+    get().setInputCacheAttachments(cacheKey, message.attachments);
+  },
+
   steerQueuedInputMessage: async (cacheKey, messageId) => {
     const state = get();
     const queue = state.inputQueues[cacheKey] ?? [];
@@ -1665,12 +1714,7 @@ export const useStore = create<AppState>((set, get) => ({
     // 草稿非空时先入队保底，避免被队列消息覆盖丢失；排到队首，本轮投递后最先放行。
     const cache = state.inputCaches[cacheKey];
     const draftMessage = cache && (cache.text.trim().length > 0 || cache.attachments.length > 0)
-      ? {
-        id: newQueuedMessageId(),
-        text: cache.text,
-        attachments: cache.attachments.map((attachment) => ({ ...attachment })),
-        queuedAt: Date.now(),
-      }
+      ? queuedMessageFromCache(cache)
       : null;
     set((current) => {
       const remaining = (current.inputQueues[cacheKey] ?? []).filter((item) => item.id !== messageId);

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -57,6 +57,18 @@ interface SessionViewCache {
 
 const sessionViewCaches = new Map<string, SessionViewCache>();
 
+/** 输入队列消息：执行期间暂存、等待空闲后按序投递的用户输入（含附件快照）。 */
+export interface QueuedInputMessage {
+  id: string;
+  text: string;
+  attachments: RawAttachment[];
+  queuedAt: number;
+}
+
+function newQueuedMessageId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
 function commitSessionSwitch(sessionId: string, requestVersion: number): Promise<boolean> {
   const commit = switchCommitQueue.then(async () => {
     if (requestVersion !== switchRequestVersion) return false;
@@ -832,6 +844,16 @@ export interface AppState {
   // 多会话运行状态 (session_id -> status)
   sessionRunStatuses: Record<string, string>;
 
+  // 输入队列 (cacheKey -> 待投递消息，队首先行)
+  inputQueues: Record<string, QueuedInputMessage[]>;
+  /** 执行中 Enter：把当前草稿（文本+附件快照）排入会话队列并清空草稿。 */
+  enqueueInputMessage: (cacheKey: string) => void;
+  removeQueuedInputMessage: (cacheKey: string, messageId: string) => void;
+  /** 立即投递指定队列消息：空闲走 sendMessage 开新轮，执行中走 appendMessage 引导。 */
+  steerQueuedInputMessage: (cacheKey: string, messageId: string) => Promise<boolean>;
+  /** turn 结束（runStatus 回 idle）且草稿为空时自动放行队首；失败不自动重试。 */
+  dequeueNextQueuedInput: (cacheKey: string) => Promise<boolean>;
+
   // 流式消息状态
   streamingMessageId: string | null;
   streamingContent: string;
@@ -964,6 +986,7 @@ export const useStore = create<AppState>((set, get) => ({
   workspaceDir: '',
   sessionCwd: '',
   sessionRunStatuses: {},
+  inputQueues: {},
   streamingMessageId: null,
   streamingContent: '',
   streamingReasoningContent: '',
@@ -1239,12 +1262,15 @@ export const useStore = create<AppState>((set, get) => ({
       set((state) => {
         const inputCaches = { ...state.inputCaches };
         const sessionRunStatuses = { ...state.sessionRunStatuses };
+        const inputQueues = { ...state.inputQueues };
         delete inputCaches[deletedSessionId];
         delete sessionRunStatuses[deletedSessionId];
+        delete inputQueues[deletedSessionId];
         return {
           sessions: state.sessions.filter((s) => s.id !== deletedSessionId),
           inputCaches,
           sessionRunStatuses,
+          inputQueues,
         };
       });
 
@@ -1277,14 +1303,17 @@ export const useStore = create<AppState>((set, get) => ({
       set((state) => {
         const inputCaches = { ...state.inputCaches };
         const sessionRunStatuses = { ...state.sessionRunStatuses };
+        const inputQueues = { ...state.inputQueues };
         for (const sessionId of succeededIds) {
           delete inputCaches[sessionId];
           delete sessionRunStatuses[sessionId];
+          delete inputQueues[sessionId];
         }
         return {
           sessions: remainingSessions,
           inputCaches,
           sessionRunStatuses,
+          inputQueues,
         };
       });
 
@@ -1590,6 +1619,107 @@ export const useStore = create<AppState>((set, get) => ({
     }
   },
 
+  // ===== 输入队列 =====
+  // 执行中 Enter 不再直接追加引导，而是把当前草稿排入会话队列；投递统一走
+  // "写回草稿 + 标准 sendMessage/appendMessage"路径，天然满足 revision/claim
+  // 校验与防重复投递，且成功后由 settle 正常清空草稿。
+
+  enqueueInputMessage: (cacheKey) => {
+    const cache = get().inputCaches[cacheKey];
+    if (!cache || (cache.text.trim().length === 0 && cache.attachments.length === 0)) return;
+    const message: QueuedInputMessage = {
+      id: newQueuedMessageId(),
+      text: cache.text,
+      attachments: cache.attachments.map((attachment) => ({ ...attachment })),
+      queuedAt: Date.now(),
+    };
+    set((state) => ({
+      inputQueues: {
+        ...state.inputQueues,
+        [cacheKey]: [...(state.inputQueues[cacheKey] ?? []), message],
+      },
+    }));
+    get().setInputCacheText(cacheKey, '');
+    get().setInputCacheAttachments(cacheKey, []);
+  },
+
+  removeQueuedInputMessage: (cacheKey, messageId) => {
+    set((state) => {
+      const queue = state.inputQueues[cacheKey];
+      if (!queue?.some((message) => message.id === messageId)) return state;
+      return {
+        inputQueues: {
+          ...state.inputQueues,
+          [cacheKey]: queue.filter((message) => message.id !== messageId),
+        },
+      };
+    });
+  },
+
+  steerQueuedInputMessage: async (cacheKey, messageId) => {
+    const state = get();
+    const queue = state.inputQueues[cacheKey] ?? [];
+    const index = queue.findIndex((message) => message.id === messageId);
+    if (index < 0) return false;
+    const message = queue[index];
+    // 草稿非空时先入队保底，避免被队列消息覆盖丢失；排到队首，本轮投递后最先放行。
+    const cache = state.inputCaches[cacheKey];
+    const draftMessage = cache && (cache.text.trim().length > 0 || cache.attachments.length > 0)
+      ? {
+        id: newQueuedMessageId(),
+        text: cache.text,
+        attachments: cache.attachments.map((attachment) => ({ ...attachment })),
+        queuedAt: Date.now(),
+      }
+      : null;
+    set((current) => {
+      const remaining = (current.inputQueues[cacheKey] ?? []).filter((item) => item.id !== messageId);
+      return {
+        inputQueues: {
+          ...current.inputQueues,
+          [cacheKey]: draftMessage ? [draftMessage, ...remaining] : remaining,
+        },
+      };
+    });
+
+    get().setInputCacheText(cacheKey, message.text);
+    get().setInputCacheAttachments(cacheKey, message.attachments);
+    const latest = get().inputCaches[cacheKey];
+    if (!latest) return false;
+    const content = message.text.trim()
+      || (message.attachments.length > 0 ? '请处理这些附件。' : message.text);
+    const isIdle = !get().sessionRunStatuses[cacheKey];
+    const delivered = isIdle
+      ? await get().sendMessage(cacheKey, content, latest.attachments, latest.revision)
+      : await get().appendMessage(cacheKey, content, latest.attachments, latest.revision);
+    if (!delivered) {
+      // 失败回插队首并清空草稿（内容仍在队列，不丢失）。
+      set((current) => {
+        const currentQueue = current.inputQueues[cacheKey] ?? [];
+        if (currentQueue.some((item) => item.id === message.id)) return current;
+        return {
+          inputQueues: { ...current.inputQueues, [cacheKey]: [message, ...currentQueue] },
+        };
+      });
+      get().setInputCacheText(cacheKey, '');
+      get().setInputCacheAttachments(cacheKey, []);
+      return false;
+    }
+    return true;
+  },
+
+  dequeueNextQueuedInput: async (cacheKey) => {
+    const state = get();
+    if (state.sessionRunStatuses[cacheKey]) return false;
+    const cache = state.inputCaches[cacheKey];
+    if (cache && (cache.text.trim().length > 0 || cache.attachments.length > 0 || cache.is_sending)) {
+      return false;
+    }
+    const first = state.inputQueues[cacheKey]?.[0];
+    if (!first) return false;
+    return get().steerQueuedInputMessage(cacheKey, first.id);
+  },
+
   // 编辑态有自己的 revision；这里只按显式 session_id 更新该会话发送状态。
   editAndResend: async (
     sessionId,
@@ -1828,6 +1958,10 @@ export const useStore = create<AppState>((set, get) => ({
         sessionRunStatuses: nextStatuses,
       };
     });
+    // 上下文管理结束回到空闲：若之前积累了输入队列，继续放行队首。
+    if (activeSessionId) {
+      void get().dequeueNextQueuedInput(activeSessionId);
+    }
   },
 
   applyStreamEvents: (events) => {
@@ -1905,10 +2039,15 @@ export const useStore = create<AppState>((set, get) => ({
     const nextState = get();
     const appIsForeground = document.visibilityState === 'visible' && document.hasFocus();
     for (const sessionId of Object.keys(previousStatuses)) {
-      if (!nextState.sessionRunStatuses[sessionId]
-        && (sessionId !== nextState.activeSessionId || !appIsForeground)) {
-        const session = nextState.sessions.find((item) => item.id === sessionId);
-        notifyBackgroundSessionCompleted(session?.title || '对话', sessionId).catch(console.warn);
+      if (!nextState.sessionRunStatuses[sessionId]) {
+        // 执行结束的会话若留有输入队列且草稿为空，自动放行队首。
+        if ((nextState.inputQueues[sessionId]?.length ?? 0) > 0) {
+          void get().dequeueNextQueuedInput(sessionId);
+        }
+        if (sessionId !== nextState.activeSessionId || !appIsForeground) {
+          const session = nextState.sessions.find((item) => item.id === sessionId);
+          notifyBackgroundSessionCompleted(session?.title || '对话', sessionId).catch(console.warn);
+        }
       }
     }
   },


### PR DESCRIPTION
## 变更内容

执行期间的输入交互从「Enter 直接追加引导」改为「排队 + 显式引导」模型：

- **执行中 Enter**：当前输入（含附件快照）排入会话队列并清空草稿，不打断正在执行的任务；slash 命令仍直接执行，不入队
- **Cmd/Ctrl+Enter**：立即投递当前输入——空闲时开新轮，执行中作为引导消息（InjectUserMessage）追加
- **队列 UI**：输入框上方逐条展示队列（序号、内容摘要、附件数），每条可单独「立即引导/发送」或移除；投递队列消息时若草稿非空，草稿自动转入队首，不丢失
- **自动放行**：turn 结束（runStatus 回 idle）且草稿为空时自动按序投递队首；上下文压缩/清理结束后同样触发；投递失败回插队首，不自动重试
- **删除会话**时同步清理其队列；队列仅内存态，不做持久化

## 实现说明

- 队列投递统一走「写回草稿 + 现有 sendMessage/appendMessage」路径，天然复用 revision/claim 校验、防重复投递与附件归档，后端零改动
- `applyStreamEvents` 在会话从执行转为空闲时触发自动放行，后台会话同样生效
- 快捷键文案按平台显示 Cmd+Enter / Ctrl+Enter

## 测试情况

- `yarn build`（tsc -b + vite build）通过
- `yarn test` 全部 212 个测试通过
- 键盘边界：IME 输入法组合期 Enter 不触发；mention 补全菜单打开时 Enter 仍选中候选，Cmd+Enter 落入投递分支
