### PR TITLE
chore(plugin): 发布 interaction 插件 v0.3.2

### DIFF
--- a/plugins/tiangong-plugin-interaction/package.json
+++ b/plugins/tiangong-plugin-interaction/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiangong-plugin-interaction",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/plugins/tiangong-plugin-interaction/plugin.json
+++ b/plugins/tiangong-plugin-interaction/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "interaction",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "entrypoints": [
     "desktop"
   ],


### PR DESCRIPTION
## 变更内容

- 审批征询插件（interaction）版本号 v0.3.1 → v0.3.2，同步 plugin.json 与 package.json
- 发布内容为 #437 的本体调整：request_user 用户等待时限由 15 秒调整为 2 分钟，倒计时超过 1 分钟以「X 分 Y 秒」格式显示，宿主兜底 timeout_ms 同步 125000

## 测试情况

- `yarn test`：4 个单元测试全部通过
- `yarn package`：构建与组装正常，release/plugin.json 版本号确认为 0.3.2