### PR TITLE
fix(ci): 发布链支持 plugin-creator 目录命名（resolve 探测 + 失败级联防御）

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -51,7 +51,11 @@ jobs:
           python3 - "$plugin_id" >> "$GITHUB_OUTPUT" <<'PY'
           import json, os, sys
           plugin_id = sys.argv[1]
-          for root in (f"plugins/tiangong-plugin-{plugin_id}", f"plugins/{plugin_id}"):
+          for root in (
+              f"plugins/tiangong-plugin-{plugin_id}",
+              f"plugins/tiangong-{plugin_id}",
+              f"plugins/{plugin_id}",
+          ):
               if os.path.isfile(f"{root}/plugin.json"):
                   manifest = json.load(open(f"{root}/plugin.json"))
                   has_wasm = "true" if manifest.get("wasm") else "false"
@@ -122,7 +126,7 @@ jobs:
     needs: [resolve-plugin, build-wasm, build-ui]
     # 纯 UI 插件会跳过 build-wasm；显式判定 needs 结果，避免
     # skipped 状态传播导致整条发布链被跳过。
-    if: ${{ !cancelled() && needs.build-wasm.result != 'failure' && needs.build-ui.result != 'failure' }}
+    if: ${{ !cancelled() && needs.resolve-plugin.result == 'success' && needs.build-wasm.result != 'failure' && needs.build-ui.result != 'failure' }}
     runs-on: ${{ matrix.runner }}
     defaults:
       run:


### PR DESCRIPTION
## 问题

plugin-creator v0.1.0 首次发布失败（run 32833944739 / 32833946753），两处：

1. **resolve 探测不到清单**：`plugin.json not found for plugin-creator`——探测只拼 `plugins/tiangong-plugin-{id}` 与 `plugins/{id}`，而 plugin-creator 的目录是 `plugins/tiangong-plugin-creator`（id 中的 plugin 段与目录前缀重复，拼出 `tiangong-plugin-plugin-creator` 不存在）。interaction 等 id 无重复段故未暴露。
2. **失败级联**：resolve 失败后 build-plugin 的 `!cancelled()` 判定仍放行构建，has_ui 为空 → 不下载预构建 UI → Windows 无 yarn 报 `program not found`。

## 修复

- 探测列表补 `plugins/tiangong-{id}` 候选（不改已装用户的插件 id，不动目录）
- build-plugin 的 if 补 `needs.resolve-plugin.result == 'success'`，resolve 失败即整链停止

## 验证

本地 `xtask validate-plugin plugin-creator` 通过；合并后重发 tag 验证三平台构建与 OSS 上架。

> 注：这是发布链路的阻断修复，合并后将立即重新触发 plugin-creator v0.1.0 发布。