### PR TITLE
fix(llm): 流式传输错误重试、移除非流式回退、接住忽略 stream 的一次性 JSON 响应

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10629,6 +10629,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "base64 0.23.1",
+ "eventsource-stream",
  "futures-util",
  "jsonschema",
  "reqwest 0.13.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10394,12 +10394,14 @@ dependencies = [
 name = "tiangong-anthropic"
 version = "0.15.1"
 dependencies = [
+ "bytes",
  "eventsource-stream",
  "futures-util",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+ "tokio",
 ]
 
 [[package]]
@@ -10582,6 +10584,7 @@ dependencies = [
 name = "tiangong-deepseek"
 version = "0.1.3"
 dependencies = [
+ "bytes",
  "eventsource-stream",
  "futures-util",
  "reqwest 0.13.4",
@@ -10629,6 +10632,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "base64 0.23.1",
+ "bytes",
  "eventsource-stream",
  "futures-util",
  "jsonschema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10580,7 +10580,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-deepseek"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "eventsource-stream",
  "futures-util",

--- a/crates/tiangong-anthropic/Cargo.toml
+++ b/crates/tiangong-anthropic/Cargo.toml
@@ -10,4 +10,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["json", "rustls", "stream"] }
 eventsource-stream = { workspace = true }
+bytes = "1"
+tokio = { workspace = true, features = ["time"] }
 futures-util = { workspace = true }

--- a/crates/tiangong-anthropic/src/client.rs
+++ b/crates/tiangong-anthropic/src/client.rs
@@ -6,9 +6,61 @@ use serde_json::Value;
 use crate::config::AnthropicConfig;
 use crate::error::AnthropicError;
 use crate::types::{
-    ContentBlockDeltaData, ContentBlockStartData, EventStream, MessageDeltaData, MessageStartData,
-    MessagesCreateRequest, MessagesCreateResponse, ModelsListResponse, StreamEvent, ThinkingConfig,
+    ContentBlock, ContentBlockDeltaData, ContentBlockStartData, EventStream, MessageDeltaData,
+    MessageStartData, MessagesCreateRequest, MessagesCreateResponse, ModelsListResponse,
+    StreamEvent, ThinkingConfig,
 };
+
+/// 把一次性完整响应合成为等价的流事件序列。
+///
+/// 网关忽略 stream 参数返回 application/json 时，SDK 在内部按完整响应
+/// 接住并合成事件流，调用方无需感知差异。
+fn complete_response_events(response: MessagesCreateResponse) -> Vec<StreamEvent> {
+    let mut events = vec![StreamEvent::MessageStart {
+        message: MessageStartData {
+            id: response.id,
+            model: response.model,
+            role: response.role,
+            content: Vec::new(),
+            stop_reason: None,
+            stop_sequence: None,
+            usage: None,
+        },
+    }];
+    for (index, block) in response.content.into_iter().enumerate() {
+        let content_block = match block {
+            ContentBlock::Text { text } => ContentBlockStartData::Text { text },
+            ContentBlock::ToolUse { id, name, input } => {
+                ContentBlockStartData::ToolUse { id, name, input }
+            }
+            ContentBlock::Thinking {
+                thinking,
+                signature,
+            } => ContentBlockStartData::Thinking {
+                thinking,
+                signature: signature.unwrap_or_default(),
+            },
+            ContentBlock::RedactedThinking { data } => {
+                ContentBlockStartData::RedactedThinking { data }
+            }
+            ContentBlock::ToolResult { .. } | ContentBlock::Unknown => continue,
+        };
+        events.push(StreamEvent::ContentBlockStart {
+            index,
+            content_block,
+        });
+        events.push(StreamEvent::ContentBlockStop { index });
+    }
+    events.push(StreamEvent::MessageDelta {
+        delta: MessageDeltaData {
+            stop_reason: response.stop_reason,
+            stop_sequence: response.stop_sequence,
+        },
+        usage: response.usage,
+    });
+    events.push(StreamEvent::MessageStop);
+    events
+}
 
 /// 官方 Anthropic API 域名。
 const OFFICIAL_API_HOST: &str = "api.anthropic.com";
@@ -70,6 +122,21 @@ impl AnthropicClient {
 
         if !response.status().is_success() {
             return Err(parse_error_response(response).await);
+        }
+
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        if !content_type.contains("text/event-stream") {
+            // 网关忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些行
+            // 全部当未知字段丢弃且不报错，在 SDK 内按完整响应接住并合成事件流。
+            let complete = parse_json_response(response).await?;
+            return Ok(Box::pin(stream::iter(
+                complete_response_events(complete).into_iter().map(Ok),
+            )));
         }
 
         let sse_stream = response.bytes_stream().eventsource();
@@ -396,5 +463,48 @@ mod tests {
         let mut request = request_with(32_768, Some(ThinkingConfig::Disabled));
         client.apply_official_thinking_budget(&mut request);
         assert_eq!(request.thinking, Some(ThinkingConfig::Disabled));
+    }
+
+    #[test]
+    fn complete_response_events_synthesizes_stream_sequence() {
+        // 网关忽略 stream 参数返回一次性 JSON 时，完整响应应合成为等价事件流：
+        // MessageStart → 每个内容块 Start/Stop（完整内容在 Start）→ MessageDelta → MessageStop。
+        let response: MessagesCreateResponse = serde_json::from_value(serde_json::json!({
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-5",
+            "content": [
+                { "type": "text", "text": "一次性完整回复" },
+                { "type": "tool_use", "id": "call_tool", "name": "read_file", "input": {"path": "TODO.md"} }
+            ],
+            "stop_reason": "tool_use",
+            "usage": { "input_tokens": 3, "output_tokens": 5 }
+        }))
+        .unwrap();
+
+        let events = complete_response_events(response);
+
+        assert!(
+            matches!(&events[0], StreamEvent::MessageStart { message } if message.id == "msg_1")
+        );
+        assert!(matches!(&events[1],
+            StreamEvent::ContentBlockStart { index: 0, content_block: ContentBlockStartData::Text { text } }
+            if text == "一次性完整回复"));
+        assert!(matches!(
+            &events[2],
+            StreamEvent::ContentBlockStop { index: 0 }
+        ));
+        assert!(matches!(&events[3],
+            StreamEvent::ContentBlockStart { index: 1, content_block: ContentBlockStartData::ToolUse { id, name, input } }
+            if id == "call_tool" && name == "read_file" && input["path"] == "TODO.md"));
+        assert!(matches!(
+            &events[4],
+            StreamEvent::ContentBlockStop { index: 1 }
+        ));
+        assert!(matches!(&events[5],
+            StreamEvent::MessageDelta { delta, usage: Some(_) } if delta.stop_reason.as_deref() == Some("tool_use")));
+        assert!(matches!(&events[6], StreamEvent::MessageStop));
+        assert_eq!(events.len(), 7);
     }
 }

--- a/crates/tiangong-anthropic/src/client.rs
+++ b/crates/tiangong-anthropic/src/client.rs
@@ -1,4 +1,3 @@
-use eventsource_stream::Eventsource;
 use futures_util::StreamExt;
 use futures_util::stream;
 use serde_json::Value;
@@ -62,6 +61,57 @@ fn complete_response_events(response: MessagesCreateResponse) -> Vec<StreamEvent
     events
 }
 
+/// SSE 字节流转 Anthropic 事件流。
+fn anthropic_sse_stream<S>(byte_stream: S) -> EventStream
+where
+    S: futures_util::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+{
+    use eventsource_stream::Eventsource;
+    use futures_util::StreamExt;
+    let sse_stream = Box::pin(byte_stream.eventsource());
+    Box::pin(stream::unfold(sse_stream, |mut sse_stream| async move {
+        match sse_stream.next().await {
+            Some(Ok(message)) => {
+                let item = parse_sse_event(&message.event, &message.data);
+                Some((item, sse_stream))
+            }
+            Some(Err(err)) => Some((Err(AnthropicError::Stream(err.to_string())), sse_stream)),
+            None => None,
+        }
+    }))
+}
+
+/// 判断响应首块是否是 JSON（跳过空白后以 `{` 或 `[` 开头）。
+fn looks_like_json(first: &[u8]) -> bool {
+    first
+        .iter()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_some_and(|byte| *byte == b'{' || *byte == b'[')
+}
+
+/// 聚合首块与剩余响应体并解析为完整响应，整体受 timeout 约束。
+async fn read_complete_response(
+    mut response: reqwest::Response,
+    first: bytes::Bytes,
+    timeout: std::time::Duration,
+) -> Result<MessagesCreateResponse, AnthropicError> {
+    let read = async {
+        let mut buf = first.to_vec();
+        while let Some(chunk) = response.chunk().await.map_err(map_reqwest_error)? {
+            buf.extend_from_slice(&chunk);
+        }
+        serde_json::from_slice::<MessagesCreateResponse>(&buf).map_err(|err| {
+            AnthropicError::Serialization(format!(
+                "{err}: {}",
+                String::from_utf8_lossy(&buf[..buf.len().min(256)])
+            ))
+        })
+    };
+    tokio::time::timeout(timeout, read)
+        .await
+        .map_err(|_| AnthropicError::Timeout(format!("{} ms", timeout.as_millis())))?
+}
+
 /// 官方 Anthropic API 域名。
 const OFFICIAL_API_HOST: &str = "api.anthropic.com";
 /// 默认思考预算下，为正文（含工具调用）保留的输出空间。
@@ -112,13 +162,18 @@ impl AnthropicClient {
     ) -> Result<EventStream, AnthropicError> {
         self.apply_official_thinking_budget(&mut request);
         request.stream = Some(true);
-        let response = self
-            .stream_request_builder("/v1/messages")
-            .header(reqwest::header::ACCEPT, "text/event-stream")
-            .json(&request)
-            .send()
-            .await
-            .map_err(map_reqwest_error)?;
+        // 建连与等待响应头受用户配置的请求超时约束，避免网关建连后
+        // 不返回响应头导致永久等待；SSE 建流成功后不受总时限限制。
+        let response = tokio::time::timeout(
+            self.config.timeout,
+            self.stream_request_builder("/v1/messages")
+                .header(reqwest::header::ACCEPT, "text/event-stream")
+                .json(&request)
+                .send(),
+        )
+        .await
+        .map_err(|_| AnthropicError::Timeout(format!("{} ms", self.config.timeout.as_millis())))?
+        .map_err(map_reqwest_error)?;
 
         if !response.status().is_success() {
             return Err(parse_error_response(response).await);
@@ -130,27 +185,31 @@ impl AnthropicClient {
             .and_then(|value| value.to_str().ok())
             .unwrap_or_default()
             .to_ascii_lowercase();
-        if !content_type.contains("text/event-stream") {
+        if content_type.contains("text/event-stream") {
+            return Ok(anthropic_sse_stream(response.bytes_stream()));
+        }
+
+        // 类型不明确（部分网关漏标或错标）时按首块内容探测：JSON 以 `{`/`[`
+        // 开头，SSE 事件以 `data:` 等开头。
+        let mut response = response;
+        let first = response
+            .chunk()
+            .await
+            .map_err(map_reqwest_error)?
+            .unwrap_or_default();
+        if content_type.contains("json") || looks_like_json(&first) {
             // 网关忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些行
-            // 全部当未知字段丢弃且不报错，在 SDK 内按完整响应接住并合成事件流。
-            let complete = parse_json_response(response).await?;
+            // 全部当未知字段丢弃且不报错，在 SDK 内按完整响应接住并合成
+            // 事件流。完整读取受超时约束，避免迟迟不结束的响应永久等待。
+            let complete = read_complete_response(response, first, self.config.timeout).await?;
             return Ok(Box::pin(stream::iter(
                 complete_response_events(complete).into_iter().map(Ok),
             )));
         }
-
-        let sse_stream = response.bytes_stream().eventsource();
-        let stream = stream::unfold(sse_stream, |mut sse_stream| async move {
-            match sse_stream.next().await {
-                Some(Ok(message)) => {
-                    let item = parse_sse_event(&message.event, &message.data);
-                    Some((item, sse_stream))
-                }
-                Some(Err(err)) => Some((Err(AnthropicError::Stream(err.to_string())), sse_stream)),
-                None => None,
-            }
-        });
-        Ok(Box::pin(stream))
+        // 首块不是 JSON：按 SSE 流解析，把首块拼回流头。
+        let byte_stream = stream::once(async move { Ok::<_, reqwest::Error>(first) })
+            .chain(response.bytes_stream());
+        Ok(anthropic_sse_stream(byte_stream))
     }
 
     pub async fn list_models(&self) -> Result<ModelsListResponse, AnthropicError> {

--- a/crates/tiangong-anthropic/src/error.rs
+++ b/crates/tiangong-anthropic/src/error.rs
@@ -23,6 +23,9 @@ pub enum AnthropicError {
     #[error("流式处理失败：{0}")]
     Stream(String),
 
+    #[error("请求超时：{0}")]
+    Timeout(String),
+
     #[error("Anthropic API 错误：{0}")]
     Api(String),
 }

--- a/crates/tiangong-deepseek/Cargo.toml
+++ b/crates/tiangong-deepseek/Cargo.toml
@@ -14,6 +14,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
 eventsource-stream = "0.2"
+bytes = "1"
+tokio = { workspace = true, features = ["time"] }
 futures-util = "0.3"
 tracing = { workspace = true }
 

--- a/crates/tiangong-deepseek/Cargo.toml
+++ b/crates/tiangong-deepseek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-deepseek"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "An asynchronous Rust client for the DeepSeek API, supporting chat completions (with SSE streaming), responses, files, model listing, and balance queries."

--- a/crates/tiangong-deepseek/src/chat.rs
+++ b/crates/tiangong-deepseek/src/chat.rs
@@ -8,6 +8,48 @@ use crate::types::{
     ChatCompletionRequest, ChatCompletionResponse, EventStream, StreamChunk, StreamEvent,
 };
 
+/// 把一次性完整响应合成为等价的流事件序列。
+///
+/// 网关忽略 stream 参数返回 application/json 时，SDK 在内部按完整响应
+/// 接住并合成事件流，调用方无需感知差异。
+fn complete_response_events(response: ChatCompletionResponse) -> Vec<StreamEvent> {
+    let Some(choice) = response.choices.into_iter().next() else {
+        return vec![StreamEvent::Done];
+    };
+    let mut events = Vec::new();
+    if let Some(reasoning) = choice
+        .message
+        .reasoning_content
+        .filter(|value| !value.is_empty())
+    {
+        events.push(StreamEvent::ReasoningDelta(reasoning));
+    }
+    if let Some(text) = choice.message.content.filter(|value| !value.is_empty()) {
+        events.push(StreamEvent::TextDelta(text));
+    }
+    for (index, tool_call) in choice
+        .message
+        .tool_calls
+        .unwrap_or_default()
+        .into_iter()
+        .enumerate()
+    {
+        events.push(StreamEvent::ToolCallStart {
+            id: tool_call.id,
+            name: tool_call.function.name,
+        });
+        if !tool_call.function.arguments.is_empty() {
+            events.push(StreamEvent::ToolCallDelta {
+                index: index as u32,
+                arguments: tool_call.function.arguments,
+            });
+        }
+    }
+    events.push(StreamEvent::Usage(response.usage));
+    events.push(StreamEvent::Done);
+    events
+}
+
 pub struct Chat<'c> {
     client: &'c DeepSeekClient,
 }
@@ -41,30 +83,48 @@ impl<'c> Chat<'c> {
             .post_stream_raw("/chat/completions", &request)
             .await?;
 
-        let sse_stream = response.bytes_stream().eventsource();
-        // 第一层：SSE message → Vec<StreamEvent>（单个 chunk 可能产出多个事件）。
-        let chunk_stream = stream::unfold(sse_stream, |mut sse_stream| async move {
-            match sse_stream.next().await {
-                Some(Ok(message)) => {
-                    if message.data == "[DONE]" {
-                        Some((vec![Ok(StreamEvent::Done)], sse_stream))
-                    } else {
-                        Some((parse_stream_chunk(&message.data), sse_stream))
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+
+        let flat: EventStream = if content_type.contains("text/event-stream") {
+            let sse_stream = response.bytes_stream().eventsource();
+            // 第一层：SSE message → Vec<StreamEvent>（单个 chunk 可能产出多个事件）。
+            let chunk_stream = stream::unfold(sse_stream, |mut sse_stream| async move {
+                match sse_stream.next().await {
+                    Some(Ok(message)) => {
+                        if message.data == "[DONE]" {
+                            Some((vec![Ok(StreamEvent::Done)], sse_stream))
+                        } else {
+                            Some((parse_stream_chunk(&message.data), sse_stream))
+                        }
                     }
+                    Some(Err(err)) => Some((
+                        vec![Err(DeepSeekError::Stream(err.to_string()))],
+                        sse_stream,
+                    )),
+                    None => None,
                 }
-                Some(Err(err)) => Some((
-                    vec![Err(DeepSeekError::Stream(err.to_string()))],
-                    sse_stream,
-                )),
-                None => None,
-            }
-        });
-        let flat = chunk_stream.flat_map(stream::iter);
+            });
+            Box::pin(chunk_stream.flat_map(stream::iter))
+        } else {
+            // 网关忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些行全部当
+            // 未知字段丢弃且不报错，在 SDK 内按完整响应接住并合成事件流。
+            let complete: ChatCompletionResponse =
+                crate::client::parse_json_response(response).await?;
+            Box::pin(stream::iter(
+                complete_response_events(complete).into_iter().map(Ok),
+            ))
+        };
 
         // 第二层：文本协议兜底缓冲。普通文本正常透传；确认命中文本工具协议后，
         // 等完整响应结束再统一解析，避免按单个 invoke 尾缀提前拆散一组工具调用。
+        // 一次性 JSON 分支同样过缓冲，保持文本协议工具调用识别一致。
         if !enable_buffer {
-            return Ok(Box::pin(flat));
+            return Ok(flat);
         }
 
         let state = BufferState::default();

--- a/crates/tiangong-deepseek/src/chat.rs
+++ b/crates/tiangong-deepseek/src/chat.rs
@@ -1,4 +1,3 @@
-use eventsource_stream::Eventsource;
 use futures_util::{StreamExt, stream};
 
 use crate::client::DeepSeekClient;
@@ -78,10 +77,15 @@ impl<'c> Chat<'c> {
         // 仅当请求携带 tools 时才启用文本协议兜底缓冲。即使 tool_choice=none，调用方
         // 也可能保留 tools schema；若模型仍返回文本工具调用，流末会完整识别并交由上层续作。
         let enable_buffer = request.tools.is_some();
-        let response = self
-            .client
-            .post_stream_raw("/chat/completions", &request)
-            .await?;
+        // 建连与等待响应头受用户配置的请求超时约束，避免网关建连后
+        // 不返回响应头导致永久等待；SSE 建流成功后不受总时限限制。
+        let timeout = self.client.stream_timeout();
+        let mut response = tokio::time::timeout(
+            timeout,
+            self.client.post_stream_raw("/chat/completions", &request),
+        )
+        .await
+        .map_err(|_| DeepSeekError::Timeout(format!("{} ms", timeout.as_millis())))??;
 
         let content_type = response
             .headers()
@@ -91,33 +95,34 @@ impl<'c> Chat<'c> {
             .to_ascii_lowercase();
 
         let flat: EventStream = if content_type.contains("text/event-stream") {
-            let sse_stream = response.bytes_stream().eventsource();
-            // 第一层：SSE message → Vec<StreamEvent>（单个 chunk 可能产出多个事件）。
-            let chunk_stream = stream::unfold(sse_stream, |mut sse_stream| async move {
-                match sse_stream.next().await {
-                    Some(Ok(message)) => {
-                        if message.data == "[DONE]" {
-                            Some((vec![Ok(StreamEvent::Done)], sse_stream))
-                        } else {
-                            Some((parse_stream_chunk(&message.data), sse_stream))
-                        }
-                    }
-                    Some(Err(err)) => Some((
-                        vec![Err(DeepSeekError::Stream(err.to_string()))],
-                        sse_stream,
-                    )),
-                    None => None,
-                }
-            });
-            Box::pin(chunk_stream.flat_map(stream::iter))
+            Box::pin(chat_sse_chunk_stream(response.bytes_stream()))
         } else {
-            // 网关忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些行全部当
-            // 未知字段丢弃且不报错，在 SDK 内按完整响应接住并合成事件流。
-            let complete: ChatCompletionResponse =
-                crate::client::parse_json_response(response).await?;
-            Box::pin(stream::iter(
-                complete_response_events(complete).into_iter().map(Ok),
-            ))
+            // 类型不明确（部分网关漏标或错标）时按首块内容探测：
+            // JSON 以 `{`/`[` 开头，SSE 事件以 `data:` 等开头。
+            let first = response
+                .chunk()
+                .await
+                .map_err(|err| DeepSeekError::Transport(err.to_string()))?
+                .unwrap_or_default();
+            if content_type.contains("json") || looks_like_json(&first) {
+                // 网关忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些行全部当
+                // 未知字段丢弃且不报错，在 SDK 内按完整响应接住并合成事件流。
+                // 完整读取受超时约束，避免迟迟不结束的响应永久等待。
+                let complete: ChatCompletionResponse = crate::client::read_complete_response(
+                    response,
+                    first,
+                    self.client.stream_timeout(),
+                )
+                .await?;
+                Box::pin(stream::iter(
+                    complete_response_events(complete).into_iter().map(Ok),
+                ))
+            } else {
+                // 首块不是 JSON：按 SSE 流解析，把首块拼回流头。
+                let byte_stream = stream::once(async move { Ok::<_, reqwest::Error>(first) })
+                    .chain(response.bytes_stream());
+                Box::pin(chat_sse_chunk_stream(byte_stream))
+            }
         };
 
         // 第二层：文本协议兜底缓冲。普通文本正常透传；确认命中文本工具协议后，
@@ -136,6 +141,43 @@ impl<'c> Chat<'c> {
 
         Ok(Box::pin(buffered))
     }
+}
+
+/// SSE 字节流 → Vec<StreamEvent> 流（单个 chunk 可能产出多个事件）。
+fn chat_sse_chunk_stream<S>(
+    byte_stream: S,
+) -> impl futures_util::Stream<Item = Result<StreamEvent, DeepSeekError>>
+where
+    S: futures_util::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+{
+    use eventsource_stream::Eventsource;
+    use futures_util::StreamExt;
+    let sse_stream = Box::pin(byte_stream.eventsource());
+    let chunk_stream = stream::unfold(sse_stream, |mut sse_stream| async move {
+        match sse_stream.next().await {
+            Some(Ok(message)) => {
+                if message.data == "[DONE]" {
+                    Some((vec![Ok(StreamEvent::Done)], sse_stream))
+                } else {
+                    Some((parse_stream_chunk(&message.data), sse_stream))
+                }
+            }
+            Some(Err(err)) => Some((
+                vec![Err(DeepSeekError::Stream(err.to_string()))],
+                sse_stream,
+            )),
+            None => None,
+        }
+    });
+    chunk_stream.flat_map(stream::iter)
+}
+
+/// 判断响应首块是否是 JSON（跳过空白后以 `{` 或 `[` 开头）。
+fn looks_like_json(first: &[u8]) -> bool {
+    first
+        .iter()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_some_and(|byte| *byte == b'{' || *byte == b'[')
 }
 
 /// 文本协议缓冲状态机。

--- a/crates/tiangong-deepseek/src/client.rs
+++ b/crates/tiangong-deepseek/src/client.rs
@@ -34,6 +34,11 @@ impl DeepSeekClient {
 
     // ── 能力访问器 ──────────────────────────────────────────
 
+    /// 流式请求读取一次性完整响应的总时限。
+    pub(crate) fn stream_timeout(&self) -> std::time::Duration {
+        self.config.timeout
+    }
+
     pub fn chat(&self) -> Chat<'_> {
         Chat::new(self)
     }
@@ -210,6 +215,34 @@ pub(crate) async fn parse_json_response<T: DeserializeOwned>(
             String::from_utf8_lossy(&body[..body.len().min(512)])
         ))
     })
+}
+
+/// 聚合首块与剩余响应体并解析为完整响应，整体受 timeout 约束。
+/// 供 chat/responses 流式入口在服务端忽略 stream 参数返回一次性 JSON 时使用。
+pub(crate) async fn read_complete_response<T: serde::de::DeserializeOwned>(
+    mut response: reqwest::Response,
+    first: bytes::Bytes,
+    timeout: std::time::Duration,
+) -> Result<T, DeepSeekError> {
+    let read = async {
+        let mut buf = first.to_vec();
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|err| DeepSeekError::Transport(err.to_string()))?
+        {
+            buf.extend_from_slice(&chunk);
+        }
+        serde_json::from_slice::<T>(&buf).map_err(|err| {
+            DeepSeekError::Serialization(format!(
+                "{err}: {}",
+                String::from_utf8_lossy(&buf[..buf.len().min(256)])
+            ))
+        })
+    };
+    tokio::time::timeout(timeout, read)
+        .await
+        .map_err(|_| DeepSeekError::Timeout(format!("{} ms", timeout.as_millis())))?
 }
 
 fn classify_http_error(status: reqwest::StatusCode, body_text: String) -> DeepSeekError {

--- a/crates/tiangong-deepseek/src/client.rs
+++ b/crates/tiangong-deepseek/src/client.rs
@@ -190,7 +190,7 @@ async fn parse_error_response(response: reqwest::Response) -> DeepSeekError {
     classify_http_error(status, body_text)
 }
 
-async fn parse_json_response<T: DeserializeOwned>(
+pub(crate) async fn parse_json_response<T: DeserializeOwned>(
     response: reqwest::Response,
 ) -> Result<T, DeepSeekError> {
     let status = response.status();

--- a/crates/tiangong-deepseek/src/error.rs
+++ b/crates/tiangong-deepseek/src/error.rs
@@ -17,6 +17,9 @@ pub enum DeepSeekError {
     #[error("rate limited: {0}")]
     RateLimited(String),
 
+    #[error("request timeout: {0}")]
+    Timeout(String),
+
     #[error("serialization error: {0}")]
     Serialization(String),
 

--- a/crates/tiangong-deepseek/src/responses.rs
+++ b/crates/tiangong-deepseek/src/responses.rs
@@ -1,4 +1,3 @@
-use eventsource_stream::Eventsource;
 use futures_util::{StreamExt, stream};
 
 use crate::client::DeepSeekClient;
@@ -41,7 +40,13 @@ impl<'c> Responses<'c> {
         mut request: CreateResponseRequest,
     ) -> Result<ResponsesEventStream, DeepSeekError> {
         request.stream = Some(true);
-        let response = self.client.post_stream_raw("/responses", &request).await?;
+        // 建连与等待响应头受用户配置的请求超时约束，避免网关建连后
+        // 不返回响应头导致永久等待；SSE 建流成功后不受总时限限制。
+        let timeout = self.client.stream_timeout();
+        let mut response =
+            tokio::time::timeout(timeout, self.client.post_stream_raw("/responses", &request))
+                .await
+                .map_err(|_| DeepSeekError::Timeout(format!("{} ms", timeout.as_millis())))??;
 
         let content_type = response
             .headers()
@@ -51,43 +56,81 @@ impl<'c> Responses<'c> {
             .to_ascii_lowercase();
 
         if !content_type.contains("text/event-stream") {
-            // 网关忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些行全部当
-            // 未知字段丢弃且不报错，在 SDK 内按完整响应接住并合成事件流。
-            let complete: ResponseObject = crate::client::parse_json_response(response).await?;
-            return Ok(Box::pin(stream::iter(
-                complete_response_events(complete).into_iter().map(Ok),
-            )));
+            // 类型不明确（部分网关漏标或错标）时按首块内容探测。
+            let first = response
+                .chunk()
+                .await
+                .map_err(|err| DeepSeekError::Transport(err.to_string()))?
+                .unwrap_or_default();
+            if content_type.contains("json") || looks_like_json(&first) {
+                // 网关忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些行全部当
+                // 未知字段丢弃且不报错，在 SDK 内按完整响应接住并合成事件流。
+                // 完整读取受超时约束，避免迟迟不结束的响应永久等待。
+                let complete: ResponseObject = crate::client::read_complete_response(
+                    response,
+                    first,
+                    self.client.stream_timeout(),
+                )
+                .await?;
+                return Ok(Box::pin(stream::iter(
+                    complete_response_events(complete).into_iter().map(Ok),
+                )));
+            }
+            // 首块不是 JSON：按 SSE 流解析，把首块拼回流头。
+            let byte_stream = stream::once(async move { Ok::<_, reqwest::Error>(first) })
+                .chain(response.bytes_stream());
+            return Ok(Box::pin(responses_sse_event_stream(byte_stream)));
         }
 
-        let sse_stream = response.bytes_stream().eventsource();
-        let event_stream = stream::unfold(
-            (sse_stream, false),
-            |(mut sse_stream, terminated)| async move {
-                if terminated {
-                    return None;
-                }
-                match sse_stream.next().await {
-                    Some(Ok(message)) => {
-                        let event = parse_stream_event(&message.data);
-                        let is_terminal = matches!(
-                            &event,
-                            Ok(ResponsesStreamEvent::ResponseCompleted { .. }
-                                | ResponsesStreamEvent::ResponseIncomplete { .. }
-                                | ResponsesStreamEvent::ResponseFailed { .. })
-                        );
-                        Some((event, (sse_stream, is_terminal)))
-                    }
-                    Some(Err(err)) => Some((
-                        Err(DeepSeekError::Stream(err.to_string())),
-                        (sse_stream, true),
-                    )),
-                    None => None,
-                }
-            },
-        );
-
-        Ok(Box::pin(event_stream))
+        Ok(Box::pin(responses_sse_event_stream(
+            response.bytes_stream(),
+        )))
     }
+}
+
+/// SSE 字节流转 Responses 流事件；终止事件后流结束。
+fn responses_sse_event_stream<S>(
+    byte_stream: S,
+) -> impl futures_util::Stream<Item = Result<ResponsesStreamEvent, DeepSeekError>>
+where
+    S: futures_util::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+{
+    use eventsource_stream::Eventsource;
+    use futures_util::StreamExt;
+    let sse_stream = Box::pin(byte_stream.eventsource());
+    stream::unfold(
+        (sse_stream, false),
+        |(mut sse_stream, terminated)| async move {
+            if terminated {
+                return None;
+            }
+            match sse_stream.next().await {
+                Some(Ok(message)) => {
+                    let event = parse_stream_event(&message.data);
+                    let is_terminal = matches!(
+                        &event,
+                        Ok(ResponsesStreamEvent::ResponseCompleted { .. }
+                            | ResponsesStreamEvent::ResponseIncomplete { .. }
+                            | ResponsesStreamEvent::ResponseFailed { .. })
+                    );
+                    Some((event, (sse_stream, is_terminal)))
+                }
+                Some(Err(err)) => Some((
+                    Err(DeepSeekError::Stream(err.to_string())),
+                    (sse_stream, true),
+                )),
+                None => None,
+            }
+        },
+    )
+}
+
+/// 判断响应首块是否是 JSON（跳过空白后以 `{` 或 `[` 开头）。
+fn looks_like_json(first: &[u8]) -> bool {
+    first
+        .iter()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_some_and(|byte| *byte == b'{' || *byte == b'[')
 }
 
 /// 把一次性完整响应合成为等价的流事件序列。

--- a/crates/tiangong-deepseek/src/responses.rs
+++ b/crates/tiangong-deepseek/src/responses.rs
@@ -43,6 +43,22 @@ impl<'c> Responses<'c> {
         request.stream = Some(true);
         let response = self.client.post_stream_raw("/responses", &request).await?;
 
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+
+        if !content_type.contains("text/event-stream") {
+            // 网关忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些行全部当
+            // 未知字段丢弃且不报错，在 SDK 内按完整响应接住并合成事件流。
+            let complete: ResponseObject = crate::client::parse_json_response(response).await?;
+            return Ok(Box::pin(stream::iter(
+                complete_response_events(complete).into_iter().map(Ok),
+            )));
+        }
+
         let sse_stream = response.bytes_stream().eventsource();
         let event_stream = stream::unfold(
             (sse_stream, false),
@@ -72,6 +88,24 @@ impl<'c> Responses<'c> {
 
         Ok(Box::pin(event_stream))
     }
+}
+
+/// 把一次性完整响应合成为等价的流事件序列。
+///
+/// 网关忽略 stream 参数返回 application/json 时，SDK 在内部按完整响应
+/// 接住并合成事件流，调用方无需感知差异。ResponseCompleted 为终止事件，
+/// 流在其后自然结束。
+fn complete_response_events(response: ResponseObject) -> Vec<ResponsesStreamEvent> {
+    vec![
+        ResponsesStreamEvent::ResponseCreated {
+            sequence_number: 0,
+            response: response.clone(),
+        },
+        ResponsesStreamEvent::ResponseCompleted {
+            sequence_number: 1,
+            response,
+        },
+    ]
 }
 
 /// 解析单条 SSE data 为流事件。

--- a/crates/tiangong-deepseek/src/tests.rs
+++ b/crates/tiangong-deepseek/src/tests.rs
@@ -1267,3 +1267,53 @@ async fn chat_stream_accepts_server_ignoring_stream_flag() {
     assert_eq!(text, "一次性完整回复");
     assert!(done, "应收到终止事件");
 }
+
+#[tokio::test]
+async fn chat_stream_sniffs_sse_body_when_content_type_mislabeled() {
+    // 部分网关返回标准 SSE 数据但漏标/错标响应类型：应按首块内容探测后
+    // 仍走流式解析，而不是当成一次性 JSON 读取失败。
+    use futures_util::StreamExt;
+
+    let sse = concat!(
+        "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"漏标类型的流式回复\"}}]}\n\n",
+        "data: {\"id\":\"c2\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    let server = MockServer::start(vec![http_response(
+        "200 OK",
+        "application/octet-stream",
+        sse.as_bytes(),
+    )]);
+    let client = mock_client(&server.addr);
+
+    let mut stream = client
+        .chat()
+        .create_stream(crate::types::ChatCompletionRequest {
+            model: crate::types::MODEL_V4_FLASH.into(),
+            messages: vec![crate::types::ChatMessage {
+                role: crate::types::MessageRole::User,
+                content: Some(json!("你好")),
+                reasoning_content: None,
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+                prefix: false,
+            }],
+            stream: Some(true),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let mut text = String::new();
+    let mut done = false;
+    while let Some(event) = stream.next().await {
+        match event.expect("流事件应无错误") {
+            crate::types::StreamEvent::TextDelta(delta) => text.push_str(&delta),
+            crate::types::StreamEvent::Done => done = true,
+            _ => {}
+        }
+    }
+    assert_eq!(text, "漏标类型的流式回复");
+    assert!(done, "应收到终止事件");
+}

--- a/crates/tiangong-deepseek/src/tests.rs
+++ b/crates/tiangong-deepseek/src/tests.rs
@@ -1224,3 +1224,46 @@ async fn files_retrieve_and_delete_encode_file_id_in_path() {
         "删除路径应编码：{delete_line}"
     );
 }
+
+#[tokio::test]
+async fn chat_stream_accepts_server_ignoring_stream_flag() {
+    // 网关忽略 stream 参数返回一次性 JSON 时，SDK 应在内部按完整响应接住并
+    // 合成流事件，而不是让 SSE 解析器静默丢弃后报空流。
+    use futures_util::StreamExt;
+
+    let body = r#"{"id":"cmpl_1","object":"chat.completion","created":0,"model":"deepseek-v4-flash","choices":[{"index":0,"message":{"role":"assistant","content":"一次性完整回复"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":3}}"#
+        .as_bytes();
+    let server = MockServer::start(vec![http_response("200 OK", "application/json", body)]);
+    let client = mock_client(&server.addr);
+
+    let mut stream = client
+        .chat()
+        .create_stream(crate::types::ChatCompletionRequest {
+            model: crate::types::MODEL_V4_FLASH.into(),
+            messages: vec![crate::types::ChatMessage {
+                role: crate::types::MessageRole::User,
+                content: Some(json!("你好")),
+                reasoning_content: None,
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+                prefix: false,
+            }],
+            stream: Some(true),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let mut text = String::new();
+    let mut done = false;
+    while let Some(event) = stream.next().await {
+        match event.expect("流事件应无错误") {
+            crate::types::StreamEvent::TextDelta(delta) => text.push_str(&delta),
+            crate::types::StreamEvent::Done => done = true,
+            _ => {}
+        }
+    }
+    assert_eq!(text, "一次性完整回复");
+    assert!(done, "应收到终止事件");
+}

--- a/crates/tiangong-llm/Cargo.toml
+++ b/crates/tiangong-llm/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 async-openai = { workspace = true, features = ["byot", "chat-completion", "model", "responses"] }
 eventsource-stream = { workspace = true }
+bytes = "1"
 backoff = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "sync"] }
 reqwest = { workspace = true, default-features = false, features = ["json", "rustls"] }

--- a/crates/tiangong-llm/Cargo.toml
+++ b/crates/tiangong-llm/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 async-openai = { workspace = true, features = ["byot", "chat-completion", "model", "responses"] }
+eventsource-stream = { workspace = true }
 backoff = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "sync"] }
 reqwest = { workspace = true, default-features = false, features = ["json", "rustls"] }

--- a/crates/tiangong-llm/src/provider_client.rs
+++ b/crates/tiangong-llm/src/provider_client.rs
@@ -689,59 +689,12 @@ impl SingleProviderClient {
         tool_choice: Option<ToolChoice>,
         chunk_tx: tokio::sync::mpsc::UnboundedSender<ModelStreamChunk>,
     ) -> Result<ModelFunctionResponse> {
+        // 流式失败直接失败，不回退非流式：中途断开时已推送内容会与非流式
+        // 完整响应拼接重复，且非流式整包等待更容易超时。不支持流式的服务不再兼容。
         let response = self
-            .stream_function_calls_attempt(&req, &functions, tool_choice, &chunk_tx)
+            .stream_function_calls_streaming(&req, &functions, tool_choice, &chunk_tx)
             .await?;
         filter_invalid_openai_tool_calls(self.protocol(), &functions, response)
-    }
-
-    async fn stream_function_calls_attempt(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-        chunk_tx: &tokio::sync::mpsc::UnboundedSender<ModelStreamChunk>,
-    ) -> Result<ModelFunctionResponse> {
-        match self
-            .stream_function_calls_streaming(req, functions, tool_choice.clone(), chunk_tx)
-            .await
-        {
-            Ok(response) => Ok(response),
-            Err(err) => {
-                // 确定性失败（400/401 等）换非流式重发同样失败，直接失败不再回退。
-                if is_deterministic_llm_error(&err) {
-                    return Err(err);
-                }
-                if let Some(on_retry) = &self.on_retry {
-                    on_retry(1, MAX_RETRIES, 0, &err.to_string());
-                }
-                // 直接 await provider future；上层 abort 流任务时 HTTP future 会随之
-                // drop，不能使用不可取消的 spawn_blocking，否则旧请求会越过轮次屏障。
-                let response = self
-                    .complete_with_functions_with_tool_choice_async_once(
-                        req,
-                        functions,
-                        tool_choice,
-                    )
-                    .await
-                    .context("流式失败后回退非流式调用失败")?;
-                if !response.reasoning_content.is_empty() {
-                    let _ = chunk_tx.send(ModelStreamChunk {
-                        content: String::new(),
-                        reasoning_content: response.reasoning_content.clone(),
-                        usage: None,
-                    });
-                }
-                if !response.text.is_empty() {
-                    let _ = chunk_tx.send(ModelStreamChunk {
-                        content: response.text.clone(),
-                        reasoning_content: String::new(),
-                        usage: None,
-                    });
-                }
-                Ok(response)
-            }
-        }
     }
 
     async fn stream_function_calls_streaming(
@@ -942,35 +895,13 @@ impl SingleProviderClient {
         on_delta: &mut dyn FnMut(&ModelStreamChunk),
     ) -> Result<ModelFunctionResponse> {
         if use_stream_mode() {
-            match self.complete_with_functions_stream_impl_with_tool_choice(
+            // 流式失败直接失败，不回退非流式（同 async 路径）。
+            self.complete_with_functions_stream_impl_with_tool_choice(
                 req,
                 functions,
-                tool_choice.clone(),
+                tool_choice,
                 on_delta,
-            ) {
-                Ok(resp) => Ok(resp),
-                Err(err) if is_deterministic_llm_error(&err) => Err(err),
-                Err(_) => {
-                    // 流式失败，回退到非流式，一次性推送 reasoning + content
-                    let resp =
-                        self.complete_with_functions_with_tool_choice(req, functions, tool_choice)?;
-                    if !resp.reasoning_content.is_empty() {
-                        on_delta(&ModelStreamChunk {
-                            content: String::new(),
-                            reasoning_content: resp.reasoning_content.clone(),
-                            usage: None,
-                        });
-                    }
-                    if !resp.text.is_empty() {
-                        on_delta(&ModelStreamChunk {
-                            content: resp.text.clone(),
-                            reasoning_content: String::new(),
-                            usage: None,
-                        });
-                    }
-                    Ok(resp)
-                }
-            }
+            )
         } else {
             let resp =
                 self.complete_with_functions_with_tool_choice(req, functions, tool_choice)?;
@@ -1894,22 +1825,6 @@ fn block_on_provider_stream(
 
 fn map_llm_error(error: crate::error::LlmError) -> anyhow::Error {
     anyhow::Error::new(error)
-}
-
-/// 判断错误是否为确定性失败（配置、认证、请求无效类）。
-///
-/// 这类错误与调用方式（流式/非流式）无关，换非流式重发同样失败，
-/// 流式失败后不应回退非流式重试。
-fn is_deterministic_llm_error(err: &anyhow::Error) -> bool {
-    err.downcast_ref::<crate::error::LlmError>()
-        .is_some_and(|error| {
-            matches!(
-                error,
-                crate::error::LlmError::Configuration(_)
-                    | crate::error::LlmError::Authentication(_)
-                    | crate::error::LlmError::InvalidRequest(_)
-            )
-        })
 }
 
 // ── 重试相关 ──────────────────────────────────────────────

--- a/crates/tiangong-llm/src/provider_client.rs
+++ b/crates/tiangong-llm/src/provider_client.rs
@@ -2190,6 +2190,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn openai_stream_accepts_server_ignoring_stream_flag() {
+        // 部分网关忽略 stream 参数，返回 application/json 的一次性完整响应；
+        // llm 层应按完整结果接住并合成流事件，而不是让 SSE 解析器静默丢弃。
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", "Bearer test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "chatcmpl-complete",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "test-model",
+                "choices": [{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "一次性完整回复",
+                        "tool_calls": [{
+                            "id": "call_tool",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": "{\"path\":\"TODO.md\"}"
+                            }
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }],
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 5,
+                    "total_tokens": 8
+                }
+            })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let client = SingleProviderClient::new(ModelEndpoint {
+            base_url: server.uri(),
+            api_key: "test-key".to_string(),
+            model: "test-model".to_string(),
+            protocol: ProviderProtocol::OpenAiChatCompletions,
+            timeout_ms: 5_000,
+            options: serde_json::Value::Object(serde_json::Map::new()),
+        });
+        let request = ModelRequest {
+            user_input: "检查项目".to_string(),
+            context: vec![Message::new(MessageRole::System, "system")],
+            reasoning_effort: ReasoningEffort::None,
+            max_output_tokens: None,
+        };
+        let functions = vec![schema_tool("read_file"), schema_tool("other_tool")];
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let response = client
+            .stream_function_calls(request, functions, chunk_tx)
+            .await
+            .unwrap();
+
+        assert_eq!(response.text, "一次性完整回复");
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].id, "call_tool");
+        assert_eq!(response.tool_calls[0].name, "read_file");
+        assert_eq!(
+            response.tool_calls[0].arguments,
+            serde_json::json!({"path": "TODO.md"})
+        );
+        assert_eq!(response.usage.total_tokens, 8);
+        let mut streamed_text = String::new();
+        while let Ok(chunk) = chunk_rx.try_recv() {
+            streamed_text.push_str(&chunk.content);
+        }
+        assert_eq!(streamed_text, "一次性完整回复");
+    }
+
+    #[tokio::test]
     async fn openai_stream_filters_invalid_parallel_calls_without_hidden_retry() {
         let server = MockServer::start().await;
         mount_openai_stream(

--- a/crates/tiangong-llm/src/provider_client.rs
+++ b/crates/tiangong-llm/src/provider_client.rs
@@ -2190,6 +2190,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn openai_stream_sniffs_sse_body_when_content_type_mislabeled() {
+        // 部分网关返回标准 SSE 数据但漏标/错标响应类型：不能一律当成一次性 JSON，
+        // 应按首块内容探测后仍走流式解析，避免流式能力回退。
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", "Bearer test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                concat!(
+                    "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"test-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"漏标类型的流式回复\"}}]}\n\n",
+                    "data: {\"id\":\"c2\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"test-model\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+                    "data: [DONE]\n\n",
+                ),
+                "application/octet-stream",
+            ))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let client = SingleProviderClient::new(ModelEndpoint {
+            base_url: server.uri(),
+            api_key: "test-key".to_string(),
+            model: "test-model".to_string(),
+            protocol: ProviderProtocol::OpenAiChatCompletions,
+            timeout_ms: 5_000,
+            options: serde_json::Value::Object(serde_json::Map::new()),
+        });
+        let request = ModelRequest {
+            user_input: "检查项目".to_string(),
+            context: vec![Message::new(MessageRole::System, "system")],
+            reasoning_effort: ReasoningEffort::None,
+            max_output_tokens: None,
+        };
+        let functions: Vec<ToolSpec> = Vec::new();
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let response = client
+            .stream_function_calls(request, functions, chunk_tx)
+            .await
+            .unwrap();
+
+        assert_eq!(response.text, "漏标类型的流式回复");
+        let mut streamed_text = String::new();
+        while let Ok(chunk) = chunk_rx.try_recv() {
+            streamed_text.push_str(&chunk.content);
+        }
+        assert_eq!(streamed_text, "漏标类型的流式回复");
+    }
+
+    #[tokio::test]
     async fn openai_stream_accepts_server_ignoring_stream_flag() {
         // 部分网关忽略 stream 参数，返回 application/json 的一次性完整响应；
         // llm 层应按完整结果接住并合成流事件，而不是让 SSE 解析器静默丢弃。

--- a/crates/tiangong-llm/src/providers/anthropic/error.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/error.rs
@@ -11,6 +11,7 @@ pub fn map_anthropic_error(error: AnthropicError) -> LlmError {
         AnthropicError::RateLimited(err) => LlmError::RateLimited(err),
         AnthropicError::Serialization(err) => LlmError::Serialization(err),
         AnthropicError::Stream(err) => LlmError::Stream(err),
+        AnthropicError::Timeout(_) => LlmError::Timeout(0),
         AnthropicError::Api(err) => LlmError::Provider {
             provider: "anthropic",
             message: err,

--- a/crates/tiangong-llm/src/providers/deepseek/error.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/error.rs
@@ -9,6 +9,7 @@ pub fn map_deepseek_error(error: tiangong_deepseek::DeepSeekError) -> LlmError {
         tiangong_deepseek::DeepSeekError::RateLimited(msg) => LlmError::RateLimited(msg),
         tiangong_deepseek::DeepSeekError::Serialization(msg) => LlmError::Serialization(msg),
         tiangong_deepseek::DeepSeekError::Stream(msg) => LlmError::Stream(msg),
+        tiangong_deepseek::DeepSeekError::Timeout(_) => LlmError::Timeout(0),
         tiangong_deepseek::DeepSeekError::Api(msg) => LlmError::Provider {
             provider: "deepseek",
             message: msg,

--- a/crates/tiangong-llm/src/providers/openai/client.rs
+++ b/crates/tiangong-llm/src/providers/openai/client.rs
@@ -14,6 +14,12 @@ use super::mapping::normalize_api_base;
 type ResponsesByotStream =
     std::pin::Pin<Box<dyn Stream<Item = Result<Value, async_openai::error::OpenAIError>> + Send>>;
 
+/// 流式请求的响应形态：正常 SSE 流，或服务端忽略 stream 参数返回的一次性 JSON。
+pub enum ResponsesStreamResponse {
+    Sse(ResponsesByotStream),
+    Complete(Value),
+}
+
 const INITIAL_RETRY_DELAY_MS: u64 = 1000;
 
 #[derive(Clone)]
@@ -43,11 +49,69 @@ impl ResponsesClient {
         &self,
         model: &str,
         payload: Value,
-    ) -> Result<ResponsesByotStream, LlmError> {
-        let client = self.build_client();
-        let responses = client.responses();
-        self.with_retry("openai_stream", model, true, || {
-            responses.create_stream_byot::<_, Value>(payload.clone())
+    ) -> Result<ResponsesStreamResponse, LlmError> {
+        let base = normalize_api_base(&self.config.base_url)
+            .map_err(|err| LlmError::Configuration(err.to_string()))?;
+        let url = format!("{base}/responses");
+        let api_key = self.config.api_key.clone();
+        self.with_retry("openai_stream", model, true, move || {
+            let url = url.clone();
+            let api_key = api_key.clone();
+            let payload = payload.clone();
+            async move {
+                // 不设总超时：流式响应允许长时间增量生成，总时长上限交给上层；
+                // 连接阶段卡死由 connect_timeout 兜住。
+                let client = reqwest::Client::builder()
+                    .connect_timeout(Duration::from_secs(30))
+                    .build()?;
+                let mut request = client
+                    .post(&url)
+                    .header(reqwest::header::ACCEPT, "text/event-stream")
+                    .json(&payload);
+                if !api_key.trim().is_empty() {
+                    request = request.bearer_auth(&api_key);
+                }
+                let response = request.send().await?;
+                let status = response.status();
+                if !status.is_success() {
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(async_openai::error::OpenAIError::ApiError(
+                        async_openai::error::ApiErrorResponse {
+                            status_code: status,
+                            api_error: async_openai::error::ApiError {
+                                message: format!("{status}: {body}"),
+                                r#type: None,
+                                param: None,
+                                code: None,
+                            },
+                        },
+                    ));
+                }
+                let content_type = response
+                    .headers()
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_ascii_lowercase();
+                if content_type.contains("text/event-stream") {
+                    Ok(ResponsesStreamResponse::Sse(Box::pin(
+                        crate::providers::openai_chatcompletions::client::sse_value_stream(
+                            response,
+                        ),
+                    )))
+                } else {
+                    // 服务端忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些
+                    // 行全部当未知字段丢弃且不报错，必须在 llm 层按完整响应接住。
+                    tracing::info!(
+                        operation = "openai_stream",
+                        provider = "openai",
+                        model,
+                        "服务端未按 SSE 流式返回，转按一次性完整响应处理"
+                    );
+                    let value = response.json::<Value>().await?;
+                    Ok(ResponsesStreamResponse::Complete(value))
+                }
+            }
         })
         .await
     }

--- a/crates/tiangong-llm/src/providers/openai/client.rs
+++ b/crates/tiangong-llm/src/providers/openai/client.rs
@@ -54,16 +54,20 @@ impl ResponsesClient {
             .map_err(|err| LlmError::Configuration(err.to_string()))?;
         let url = format!("{base}/responses");
         let api_key = self.config.api_key.clone();
+        let request_timeout = self.config.timeout;
         self.with_retry("openai_stream", model, true, move || {
             let url = url.clone();
             let api_key = api_key.clone();
             let payload = payload.clone();
+            let request_timeout = request_timeout;
             async move {
-                // 不设总超时：流式响应允许长时间增量生成，总时长上限交给上层；
-                // 连接阶段卡死由 connect_timeout 兜住。
-                let client = reqwest::Client::builder()
-                    .connect_timeout(Duration::from_secs(30))
-                    .build()?;
+                use crate::providers::openai_chatcompletions::client::{
+                    StreamBody, resolve_stream_body, stream_timeout_error,
+                };
+                // 建连、等待响应头与一次性响应体的读取均受用户配置的请求
+                // 超时约束。SSE 流本身允许长时间增量生成，建流成功后不再
+                // 受总时限限制。
+                let client = reqwest::Client::builder().build()?;
                 let mut request = client
                     .post(&url)
                     .header(reqwest::header::ACCEPT, "text/event-stream")
@@ -71,7 +75,9 @@ impl ResponsesClient {
                 if !api_key.trim().is_empty() {
                     request = request.bearer_auth(&api_key);
                 }
-                let response = request.send().await?;
+                let response = tokio::time::timeout(request_timeout, request.send())
+                    .await
+                    .map_err(|_| stream_timeout_error(request_timeout))??;
                 let status = response.status();
                 if !status.is_success() {
                     let body = response.text().await.unwrap_or_default();
@@ -87,29 +93,19 @@ impl ResponsesClient {
                         },
                     ));
                 }
-                let content_type = response
-                    .headers()
-                    .get(reqwest::header::CONTENT_TYPE)
-                    .and_then(|value| value.to_str().ok())
-                    .unwrap_or_default()
-                    .to_ascii_lowercase();
-                if content_type.contains("text/event-stream") {
-                    Ok(ResponsesStreamResponse::Sse(Box::pin(
-                        crate::providers::openai_chatcompletions::client::sse_value_stream(
-                            response,
-                        ),
-                    )))
-                } else {
-                    // 服务端忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些
-                    // 行全部当未知字段丢弃且不报错，必须在 llm 层按完整响应接住。
-                    tracing::info!(
-                        operation = "openai_stream",
-                        provider = "openai",
-                        model,
-                        "服务端未按 SSE 流式返回，转按一次性完整响应处理"
-                    );
-                    let value = response.json::<Value>().await?;
-                    Ok(ResponsesStreamResponse::Complete(value))
+                match resolve_stream_body(response, request_timeout).await? {
+                    StreamBody::Sse(stream) => Ok(ResponsesStreamResponse::Sse(stream)),
+                    StreamBody::Complete(value) => {
+                        // 服务端忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些
+                        // 行全部当未知字段丢弃且不报错，必须在 llm 层按完整响应接住。
+                        tracing::info!(
+                            operation = "openai_stream",
+                            provider = "openai",
+                            model,
+                            "服务端未按 SSE 流式返回，转按一次性完整响应处理"
+                        );
+                        Ok(ResponsesStreamResponse::Complete(value))
+                    }
                 }
             }
         })

--- a/crates/tiangong-llm/src/providers/openai/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai/provider.rs
@@ -73,7 +73,21 @@ impl LlmProvider for OpenAiResponsesProvider {
         let model = req.model.clone();
         let payload = build_request_json(&req, true)
             .map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
-        let stream = self.client.stream(&model, payload).await?;
+        let stream = match self.client.stream(&model, payload).await? {
+            // 服务端忽略 stream 参数返回一次性 JSON：复用非流式解析，
+            // 合成等价的流事件序列，消费方无需感知差异。
+            super::client::ResponsesStreamResponse::Complete(value) => {
+                let response =
+                    parse_complete_response(&value).map_err(|err| LlmError::Provider {
+                        provider: "openai",
+                        message: err.to_string(),
+                    })?;
+                return Ok(Box::pin(stream::iter(
+                    crate::stream::complete_response_events(response),
+                )));
+            }
+            super::client::ResponsesStreamResponse::Sse(stream) => stream,
+        };
 
         // 维护流式状态：记录是否收到过 reasoning delta 增量。
         // 流式增量一律保留；仅在全程无 delta 时，从 completed 兜底补发 reasoning。
@@ -173,6 +187,67 @@ mod tests {
             Some(Ok(ProviderStreamEvent::MessageStart))
         ));
         drop(response_stream);
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn stream_accepts_server_ignoring_stream_flag() {
+        // 部分网关忽略 stream 参数，返回 application/json 的一次性完整响应；
+        // llm 层应按完整结果接住并合成流事件，而不是让 SSE 解析器静默丢弃。
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "resp_complete",
+                "object": "response",
+                "status": "completed",
+                "model": "gpt-5.6-sol",
+                "output": [
+                    { "type": "message", "content": [{ "type": "output_text", "text": "一次性完整回复" }] },
+                    { "type": "function_call", "call_id": "call_tool", "name": "read_file", "arguments": "{\"path\":\"TODO.md\"}" }
+                ],
+                "usage": { "input_tokens": 3, "output_tokens": 5, "total_tokens": 8 }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut config = OpenAiResponsesConfig::new("test-key", server.uri());
+        config.timeout = std::time::Duration::from_secs(2);
+        config.max_retries = 0;
+        let provider = OpenAiResponsesProvider::new(config);
+        let request = ProviderRequest {
+            model: "gpt-5.6-sol".to_string(),
+            system: None,
+            messages: vec![crate::message::ChatMessage::text(
+                crate::message::MessageRole::User,
+                "你好",
+            )],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: 1024,
+            temperature: None,
+            top_p: None,
+            stop_sequences: Vec::new(),
+            metadata: None,
+            reasoning_effort: crate::request::ReasoningEffort::None,
+        };
+
+        let mut response_stream = provider.stream(request).await.unwrap();
+        let mut text = String::new();
+        let mut tool_calls = 0;
+        while let Some(event) = response_stream.next().await {
+            match event.expect("流事件应无错误") {
+                ProviderStreamEvent::TextDelta(delta) => text.push_str(&delta),
+                ProviderStreamEvent::ToolCallStart(_) => tool_calls += 1,
+                _ => {}
+            }
+        }
+        assert_eq!(text, "一次性完整回复");
+        assert_eq!(tool_calls, 1);
         server.verify().await;
     }
 

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/client.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/client.rs
@@ -27,28 +27,144 @@ pub enum OpenAiStreamResponse {
 pub(crate) fn sse_value_stream(
     response: reqwest::Response,
 ) -> impl Stream<Item = Result<Value, async_openai::error::OpenAIError>> {
+    sse_value_stream_from_bytes(response.bytes_stream())
+}
+
+/// 同 [sse_value_stream]，但接受任意字节流（用于内容探测后把首块拼回流）。
+fn sse_value_stream_from_bytes<S>(
+    byte_stream: S,
+) -> impl Stream<Item = Result<Value, async_openai::error::OpenAIError>>
+where
+    S: Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+{
     use eventsource_stream::Eventsource;
     use futures_util::StreamExt;
-    response
-        .bytes_stream()
-        .eventsource()
-        .filter_map(|event| async move {
-            match event {
-                Ok(message) => {
-                    if message.data == "[DONE]" || message.event == "keepalive" {
-                        return None;
-                    }
-                    Some(serde_json::from_str::<Value>(&message.data).map_err(|err| {
-                        async_openai::error::OpenAIError::JSONDeserialize(err, message.data)
-                    }))
+    byte_stream.eventsource().filter_map(|event| async move {
+        match event {
+            Ok(message) => {
+                if message.data == "[DONE]" || message.event == "keepalive" {
+                    return None;
                 }
-                Err(err) => Some(Err(async_openai::error::OpenAIError::StreamError(
-                    Box::new(async_openai::error::StreamError::EventStream(
-                        err.to_string(),
-                    )),
-                ))),
+                Some(serde_json::from_str::<Value>(&message.data).map_err(|err| {
+                    async_openai::error::OpenAIError::JSONDeserialize(err, message.data)
+                }))
             }
-        })
+            Err(err) => Some(Err(async_openai::error::OpenAIError::StreamError(
+                Box::new(async_openai::error::StreamError::EventStream(
+                    err.to_string(),
+                )),
+            ))),
+        }
+    })
+}
+
+/// 流式响应体的处置结果：SSE 事件流，或一次性完整 JSON。
+pub(crate) enum StreamBody {
+    Sse(OpenAiByotStream),
+    Complete(Value),
+}
+
+/// 等待响应头/读取完整响应体的超时错误。
+pub(crate) fn stream_timeout_error(timeout: Duration) -> async_openai::error::OpenAIError {
+    async_openai::error::OpenAIError::ApiError(async_openai::error::ApiErrorResponse {
+        status_code: reqwest::StatusCode::REQUEST_TIMEOUT,
+        api_error: async_openai::error::ApiError {
+            message: format!(
+                "timeout after {}ms waiting for stream response body",
+                timeout.as_millis()
+            ),
+            r#type: None,
+            param: None,
+            code: None,
+        },
+    })
+}
+
+/// 判断响应首块是否是 JSON（跳过空白后以 `{` 或 `[` 开头）。
+fn looks_like_json(first: &[u8]) -> bool {
+    first
+        .iter()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_some_and(|byte| *byte == b'{' || *byte == b'[')
+}
+
+/// 按响应类型与实际内容把流式请求的响应分流为 SSE 或一次性 JSON。
+///
+/// - 响应类型声明 `text/event-stream` → 按流式解析；
+/// - 响应类型声明 JSON → 按一次性完整响应读取；
+/// - 类型缺失或不明确（部分网关漏标或错标 `application/octet-stream`）→
+///   探测首块内容：`{`/`[` 开头按 JSON，否则仍按流式解析，避免误判真实 SSE 流。
+///
+/// 一次性响应体的完整读取受 `timeout` 约束；SSE 流本身允许长时间增量生成，
+/// 不设总时限。
+pub(crate) async fn resolve_stream_body(
+    mut response: reqwest::Response,
+    timeout: Duration,
+) -> Result<StreamBody, async_openai::error::OpenAIError> {
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if content_type.contains("text/event-stream") {
+        return Ok(StreamBody::Sse(Box::pin(sse_value_stream(response))));
+    }
+    if content_type.contains("json") {
+        return read_complete_body(response, timeout)
+            .await
+            .map(StreamBody::Complete);
+    }
+    // 类型不明确：按首块内容探测真实形态。
+    let first = response.chunk().await?.unwrap_or_default();
+    if looks_like_json(&first) {
+        return read_complete_body_with_prefix(response, first, timeout)
+            .await
+            .map(StreamBody::Complete);
+    }
+    // 首块不是 JSON：按 SSE 流解析，把首块拼回流头。
+    use futures_util::StreamExt;
+    let byte_stream = futures_util::stream::once(async move { Ok::<_, reqwest::Error>(first) })
+        .chain(response.bytes_stream());
+    Ok(StreamBody::Sse(Box::pin(sse_value_stream_from_bytes(
+        byte_stream,
+    ))))
+}
+
+async fn read_complete_body(
+    response: reqwest::Response,
+    timeout: Duration,
+) -> Result<Value, async_openai::error::OpenAIError> {
+    let bytes = tokio::time::timeout(timeout, response.bytes())
+        .await
+        .map_err(|_| stream_timeout_error(timeout))??;
+    parse_complete_body(&bytes)
+}
+
+async fn read_complete_body_with_prefix(
+    mut response: reqwest::Response,
+    first: bytes::Bytes,
+    timeout: Duration,
+) -> Result<Value, async_openai::error::OpenAIError> {
+    let bytes = tokio::time::timeout(timeout, async {
+        let mut buf = first.to_vec();
+        while let Some(chunk) = response.chunk().await? {
+            buf.extend_from_slice(&chunk);
+        }
+        Ok::<_, reqwest::Error>(buf)
+    })
+    .await
+    .map_err(|_| stream_timeout_error(timeout))??;
+    parse_complete_body(&bytes)
+}
+
+fn parse_complete_body(bytes: &[u8]) -> Result<Value, async_openai::error::OpenAIError> {
+    serde_json::from_slice(bytes).map_err(|err| {
+        async_openai::error::OpenAIError::JSONDeserialize(
+            err,
+            String::from_utf8_lossy(&bytes[..bytes.len().min(256)]).into_owned(),
+        )
+    })
 }
 
 const MAX_RETRIES: u32 = 3;
@@ -86,16 +202,17 @@ impl OpenAiClient {
             .map_err(|err| LlmError::Configuration(err.to_string()))?;
         let url = format!("{base}/chat/completions");
         let api_key = self.config.api_key.clone();
+        let request_timeout = self.config.timeout;
         self.with_retry("openai_stream", model, true, move || {
             let url = url.clone();
             let api_key = api_key.clone();
             let payload = payload.clone();
+            let request_timeout = request_timeout;
             async move {
-                // 不设总超时：流式响应允许长时间增量生成，总时长上限交给上层；
-                // 连接阶段卡死由 connect_timeout 兜住。
-                let client = reqwest::Client::builder()
-                    .connect_timeout(Duration::from_secs(30))
-                    .build()?;
+                // 建连、等待响应头与一次性响应体的读取均受用户配置的请求
+                // 超时约束。SSE 流本身允许长时间增量生成，建流成功后不再
+                // 受总时限限制。
+                let client = reqwest::Client::builder().build()?;
                 let mut request = client
                     .post(&url)
                     .header(reqwest::header::ACCEPT, "text/event-stream")
@@ -103,7 +220,9 @@ impl OpenAiClient {
                 if !api_key.trim().is_empty() {
                     request = request.bearer_auth(&api_key);
                 }
-                let response = request.send().await?;
+                let response = tokio::time::timeout(request_timeout, request.send())
+                    .await
+                    .map_err(|_| stream_timeout_error(request_timeout))??;
                 let status = response.status();
                 if !status.is_success() {
                     let body = response.text().await.unwrap_or_default();
@@ -119,27 +238,19 @@ impl OpenAiClient {
                         },
                     ));
                 }
-                let content_type = response
-                    .headers()
-                    .get(reqwest::header::CONTENT_TYPE)
-                    .and_then(|value| value.to_str().ok())
-                    .unwrap_or_default()
-                    .to_ascii_lowercase();
-                if content_type.contains("text/event-stream") {
-                    Ok(OpenAiStreamResponse::Sse(Box::pin(sse_value_stream(
-                        response,
-                    ))))
-                } else {
-                    // 服务端忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些
-                    // 行全部当未知字段丢弃且不报错，必须在 llm 层按完整响应接住。
-                    tracing::info!(
-                        operation = "openai_stream",
-                        provider = "openai",
-                        model,
-                        "服务端未按 SSE 流式返回，转按一次性完整响应处理"
-                    );
-                    let value = response.json::<Value>().await?;
-                    Ok(OpenAiStreamResponse::Complete(value))
+                match resolve_stream_body(response, request_timeout).await? {
+                    StreamBody::Sse(stream) => Ok(OpenAiStreamResponse::Sse(stream)),
+                    StreamBody::Complete(value) => {
+                        // 服务端忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些
+                        // 行全部当未知字段丢弃且不报错，必须在 llm 层按完整响应接住。
+                        tracing::info!(
+                            operation = "openai_stream",
+                            provider = "openai",
+                            model,
+                            "服务端未按 SSE 流式返回，转按一次性完整响应处理"
+                        );
+                        Ok(OpenAiStreamResponse::Complete(value))
+                    }
                 }
             }
         })

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/client.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/client.rs
@@ -16,6 +16,41 @@ use super::mapping::normalize_api_base;
 type OpenAiByotStream =
     std::pin::Pin<Box<dyn Stream<Item = Result<Value, async_openai::error::OpenAIError>> + Send>>;
 
+/// 流式请求的响应形态：正常 SSE 流，或服务端忽略 stream 参数返回的一次性 JSON。
+pub enum OpenAiStreamResponse {
+    Sse(OpenAiByotStream),
+    Complete(Value),
+}
+
+/// 把 SSE 响应体解析为 JSON 值流，跳过 [DONE] 与 keepalive。
+/// Responses 协议与 Chat Completions 的 SSE 帧格式一致，共用此实现。
+pub(crate) fn sse_value_stream(
+    response: reqwest::Response,
+) -> impl Stream<Item = Result<Value, async_openai::error::OpenAIError>> {
+    use eventsource_stream::Eventsource;
+    use futures_util::StreamExt;
+    response
+        .bytes_stream()
+        .eventsource()
+        .filter_map(|event| async move {
+            match event {
+                Ok(message) => {
+                    if message.data == "[DONE]" || message.event == "keepalive" {
+                        return None;
+                    }
+                    Some(serde_json::from_str::<Value>(&message.data).map_err(|err| {
+                        async_openai::error::OpenAIError::JSONDeserialize(err, message.data)
+                    }))
+                }
+                Err(err) => Some(Err(async_openai::error::OpenAIError::StreamError(
+                    Box::new(async_openai::error::StreamError::EventStream(
+                        err.to_string(),
+                    )),
+                ))),
+            }
+        })
+}
+
 const MAX_RETRIES: u32 = 3;
 const INITIAL_RETRY_DELAY_MS: u64 = 1000;
 
@@ -42,11 +77,71 @@ impl OpenAiClient {
         .map_err(|_| LlmError::Timeout(self.config.timeout.as_millis() as u64))?
     }
 
-    pub async fn stream(&self, model: &str, payload: Value) -> Result<OpenAiByotStream, LlmError> {
-        let client = self.build_client();
-        let chat = client.chat();
-        self.with_retry("openai_stream", model, true, || {
-            chat.create_stream_byot::<_, Value>(payload.clone())
+    pub async fn stream(
+        &self,
+        model: &str,
+        payload: Value,
+    ) -> Result<OpenAiStreamResponse, LlmError> {
+        let base = normalize_api_base(&self.config.base_url)
+            .map_err(|err| LlmError::Configuration(err.to_string()))?;
+        let url = format!("{base}/chat/completions");
+        let api_key = self.config.api_key.clone();
+        self.with_retry("openai_stream", model, true, move || {
+            let url = url.clone();
+            let api_key = api_key.clone();
+            let payload = payload.clone();
+            async move {
+                // 不设总超时：流式响应允许长时间增量生成，总时长上限交给上层；
+                // 连接阶段卡死由 connect_timeout 兜住。
+                let client = reqwest::Client::builder()
+                    .connect_timeout(Duration::from_secs(30))
+                    .build()?;
+                let mut request = client
+                    .post(&url)
+                    .header(reqwest::header::ACCEPT, "text/event-stream")
+                    .json(&payload);
+                if !api_key.trim().is_empty() {
+                    request = request.bearer_auth(&api_key);
+                }
+                let response = request.send().await?;
+                let status = response.status();
+                if !status.is_success() {
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(async_openai::error::OpenAIError::ApiError(
+                        async_openai::error::ApiErrorResponse {
+                            status_code: status,
+                            api_error: async_openai::error::ApiError {
+                                message: format!("{status}: {body}"),
+                                r#type: None,
+                                param: None,
+                                code: None,
+                            },
+                        },
+                    ));
+                }
+                let content_type = response
+                    .headers()
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_ascii_lowercase();
+                if content_type.contains("text/event-stream") {
+                    Ok(OpenAiStreamResponse::Sse(Box::pin(sse_value_stream(
+                        response,
+                    ))))
+                } else {
+                    // 服务端忽略 stream 参数返回一次性 JSON：SSE 解析器会把这些
+                    // 行全部当未知字段丢弃且不报错，必须在 llm 层按完整响应接住。
+                    tracing::info!(
+                        operation = "openai_stream",
+                        provider = "openai",
+                        model,
+                        "服务端未按 SSE 流式返回，转按一次性完整响应处理"
+                    );
+                    let value = response.json::<Value>().await?;
+                    Ok(OpenAiStreamResponse::Complete(value))
+                }
+            }
         })
         .await
     }

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/error.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/error.rs
@@ -1,7 +1,7 @@
 use crate::error::LlmError;
 
 pub fn map_openai_error(error: &async_openai::error::OpenAIError) -> LlmError {
-    let text = error.to_string();
+    let text = format_error_with_sources(error);
     if text.contains("401") {
         return LlmError::Authentication(text);
     }
@@ -18,7 +18,17 @@ pub fn map_openai_error(error: &async_openai::error::OpenAIError) -> LlmError {
 }
 
 pub fn is_retryable_openai_error(err: &async_openai::error::OpenAIError) -> bool {
-    let text = err.to_string();
+    // 传输层失败（连接被重置/断开、DNS 抖动等）是暂时性的，直接重试。
+    // reqwest 的 Display 只有 "error sending request for url (...)"，
+    // 底层原因藏在 source 链里，靠字符串匹配 "connection reset" 永远命中不了。
+    // 请求构建失败（is_builder）与超时（is_timeout）不是暂时性错误，保持不重试。
+    if let async_openai::error::OpenAIError::Reqwest(e) = err
+        && !e.is_builder()
+        && !e.is_timeout()
+    {
+        return true;
+    }
+    let text = format_error_with_sources(err);
     is_rate_limited_text(&text)
         || text.contains("500 Internal Server Error")
         || text.contains("502 Bad Gateway")
@@ -26,6 +36,19 @@ pub fn is_retryable_openai_error(err: &async_openai::error::OpenAIError) -> bool
         || text.contains("504 Gateway Timeout")
         || text.contains("connection reset")
         || text.contains("connection refused")
+}
+
+/// 拼接错误与其 source 链：reqwest 的 Display 不含底层原因，
+/// 需要手动展开才能把 "connection reset by peer" 这类信息透给用户。
+fn format_error_with_sources(error: &dyn std::error::Error) -> String {
+    let mut text = error.to_string();
+    let mut source = error.source();
+    while let Some(err) = source {
+        text.push_str(": ");
+        text.push_str(&err.to_string());
+        source = err.source();
+    }
+    text
 }
 
 fn is_rate_limited_text(text: &str) -> bool {

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/error.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/error.rs
@@ -18,13 +18,16 @@ pub fn map_openai_error(error: &async_openai::error::OpenAIError) -> LlmError {
 }
 
 pub fn is_retryable_openai_error(err: &async_openai::error::OpenAIError) -> bool {
-    // 传输层失败（连接被重置/断开、DNS 抖动等）是暂时性的，直接重试。
+    // 只重试真正可能恢复的传输层故障（连接被重置/断开、DNS 抖动等）。
     // reqwest 的 Display 只有 "error sending request for url (...)"，
-    // 底层原因藏在 source 链里，靠字符串匹配 "connection reset" 永远命中不了。
-    // 请求构建失败（is_builder）与超时（is_timeout）不是暂时性错误，保持不重试。
+    // 底层原因藏在 source 链里，无法靠字符串匹配识别。
+    // 构建失败、超时、响应体解析失败、重定向错误都是确定性失败，重试无益：
+    // 格式错误的响应重发只会重复计费并推迟报错。
     if let async_openai::error::OpenAIError::Reqwest(e) = err
         && !e.is_builder()
         && !e.is_timeout()
+        && !e.is_decode()
+        && !e.is_redirect()
     {
         return true;
     }

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/provider.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/provider.rs
@@ -82,15 +82,30 @@ impl LlmProvider for OpenAiChatCompletionsProvider {
         let model = req.model.clone();
         let payload = build_request_json(&req, true)
             .map_err(|err| LlmError::InvalidRequest(err.to_string()))?;
-        let stream = self.client.stream(&model, payload).await?;
-        let mut decoder = super::stream::OpenAiStreamDecoder::default();
-        let mapped = stream
-            .map(move |item| match item {
-                Ok(payload) => decoder.parse_payload(&payload),
-                Err(err) => vec![Err(map_openai_error(&err))],
-            })
-            .flat_map(stream::iter);
-        Ok(Box::pin(mapped))
+        match self.client.stream(&model, payload).await? {
+            super::client::OpenAiStreamResponse::Sse(stream) => {
+                let mut decoder = super::stream::OpenAiStreamDecoder::default();
+                let mapped = stream
+                    .map(move |item| match item {
+                        Ok(payload) => decoder.parse_payload(&payload),
+                        Err(err) => vec![Err(map_openai_error(&err))],
+                    })
+                    .flat_map(stream::iter);
+                Ok(Box::pin(mapped))
+            }
+            // 服务端忽略 stream 参数返回一次性 JSON：复用非流式解析，
+            // 合成等价的流事件序列，消费方无需感知差异。
+            super::client::OpenAiStreamResponse::Complete(value) => {
+                let response =
+                    parse_complete_response(&value).map_err(|err| LlmError::Provider {
+                        provider: "openai",
+                        message: err.to_string(),
+                    })?;
+                Ok(Box::pin(stream::iter(
+                    crate::stream::complete_response_events(response),
+                )))
+            }
+        }
     }
 
     async fn list_models(&self) -> Result<Vec<ProviderModelInfo>, LlmError> {

--- a/crates/tiangong-llm/src/stream.rs
+++ b/crates/tiangong-llm/src/stream.rs
@@ -30,3 +30,43 @@ pub enum ProviderStreamEvent {
 }
 
 pub type ProviderStream = Pin<Box<dyn Stream<Item = Result<ProviderStreamEvent, LlmError>> + Send>>;
+
+/// 把一次性完整响应合成为流事件序列。
+///
+/// 服务端忽略 stream 参数返回普通 JSON 时，复用非流式解析结果，
+/// 让流式消费方无差别处理。
+pub(crate) fn complete_response_events(
+    response: crate::response::ProviderResponse,
+) -> Vec<Result<ProviderStreamEvent, LlmError>> {
+    use crate::message::MessageContent;
+
+    let mut events = vec![Ok(ProviderStreamEvent::MessageStart)];
+    if let Some(reasoning) = response
+        .reasoning_content
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        events.push(Ok(ProviderStreamEvent::ReasoningDelta(
+            reasoning.to_string(),
+        )));
+    }
+    for block in &response.assistant_message.content {
+        match block {
+            MessageContent::Text(text) if !text.trim().is_empty() => {
+                events.push(Ok(ProviderStreamEvent::TextDelta(text.clone())));
+            }
+            // 完整参数直接放在 ToolCallStart，无需再跟 Delta 分片。
+            MessageContent::ToolCall(call) => {
+                events.push(Ok(ProviderStreamEvent::ToolCallStart(call.clone())));
+            }
+            _ => {}
+        }
+    }
+    if let Some(usage) = response.usage {
+        events.push(Ok(ProviderStreamEvent::Usage(usage)));
+    }
+    events.push(Ok(ProviderStreamEvent::MessageEnd {
+        stop_reason: response.stop_reason,
+    }));
+    events
+}


### PR DESCRIPTION
## 背景

使用 opencode zen 的 OpenAI 兼容接口时遇到间歇性报错「流式失败后回退非流式调用失败: 传输错误：error sending request for url」。排查确认三个层面的问题并逐一修复。

## 变更

**1. 传输错误可重试并透出底层原因**
- 可重试判断原来靠字符串匹配 connection reset，但 reqwest 错误文本不含底层原因（藏在 source 链），导致连接被重置类暂时性错误从不重试，一次网络抖动整轮请求直接失败
- 现在 Reqwest 错误（构建/超时除外）直接判定可重试，错误文本拼接 source 链，能看到 connection reset by peer 等真实原因

**2. 流式失败直接失败，移除非流式回退**
- 原来流式失败后会重发一次非流式请求：中途断开时已推送内容会与非流式完整响应拼接重复、污染会话与后续上下文；非流式整包等待更容易超时、双倍计费
- 不支持流式或忽略 stream 参数的服务不再通过重发兼容（由第 3 项在同一响应内接住）

**3. 流式入口接住服务端忽略 stream 返回的一次性 JSON**
- 部分网关对 stream:true 仍返回 application/json 完整响应；SSE 解析器把这些行全部当未知字段静默丢弃且不报错，最终只报空流错误
- 各协议在流式入口按响应内容类型分流：SSE 走原路径，一次性 JSON 解析后合成等价事件流，调用方无感知
  - openai chatcompletions / responses：llm 库内自行发请求分流，共用 complete_response_events
  - anthropic、deepseek（chat 与 responses）：SDK 内部分流并合成各自的流事件，对外仍返回统一事件流

**4. tiangong-deepseek 升级至 0.1.3**

## 测试

- 每个协议新增「服务端忽略 stream 返回 JSON → 流式调用成功」用例
- tiangong-llm 100 / tiangong-deepseek 74 / tiangong-anthropic 6 / tiangong-core 92 全部通过，clippy 零警告