### PR TITLE
fix(plugin): 主 Chat 模型多模态时附件分析插件自动停用

### DIFF
--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -1396,6 +1396,24 @@ impl From<&Session> for tiangong_types::PluginSession {
     }
 }
 
+/// 换算 Core 消息位置到插件快照位置。
+///
+/// 插件生命周期钩子携带的 `turn_start_idx` 基于 Core 完整消息列表；
+/// 快照剔除 Notice 后位置整体前移，必须同步换算才能仍指向同一条消息。
+pub fn plugin_turn_start_idx(session: &Session, turn_start_idx: usize) -> usize {
+    let removed_before = session
+        .messages
+        .get(..turn_start_idx.min(session.messages.len()))
+        .map(|prefix| {
+            prefix
+                .iter()
+                .filter(|message| message.role == MessageRole::Notice)
+                .count()
+        })
+        .unwrap_or(0);
+    turn_start_idx.saturating_sub(removed_before)
+}
+
 #[cfg(test)]
 mod plugin_session_tests {
     use super::*;
@@ -1422,5 +1440,32 @@ mod plugin_session_tests {
         assert_eq!(roles, vec!["user", "assistant"]);
         // 原会话不受影响。
         assert_eq!(session.messages.len(), 3);
+    }
+
+    #[test]
+    fn plugin_turn_start_idx_换算跳过位置之前的_notice() {
+        let mut session = Session::new("位置换算");
+        session.append_message(MessageRole::User, "第一轮");
+        session.append_message(MessageRole::Notice, "失败通知");
+        session.append_message(MessageRole::User, "第二轮");
+        session.append_message(MessageRole::Notice, "另一条通知");
+        session.append_message(MessageRole::User, "第三轮");
+
+        // 前方有一条 Notice：位置前移 1，仍指向同一条用户消息。
+        assert_eq!(plugin_turn_start_idx(&session, 2), 1);
+        assert_eq!(
+            tiangong_types::PluginSession::from(&session).messages[1].text_content(),
+            session.messages[2].text_content()
+        );
+
+        // 前方有两条 Notice：位置前移 2。
+        assert_eq!(plugin_turn_start_idx(&session, 4), 2);
+        assert_eq!(
+            tiangong_types::PluginSession::from(&session).messages[2].text_content(),
+            session.messages[4].text_content()
+        );
+
+        // 位置 0 之前无 Notice：不变。
+        assert_eq!(plugin_turn_start_idx(&session, 0), 0);
     }
 }

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -1378,6 +1378,7 @@ impl From<&Session> for tiangong_types::PluginSession {
             cwd: session.cwd.clone(),
             workspace_id,
             parent_session_id: session.parent_session_id.clone(),
+            turn_start_message_id: None,
             reasoning_effort: session
                 .reasoning_effort
                 .map(|effort| effort.as_str().to_string()),

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -1381,10 +1381,46 @@ impl From<&Session> for tiangong_types::PluginSession {
             reasoning_effort: session
                 .reasoning_effort
                 .map(|effort| effort.as_str().to_string()),
-            messages: session.messages.clone(),
+            // Notice 是宿主与用户之间的系统通知，不属于对话历史；
+            // 插件快照始终剔除，旧版本插件的会话反序列化也不含该角色。
+            messages: session
+                .messages
+                .iter()
+                .filter(|message| message.role != MessageRole::Notice)
+                .cloned()
+                .collect(),
             context_summary: session.context_summary.clone(),
             created_at: session.created_at.clone(),
             updated_at: session.updated_at.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod plugin_session_tests {
+    use super::*;
+
+    #[test]
+    fn plugin_session_转换剔除_notice_消息() {
+        let mut session = Session::new("含系统通知的会话");
+        session.append_message(MessageRole::User, "用户输入");
+        session.append_message(MessageRole::Notice, "系统通知");
+        session.append_message(MessageRole::Assistant, "回复");
+
+        let snapshot = tiangong_types::PluginSession::from(&session);
+        let roles: Vec<&str> = snapshot
+            .messages
+            .iter()
+            .map(|message| match message.role {
+                MessageRole::System => "system",
+                MessageRole::User => "user",
+                MessageRole::Assistant => "assistant",
+                MessageRole::Tool => "tool",
+                MessageRole::Notice => "notice",
+            })
+            .collect();
+        assert_eq!(roles, vec!["user", "assistant"]);
+        // 原会话不受影响。
+        assert_eq!(session.messages.len(), 3);
     }
 }

--- a/crates/tiangong-plugin-runtime/src/adapter.rs
+++ b/crates/tiangong-plugin-runtime/src/adapter.rs
@@ -350,7 +350,12 @@ impl WasmPluginAdapter {
         turn_start_idx: usize,
         call: impl Fn(&mut WasmPlugin, String, u32) -> anyhow::Result<()> + Send + Sync,
     ) {
-        let plugin_session = tiangong_types::PluginSession::from(session);
+        let mut plugin_session = tiangong_types::PluginSession::from(session);
+        // 本轮起点同时以消息 ID 提供：插件按 ID 定位不受快照消息增删影响。
+        plugin_session.turn_start_message_id = session
+            .messages
+            .get(turn_start_idx)
+            .map(|message| message.id.clone());
         let json = match serde_json::to_string(&plugin_session) {
             Ok(j) => j,
             Err(e) => {
@@ -364,7 +369,7 @@ impl WasmPluginAdapter {
         if !self.is_enabled() {
             return;
         }
-        // 快照剔除 Notice 后位置前移，同步换算保证仍指向同一条消息。
+        // idx 兼容仍按位置定位的旧版插件；快照剔除 Notice 后位置前移，同步换算。
         let idx = tiangong_core::session::plugin_turn_start_idx(session, turn_start_idx) as u32;
         if let Err(error) = self.call_wasm_off_runtime(move |plugin| call(plugin, json, idx)) {
             tracing::warn!(plugin_id = %self.id, hook, %error, "wasm 生命周期钩子失败");

--- a/crates/tiangong-plugin-runtime/src/adapter.rs
+++ b/crates/tiangong-plugin-runtime/src/adapter.rs
@@ -188,7 +188,7 @@ impl Plugin for WasmPluginAdapter {
     /// CoreConfig 变更：序列化为 JSON 转发到 WASM 组件的 on-config-updated。
     /// 序列化失败（不应发生）或 WASM 调用失败时仅记录 warning，不阻断 core 流程。
     fn on_config_updated(&self, config: &CoreConfig) {
-        let config_json = match serde_json::to_string(config) {
+        let config_json = match plugin_config_payload(config) {
             Ok(json) => json,
             Err(e) => {
                 tracing::warn!("序列化 CoreConfig 失败，跳过 wasm 插件通知: {e}");
@@ -495,4 +495,34 @@ where
             .map_err(|e| anyhow::anyhow!("wasm 插件锁中毒: {e}"))?;
         call(&mut plugin)
     })
+}
+
+/// 序列化 CoreConfig 为插件配置载荷，并附加主 Chat 模型的能力声明。
+///
+/// CoreConfig 只含端点信息（base_url/model 等），不含能力路由；插件需要
+/// 能力信息判断自身是否需要注册（如多模态主模型直接内联图片时，
+/// 附件分析插件无需再提供工具）。配置尚未初始化时附加空列表（保守保留插件工具）。
+fn plugin_config_payload(config: &CoreConfig) -> anyhow::Result<String> {
+    let mut value = serde_json::to_value(config)?;
+    let chat_capabilities: Vec<String> = tiangong_config::registry::try_models()
+        .and_then(|models| {
+            models
+                .routing
+                .get(&tiangong_llm::models_config::RoutingSlot::Chat)
+                .map(|entry| {
+                    entry
+                        .capabilities
+                        .iter()
+                        .map(|cap| cap.key().to_string())
+                        .collect()
+                })
+        })
+        .unwrap_or_default();
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "chat_capabilities".to_string(),
+            serde_json::json!(chat_capabilities),
+        );
+    }
+    Ok(serde_json::to_string(&value)?)
 }

--- a/crates/tiangong-plugin-runtime/src/adapter.rs
+++ b/crates/tiangong-plugin-runtime/src/adapter.rs
@@ -364,7 +364,8 @@ impl WasmPluginAdapter {
         if !self.is_enabled() {
             return;
         }
-        let idx = turn_start_idx as u32;
+        // 快照剔除 Notice 后位置前移，同步换算保证仍指向同一条消息。
+        let idx = tiangong_core::session::plugin_turn_start_idx(session, turn_start_idx) as u32;
         if let Err(error) = self.call_wasm_off_runtime(move |plugin| call(plugin, json, idx)) {
             tracing::warn!(plugin_id = %self.id, hook, %error, "wasm 生命周期钩子失败");
         }

--- a/crates/tiangong-types/src/plugin_session.rs
+++ b/crates/tiangong-types/src/plugin_session.rs
@@ -23,6 +23,12 @@ pub struct PluginSession {
     /// 父会话 ID（子 Agent 时存在）。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_session_id: Option<String>,
+    /// 本轮起始用户消息 ID（on_turn_started / on_turn_finished 钩子填充）。
+    ///
+    /// 插件按 ID 定位本轮起点，不受快照消息增删（如剔除 Notice）影响；
+    /// 其余钩子（会话就绪/结束）无本轮概念，不填充。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_start_message_id: Option<String>,
     /// 思考强度。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,

--- a/plugins/tiangong-plugin-analyze-attachment/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-analyze-attachment/wasm/src/lib.rs
@@ -204,21 +204,18 @@ fn find_attachment_source(
     message_id: Option<&str>,
     attachment_index: Option<usize>,
 ) -> (String, Vec<String>) {
-    // 定位消息：优先按 message_id 精确匹配；模型编造或误传 ID 时
-    // 回退到最后一条带图片附件的用户消息，避免直接报错。
-    let source = message_id
-        .and_then(|id| {
-            messages
-                .iter()
-                .find(|msg| msg.get("id").and_then(Value::as_str) == Some(id))
-        })
-        .filter(|msg| !message_image_paths(msg).is_empty())
-        .or_else(|| {
-            messages
-                .iter()
-                .rev()
-                .find(|msg| is_user_message_with_image(msg))
-        });
+    // 定位消息：明确提供 message_id 时严格精确匹配——ID 不存在或该消息
+    // 没有图片都视为定位失败并报错，绝不回退到其他消息（避免误用历史图片
+    // 生成看似正常但内容错误的分析）。仅省略 ID 时取最近一条带图用户消息。
+    let source = match message_id {
+        Some(id) => messages
+            .iter()
+            .find(|msg| msg.get("id").and_then(Value::as_str) == Some(id)),
+        None => messages
+            .iter()
+            .rev()
+            .find(|msg| is_user_message_with_image(msg)),
+    };
 
     let Some(source) = source else {
         return (String::new(), Vec::new());
@@ -324,15 +321,15 @@ mod tests {
     }
 
     #[test]
-    fn message_id_未命中时回退到最后一条带图用户消息() {
+    fn message_id_未命中时返回空() {
         let messages = vec![
             user_message_with_image("msg-1", "第一张", "/tmp/a.png"),
             json!({ "id": "msg-2", "role": "assistant", "content": [{ "type": "text", "text": "收到" }] }),
         ];
-        // 模型编造的 ID 在会话中不存在。
+        // 模型编造的 ID 在会话中不存在：严格失败，不回退到历史图片。
         let (text, images) = find_attachment_source(&messages, Some("made-up-id"), Some(0));
-        assert_eq!(text, "第一张");
-        assert_eq!(images, vec!["/tmp/a.png".to_string()]);
+        assert_eq!(text, "");
+        assert!(images.is_empty());
     }
 
     #[test]
@@ -347,14 +344,15 @@ mod tests {
     }
 
     #[test]
-    fn 无任何图片附件时返回空() {
+    fn message_id_命中但无图时图片为空() {
         let messages = vec![json!({
             "id": "msg-1",
             "role": "user",
             "content": [{ "type": "text", "text": "纯文本" }]
         })];
+        // 严格匹配：消息找得到（文本正常提取），但没有图片可解析。
         let (text, images) = find_attachment_source(&messages, Some("msg-1"), Some(0));
-        assert_eq!(text, "");
+        assert_eq!(text, "纯文本");
         assert!(images.is_empty());
     }
 

--- a/plugins/tiangong-plugin-analyze-attachment/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-analyze-attachment/wasm/src/lib.rs
@@ -31,6 +31,13 @@ fn plugin_err(message: impl Into<String>) -> PluginError {
 // 缓存的会话消息（thread-local，生命周期钩子注入）。
 thread_local! {
     static SESSION_MESSAGES: std::cell::RefCell<Vec<Value>> = const { std::cell::RefCell::new(Vec::new()) };
+    // 主 Chat 模型是否多模态（on_config_updated 注入）。
+    static CHAT_MULTIMODAL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// 主模型可直接看图时本插件没有存在意义：工具与提示段都不再提供。
+fn chat_is_multimodal() -> bool {
+    CHAT_MULTIMODAL.with(|flag| flag.get())
 }
 
 struct Component;
@@ -45,6 +52,9 @@ impl Guest for Component {
     }
 
     fn tool_specs() -> Result<Vec<ToolSpec>, PluginError> {
+        if chat_is_multimodal() {
+            return Ok(Vec::new());
+        }
         Ok(vec![ToolSpec {
             name: TOOL_ANALYZE_ATTACHMENT.to_string(),
             description: "按需调用多模态模型解析用户上传的图片附件。只有当用户问题确实需要查看图片内容时才调用；文档和其他文件应使用对应文件工具。重要：message_id 必须使用用户消息中提示文字所标注的 ID，不要使用其他消息的 ID。".to_string(),
@@ -54,6 +64,9 @@ impl Guest for Component {
     }
 
     fn prompt_sections() -> Result<Vec<String>, PluginError> {
+        if chat_is_multimodal() {
+            return Ok(Vec::new());
+        }
         Ok(vec![format!(
             "## 附件分析工具\n\
              当用户消息明确列出需要分析的图片资源，且回答确实需要查看图片内容时，可调用 `{TOOL_ANALYZE_ATTACHMENT}`。\n\
@@ -63,6 +76,18 @@ impl Guest for Component {
     }
 
     fn handle_tool(call: ToolCall) -> Result<ToolResult, PluginError> {
+        if chat_is_multimodal() {
+            return Ok(ToolResult {
+                ok: false,
+                summary: "主模型已具备多模态能力，本插件未注册工具；请直接根据对话中的图片内容回答"
+                    .to_string(),
+                stdout: String::new(),
+                stderr: "chat model is multimodal; analyze_attachment is not registered"
+                    .to_string(),
+                exit_code: 1,
+                execution: None,
+            });
+        }
         match call.name.as_str() {
             TOOL_ANALYZE_ATTACHMENT => handle_analyze(&call),
             other => Err(plugin_err(format!("未知的 Attachment 工具: {other}"))),
@@ -77,7 +102,13 @@ impl Guest for Component {
         Ok(())
     }
 
-    fn on_config_updated(_config_json: String) -> Result<(), PluginError> {
+    fn on_config_updated(config_json: String) -> Result<(), PluginError> {
+        let config: Value = serde_json::from_str(&config_json).unwrap_or(Value::Null);
+        let multimodal = config
+            .get("chat_capabilities")
+            .and_then(Value::as_array)
+            .is_some_and(|caps| caps.iter().any(|cap| cap.as_str() == Some("multimodal")));
+        CHAT_MULTIMODAL.with(|flag| flag.set(multimodal));
         Ok(())
     }
 
@@ -173,47 +204,42 @@ fn find_attachment_source(
     message_id: Option<&str>,
     attachment_index: Option<usize>,
 ) -> (String, Vec<String>) {
-    // 定位消息：优先按 message_id，否则取最后一条带附件的用户消息。
-    let source = if let Some(id) = message_id {
-        messages
-            .iter()
-            .find(|msg| msg.get("id").and_then(Value::as_str) == Some(id))
-    } else {
-        messages
-            .iter()
-            .rev()
-            .find(|msg| msg.get("role").and_then(Value::as_str) == Some("user"))
-    };
+    // 定位消息：优先按 message_id 精确匹配；模型编造或误传 ID 时
+    // 回退到最后一条带图片附件的用户消息，避免直接报错。
+    let source = message_id
+        .and_then(|id| {
+            messages
+                .iter()
+                .find(|msg| msg.get("id").and_then(Value::as_str) == Some(id))
+        })
+        .filter(|msg| !message_image_paths(msg).is_empty())
+        .or_else(|| {
+            messages
+                .iter()
+                .rev()
+                .find(|msg| is_user_message_with_image(msg))
+        });
 
     let Some(source) = source else {
         return (String::new(), Vec::new());
     };
 
-    // 提取文本内容。
+    // 提取文本内容：用户文本在 content 数组的 text 块中。
     let user_text = source
-        .get("text_content")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
-
-    // 从 content blocks 提取图片路径。
-    let content = source.get("content").and_then(Value::as_array);
-    let mut all_images = Vec::new();
-    if let Some(content) = content {
-        for block in content {
-            // ContentBlock::Image { asset: { local_path } }
-            if let Some(asset) = block
-                .get("asset")
-                .or_else(|| block.get("AssetReference").and_then(|a| a.get("asset")))
-                && let Some(path) = asset.get("local_path").and_then(Value::as_str)
-                && !path.is_empty()
-            {
-                all_images.push(path.to_string());
-            }
-        }
-    }
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|blocks| {
+            blocks
+                .iter()
+                .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|block| block.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
 
     // 按序号筛选或返回全部。
+    let all_images = message_image_paths(source);
     let images = match attachment_index {
         Some(index) => all_images
             .get(index)
@@ -224,6 +250,32 @@ fn find_attachment_source(
     };
 
     (user_text, images)
+}
+
+/// 消息是否为带图片附件的用户消息。
+fn is_user_message_with_image(msg: &Value) -> bool {
+    msg.get("role").and_then(Value::as_str) == Some("user") && !message_image_paths(msg).is_empty()
+}
+
+/// 从消息 content blocks 提取图片本地路径。
+fn message_image_paths(msg: &Value) -> Vec<String> {
+    msg.get("content")
+        .and_then(Value::as_array)
+        .map(|blocks| {
+            blocks
+                .iter()
+                // ContentBlock::Image { asset: { local_path } }
+                .filter_map(|block| {
+                    block
+                        .get("asset")
+                        .or_else(|| block.get("AssetReference").and_then(|a| a.get("asset")))
+                        .and_then(|asset| asset.get("local_path").and_then(Value::as_str))
+                        .filter(|path| !path.is_empty())
+                        .map(String::from)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 impl UiGuest for Component {
@@ -246,3 +298,105 @@ impl UiGuest for Component {
     }
 }
 bindings::export!(Component with_types_in bindings);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn user_message_with_image(id: &str, text: &str, path: &str) -> Value {
+        json!({
+            "id": id,
+            "role": "user",
+            "content": [
+                { "type": "text", "text": text },
+                { "type": "image", "asset": { "local_path": path } }
+            ]
+        })
+    }
+
+    #[test]
+    fn message_id_命中时提取文本与图片路径() {
+        let messages = vec![user_message_with_image("msg-1", "看这张图", "/tmp/a.png")];
+        let (text, images) = find_attachment_source(&messages, Some("msg-1"), Some(0));
+        assert_eq!(text, "看这张图");
+        assert_eq!(images, vec!["/tmp/a.png".to_string()]);
+    }
+
+    #[test]
+    fn message_id_未命中时回退到最后一条带图用户消息() {
+        let messages = vec![
+            user_message_with_image("msg-1", "第一张", "/tmp/a.png"),
+            json!({ "id": "msg-2", "role": "assistant", "content": [{ "type": "text", "text": "收到" }] }),
+        ];
+        // 模型编造的 ID 在会话中不存在。
+        let (text, images) = find_attachment_source(&messages, Some("made-up-id"), Some(0));
+        assert_eq!(text, "第一张");
+        assert_eq!(images, vec!["/tmp/a.png".to_string()]);
+    }
+
+    #[test]
+    fn 省略_message_id_时取最近带图用户消息() {
+        let messages = vec![
+            user_message_with_image("msg-1", "第一张", "/tmp/a.png"),
+            user_message_with_image("msg-2", "第二张", "/tmp/b.png"),
+        ];
+        let (text, images) = find_attachment_source(&messages, None, None);
+        assert_eq!(text, "第二张");
+        assert_eq!(images, vec!["/tmp/b.png".to_string()]);
+    }
+
+    #[test]
+    fn 无任何图片附件时返回空() {
+        let messages = vec![json!({
+            "id": "msg-1",
+            "role": "user",
+            "content": [{ "type": "text", "text": "纯文本" }]
+        })];
+        let (text, images) = find_attachment_source(&messages, Some("msg-1"), Some(0));
+        assert_eq!(text, "");
+        assert!(images.is_empty());
+    }
+
+    #[test]
+    fn chat_多模态时工具与提示段为空() {
+        Component::on_config_updated(
+            r#"{"llm":{},"chat_capabilities":["chat","multimodal"]}"#.to_string(),
+        )
+        .unwrap();
+        assert!(Component::tool_specs().unwrap().is_empty());
+        assert!(Component::prompt_sections().unwrap().is_empty());
+    }
+
+    #[test]
+    fn chat_非多模态时正常提供工具与提示段() {
+        Component::on_config_updated(r#"{"llm":{},"chat_capabilities":["chat"]}"#.to_string())
+            .unwrap();
+        assert_eq!(Component::tool_specs().unwrap().len(), 1);
+        assert_eq!(Component::prompt_sections().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn 主模型切换时工具与提示段跟随变化() {
+        // 多模态主模型：不提供工具。
+        Component::on_config_updated(
+            r#"{"llm":{},"chat_capabilities":["chat","multimodal"]}"#.to_string(),
+        )
+        .unwrap();
+        assert!(Component::tool_specs().unwrap().is_empty());
+
+        // 切换到非多模态主模型：恢复工具与提示段。
+        Component::on_config_updated(r#"{"llm":{},"chat_capabilities":["chat"]}"#.to_string())
+            .unwrap();
+        assert_eq!(Component::tool_specs().unwrap().len(), 1);
+        assert_eq!(Component::prompt_sections().unwrap().len(), 1);
+
+        // 再切回多模态主模型：再次隐藏。
+        Component::on_config_updated(
+            r#"{"llm":{},"chat_capabilities":["chat","multimodal"]}"#.to_string(),
+        )
+        .unwrap();
+        assert!(Component::tool_specs().unwrap().is_empty());
+        assert!(Component::prompt_sections().unwrap().is_empty());
+    }
+}

--- a/plugins/tiangong-plugin-index/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-index/wasm/src/lib.rs
@@ -327,7 +327,15 @@ fn handle_search_code(call: &ToolCall) -> Result<ToolResult, PluginError> {
 fn forward_turn_batch(session_json: &str, turn_start_idx: u32) -> Result<(), PluginError> {
     let session: PluginSession = serde_json::from_str(session_json)
         .map_err(|e| plugin_err(format!("解析 session 失败: {e}")))?;
-    let start = turn_start_idx as usize;
+    // 优先按本轮起始消息 ID 定位（不受快照消息增删影响）；旧宿主未提供时回退 idx。
+    let start = match &session.turn_start_message_id {
+        Some(id) => session
+            .messages
+            .iter()
+            .position(|msg| &msg.id == id)
+            .unwrap_or(turn_start_idx as usize),
+        None => turn_start_idx as usize,
+    };
     let turns: Vec<TurnData> = session
         .messages
         .get(start..)

--- a/plugins/tiangong-plugin-memory/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-memory/wasm/src/lib.rs
@@ -514,7 +514,15 @@ fn forward_turn_rumination(session_json: &str, turn_start_idx: u32) -> Result<()
     let session: tiangong_types::PluginSession = serde_json::from_str(session_json)
         .map_err(|e| PluginError::Message(format!("解析 PluginSession 失败: {e}")))?;
 
-    let idx = turn_start_idx as usize;
+    // 优先按本轮起始消息 ID 定位（不受快照消息增删影响）；旧宿主未提供时回退 idx。
+    let idx = match &session.turn_start_message_id {
+        Some(id) => session
+            .messages
+            .iter()
+            .position(|msg| &msg.id == id)
+            .unwrap_or(turn_start_idx as usize),
+        None => turn_start_idx as usize,
+    };
     let all_messages = &session.messages;
 
     // 校验起点：必须是 User 且非 CompressedResume。


### PR DESCRIPTION
## 问题

多模态主模型的会话中，`analyze_attachment` 工具仍被注册并出现在工具列表与系统提示中，模型收到已内联的图片仍选择调用该插件；且模型编造了不存在的 `message_id`（UUID 格式），插件按 ID 精确匹配失败后报「未找到可解析的图片附件」。

另有运行时警告：宿主 Notice 系统通知进入插件会话快照后，旧版插件（类型定义无该角色）反序列化失败。

## 变更

- **配置钩子附加主模型能力**：WASM Adapter 转发 `on-config-updated` 时在载荷中附加 `chat_capabilities`（来自当前 Chat 路由，配置未初始化时为空）。core 零改动。
- **插件内自主停用**：analyze-attachment 据此判断——主模型多模态时 `tool_specs`/`prompt_sections` 返回空，误调用时返回明确提示；主模型切换后下一轮自动跟随。
- **定位健壮性**：`message_id` 未命中或对应消息无图时回退到最后一条带图用户消息；用户原文与图片路径统一从 content blocks 提取（修复原读取不存在的 `text_content` 字段）。
- **插件快照剔除 Notice**：`PluginSession::from(&Session)` 过滤 Notice 消息（系统通知不属于对话历史），所有插件无需重新发布即可消除解析告警。

## 测试

- 插件新增 7 个行为测试（多模态停用、切换跟随、message_id 回退、文本提取）全部通过
- 新增 PluginSession 剔除 Notice 的转换测试
- tiangong-core / tiangong-plugin-runtime / 插件 crate 全部测试通过，clippy 干净
- 全量测试中压缩相关用例的偶发失败在 main 基线同样复现（4/4），确认与本分支无关