### PR TITLE
chore(plugin): 发布 analyze-attachment/index/memory/terminal 插件新版本

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10910,7 +10910,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-analyze-attachment-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -10918,7 +10918,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-analyze-attachment-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10940,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-analyze-attachment-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11258,7 +11258,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-index-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11266,7 +11266,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-index-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11289,7 +11289,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-index-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11340,7 +11340,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -11348,7 +11348,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "tiangong-memory",
@@ -11360,7 +11360,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-wasm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "scru128",
  "serde",
@@ -11585,7 +11585,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-terminal-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/plugins/tiangong-plugin-analyze-attachment/plugin.json
+++ b/plugins/tiangong-plugin-analyze-attachment/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "analyze-attachment",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "wasm": {
     "binary": "tiangong_plugin_analyze_attachment_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-analyze-attachment/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-analyze-attachment/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-analyze-attachment-protocol"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-analyze-attachment/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-analyze-attachment/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-analyze-attachment-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Analyze-Attachment 独立 sidecar（读取模型配置、构造多模态请求、调用 LLM）"

--- a/plugins/tiangong-plugin-analyze-attachment/wasm/Cargo.toml
+++ b/plugins/tiangong-plugin-analyze-attachment/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-analyze-attachment-wasm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Analyze-Attachment 插件的 WASM 组件"

--- a/plugins/tiangong-plugin-index/plugin.json
+++ b/plugins/tiangong-plugin-index/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "index",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "wasm": {
     "binary": "tiangong_plugin_index_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-index/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-index/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-index-protocol"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-index/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-index/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-index-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Index 独立 sidecar 进程（承载 tantivy 索引、后台扫描、rg/grep 检索原生运行）"

--- a/plugins/tiangong-plugin-index/wasm/Cargo.toml
+++ b/plugins/tiangong-plugin-index/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-index-wasm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Index 插件的 WASM 组件"

--- a/plugins/tiangong-plugin-memory/plugin.json
+++ b/plugins/tiangong-plugin-memory/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "memory",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "wasm": {
     "binary": "tiangong_plugin_memory_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-memory/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Memory System 独立 sidecar 进程（承载 SQLite/tantivy/lancedb 原生运行）"

--- a/plugins/tiangong-plugin-memory/wasm/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-wasm"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Memory 插件的 WASM 组件"

--- a/plugins/tiangong-plugin-terminal/package.json
+++ b/plugins/tiangong-plugin-terminal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiangong-plugin-terminal",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/plugins/tiangong-plugin-terminal/plugin.json
+++ b/plugins/tiangong-plugin-terminal/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "terminal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "entrypoints": [
     "desktop"
   ],

--- a/plugins/tiangong-plugin-terminal/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-terminal/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-terminal-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## 变更内容

v0.15.0 之后四个发生本体调整的插件统一升级版本号，合并后打标签触发 OSS 发布：

| 插件 | 版本 | 携带变更 |
|---|---|---|
| analyze-attachment | 0.1.0 → 0.1.1 | 主模型多模态时自动停用工具注册、快照剔除 Notice、附件定位按 message_id 精确匹配（#435） |
| index | 0.1.0 → 0.1.1 | 轮次锚点改以 turn_start_message_id 提供（#435） |
| memory | 0.1.2 → 0.1.3 | 轮次锚点改以 turn_start_message_id 提供（#435） |
| terminal | 0.1.0 → 0.1.1 | 取消后台隐藏实例策略，工具拉起统一建立拓展区可见标签（#429） |

同步 plugin.json、package.json（terminal）、各 crate Cargo.toml 与 Cargo.lock；transport_protocol / business_protocol 属协议版本，不在本次范围。

## 测试情况

- `xtask validate-plugin` 四个插件全部通过
- 插件 crate `cargo check` 通过
- terminal 插件 `yarn build` 与 `yarn typecheck` 通过
- pre-push 钩子：cargo check / clippy / nextest、前端 yarn build / yarn test 全部通过

## 合并后动作

依次打标签触发 OSS 发布：`plugin/analyze-attachment/v0.1.1`、`plugin/index/v0.1.1`、`plugin/memory/v0.1.3`、`plugin/terminal/v0.1.1`