### PR TITLE
feat(context): 压缩阈值从上下文窗口 95% 调整为 70%

### DIFF
--- a/crates/tiangong-core/src/context/organizer.rs
+++ b/crates/tiangong-core/src/context/organizer.rs
@@ -13,6 +13,8 @@ impl ContextOrganizer {
     const SAFETY_MARGIN_DIVISOR: usize = 100;
     const MIN_SAFETY_MARGIN_TOKENS: usize = 4_096;
     pub const MIN_COMPRESSION_OUTPUT_TOKENS: usize = 2_048;
+    /// 默认压缩触发比例：上下文窗口的 70%。
+    const DEFAULT_TRIGGER_PERCENT: usize = 70;
 
     pub fn new(context_limit: usize) -> Self {
         Self {
@@ -48,12 +50,20 @@ impl ContextOrganizer {
             .saturating_sub(self.safety_margin_tokens())
     }
 
-    /// 压缩阈值（token 数）
+    /// 压缩阈值（token 数）。
+    ///
+    /// 默认在上下文窗口的 70% 处触发；用户覆盖值与默认值都不能突破派生的安全上限。
     pub fn token_threshold(&self) -> usize {
-        self.requested_threshold.map_or_else(
-            || self.safe_threshold(),
-            |requested| requested.min(self.safe_threshold()),
-        )
+        self.requested_threshold
+            .unwrap_or_else(|| self.default_trigger_tokens())
+            .min(self.safe_threshold())
+    }
+
+    /// 默认触发点：上下文窗口的 70%。
+    fn default_trigger_tokens(&self) -> usize {
+        self.context_limit
+            .saturating_mul(Self::DEFAULT_TRIGGER_PERCENT)
+            / 100
     }
 
     /// 基于 API 返回的输入与输出总量判断是否需要压缩。
@@ -92,7 +102,7 @@ mod tests {
 
         assert_eq!(organizer.target_output_tokens(), 10_000);
         assert_eq!(organizer.safety_margin_tokens(), 4_096);
-        assert_eq!(organizer.token_threshold(), 185_904);
+        assert_eq!(organizer.token_threshold(), 140_000);
     }
 
     #[test]
@@ -101,7 +111,7 @@ mod tests {
 
         assert_eq!(organizer.target_output_tokens(), 50_000);
         assert_eq!(organizer.safety_margin_tokens(), 10_000);
-        assert_eq!(organizer.token_threshold(), 940_000);
+        assert_eq!(organizer.token_threshold(), 700_000);
         assert_eq!(organizer.compression_output_budget(950_000), Some(40_000));
     }
 
@@ -111,7 +121,7 @@ mod tests {
 
         assert_eq!(organizer.target_output_tokens(), 100_000);
         assert_eq!(organizer.safety_margin_tokens(), 20_000);
-        assert_eq!(organizer.token_threshold(), 1_880_000);
+        assert_eq!(organizer.token_threshold(), 1_400_000);
     }
 
     #[test]

--- a/src-tauri/src/view.rs
+++ b/src-tauri/src/view.rs
@@ -31,7 +31,10 @@ impl TokenStatsView {
         let usage = core_session.total_usage();
         Self {
             current_tokens: core_session.current_tokens,
-            compression_threshold_tokens: context_limit_tokens.saturating_mul(95) / 100,
+            compression_threshold_tokens: tiangong_core::context::organizer::ContextOrganizer::new(
+                context_limit_tokens,
+            )
+            .token_threshold(),
             context_limit_tokens,
             total_prompt_tokens: usage.prompt_tokens,
             total_completion_tokens: usage.completion_tokens,


### PR DESCRIPTION
## 变更内容

- `ContextOrganizer` 默认压缩触发点从派生安全阈值（约窗口 93%~94%）调整为窗口的 70%，仍保留派生安全上限钳制与用户覆盖只能提前触发的语义
- 移除 `src-tauri/src/view.rs` 中硬编码的 `95 / 100`，会话加载时的阈值展示改为复用 `ContextOrganizer::token_threshold()`，与运行时流式下发口径一致（消除双处定义不一致）
- 同步更新 `organizer.rs` 阈值相关单元测试断言：
  - 200k 窗口 → 140_000
  - 1M 窗口 → 700_000
  - 2M 窗口 → 1_400_000

## 测试情况

- `cargo test -p tiangong-core --lib -- --test-threads=1`：92/92 全部通过
- `cargo clippy` / `cargo fmt --check`：无警告
- 桌面端 `cargo check -p tiangong`：通过
- 注：测试并行执行时存在与本次改动无关的偶发超时（原始 main 同样复现），串行执行稳定通过