### PR TITLE
fix(plugin): 审批征询等待时间由 15 秒调整为 2 分钟

### DIFF
--- a/plugins/tiangong-plugin-interaction/README.md
+++ b/plugins/tiangong-plugin-interaction/README.md
@@ -11,7 +11,7 @@
 
 - 支持审批、确认、单选、多选、文本输入和完整表单六类交互
 - 交互期间覆盖并锁定会话输入区，避免同时提交其他消息
-- 每次请求提供 15 秒处理时间；关闭、超时和提交结果都会明确反馈给 Agent
+- 每次请求提供 2 分钟处理时间；关闭、超时和提交结果都会明确反馈给 Agent
 - 弹层高度随内容自适应，只有超长说明、选项或表单内容会在中间区域滚动
 
 ## 功能展示
@@ -42,7 +42,7 @@ plugins/tiangong-plugin-interaction/
 ├── index.html       # Vite 入口
 ├── src/
 │   ├── main.ts
-│   ├── interaction.ts       # 参数解析、15 秒时限与完整工具结果
+│   ├── interaction.ts       # 参数解析、2 分钟时限与完整工具结果
 │   ├── interaction.test.ts  # 插件业务边界单元测试
 │   └── App.vue              # 六种界面、倒计时与提交处理
 ├── dist/index.html  # 构建产物（清单 entry 指向此处）
@@ -76,7 +76,7 @@ yarn package        # 开发期打包：构建 + 组装 release/ 插件包
 - manifest 声明 `request_user` 工具与提示词，使用 `tool.provide`、
   `capabilities.events: ["tool.*"]`
 - 订阅 `tool.requested` / `tool.closed`，通过 `tool.resolve` 提交完整工具结果
-- 插件按调用创建时间独立执行 15 秒用户时限，宿主只按 `timeout_ms: 20000` 处理插件失联
+- 插件按调用创建时间独立执行 2 分钟用户时限，宿主只按 `timeout_ms: 125000` 处理插件失联
 - approval 将用户选择作为普通工具结果返回 Agent，由 Agent 决定后续步骤；Core 不解释或保存该选择
 - 交互界面作为会话区域独立 Shadow 弹层覆盖并锁定输入区，高度随内容增长、最高 520px；超长文本、选项或表单仅滚动中间内容区，关闭界面会向 Agent 返回明确的取消原因
 - 插件按宿主注入的当前会话显示请求，并保存其他运行中会话的待处理项

--- a/plugins/tiangong-plugin-interaction/plugin.json
+++ b/plugins/tiangong-plugin-interaction/plugin.json
@@ -118,10 +118,10 @@
           "title"
         ]
       },
-      "timeout_ms": 20000
+      "timeout_ms": 125000
     }
   ],
   "prompt": [
-    "交互工具使用规范：审批与普通征询统一调用 request_user；审批时将 kind 设为 approval，需要确认、选择或补充信息时使用对应 kind。choice/multi_choice 必须提供非空 options；form 必须提供 fields。request_user 必须独占一个工具调用批次，不要与其他工具同时调用。插件会在 15 秒内返回用户响应、取消或超时结果；approval 返回的是用户意见，由你结合任务自行决定后续步骤。"
+    "交互工具使用规范：审批与普通征询统一调用 request_user；审批时将 kind 设为 approval，需要确认、选择或补充信息时使用对应 kind。choice/multi_choice 必须提供非空 options；form 必须提供 fields。request_user 必须独占一个工具调用批次，不要与其他工具同时调用。插件会在 2 分钟内返回用户响应、取消或超时结果；approval 返回的是用户意见，由你结合任务自行决定后续步骤。"
   ]
 }

--- a/plugins/tiangong-plugin-interaction/src/App.vue
+++ b/plugins/tiangong-plugin-interaction/src/App.vue
@@ -61,7 +61,11 @@ const remainingText = computed(() => {
   if (request.value.status === 'cancelled') return '已取消';
   if (request.value.status === 'submitting') return '正在提交';
   if (remainingMs.value <= 0) return '已到期限';
-  return `剩余 ${Math.ceil(remainingMs.value / 1000)} 秒`;
+  const seconds = Math.ceil(remainingMs.value / 1000);
+  if (seconds >= 60) {
+    return `剩余 ${Math.floor(seconds / 60)} 分 ${seconds % 60} 秒`;
+  }
+  return `剩余 ${seconds} 秒`;
 });
 
 const locked = computed(() => !request.value || request.value.status !== 'pending');

--- a/plugins/tiangong-plugin-interaction/src/interaction.test.ts
+++ b/plugins/tiangong-plugin-interaction/src/interaction.test.ts
@@ -21,14 +21,14 @@ function invocation(argumentsValue: Record<string, unknown>): ToolInvocation {
 }
 
 describe('interaction 业务边界', () => {
-  it('由插件按调用创建时间独立计算 15 秒截止时间', () => {
+  it('由插件按调用创建时间独立计算 2 分钟截止时间', () => {
     const request = parseInvocation(invocation({
       kind: 'approval',
       title: '是否继续',
     }));
 
     expect(request.deadlineMs - request.createdAtMs).toBe(USER_TIMEOUT_MS);
-    expect(USER_TIMEOUT_MS).toBe(15_000);
+    expect(USER_TIMEOUT_MS).toBe(120_000);
   });
 
   it('审批不需要宿主挑战并以普通工具结果返回用户意见', () => {

--- a/plugins/tiangong-plugin-interaction/src/interaction.ts
+++ b/plugins/tiangong-plugin-interaction/src/interaction.ts
@@ -34,7 +34,7 @@ export interface InteractionRequest {
   values: Record<string, string | boolean>;
 }
 
-export const USER_TIMEOUT_MS = 15_000;
+export const USER_TIMEOUT_MS = 120_000;
 export const USER_CLOSED_MESSAGE = '用户关闭了相关操作';
 
 export function approvalOpinion(decision: ApprovalOpinion) {


### PR DESCRIPTION
## 变更内容

- `request_user` 用户响应等待时间 `USER_TIMEOUT_MS` 由 15 秒（15_000ms）调整为 2 分钟（120_000ms）
- 宿主兜底超时 `timeout_ms` 由 20000 同步调整为 125000，保持原有 5 秒提交余量（校验范围 1000..=300000 内）
- 倒计时显示超过 1 分钟时改为「剩余 X 分 Y 秒」格式，不足 1 分钟仍显示秒数
- 同步更新 prompt 文案（15 秒 → 2 分钟）、README 描述与单元测试断言

## 测试情况

- `yarn test`：4 个单元测试全部通过（含 2 分钟时限断言）
- `yarn package`：类型检查（vue-tsc）+ 构建通过，产物 `dist/index.html` 已包含 120_000 时限与分秒倒计时，`release/plugin.json` 已同步 125000 与新文案