### PR TITLE
feat(ui): 优化消息列表横条导航边栏

### DIFF
--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -3,7 +3,7 @@ import { useSearchStore } from "@/store/useSearchStore";
 import { findSearchMatches } from "@/utils/search";
 import { SearchBar } from "./SearchBar";
 import { ScrollArea } from "./ui/scroll-area";
-import { RulerScrollbar } from "./ui/ruler-scrollbar";
+import { RulerScrollbar, TurnPreviewCard } from "./ui/ruler-scrollbar";
 import {
   Loader2,
   Cpu,
@@ -14,7 +14,6 @@ import {
 import 'md-editor-rt/lib/preview.css';
 import { open } from '@tauri-apps/plugin-dialog';
 import { AgentPanel } from "./AgentPanel";
-import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
 import { api, hasMediaBlocks, textContent, type ContentBlock } from "@/api/tauri";
 import {
   type Attachment,
@@ -93,19 +92,11 @@ export function MessageList() {
   const editingTextareaRef = useRef<MentionEditorHandle>(null!);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const isAtBottomRef = useRef(true);
-  // 百分比轨道：鼠标 Y 比例映射到的用户提问序号，-1 表示未在轨道内
-  const [hoverUserPos, setHoverUserPos] = useState(-1);
-  const hoverUserPosRef = useRef(-1);
-  // 正态点显隐：鼠标进入轨道时显示，离开 1.5s 后隐藏
-  const [railHovered, setRailHovered] = useState(false);
-  const railHideTimerRef = useRef<number | null>(null);
-  // 鼠标在轨道内的 Y 比例（0~1），用于点列块平移跟随；-1 表示未在轨道内
-  const hoverRatioRef = useRef(-1);
-  // 点列块的 top 像素值（已 clamp + 吸附），避免滑到顶/底时块超出轨道被裁
-  const [dotsTopPx, setDotsTopPx] = useState<number | null>(null);
-  // 点列块与轨道主体，用于计算平移量
-  const railTrackRef = useRef<HTMLDivElement>(null);
-  const railDotsRef = useRef<HTMLDivElement>(null);
+  // 刻度尺 hover 预览：指针在轨道内的 y 与轨道总高；null 表示未悬停
+  const [railHoverInfo, setRailHoverInfo] = useState<{ y: number; trackH: number } | null>(null);
+  const railPreviewHideTimerRef = useRef<number | null>(null);
+  // 刻度尺轨道高度（挂载/尺寸变化时上报一次），用于把节点文档比例换算为像素
+  const [rulerTrackH, setRulerTrackH] = useState(0);
 
   // 检查 TTS 能力
   useEffect(() => {
@@ -120,24 +111,9 @@ export function MessageList() {
     setIsAtBottom(true);
   }, [activeSessionId]);
 
-  // 卸载时清理正态点隐藏定时器
+  // 卸载时清理刻度尺预览卡片的隐藏定时器
   useEffect(() => () => {
-    if (railHideTimerRef.current) window.clearTimeout(railHideTimerRef.current);
-  }, []);
-
-  // 根据鼠标 Y 比例计算点列块 top（像素），含 clamp 与端点吸附，避免滑到顶/底时块被裁
-  const calcDotsTop = useCallback((ratio: number): number => {
-    const track = railTrackRef.current;
-    const dots = railDotsRef.current;
-    if (!track || !dots) return 0;
-    const trackH = track.clientHeight;
-    const dotsH = dots.offsetHeight;
-    // 块可活动范围：[0, 轨道高 - 块高]；块高大于轨道高时退化为 0
-    const maxTop = Math.max(0, trackH - dotsH);
-    // 期望的块顶边 = 目标中心 Y - 块高/2，clamp 到可活动范围防止溢出被裁
-    // 不做吸附：直接跟随鼠标到端点贴住，避免"咬"的吸附感
-    const top = Math.max(0, Math.min(maxTop, ratio * trackH - dotsH / 2));
-    return top;
+    if (railPreviewHideTimerRef.current) window.clearTimeout(railPreviewHideTimerRef.current);
   }, []);
 
   // 监听滚动位置，维护 isAtBottom 状态
@@ -690,60 +666,62 @@ export function MessageList() {
     return () => document.removeEventListener('click', handler);
   }, []);
 
-  // 当前视口顶部对应的用户提问序号，用于导航轨道点激活
-  // 滚动时 virtualizer 触发 rerender，render 期即可读到最新 scrollOffset
-  const activeUserPos = (() => {
-    if (userGroupIndices.length === 0) return -1;
-    const item = virtualizer.getVirtualItemForOffset(virtualizer.scrollOffset ?? 0);
-    if (!item) return -1;
-    return findUserCursorPos(item.index);
-  })();
-
-  // ---- 百分比磁吸轨道的派生数据 ----
+  // ---- 会话导航 ----
   const userCount = userGroupIndices.length;
-  // 每条用户提问的预览文本（前 15 字符，超出补 ...）
-  const userPreviews = useMemo(
-    () => userGroupIndices.map(idx => {
-      const raw = textContent(completedGroups[idx].messages[0]);
-      const scheduledTask = parseScheduledTaskMessage(raw);
-      const webhook = parseWebhookMessage(raw);
-      const preview = scheduledTask
-        ? `定时：${scheduledTask.name || '未命名任务'}`
-        : webhook
-          ? `Webhook：${webhook.name || '未命名触发'}`
-          : raw;
-      return (preview.length > 15 ? preview.slice(0, 15) + '...' : preview) || '(空消息)';
-    }),
-    [userGroupIndices, completedGroups],
-  );
 
-  // ≤9 条直接平铺；>9 条按鼠标 Y 比例（无 hover 时回退到激活序号）做高斯窗口
-  const railSpread = userCount > 9;
-  // 游标：鼠标 hover 时跟随鼠标比例，否则回退到当前激活序号
-  const railCursor = hoverUserPos >= 0 ? hoverUserPos : Math.max(0, activeUserPos);
-  // 正态点仅在鼠标位于轨道内时显示；>9 条且未悬停时只渲染细条背景
-  const showRailDots = railHovered;
-  // 高斯窗口：σ 越小点收缩越快；此处用 σ=2 让 9 个点呈现明显的大小渐变
-  const railPoints = useMemo<{ groupIndex: number; pos: number; size: number }[]>(() => {
-    if (!railSpread) {
-      // 平铺模式：所有点等大（size=1），均可视为候选最大点
-      return userGroupIndices.map((groupIndex, pos) => ({ groupIndex, pos, size: 1 }));
+  // ---- 刻度尺 hover 预览的节点数据 ----
+  // 每轮会话：用户提问摘要 + 其后第一个有文字的回答轮摘要 + 全文比例位置
+  const totalSize = virtualizer.getTotalSize();
+  const turnNodes = useMemo(() => {
+    if (!(totalSize > 0)) return [];
+    const measurements = virtualizer.measurementsCache;
+    return userGroupIndices.map((groupIndex, pos) => {
+      const qRaw = textContent(completedGroups[groupIndex].messages[0]);
+      const scheduledTask = parseScheduledTaskMessage(qRaw);
+      const webhook = parseWebhookMessage(qRaw);
+      const question = (
+        scheduledTask
+          ? `定时：${scheduledTask.name || '未命名任务'}`
+          : webhook
+            ? `Webhook：${webhook.name || '未命名触发'}`
+            : qRaw
+      ).trim().slice(0, 160);
+      // 提问之后、下一条提问之前的回答里，取第一段有文字的回复
+      let answer = '';
+      for (let j = groupIndex + 1; j < completedGroups.length; j++) {
+        if (completedGroups[j].type === 'user') break;
+        const text = completedGroups[j].messages.map(m => textContent(m)).join('\n').trim();
+        if (text) { answer = text; break; }
+      }
+      return {
+        pos,
+        groupIndex,
+        question,
+        answer: answer.slice(0, 360),
+        docRatio: (measurements[groupIndex]?.start ?? 0) / totalSize,
+      };
+    });
+  }, [userGroupIndices, completedGroups, totalSize]);
+
+  // 节点在刻度尺轨道上的像素位置（常显淡杠用）
+  const nodeTops = useMemo(() => {
+    if (!(rulerTrackH > 0)) return [];
+    return turnNodes.map(n => Math.round(n.docRatio * rulerTrackH));
+  }, [turnNodes, rulerTrackH]);
+
+  // hover 吸附：按轨道像素距离取最近的会话轮节点
+  const railActiveNodeIdx = (() => {
+    const trackH = railHoverInfo?.trackH ?? rulerTrackH;
+    if (!railHoverInfo || turnNodes.length === 0 || !(trackH > 0)) return -1;
+    let best = 0;
+    let bestDist = Infinity;
+    for (let i = 0; i < turnNodes.length; i++) {
+      const top = turnNodes[i].docRatio * trackH;
+      const dist = Math.abs(top - railHoverInfo.y);
+      if (dist < bestDist) { bestDist = dist; best = i; }
     }
-    const sigma = 2;
-    const windowSize = 9;
-    const half = Math.floor(windowSize / 2);
-    // 以游标为中心取 [-half, +half] 范围，裁剪到 [0, userCount-1]
-    const points: { groupIndex: number; pos: number; size: number }[] = [];
-    for (let off = -half; off <= half; off++) {
-      const pos = railCursor + off;
-      if (pos < 0 || pos >= userCount) continue;
-      // 高斯权重映射到点尺寸（0.5 ~ 1.0），中心 1.0，边缘 ~0.5
-      const w = Math.exp(-(off * off) / (2 * sigma * sigma));
-      const size = 0.5 + 0.5 * w;
-      points.push({ groupIndex: userGroupIndices[pos], pos, size });
-    }
-    return points;
-  }, [railSpread, userGroupIndices, railCursor, userCount]);
+    return best;
+  })();
 
   return (
     <div className="relative h-full">
@@ -942,137 +920,77 @@ export function MessageList() {
 
     {/* 右侧刻度尺滚动条：常驻贴右缘，整列均匀小横线刻度，当前视口对应区间的
         刻度变亮（内容极长时表现为一条亮横杠）；点击/拖动直接映射滚动，
-        无可滚动内容时自动隐藏。替代原生滚动条与旧半透明圆角轨道条。 */}
-    <RulerScrollbar viewportRef={viewportRef} />
+        悬停在刻度尺上滚动滚轮可快速翻动长对话；无可滚动内容时自动隐藏。
+        悬停时刻度变亮、显示吸附节点亮杠，并在其左侧弹出问答预览小卡片；
+        各提问节点以淡色横杠常显。 */}
+    <RulerScrollbar
+      viewportRef={viewportRef}
+      markerTops={nodeTops}
+      activeMarker={railActiveNodeIdx >= 0 ? railActiveNodeIdx : null}
+      onLayout={setRulerTrackH}
+      onHover={(info) => {
+        if (railPreviewHideTimerRef.current) {
+          window.clearTimeout(railPreviewHideTimerRef.current);
+          railPreviewHideTimerRef.current = null;
+        }
+        if (info) {
+          setRailHoverInfo(info);
+        } else {
+          // 延迟隐藏，给指针移入预览卡片留出桥接时间
+          railPreviewHideTimerRef.current = window.setTimeout(() => {
+            setRailHoverInfo(null);
+            railPreviewHideTimerRef.current = null;
+          }, 220);
+        }
+      }}
+    />
 
-    {/* 右侧百分比磁吸轨道：离开底部时，鼠标移入右侧区域才显示。
-        ≤9 条平铺等间距；>9 条按游标（hover/激活）做高斯窗口，渲染离游标最近的 9 个点，
-        中心点最大并向两侧正态衰减；每点显示预览，点 hover 可点选跳转；
-        滚动位置指示由左侧的刻度尺滚动条承担，本层只负责按提问跳转。
-        外层为 group + 透明感应条（让开右侧 20px 刻度尺区域）捕获 hover；内部交互层用
-        group-hover 控制显隐，避免感应区过大遮挡消息内容。 */}
+    {/* 刻度尺 hover 弹出的问答预览小卡片 */}
+    {railHoverInfo && railActiveNodeIdx >= 0 && (() => {
+      const node = turnNodes[railActiveNodeIdx];
+      // 以卡片估算半高做防溢出 clamp，贴边时不越出会话区
+      const half = 88;
+      const cardTop = Math.min(Math.max(railHoverInfo.y, half), Math.max(half, railHoverInfo.trackH - half));
+      return (
+        <div
+          className="ruler-card-enter absolute z-30"
+          style={{ right: 30, top: cardTop, transform: 'translateY(-50%)' }}
+          onMouseEnter={() => {
+            if (railPreviewHideTimerRef.current) {
+              window.clearTimeout(railPreviewHideTimerRef.current);
+              railPreviewHideTimerRef.current = null;
+            }
+          }}
+          onMouseLeave={() => {
+            if (railPreviewHideTimerRef.current) window.clearTimeout(railPreviewHideTimerRef.current);
+            railPreviewHideTimerRef.current = window.setTimeout(() => {
+              setRailHoverInfo(null);
+              railPreviewHideTimerRef.current = null;
+            }, 220);
+          }}
+        >
+          <TurnPreviewCard
+            question={node.question}
+            answer={node.answer}
+            onClick={() => {
+              setRailHoverInfo(null);
+              scrollToUserGroupTop(node.groupIndex);
+            }}
+          />
+        </div>
+      );
+    })()}
+
+    {/* 右下角导航按钮组：离开底部时出现；逐条跳转与回底由刻度尺旁边的按钮承担 */}
     {userCount > 0 && (
       <div
-        // pointer-events-none：容器矩形不得拦截下层刻度尺滚动条的点击/拖动，
-        // 需要交互的子元素（感应条/轨道层/按钮组）各自恢复 auto
-        className={`group pointer-events-none absolute inset-y-0 right-0 z-20 flex flex-col items-end transition-opacity duration-200 ${
+        className={`pointer-events-none absolute inset-y-0 right-0 z-30 flex items-end pb-2 pr-1 transition-opacity duration-200 ${
           isAtBottom ? 'opacity-0' : 'opacity-100'
         }`}
       >
-        {/* 透明 hover 感应条（20px 宽，位于刻度尺左侧），仅捕获鼠标进出触发 group-hover；
-            不覆盖刻度尺，保证拖动滚动条时不误弹磁吸点列。 */}
-        <div className="pointer-events-auto absolute inset-y-0 right-5 w-5" />
-        {/* 轨道主体：百分比磁吸。点列块整体跟随鼠标 Y 平移（中心点贴鼠标），
-            内容随游标变化 —— 跟随、可点选、百分比三者统一 */}
-        <div
-          ref={railTrackRef}
-          className={`pointer-events-none relative flex min-h-0 flex-1 flex-col items-end py-1 transition-opacity duration-150 opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 ${
-            railHovered ? 'pointer-events-auto !opacity-100' : ''
-          }`}
-          onMouseMove={(e) => {
-            const rect = e.currentTarget.getBoundingClientRect();
-            const ratio = Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height));
-            // 更新点列块平移比例
-            if (ratio !== hoverRatioRef.current) {
-              hoverRatioRef.current = ratio;
-              // 计算 clamp + 吸附后的 top 像素，避免滑到顶/底时块超出轨道被裁
-              setDotsTopPx(calcDotsTop(ratio));
-            }
-            // 鼠标 Y 比例映射到用户提问序号
-            const pos = Math.round(ratio * (userCount - 1));
-            if (pos >= 0 && pos < userCount && pos !== hoverUserPosRef.current) {
-              hoverUserPosRef.current = pos;
-              setHoverUserPos(pos);
-            }
-          }}
-          onMouseEnter={() => {
-            if (railHideTimerRef.current) {
-              window.clearTimeout(railHideTimerRef.current);
-              railHideTimerRef.current = null;
-            }
-            setRailHovered(true);
-          }}
-          onMouseLeave={() => {
-            // 冻结在鼠标移出时的最后位置：不重置 hoverRatio/hoverUserPos，
-            // 保证鼠标移到正态点上点选时仍是正确的消息位置；
-            // 仅启动 1.5s 隐藏定时器
-            if (railHideTimerRef.current) window.clearTimeout(railHideTimerRef.current);
-            railHideTimerRef.current = window.setTimeout(() => {
-              setRailHovered(false);
-              railHideTimerRef.current = null;
-            }, 1500);
-          }}
-        >
-          {(railSpread ? showRailDots : true) && (
-          <TooltipProvider delayDuration={200}>
-            {/* 点列块：absolute 定位，top 按鼠标 Y 计算（clamp 防溢出），
-                内容随游标变化。right-7 让点列位于 15px 滑轨左侧并留出间距 */}
-            <div
-              ref={railDotsRef}
-              className="absolute right-7 flex flex-col items-end gap-1.5"
-              onMouseMove={(e) => e.stopPropagation()}
-              style={{
-                // 顶边定位（已 clamp + 吸附），避免 translateY(-50%) 在端点溢出被裁；
-                // dotsTopPx 为 null（首次未移动）时居中兜底
-                top: dotsTopPx != null ? `${dotsTopPx}px` : '50%',
-                transform: dotsTopPx != null ? 'none' : 'translateY(-50%)',
-                transition: 'top 0.18s cubic-bezier(0.22, 0.61, 0.36, 1), opacity 0.15s',
-              }}
-            >
-              {railPoints.map((p, slotIdx) => {
-                const preview = userPreviews[p.pos];
-                const active = p.pos === activeUserPos;
-                // 每个点都显示消息预览：按高斯权重调整字号与透明度，中心点最醒目
-                const opacity = 0.45 + p.size * 0.55;
-                const fontSize = 9 + Math.round(p.size * 3); // 9~12px
-                return (
-                  <div key={slotIdx} className="flex items-center gap-1.5">
-                    <span
-                      className="max-w-[140px] truncate text-muted-foreground"
-                      style={{
-                        opacity,
-                        fontSize: `${fontSize}px`,
-                        // 文本透明度与字号变化平滑过渡，与点动画同步
-                        transition: 'opacity 0.2s ease-out, font-size 0.2s ease-out',
-                      }}
-                    >
-                      {preview}
-                    </span>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={() => scrollToUserGroupTop(p.groupIndex)}
-                          aria-label={`跳转到用户提问：${preview}`}
-                          style={{
-                            // 固定基础尺寸 12px（中心点最大），用 transform: scale 按高斯权重
-                            // 缩放（0.5~1.0）。transform 走 GPU 合成层，过渡比 width/height 更流畅
-                            width: 12,
-                            height: 12,
-                            transform: `scale(${p.size})`,
-                            transition: 'transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), background-color 0.15s ease-out',
-                          }}
-                          className={`rounded-full ${
-                            active
-                              ? 'bg-primary'
-                              : 'bg-muted-foreground/50 hover:bg-muted-foreground'
-                          }`}
-                        />
-                      </TooltipTrigger>
-                      <TooltipContent side="left" className="max-w-[200px] text-xs break-all">
-                        {preview}
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                );
-              })}
-            </div>
-          </TooltipProvider>
-          )}
-        </div>
-
-        {/* 滚动按钮组：独立钉在右下角，不透明背景遮挡溢出 */}
-        <div className="pointer-events-auto relative z-30 mt-2 flex flex-col items-center gap-2 rounded-lg bg-background/80 p-1 shadow-md backdrop-blur">
+        <div className={`flex flex-col items-center gap-2 rounded-lg bg-background/80 p-1 shadow-md backdrop-blur ${
+          isAtBottom ? 'pointer-events-none' : 'pointer-events-auto'
+        }`}>
           <button
             type="button"
             onClick={scrollToPrevUserMessage}

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -3,6 +3,7 @@ import { useSearchStore } from "@/store/useSearchStore";
 import { findSearchMatches } from "@/utils/search";
 import { SearchBar } from "./SearchBar";
 import { ScrollArea } from "./ui/scroll-area";
+import { RulerScrollbar } from "./ui/ruler-scrollbar";
 import {
   Loader2,
   Cpu,
@@ -939,21 +940,28 @@ export function MessageList() {
       </div>
     </ScrollArea>
 
-    {/* 右侧百分比磁吸轨道：离开底部时，鼠标移入右侧区域才显示。替代原生滚动条，贴右边缘。
+    {/* 右侧刻度尺滚动条：常驻贴右缘，整列均匀小横线刻度，当前视口对应区间的
+        刻度变亮（内容极长时表现为一条亮横杠）；点击/拖动直接映射滚动，
+        无可滚动内容时自动隐藏。替代原生滚动条与旧半透明圆角轨道条。 */}
+    <RulerScrollbar viewportRef={viewportRef} />
+
+    {/* 右侧百分比磁吸轨道：离开底部时，鼠标移入右侧区域才显示。
         ≤9 条平铺等间距；>9 条按游标（hover/激活）做高斯窗口，渲染离游标最近的 9 个点，
-        中心点最大并向两侧正态衰减；每点显示预览，点 hover 可点选跳转，
-        点击轨道空白按百分比跳转；背景条带滚动位置 thumb 指示当前视图。
-        外层为 group + 透明感应条（w-6）捕获 hover；内部交互层用 group-hover 控制显隐，
-        避免感应区过大遮挡消息内容。 */}
+        中心点最大并向两侧正态衰减；每点显示预览，点 hover 可点选跳转；
+        滚动位置指示由左侧的刻度尺滚动条承担，本层只负责按提问跳转。
+        外层为 group + 透明感应条（让开右侧 20px 刻度尺区域）捕获 hover；内部交互层用
+        group-hover 控制显隐，避免感应区过大遮挡消息内容。 */}
     {userCount > 0 && (
       <div
-        className={`group absolute inset-y-0 right-0 z-20 flex flex-col items-end transition-opacity duration-200 ${
+        // pointer-events-none：容器矩形不得拦截下层刻度尺滚动条的点击/拖动，
+        // 需要交互的子元素（感应条/轨道层/按钮组）各自恢复 auto
+        className={`group pointer-events-none absolute inset-y-0 right-0 z-20 flex flex-col items-end transition-opacity duration-200 ${
           isAtBottom ? 'opacity-0' : 'opacity-100'
         }`}
       >
-        {/* 透明 hover 感应条：贴右边缘（24px 宽），仅捕获鼠标进出触发 group-hover。
-            不影响消息内容交互（消息内容不延伸到最右 24px 内的概率极低）。 */}
-        <div className="absolute inset-y-0 right-0 w-6" />
+        {/* 透明 hover 感应条（20px 宽，位于刻度尺左侧），仅捕获鼠标进出触发 group-hover；
+            不覆盖刻度尺，保证拖动滚动条时不误弹磁吸点列。 */}
+        <div className="pointer-events-auto absolute inset-y-0 right-5 w-5" />
         {/* 轨道主体：百分比磁吸。点列块整体跟随鼠标 Y 平移（中心点贴鼠标），
             内容随游标变化 —— 跟随、可点选、百分比三者统一 */}
         <div
@@ -995,22 +1003,6 @@ export function MessageList() {
             }, 1500);
           }}
         >
-          {/* 轨道背景条：贴右边缘，替代原生滚动条 */}
-          <div className="absolute inset-y-2 right-1 w-[15px] rounded-full bg-muted-foreground/15" />
-          <button
-            type="button"
-            data-rail="bg"
-            aria-label="按百分比跳转到用户提问"
-            onClick={(e) => {
-              const rect = e.currentTarget.getBoundingClientRect();
-              const ratio = Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height));
-              const pos = Math.round(ratio * (userCount - 1));
-              if (pos >= 0 && pos < userCount) {
-                scrollToUserGroupTop(userGroupIndices[pos]);
-              }
-            }}
-            className="absolute inset-y-2 right-1 w-[15px] cursor-pointer"
-          />
           {(railSpread ? showRailDots : true) && (
           <TooltipProvider delayDuration={200}>
             {/* 点列块：absolute 定位，top 按鼠标 Y 计算（clamp 防溢出），

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -90,13 +90,10 @@ export function MessageList() {
   const editingGenerationRef = useRef(0);
   const editingBaseContentRef = useRef<ContentBlock[]>([]);
   const editingTextareaRef = useRef<MentionEditorHandle>(null!);
-  const [isAtBottom, setIsAtBottom] = useState(true);
   const isAtBottomRef = useRef(true);
-  // 刻度尺 hover 预览：指针在轨道内的 y 与轨道总高；null 表示未悬停
-  const [railHoverInfo, setRailHoverInfo] = useState<{ y: number; trackH: number } | null>(null);
+  // 用户消息边栏 hover：命中的用户消息序号及预览卡片位置
+  const [railHoverInfo, setRailHoverInfo] = useState<{ markerIndex: number; y: number; trackH: number } | null>(null);
   const railPreviewHideTimerRef = useRef<number | null>(null);
-  // 刻度尺轨道高度（挂载/尺寸变化时上报一次），用于把节点文档比例换算为像素
-  const [rulerTrackH, setRulerTrackH] = useState(0);
 
   // 检查 TTS 能力
   useEffect(() => {
@@ -108,7 +105,6 @@ export function MessageList() {
     useSearchStore.getState().closeSearch();
     // 切换会话视为重新进入，默认在底部
     isAtBottomRef.current = true;
-    setIsAtBottom(true);
   }, [activeSessionId]);
 
   // 卸载时清理刻度尺预览卡片的隐藏定时器
@@ -126,7 +122,6 @@ export function MessageList() {
       const next = distance < threshold;
       if (next !== isAtBottomRef.current) {
         isAtBottomRef.current = next;
-        setIsAtBottom(next);
       }
     };
     el.addEventListener('scroll', handleScroll, { passive: true });
@@ -361,8 +356,7 @@ export function MessageList() {
     // 用户翻动页面离开底部后跟随自动关闭，拉回最底部时由滚动事件重新开启
     if (isUserSelfSent) {
       isAtBottomRef.current = true;
-      setIsAtBottom(true);
-    }
+      }
     // 用户离开底部时，新消息/流式 id 变化不强制拉回；tab 切换与用户主动发送始终跟随
     const shouldScroll =
       tabChanged
@@ -426,7 +420,6 @@ export function MessageList() {
     if (!el) return;
     el.scrollTo({ top: el.scrollHeight, behavior: 'auto' });
     isAtBottomRef.current = true;
-    setIsAtBottom(true);
   }, []);
 
   // 滚动到指定 group 并对齐到视口顶部：两阶段定位避免虚拟列表估算高度导致的偏差
@@ -441,7 +434,6 @@ export function MessageList() {
       });
     });
     isAtBottomRef.current = false;
-    setIsAtBottom(false);
   }, [virtualizer]);
 
   // 根据参考 index 找到当前"游标"在 userGroupIndices 中的位置
@@ -669,12 +661,9 @@ export function MessageList() {
   // ---- 会话导航 ----
   const userCount = userGroupIndices.length;
 
-  // ---- 刻度尺 hover 预览的节点数据 ----
-  // 每轮会话：用户提问摘要 + 其后第一个有文字的回答轮摘要 + 全文比例位置
-  const totalSize = virtualizer.getTotalSize();
+  // ---- 用户消息边栏节点数据 ----
+  // 每根横条严格对应一条用户消息，顺序与 userGroupIndices 一致。
   const turnNodes = useMemo(() => {
-    if (!(totalSize > 0)) return [];
-    const measurements = virtualizer.measurementsCache;
     return userGroupIndices.map((groupIndex, pos) => {
       const qRaw = textContent(completedGroups[groupIndex].messages[0]);
       const scheduledTask = parseScheduledTaskMessage(qRaw);
@@ -686,42 +675,25 @@ export function MessageList() {
             ? `Webhook：${webhook.name || '未命名触发'}`
             : qRaw
       ).trim().slice(0, 160);
-      // 提问之后、下一条提问之前的回答里，取第一段有文字的回复
       let answer = '';
       for (let j = groupIndex + 1; j < completedGroups.length; j++) {
         if (completedGroups[j].type === 'user') break;
         const text = completedGroups[j].messages.map(m => textContent(m)).join('\n').trim();
         if (text) { answer = text; break; }
       }
-      return {
-        pos,
-        groupIndex,
-        question,
-        answer: answer.slice(0, 360),
-        docRatio: (measurements[groupIndex]?.start ?? 0) / totalSize,
-      };
+      return { pos, groupIndex, question, answer: answer.slice(0, 360) };
     });
-  }, [userGroupIndices, completedGroups, totalSize]);
+  }, [userGroupIndices, completedGroups]);
 
-  // 节点在刻度尺轨道上的像素位置（常显淡杠用）
-  const nodeTops = useMemo(() => {
-    if (!(rulerTrackH > 0)) return [];
-    return turnNodes.map(n => Math.round(n.docRatio * rulerTrackH));
-  }, [turnNodes, rulerTrackH]);
-
-  // hover 吸附：按轨道像素距离取最近的会话轮节点
-  const railActiveNodeIdx = (() => {
-    const trackH = railHoverInfo?.trackH ?? rulerTrackH;
-    if (!railHoverInfo || turnNodes.length === 0 || !(trackH > 0)) return -1;
-    let best = 0;
-    let bestDist = Infinity;
-    for (let i = 0; i < turnNodes.length; i++) {
-      const top = turnNodes[i].docRatio * trackH;
-      const dist = Math.abs(top - railHoverInfo.y);
-      if (dist < bestDist) { bestDist = dist; best = i; }
-    }
-    return best;
+  // 正文当前可见位置对应的用户消息，用于边栏弱高亮。
+  const activeUserPos = (() => {
+    if (userGroupIndices.length === 0) return -1;
+    const item = virtualizer.getVirtualItemForOffset(virtualizer.scrollOffset ?? 0);
+    if (!item) return -1;
+    return findUserCursorPos(item.index);
   })();
+
+  const railActiveNodeIdx = railHoverInfo?.markerIndex ?? -1;
 
   return (
     <div className="relative h-full">
@@ -918,16 +890,19 @@ export function MessageList() {
       </div>
     </ScrollArea>
 
-    {/* 右侧刻度尺滚动条：常驻贴右缘，整列均匀小横线刻度，当前视口对应区间的
-        刻度变亮（内容极长时表现为一条亮横杠）；点击/拖动直接映射滚动，
-        悬停在刻度尺上滚动滚轮可快速翻动长对话；无可滚动内容时自动隐藏。
-        悬停时刻度变亮、显示吸附节点亮杠，并在其左侧弹出问答预览小卡片；
-        各提问节点以淡色横杠常显。 */}
+    {/* 右侧导航区：横条边栏与三个导航按钮共用鼠标移入显示逻辑。
+        边栏始终为按钮组预留底部空间，避免最后几根横条被遮挡。 */}
+    {userCount > 0 && (
+    <div className="group/navigation absolute inset-y-0 right-0 z-20 w-[54px]">
     <RulerScrollbar
-      viewportRef={viewportRef}
-      markerTops={nodeTops}
-      activeMarker={railActiveNodeIdx >= 0 ? railActiveNodeIdx : null}
-      onLayout={setRulerTrackH}
+      markerCount={turnNodes.length}
+      bottomInset={152}
+      className="opacity-0 transition-opacity duration-200 group-hover/navigation:opacity-100 group-focus-within/navigation:opacity-100"
+      currentMarker={activeUserPos >= 0 ? activeUserPos : null}
+      onSelect={(markerIndex) => {
+        const node = turnNodes[markerIndex];
+        if (node) scrollToUserGroupTop(node.groupIndex);
+      }}
       onHover={(info) => {
         if (railPreviewHideTimerRef.current) {
           window.clearTimeout(railPreviewHideTimerRef.current);
@@ -954,7 +929,7 @@ export function MessageList() {
       return (
         <div
           className="ruler-card-enter absolute z-30"
-          style={{ right: 30, top: cardTop, transform: 'translateY(-50%)' }}
+          style={{ right: 56, top: cardTop, transform: 'translateY(-50%)' }}
           onMouseEnter={() => {
             if (railPreviewHideTimerRef.current) {
               window.clearTimeout(railPreviewHideTimerRef.current);
@@ -981,16 +956,9 @@ export function MessageList() {
       );
     })()}
 
-    {/* 右下角导航按钮组：离开底部时出现；逐条跳转与回底由刻度尺旁边的按钮承担 */}
-    {userCount > 0 && (
-      <div
-        className={`pointer-events-none absolute inset-y-0 right-0 z-30 flex items-end pb-2 pr-1 transition-opacity duration-200 ${
-          isAtBottom ? 'opacity-0' : 'opacity-100'
-        }`}
-      >
-        <div className={`flex flex-col items-center gap-2 rounded-lg bg-background/80 p-1 shadow-md backdrop-blur ${
-          isAtBottom ? 'pointer-events-none' : 'pointer-events-auto'
-        }`}>
+    {/* 右下角导航按钮组：与横条边栏一起在鼠标进入右侧导航区时显示。 */}
+      <div className="pointer-events-none absolute inset-y-0 right-0 z-30 flex items-end pb-2 pr-1 opacity-0 transition-opacity duration-200 group-hover/navigation:opacity-100 group-focus-within/navigation:opacity-100">
+        <div className="pointer-events-none flex flex-col items-center gap-2 rounded-lg bg-background/80 p-1 shadow-md backdrop-blur group-hover/navigation:pointer-events-auto group-focus-within/navigation:pointer-events-auto">
           <button
             type="button"
             onClick={scrollToPrevUserMessage}
@@ -1020,6 +988,7 @@ export function MessageList() {
           </button>
         </div>
       </div>
+    </div>
     )}
     </div>
   );

--- a/frontend/src/components/ui/ruler-scrollbar.tsx
+++ b/frontend/src/components/ui/ruler-scrollbar.tsx
@@ -4,12 +4,27 @@ import { cn } from "@/lib/utils"
 /**
  * 刻度尺式竖直滚动条：整条高度均匀铺满小横线刻度，当前视口对应区间的
  * 刻度整体转亮（内容极长时表现为一条亮横杠），形似编辑器 overview ruler。
- * 点击/拖动任意位置直接映射滚动；无可滚动内容时整体隐藏。
+ * 点击/拖动任意位置直接映射滚动；悬停时滚轮可直接翻动视口内容；
+ * 无可滚动内容时整体隐藏。
+ *
+ * 节点横杠：markerTops 以淡色短杠常显（相邻过近时合并），
+ * hover 吸附的节点显示为发光亮杠；通过 onHover 把指针 Y 上报给父层
+ * （父层负责展示问答预览小卡片）。onLayout 在轨道尺寸变化时上报高度。
  */
 interface RulerScrollbarProps {
   viewportRef: React.RefObject<HTMLDivElement | null>
   /** 刻度垂直间距（px） */
   tickSpacing?: number
+  /** 各预览节点在轨道内的 y 坐标（px），由父层按文档位置换算 */
+  markerTops?: number[]
+  /** 当前 hover 吸附的节点下标；hover 时在该 y 处渲染亮杠标记 */
+  activeMarker?: number | null
+  /** hover 变化回调：y 为相对轨道顶部的像素、trackH 为轨道总高，null 表示移出/拖动中 */
+  onHover?: (info: { y: number; trackH: number } | null) => void
+  /** 轨道高度变化回调（挂载/窗口尺寸变化时），用于父层把文档比例换算为像素 */
+  onLayout?: (trackH: number) => void
+  /** 悬停刻度尺滚动滚轮时的速度倍率（相对正常滚动幅度） */
+  wheelBoost?: number
   className?: string
 }
 
@@ -17,7 +32,16 @@ interface RulerScrollbarProps {
 const TICK_LEFT = 3
 const TICK_WIDTH = 13
 
-export function RulerScrollbar({ viewportRef, tickSpacing = 8, className }: RulerScrollbarProps) {
+export function RulerScrollbar({
+  viewportRef,
+  tickSpacing = 8,
+  markerTops,
+  activeMarker = null,
+  onHover,
+  onLayout,
+  wheelBoost = 3,
+  className,
+}: RulerScrollbarProps) {
   const rootRef = React.useRef<HTMLDivElement>(null)
   const dragRef = React.useRef<{ grabOffset: number } | null>(null)
   const [hovered, setHovered] = React.useState(false)
@@ -57,6 +81,26 @@ export function RulerScrollbar({ viewportRef, tickSpacing = 8, className }: Rule
   const { trackH, scrollTop, scrollHeight, clientHeight } = dims
   const scrollable = trackH > 0 && scrollHeight - clientHeight > 4
 
+  // 轨道高度变化时上报给父层（首次挂载也触发一次）
+  React.useEffect(() => {
+    onLayout?.(trackH)
+  }, [trackH, onLayout])
+
+  // 悬停时刻度尺上滚动滚轮 → 直接翻动视口内容（倍速，便于超长对话跳转）。
+  // React 的 onWheel 是被动监听无法 preventDefault，这里用原生监听接管。
+  React.useEffect(() => {
+    const root = rootRef.current
+    const el = viewportRef.current
+    if (!root || !el) return
+    const onWheel = (e: WheelEvent) => {
+      if (!(el.scrollHeight - el.clientHeight > 4)) return
+      e.preventDefault()
+      el.scrollBy({ top: e.deltaY * wheelBoost })
+    }
+    root.addEventListener("wheel", onWheel, { passive: false })
+    return () => root.removeEventListener("wheel", onWheel)
+  }, [viewportRef, wheelBoost, scrollable])
+
   const maxScroll = Math.max(1, scrollHeight - clientHeight)
   // thumb 高度按视口占比取值，最小一格刻度——内容极长时恰好只亮一条线
   const thumbH = Math.min(trackH, Math.max(tickSpacing, Math.round(trackH * (clientHeight / Math.max(1, scrollHeight)))))
@@ -78,6 +122,8 @@ export function RulerScrollbar({ viewportRef, tickSpacing = 8, className }: Rule
   const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!scrollable || !viewportRef.current) return
     e.preventDefault()
+    // 开始滚动定位：预览卡片立即退场，避免视觉残留
+    onHover?.(null)
     const rect = rootRef.current?.getBoundingClientRect()
     if (!rect) return
     const yInTrack = e.clientY - rect.top
@@ -91,7 +137,15 @@ export function RulerScrollbar({ viewportRef, tickSpacing = 8, className }: Rule
   }
 
   const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (dragRef.current) applyClientY(e.clientY)
+    if (dragRef.current) {
+      applyClientY(e.clientY)
+      return
+    }
+    // 非拖动的悬停：把指针 Y 报给父层用于吸附节点与预览卡片
+    if (onHover && trackH > 0) {
+      const rect = rootRef.current?.getBoundingClientRect()
+      if (rect) onHover({ y: Math.min(Math.max(e.clientY - rect.top, 0), trackH), trackH })
+    }
   }
 
   const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -107,8 +161,9 @@ export function RulerScrollbar({ viewportRef, tickSpacing = 8, className }: Rule
   // 亮层盒子裁出当前视口区间 → 区间内的刻度变亮
   const tickPattern = (lineColor: string) =>
     `repeating-linear-gradient(to bottom, ${lineColor} 0px, ${lineColor} 1px, transparent 1px, transparent ${tickSpacing}px)`
-  const idleLine = `hsl(var(--muted-foreground) / ${hovered ? 0.38 : 0.26})`
-  const activeLine = `hsl(var(--foreground) / ${hovered ? 0.85 : 0.6})`
+  const idleLine = `hsl(var(--muted-foreground) / ${hovered ? 0.45 : 0.26})`
+  const activeLine = `hsl(var(--foreground) / ${hovered ? 0.9 : 0.6})`
+  const markerTop = hovered && activeMarker != null ? markerTops?.[activeMarker] ?? null : null
 
   return (
     <div
@@ -130,17 +185,49 @@ export function RulerScrollbar({ viewportRef, tickSpacing = 8, className }: Rule
       onPointerUp={endDrag}
       onPointerCancel={endDrag}
       onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      onMouseLeave={() => {
+        setHovered(false)
+        onHover?.(null)
+      }}
     >
+      {/* 悬停底板：给刻度一个可感知的落区 */}
+      {hovered && (
+        <div className="absolute inset-y-1 right-0 w-[21px] rounded-lg bg-muted/50 shadow-[inset_0_0_0_1px_hsl(var(--border))]" />
+      )}
       {/* 暗刻度轨道 */}
       <div
-        className="absolute bottom-0 top-0 border-r border-muted-foreground/15"
+        className="absolute bottom-0 top-0"
         style={{
           left: TICK_LEFT,
-          width: TICK_WIDTH,
+          width: TICK_WIDTH + 3,
           backgroundImage: tickPattern(idleLine),
+          backgroundSize: `${TICK_WIDTH}px 100%`,
+          backgroundRepeat: 'no-repeat',
         }}
       />
+      {/* 淡竖分隔线贴刻度右缘 */}
+      <div className="absolute bottom-0 top-0 w-px bg-muted-foreground/15" style={{ left: TICK_LEFT + TICK_WIDTH + 2 }} />
+      {/* 常显节点淡杠：每条提问在全文中的位置；相邻过近时合并避免糊成一片 */}
+      {markerTops && markerTops.length > 0 && (() => {
+        const bars: number[] = []
+        for (const raw of markerTops) {
+          const top = Math.min(Math.max(Math.round(raw), 0), Math.max(0, trackH - 1))
+          if (bars.length === 0 || top - bars[bars.length - 1] >= 4) bars.push(top)
+        }
+        return bars.map((top, i) => (
+          <div
+            key={i}
+            className="absolute rounded-full"
+            style={{
+              left: TICK_LEFT,
+              width: TICK_WIDTH,
+              top,
+              height: 1.5,
+              background: 'hsl(var(--muted-foreground) / 0.35)',
+            }}
+          />
+        ))
+      })()}
       {/* 亮 thumb 层：overflow 裁出视口区间，内部纹样与全局相位对齐 */}
       <div
         className="absolute overflow-hidden"
@@ -153,6 +240,53 @@ export function RulerScrollbar({ viewportRef, tickSpacing = 8, className }: Rule
           backgroundPositionY: `${-thumbTop}px`,
         }}
       />
+      {/* 吸附节点亮杠：指示 hover 命中的提问在全文中的位置 */}
+      {markerTop != null && (
+        <div
+          className="pointer-events-none absolute rounded-full bg-primary shadow-[0_0_6px_hsl(var(--primary)/0.8)]"
+          style={{ left: TICK_LEFT - 2, top: Math.round(markerTop) - 1.5, width: TICK_WIDTH + 4, height: 3 }}
+        />
+      )}
     </div>
+  )
+}
+
+/**
+ * 会话预览小卡片：上方为用户提问、下方为回答摘要，整卡可点击跳转该轮会话。
+ * 独立导出以便复用与单独验证。
+ */
+export function TurnPreviewCard({
+  question,
+  answer,
+  onClick,
+  className,
+  style,
+}: {
+  question: string
+  answer: string
+  onClick?: () => void
+  className?: string
+  style?: React.CSSProperties
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "block w-[290px] cursor-pointer rounded-xl border border-border/80 bg-background/95 p-3 text-left shadow-xl backdrop-blur-md",
+        "transition-transform duration-150 hover:border-muted-foreground/40",
+        className,
+      )}
+      style={style}
+    >
+      {/* 提问（前景色加粗）与回答摘要（弱化灰）以颜色区分，不加文字标签 */}
+      <div className="line-clamp-2 whitespace-pre-wrap break-words text-xs font-medium leading-5 text-foreground">
+        {question || '(空消息)'}
+      </div>
+      <div className="my-2 border-t border-border/60" />
+      <div className="line-clamp-3 whitespace-pre-wrap break-words text-xs leading-5 text-muted-foreground">
+        {answer.trim() || '(本轮暂无文字回复)'}
+      </div>
+    </button>
   )
 }

--- a/frontend/src/components/ui/ruler-scrollbar.tsx
+++ b/frontend/src/components/ui/ruler-scrollbar.tsx
@@ -1,277 +1,206 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
 
-/**
- * 刻度线式竖直滚动条：整条高度由固定间距的短横线组成（flex 布局逐条排列，
- * 每格定高保证刚性等距），当前视口对应的区段横线转亮，形似编辑器 overview ruler。
- * 点击/拖动任意位置直接映射滚动；悬停时滚轮可直接翻动视口内容；
- * 无可滚动内容时整体隐藏。
- *
- * 节点指示：markerTops 对应的横线常显为加重色，hover 吸附的节点进一步
- * 显示为发光亮杠；onHover 把指针 Y 上报给父层展示问答预览卡片，
- * onLayout 在轨道尺寸变化时上报高度。
- */
 interface RulerScrollbarProps {
-  viewportRef: React.RefObject<HTMLDivElement | null>
-  /** 刻度垂直间距（px），也是每根横线所在格子的固定高度 */
-  tickSpacing?: number
-  /** 各预览节点在轨道内的 y 坐标（px），由父层按文档位置换算 */
-  markerTops?: number[]
-  /** 当前 hover 吸附的节点下标；hover 时在该节点横线上渲染发光亮杠 */
-  activeMarker?: number | null
-  /** hover 变化回调：y 为相对轨道顶部的像素、trackH 为轨道总高，null 表示移出/拖动中 */
-  onHover?: (info: { y: number; trackH: number } | null) => void
-  /** 轨道高度变化回调（挂载/窗口尺寸变化时），用于父层把文档比例换算为像素 */
-  onLayout?: (trackH: number) => void
-  /** 悬停刻度尺滚动滚轮时的速度倍率（相对正常滚动幅度） */
-  wheelBoost?: number
+  /** 用户消息数量；边栏严格按一条用户消息生成一根横条 */
+  markerCount: number
+  /** 当前消息列表所在位置对应的用户消息 */
+  currentMarker?: number | null
+  /** 鼠标命中的用户消息；用于父层展示预览 */
+  onHover?: (info: { markerIndex: number; y: number; trackH: number } | null) => void
+  /** 点击横条时跳转到对应用户消息 */
+  onSelect?: (markerIndex: number) => void
+  /** 底部需要避让的高度，例如右下角导航按钮组 */
+  bottomInset?: number
   className?: string
 }
 
-// 横线的宽度：普通刻度稍窄，落在刻度列右侧、朝左伸向内容方向，右缘留一根淡竖分隔线
-const TICK_RIGHT = 10
-const TICK_WIDTH = 13
+const ROW_HEIGHT = 12
+const TRACK_PADDING = 10
+const BASE_WIDTH = 11
+const GAUSS_SIGMA = 34
+const GAUSS_EXTRA_WIDTH = 34
 
-// 正态（高斯）悬停效果参数：σ 越小中心的横线越突出；
-// 中心横线在基础宽度上最多再加 GAUSS_EXTRA_WIDTH px
-const GAUSS_SIGMA = 26
-const GAUSS_EXTRA_WIDTH = 13
-
+/**
+ * 用户消息导航边栏。
+ *
+ * 它不是消息正文的第二根滚动条：边栏中每根横条只对应一条用户消息，横条较多时
+ * 边栏拥有独立滚动位置。鼠标滚轮、方向键和翻页键只移动边栏；点击横条才跳转正文。
+ */
 export function RulerScrollbar({
-  viewportRef,
-  tickSpacing = 8,
-  markerTops,
-  activeMarker = null,
+  markerCount,
+  currentMarker = null,
   onHover,
-  onLayout,
-  wheelBoost = 3,
+  onSelect,
+  bottomInset = 0,
   className,
 }: RulerScrollbarProps) {
   const rootRef = React.useRef<HTMLDivElement>(null)
-  const dragRef = React.useRef<{ grabOffset: number; thumbSpan: number } | null>(null)
-  // 指针在轨道内的 Y（驱动正态高度变化）；仅在组件内部使用，不影响父层渲染
+  const railRef = React.useRef<HTMLDivElement>(null)
+  const frameRef = React.useRef<number | null>(null)
+  const pendingPointerRef = React.useRef<number | null>(null)
   const [pointerY, setPointerY] = React.useState<number | null>(null)
-  const pointerYRef = React.useRef<number | null>(null)
-  const [hovered, setHovered] = React.useState(false)
-  const [dims, setDims] = React.useState({ trackH: 0, scrollTop: 0, scrollHeight: 0, clientHeight: 0 })
+  const [hoveredMarker, setHoveredMarker] = React.useState<number | null>(null)
+  const [railScrollTop, setRailScrollTop] = React.useState(0)
+  const [railHeight, setRailHeight] = React.useState(0)
 
-  React.useEffect(() => {
-    const el = viewportRef.current
-    if (!el) return
-    const update = () => {
-      setDims(prev => {
-        const next = {
-          trackH: rootRef.current?.clientHeight ?? prev.trackH,
-          scrollTop: el.scrollTop,
-          scrollHeight: el.scrollHeight,
-          clientHeight: el.clientHeight,
-        }
-        return (prev.trackH === next.trackH &&
-          prev.scrollTop === next.scrollTop &&
-          prev.scrollHeight === next.scrollHeight &&
-          prev.clientHeight === next.clientHeight)
-          ? prev
-          : next
-      })
-    }
-    update()
-    el.addEventListener("scroll", update, { passive: true })
-    // 视口尺寸与内容高度都要盯住：流式追加消息时只有子容器会长高
-    const ro = new ResizeObserver(update)
-    ro.observe(el)
-    if (el.firstElementChild) ro.observe(el.firstElementChild)
-    return () => {
-      el.removeEventListener("scroll", update)
-      ro.disconnect()
-    }
-  }, [viewportRef])
+  const markersHeight = markerCount * ROW_HEIGHT
+  const contentHeight = markersHeight + TRACK_PADDING * 2
+  const centeredOffset = Math.max(TRACK_PADDING, (railHeight - markersHeight) / 2)
 
-  const { trackH, scrollTop, scrollHeight, clientHeight } = dims
-  const scrollable = trackH > 0 && scrollHeight - clientHeight > 4
-
-  // 轨道高度变化时上报给父层（首次挂载也触发一次）
-  React.useEffect(() => {
-    onLayout?.(trackH)
-  }, [trackH, onLayout])
-
-  // 悬停时刻度尺上滚动滚轮 → 直接翻动视口内容（倍速，便于超长对话跳转）。
-  // React 的 onWheel 是被动监听无法 preventDefault，这里用原生监听接管。
-  React.useEffect(() => {
+  const updatePointer = React.useCallback((clientY: number) => {
     const root = rootRef.current
-    const el = viewportRef.current
-    if (!root || !el) return
-    const onWheel = (e: WheelEvent) => {
-      if (!(el.scrollHeight - el.clientHeight > 4)) return
-      e.preventDefault()
-      el.scrollTop += e.deltaY * wheelBoost
-    }
-    root.addEventListener("wheel", onWheel, { passive: false })
-    return () => root.removeEventListener("wheel", onWheel)
-  }, [viewportRef, wheelBoost])
+    const rail = railRef.current
+    if (!root || !rail || markerCount === 0) return
 
-  const maxScroll = Math.max(1, scrollHeight - clientHeight)
-  // 视口段（thumb）高度按可见占比取值，最小一根刻度——内容极长时只亮一条线
-  const thumbH = Math.min(trackH, Math.max(tickSpacing, Math.round(trackH * (clientHeight / Math.max(1, scrollHeight)))))
-  const thumbTop = Math.round(
-    Math.min(1, Math.max(0, scrollTop / maxScroll)) * Math.max(0, trackH - thumbH),
-  )
+    const rect = root.getBoundingClientRect()
+    const y = Math.min(Math.max(clientY - rect.top, 0), rect.height)
+    setPointerY(y)
 
-  const applyDragRatio = (clientY: number) => {
-    const el = viewportRef.current
-    const drag = dragRef.current
-    if (!el || !drag || trackH <= 0 || !scrollable) return
-    const rect = rootRef.current?.getBoundingClientRect()
-    if (!rect) return
-    // 按住已有位置（thumb）时相对位移；点击空白时 thumb 中心吸附到点击处后继续拖动
-    const raw = (clientY - rect.top - drag.grabOffset) / Math.max(1, trackH - drag.thumbSpan)
-    const clamped = Math.min(Math.max(raw, 0), 1)
-    el.scrollTop = clamped * maxScroll
+    const contentY = y + rail.scrollTop - centeredOffset
+    const markerIndex = Math.min(markerCount - 1, Math.max(0, Math.round((contentY - ROW_HEIGHT / 2) / ROW_HEIGHT)))
+    setHoveredMarker(markerIndex)
+    onHover?.({ markerIndex, y, trackH: rect.height })
+  }, [centeredOffset, markerCount, onHover])
+
+  const schedulePointerUpdate = (clientY: number) => {
+    pendingPointerRef.current = clientY
+    if (frameRef.current != null) return
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null
+      if (pendingPointerRef.current != null) updatePointer(pendingPointerRef.current)
+    })
   }
 
-  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!scrollable || !viewportRef.current) return
-    e.preventDefault()
-    // 开始滚动定位：预览卡片立即退场，避免视觉残留
-    onHover?.(null)
-    const rect = rootRef.current?.getBoundingClientRect()
-    if (!rect) return
-    const yInTrack = e.clientY - rect.top
-    // 点中视口段保持相对抓取；点空白则以点击处为中心跳转过去并继续拖动
-    const inThumb = yInTrack >= thumbTop && yInTrack <= thumbTop + thumbH
-    const grabOffset = inThumb
-      ? yInTrack - thumbTop
-      : Math.round(thumbH / 2)
-    dragRef.current = { grabOffset, thumbSpan: thumbH }
-    e.currentTarget.setPointerCapture(e.pointerId)
-    applyDragRatio(e.clientY)
+  React.useEffect(() => {
+    const rail = railRef.current
+    if (!rail) return
+    const updateHeight = () => setRailHeight(rail.clientHeight)
+    updateHeight()
+    const observer = new ResizeObserver(updateHeight)
+    observer.observe(rail)
+    return () => observer.disconnect()
+  }, [])
+
+  React.useEffect(() => () => {
+    if (frameRef.current != null) cancelAnimationFrame(frameRef.current)
+  }, [])
+
+  const scrollRailBy = React.useCallback((delta: number) => {
+    const rail = railRef.current
+    if (!rail) return
+    rail.scrollTop += delta
+    setRailScrollTop(rail.scrollTop)
+  }, [])
+
+  const onWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+    // 阻断滚轮继续冒泡到消息视口；滚轮只翻动这列用户消息横条。
+    event.preventDefault()
+    event.stopPropagation()
+    scrollRailBy(event.deltaY)
+    if (pendingPointerRef.current != null) schedulePointerUpdate(pendingPointerRef.current)
   }
 
-  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (dragRef.current) {
-      applyDragRatio(e.clientY)
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const rail = railRef.current
+    if (!rail) return
+    let delta: number | null = null
+    if (event.key === "ArrowUp") delta = -ROW_HEIGHT
+    if (event.key === "ArrowDown") delta = ROW_HEIGHT
+    if (event.key === "PageUp") delta = -rail.clientHeight * 0.8
+    if (event.key === "PageDown") delta = rail.clientHeight * 0.8
+    if (event.key === "Home") {
+      event.preventDefault()
+      rail.scrollTop = 0
+      setRailScrollTop(0)
       return
     }
-    // 非拖动的悬停：记录指针 Y（驱动正态高度变化），并把吸附信息报给父层
-    if (trackH > 0) {
-      const rect = rootRef.current?.getBoundingClientRect()
-      if (!rect) return
-      const y = Math.min(Math.max(e.clientY - rect.top, 0), trackH)
-      if (y !== pointerYRef.current) {
-        pointerYRef.current = y
-        setPointerY(y)
-      }
-      onHover?.({ y, trackH })
+    if (event.key === "End") {
+      event.preventDefault()
+      rail.scrollTop = rail.scrollHeight
+      setRailScrollTop(rail.scrollTop)
+      return
+    }
+    if (delta != null) {
+      event.preventDefault()
+      scrollRailBy(delta)
     }
   }
 
-  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (dragRef.current) {
-      dragRef.current = null
-      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-        e.currentTarget.releasePointerCapture(e.pointerId)
-      }
-    }
-  }
-
-  // ---- 刻度线数据：全部由 DOM 横线元素构成（flex 逐条排列，严格等距） ----
-  const lineCount = Math.max(1, Math.floor(trackH / tickSpacing))
-
-  // 当前视口占据的亮段区间（以横线索引表示）
-  const viewportRatio = Math.min(1, clientHeight / Math.max(1, scrollHeight))
-  const brightCount = Math.max(1, Math.round(viewportRatio * lineCount))
-  const brightStart = Math.round(
-    Math.min(1, Math.max(0, scrollTop / maxScroll)) * Math.max(0, lineCount - brightCount),
-  )
-  const brightEnd = brightStart + brightCount - 1
-
-  // 节点横线：文档比例位置取整到最近的横线索引；active 单独记录用于发光
-  const nodeLineSet = React.useMemo(() => {
-    if (!(trackH > 0) || !markerTops?.length) return new Set<number>()
-    const s = new Set<number>()
-    for (const raw of markerTops) {
-      s.add(Math.min(lineCount - 1, Math.max(0, Math.round(raw / tickSpacing))))
-    }
-    return s
-  }, [markerTops, trackH, lineCount, tickSpacing])
-  const activeNodeLine =
-    hovered && activeMarker != null && markerTops?.[activeMarker] != null && trackH > 0
-      ? Math.min(lineCount - 1, Math.max(0, Math.round(markerTops[activeMarker] / tickSpacing)))
-      : -1
+  if (markerCount === 0) return null
 
   return (
     <div
       ref={rootRef}
-      role="scrollbar"
-      aria-orientation="vertical"
-      aria-valuemin={0}
-      aria-valuemax={100}
-      aria-valuenow={Math.round((scrollTop / maxScroll) * 100)}
-      aria-label="会话滚动条"
+      role="navigation"
+      tabIndex={0}
+      aria-label="用户消息导航"
       className={cn(
-        "absolute inset-y-0 right-0 z-20 w-[26px] touch-none select-none transition-opacity duration-150",
-        scrollable ? "opacity-100" : "pointer-events-none opacity-0",
-        hovered ? "cursor-grabbing" : "cursor-pointer",
+        "absolute right-0 top-0 z-20 w-[54px] select-none overflow-hidden bg-background/80 outline-none backdrop-blur-sm",
+        "focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border",
         className,
       )}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={endDrag}
-      onPointerCancel={endDrag}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => {
-        setHovered(false)
-        pointerYRef.current = null
+      style={{ bottom: bottomInset }}
+      onPointerMove={(event) => schedulePointerUpdate(event.clientY)}
+      onPointerLeave={() => {
+        pendingPointerRef.current = null
         setPointerY(null)
+        setHoveredMarker(null)
         onHover?.(null)
       }}
+      onWheel={onWheel}
+      onKeyDown={onKeyDown}
     >
-      {/* 悬停底板：给刻度一个可感知的落区 */}
-      {hovered && (
-        <div className="absolute inset-y-1 right-0 w-[21px] rounded-lg bg-muted/50 shadow-[inset_0_0_0_1px_hsl(var(--border))]" />
-      )}
-      {/* 淡竖分隔线贴刻度右缘 */}
-      <div className="absolute bottom-0 top-0 w-px bg-muted-foreground/15" style={{ right: TICK_RIGHT - 2 }} />
-      {/* 刻度横线列：flex 布局逐条收纳，每格定高（tickSpacing）保证刚性等距。
-          条贴窗口右缘，横线统一右对齐锚定——悬停正态加长时向左（内容一侧）伸出。
-          最长最亮的线始终是指针所在的那根，向两侧平滑收敛；
-          吸附到的提问节点以主题色标注 */}
-      <div className="absolute bottom-0 right-0 top-0 flex flex-col items-end" style={{ paddingRight: TICK_RIGHT }}>
-        {Array.from({ length: lineCount }, (_, i) => {
-          const isBright = i >= brightStart && i <= brightEnd
-          const isNode = nodeLineSet.has(i)
-          const isActiveNode = i === activeNodeLine
-          // 正态权重：中心（指针所在处）=1，向两侧平滑衰减
-          let depth = 0
-          if (pointerY != null) {
-            const d = i * tickSpacing + tickSpacing / 2 - pointerY
-            depth = Math.exp(-(d * d) / (2 * GAUSS_SIGMA * GAUSS_SIGMA))
-          }
-          return (
-            <div key={i} className="flex shrink-0 grow-0 items-start justify-start" style={{ height: tickSpacing }}>
-              <div
-                className="rounded-full transition-[background-color,width] duration-150"
-                style={{
-                  width: (isActiveNode || isBright ? TICK_WIDTH + 2 : TICK_WIDTH) + depth * GAUSS_EXTRA_WIDTH,
-                  height: 1.5,
-                  backgroundColor: isActiveNode
-                    ? `hsl(var(--primary) / ${Math.max(0.85, depth)})`
-                    : isBright || isNode
-                      ? `hsl(var(--foreground) / ${Math.max(isBright ? (hovered ? 0.9 : 0.65) : 0.5, depth * 0.92)})`
-                      : `hsl(var(--muted-foreground) / ${Math.max(hovered ? 0.45 : 0.26, depth * 0.8)})`,
+      <div
+        ref={railRef}
+        className="absolute inset-0 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        onScroll={(event) => setRailScrollTop(event.currentTarget.scrollTop)}
+      >
+        <div className="relative min-h-full" style={{ height: Math.max(contentHeight, railHeight, 1) }}>
+          {Array.from({ length: markerCount }, (_, index) => {
+            const centerY = centeredOffset + index * ROW_HEIGHT + ROW_HEIGHT / 2 - railScrollTop
+            const distance = pointerY == null ? Number.POSITIVE_INFINITY : centerY - pointerY
+            const depth = pointerY == null ? 0 : Math.exp(-(distance * distance) / (2 * GAUSS_SIGMA * GAUSS_SIGMA))
+            const isHovered = index === hoveredMarker
+            const isCurrent = index === currentMarker
+            const width = BASE_WIDTH + depth * GAUSS_EXTRA_WIDTH + (isHovered ? 5 : isCurrent ? 3 : 0)
+
+            return (
+              <button
+                key={index}
+                type="button"
+                aria-label={`跳转到第 ${index + 1} 条用户消息`}
+                aria-current={isCurrent ? "location" : undefined}
+                className="absolute right-2 flex w-[46px] items-center justify-end outline-none"
+                style={{ top: centeredOffset + index * ROW_HEIGHT, height: ROW_HEIGHT }}
+                onClick={() => onSelect?.(index)}
+                onFocus={() => {
+                  setHoveredMarker(index)
+                  onHover?.({ markerIndex: index, y: centerY, trackH: rootRef.current?.clientHeight ?? 0 })
                 }}
-              />
-            </div>
-          )
-        })}
+              >
+                <span
+                  className="block rounded-full"
+                  style={{
+                    width,
+                    height: isHovered ? 3 : 2,
+                    backgroundColor: isHovered
+                      ? "hsl(var(--foreground) / 0.96)"
+                      : isCurrent
+                        ? "hsl(var(--foreground) / 0.72)"
+                        : `hsl(var(--muted-foreground) / ${0.32 + depth * 0.5})`,
+                    transition: "width 45ms linear, background-color 45ms linear, height 45ms linear",
+                  }}
+                />
+              </button>
+            )
+          })}
+        </div>
       </div>
     </div>
   )
 }
 
-/**
- * 会话预览小卡片：上方为用户提问、下方为回答摘要，整卡可点击跳转该轮会话。
- * 独立导出以便复用与单独验证。
- */
 export function TurnPreviewCard({
   question,
   answer,
@@ -290,19 +219,17 @@ export function TurnPreviewCard({
       type="button"
       onClick={onClick}
       className={cn(
-        "block w-[290px] cursor-pointer rounded-xl border border-border/80 bg-background/95 p-3 text-left shadow-xl backdrop-blur-md",
-        "transition-transform duration-150 hover:border-muted-foreground/40",
+        "block w-[320px] max-w-[calc(100vw-5rem)] cursor-pointer overflow-hidden rounded-2xl border border-white/10 bg-neutral-800/95 px-4 py-3.5 text-left shadow-2xl backdrop-blur-xl",
+        "transition-[border-color,background-color] duration-150 hover:border-white/20 hover:bg-neutral-800",
         className,
       )}
       style={style}
     >
-      {/* 提问（前景色加粗）与回答摘要（弱化灰）以颜色区分，不加文字标签 */}
-      <div className="line-clamp-2 whitespace-pre-wrap break-words text-xs font-medium leading-5 text-foreground">
-        {question || '(空消息)'}
+      <div className="line-clamp-2 whitespace-pre-wrap break-words text-sm font-medium leading-5 text-neutral-100">
+        {question || "(空消息)"}
       </div>
-      <div className="my-2 border-t border-border/60" />
-      <div className="line-clamp-3 whitespace-pre-wrap break-words text-xs leading-5 text-muted-foreground">
-        {answer.trim() || '(本轮暂无文字回复)'}
+      <div className="mt-2 line-clamp-3 whitespace-pre-wrap break-words text-sm leading-5 text-neutral-400">
+        {answer.trim() || "(本轮暂无文字回复)"}
       </div>
     </button>
   )

--- a/frontend/src/components/ui/ruler-scrollbar.tsx
+++ b/frontend/src/components/ui/ruler-scrollbar.tsx
@@ -1,0 +1,158 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/**
+ * 刻度尺式竖直滚动条：整条高度均匀铺满小横线刻度，当前视口对应区间的
+ * 刻度整体转亮（内容极长时表现为一条亮横杠），形似编辑器 overview ruler。
+ * 点击/拖动任意位置直接映射滚动；无可滚动内容时整体隐藏。
+ */
+interface RulerScrollbarProps {
+  viewportRef: React.RefObject<HTMLDivElement | null>
+  /** 刻度垂直间距（px） */
+  tickSpacing?: number
+  className?: string
+}
+
+// 刻度列在轨道内的位置：距左边 3px、宽 13px，右侧留白并带一根淡竖线
+const TICK_LEFT = 3
+const TICK_WIDTH = 13
+
+export function RulerScrollbar({ viewportRef, tickSpacing = 8, className }: RulerScrollbarProps) {
+  const rootRef = React.useRef<HTMLDivElement>(null)
+  const dragRef = React.useRef<{ grabOffset: number } | null>(null)
+  const [hovered, setHovered] = React.useState(false)
+  const [dims, setDims] = React.useState({ trackH: 0, scrollTop: 0, scrollHeight: 0, clientHeight: 0 })
+
+  React.useEffect(() => {
+    const el = viewportRef.current
+    if (!el) return
+    const update = () => {
+      setDims(prev => {
+        const next = {
+          trackH: rootRef.current?.clientHeight ?? prev.trackH,
+          scrollTop: el.scrollTop,
+          scrollHeight: el.scrollHeight,
+          clientHeight: el.clientHeight,
+        }
+        return (prev.trackH === next.trackH &&
+          prev.scrollTop === next.scrollTop &&
+          prev.scrollHeight === next.scrollHeight &&
+          prev.clientHeight === next.clientHeight)
+          ? prev
+          : next
+      })
+    }
+    update()
+    el.addEventListener("scroll", update, { passive: true })
+    // 视口尺寸与内容高度都要盯住：流式追加消息时只有子容器会长高
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    if (el.firstElementChild) ro.observe(el.firstElementChild)
+    return () => {
+      el.removeEventListener("scroll", update)
+      ro.disconnect()
+    }
+  }, [viewportRef])
+
+  const { trackH, scrollTop, scrollHeight, clientHeight } = dims
+  const scrollable = trackH > 0 && scrollHeight - clientHeight > 4
+
+  const maxScroll = Math.max(1, scrollHeight - clientHeight)
+  // thumb 高度按视口占比取值，最小一格刻度——内容极长时恰好只亮一条线
+  const thumbH = Math.min(trackH, Math.max(tickSpacing, Math.round(trackH * (clientHeight / Math.max(1, scrollHeight)))))
+  const thumbTop = Math.round(Math.min(1, Math.max(0, scrollTop / maxScroll)) * (trackH - thumbH))
+
+  const applyClientY = (clientY: number) => {
+    const el = viewportRef.current
+    const drag = dragRef.current
+    if (!el || !drag || trackH <= 0) return
+    const rect = rootRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const top = Math.min(
+      Math.max(clientY - rect.top - drag.grabOffset, 0),
+      trackH - thumbH,
+    )
+    el.scrollTop = (top / Math.max(1, trackH - thumbH)) * maxScroll
+  }
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!scrollable || !viewportRef.current) return
+    e.preventDefault()
+    const rect = rootRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const yInTrack = e.clientY - rect.top
+    // 点中 thumb 保持抓取偏移；点空白则跳转过去并以 thumb 中心吸附后继续拖动
+    const grabOffset = yInTrack >= thumbTop && yInTrack <= thumbTop + thumbH
+      ? yInTrack - thumbTop
+      : Math.round(thumbH / 2)
+    dragRef.current = { grabOffset }
+    e.currentTarget.setPointerCapture(e.pointerId)
+    applyClientY(e.clientY)
+  }
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (dragRef.current) applyClientY(e.clientY)
+  }
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (dragRef.current) {
+      dragRef.current = null
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId)
+      }
+    }
+  }
+
+  // 两层用同一纹样、相位对齐（亮层按自身 top 反向平移背景），
+  // 亮层盒子裁出当前视口区间 → 区间内的刻度变亮
+  const tickPattern = (lineColor: string) =>
+    `repeating-linear-gradient(to bottom, ${lineColor} 0px, ${lineColor} 1px, transparent 1px, transparent ${tickSpacing}px)`
+  const idleLine = `hsl(var(--muted-foreground) / ${hovered ? 0.38 : 0.26})`
+  const activeLine = `hsl(var(--foreground) / ${hovered ? 0.85 : 0.6})`
+
+  return (
+    <div
+      ref={rootRef}
+      role="scrollbar"
+      aria-orientation="vertical"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round((scrollTop / maxScroll) * 100)}
+      aria-label="会话滚动条"
+      className={cn(
+        "absolute inset-y-0 right-0 z-20 w-[26px] touch-none select-none transition-opacity duration-150",
+        scrollable ? "opacity-100" : "pointer-events-none opacity-0",
+        hovered ? "cursor-grabbing" : "cursor-pointer",
+        className,
+      )}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {/* 暗刻度轨道 */}
+      <div
+        className="absolute bottom-0 top-0 border-r border-muted-foreground/15"
+        style={{
+          left: TICK_LEFT,
+          width: TICK_WIDTH,
+          backgroundImage: tickPattern(idleLine),
+        }}
+      />
+      {/* 亮 thumb 层：overflow 裁出视口区间，内部纹样与全局相位对齐 */}
+      <div
+        className="absolute overflow-hidden"
+        style={{
+          left: TICK_LEFT,
+          width: TICK_WIDTH,
+          top: thumbTop,
+          height: thumbH,
+          backgroundImage: tickPattern(activeLine),
+          backgroundPositionY: `${-thumbTop}px`,
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/ui/ruler-scrollbar.tsx
+++ b/frontend/src/components/ui/ruler-scrollbar.tsx
@@ -2,22 +2,22 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 /**
- * 刻度尺式竖直滚动条：整条高度均匀铺满小横线刻度，当前视口对应区间的
- * 刻度整体转亮（内容极长时表现为一条亮横杠），形似编辑器 overview ruler。
+ * 刻度线式竖直滚动条：整条高度由固定间距的短横线组成（flex 布局逐条排列，
+ * 每格定高保证刚性等距），当前视口对应的区段横线转亮，形似编辑器 overview ruler。
  * 点击/拖动任意位置直接映射滚动；悬停时滚轮可直接翻动视口内容；
  * 无可滚动内容时整体隐藏。
  *
- * 节点横杠：markerTops 以淡色短杠常显（相邻过近时合并），
- * hover 吸附的节点显示为发光亮杠；通过 onHover 把指针 Y 上报给父层
- * （父层负责展示问答预览小卡片）。onLayout 在轨道尺寸变化时上报高度。
+ * 节点指示：markerTops 对应的横线常显为加重色，hover 吸附的节点进一步
+ * 显示为发光亮杠；onHover 把指针 Y 上报给父层展示问答预览卡片，
+ * onLayout 在轨道尺寸变化时上报高度。
  */
 interface RulerScrollbarProps {
   viewportRef: React.RefObject<HTMLDivElement | null>
-  /** 刻度垂直间距（px） */
+  /** 刻度垂直间距（px），也是每根横线所在格子的固定高度 */
   tickSpacing?: number
   /** 各预览节点在轨道内的 y 坐标（px），由父层按文档位置换算 */
   markerTops?: number[]
-  /** 当前 hover 吸附的节点下标；hover 时在该 y 处渲染亮杠标记 */
+  /** 当前 hover 吸附的节点下标；hover 时在该节点横线上渲染发光亮杠 */
   activeMarker?: number | null
   /** hover 变化回调：y 为相对轨道顶部的像素、trackH 为轨道总高，null 表示移出/拖动中 */
   onHover?: (info: { y: number; trackH: number } | null) => void
@@ -28,9 +28,14 @@ interface RulerScrollbarProps {
   className?: string
 }
 
-// 刻度列在轨道内的位置：距左边 3px、宽 13px，右侧留白并带一根淡竖线
-const TICK_LEFT = 3
+// 横线的宽度：普通刻度稍窄，落在刻度列右侧、朝左伸向内容方向，右缘留一根淡竖分隔线
+const TICK_RIGHT = 10
 const TICK_WIDTH = 13
+
+// 正态（高斯）悬停效果参数：σ 越小中心的横线越突出；
+// 中心横线在基础宽度上最多再加 GAUSS_EXTRA_WIDTH px
+const GAUSS_SIGMA = 26
+const GAUSS_EXTRA_WIDTH = 13
 
 export function RulerScrollbar({
   viewportRef,
@@ -43,7 +48,10 @@ export function RulerScrollbar({
   className,
 }: RulerScrollbarProps) {
   const rootRef = React.useRef<HTMLDivElement>(null)
-  const dragRef = React.useRef<{ grabOffset: number } | null>(null)
+  const dragRef = React.useRef<{ grabOffset: number; thumbSpan: number } | null>(null)
+  // 指针在轨道内的 Y（驱动正态高度变化）；仅在组件内部使用，不影响父层渲染
+  const [pointerY, setPointerY] = React.useState<number | null>(null)
+  const pointerYRef = React.useRef<number | null>(null)
   const [hovered, setHovered] = React.useState(false)
   const [dims, setDims] = React.useState({ trackH: 0, scrollTop: 0, scrollHeight: 0, clientHeight: 0 })
 
@@ -95,28 +103,29 @@ export function RulerScrollbar({
     const onWheel = (e: WheelEvent) => {
       if (!(el.scrollHeight - el.clientHeight > 4)) return
       e.preventDefault()
-      el.scrollBy({ top: e.deltaY * wheelBoost })
+      el.scrollTop += e.deltaY * wheelBoost
     }
     root.addEventListener("wheel", onWheel, { passive: false })
     return () => root.removeEventListener("wheel", onWheel)
-  }, [viewportRef, wheelBoost, scrollable])
+  }, [viewportRef, wheelBoost])
 
   const maxScroll = Math.max(1, scrollHeight - clientHeight)
-  // thumb 高度按视口占比取值，最小一格刻度——内容极长时恰好只亮一条线
+  // 视口段（thumb）高度按可见占比取值，最小一根刻度——内容极长时只亮一条线
   const thumbH = Math.min(trackH, Math.max(tickSpacing, Math.round(trackH * (clientHeight / Math.max(1, scrollHeight)))))
-  const thumbTop = Math.round(Math.min(1, Math.max(0, scrollTop / maxScroll)) * (trackH - thumbH))
+  const thumbTop = Math.round(
+    Math.min(1, Math.max(0, scrollTop / maxScroll)) * Math.max(0, trackH - thumbH),
+  )
 
-  const applyClientY = (clientY: number) => {
+  const applyDragRatio = (clientY: number) => {
     const el = viewportRef.current
     const drag = dragRef.current
-    if (!el || !drag || trackH <= 0) return
+    if (!el || !drag || trackH <= 0 || !scrollable) return
     const rect = rootRef.current?.getBoundingClientRect()
     if (!rect) return
-    const top = Math.min(
-      Math.max(clientY - rect.top - drag.grabOffset, 0),
-      trackH - thumbH,
-    )
-    el.scrollTop = (top / Math.max(1, trackH - thumbH)) * maxScroll
+    // 按住已有位置（thumb）时相对位移；点击空白时 thumb 中心吸附到点击处后继续拖动
+    const raw = (clientY - rect.top - drag.grabOffset) / Math.max(1, trackH - drag.thumbSpan)
+    const clamped = Math.min(Math.max(raw, 0), 1)
+    el.scrollTop = clamped * maxScroll
   }
 
   const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -127,24 +136,31 @@ export function RulerScrollbar({
     const rect = rootRef.current?.getBoundingClientRect()
     if (!rect) return
     const yInTrack = e.clientY - rect.top
-    // 点中 thumb 保持抓取偏移；点空白则跳转过去并以 thumb 中心吸附后继续拖动
-    const grabOffset = yInTrack >= thumbTop && yInTrack <= thumbTop + thumbH
+    // 点中视口段保持相对抓取；点空白则以点击处为中心跳转过去并继续拖动
+    const inThumb = yInTrack >= thumbTop && yInTrack <= thumbTop + thumbH
+    const grabOffset = inThumb
       ? yInTrack - thumbTop
       : Math.round(thumbH / 2)
-    dragRef.current = { grabOffset }
+    dragRef.current = { grabOffset, thumbSpan: thumbH }
     e.currentTarget.setPointerCapture(e.pointerId)
-    applyClientY(e.clientY)
+    applyDragRatio(e.clientY)
   }
 
   const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
     if (dragRef.current) {
-      applyClientY(e.clientY)
+      applyDragRatio(e.clientY)
       return
     }
-    // 非拖动的悬停：把指针 Y 报给父层用于吸附节点与预览卡片
-    if (onHover && trackH > 0) {
+    // 非拖动的悬停：记录指针 Y（驱动正态高度变化），并把吸附信息报给父层
+    if (trackH > 0) {
       const rect = rootRef.current?.getBoundingClientRect()
-      if (rect) onHover({ y: Math.min(Math.max(e.clientY - rect.top, 0), trackH), trackH })
+      if (!rect) return
+      const y = Math.min(Math.max(e.clientY - rect.top, 0), trackH)
+      if (y !== pointerYRef.current) {
+        pointerYRef.current = y
+        setPointerY(y)
+      }
+      onHover?.({ y, trackH })
     }
   }
 
@@ -157,13 +173,30 @@ export function RulerScrollbar({
     }
   }
 
-  // 两层用同一纹样、相位对齐（亮层按自身 top 反向平移背景），
-  // 亮层盒子裁出当前视口区间 → 区间内的刻度变亮
-  const tickPattern = (lineColor: string) =>
-    `repeating-linear-gradient(to bottom, ${lineColor} 0px, ${lineColor} 1px, transparent 1px, transparent ${tickSpacing}px)`
-  const idleLine = `hsl(var(--muted-foreground) / ${hovered ? 0.45 : 0.26})`
-  const activeLine = `hsl(var(--foreground) / ${hovered ? 0.9 : 0.6})`
-  const markerTop = hovered && activeMarker != null ? markerTops?.[activeMarker] ?? null : null
+  // ---- 刻度线数据：全部由 DOM 横线元素构成（flex 逐条排列，严格等距） ----
+  const lineCount = Math.max(1, Math.floor(trackH / tickSpacing))
+
+  // 当前视口占据的亮段区间（以横线索引表示）
+  const viewportRatio = Math.min(1, clientHeight / Math.max(1, scrollHeight))
+  const brightCount = Math.max(1, Math.round(viewportRatio * lineCount))
+  const brightStart = Math.round(
+    Math.min(1, Math.max(0, scrollTop / maxScroll)) * Math.max(0, lineCount - brightCount),
+  )
+  const brightEnd = brightStart + brightCount - 1
+
+  // 节点横线：文档比例位置取整到最近的横线索引；active 单独记录用于发光
+  const nodeLineSet = React.useMemo(() => {
+    if (!(trackH > 0) || !markerTops?.length) return new Set<number>()
+    const s = new Set<number>()
+    for (const raw of markerTops) {
+      s.add(Math.min(lineCount - 1, Math.max(0, Math.round(raw / tickSpacing))))
+    }
+    return s
+  }, [markerTops, trackH, lineCount, tickSpacing])
+  const activeNodeLine =
+    hovered && activeMarker != null && markerTops?.[activeMarker] != null && trackH > 0
+      ? Math.min(lineCount - 1, Math.max(0, Math.round(markerTops[activeMarker] / tickSpacing)))
+      : -1
 
   return (
     <div
@@ -187,6 +220,8 @@ export function RulerScrollbar({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => {
         setHovered(false)
+        pointerYRef.current = null
+        setPointerY(null)
         onHover?.(null)
       }}
     >
@@ -194,59 +229,41 @@ export function RulerScrollbar({
       {hovered && (
         <div className="absolute inset-y-1 right-0 w-[21px] rounded-lg bg-muted/50 shadow-[inset_0_0_0_1px_hsl(var(--border))]" />
       )}
-      {/* 暗刻度轨道 */}
-      <div
-        className="absolute bottom-0 top-0"
-        style={{
-          left: TICK_LEFT,
-          width: TICK_WIDTH + 3,
-          backgroundImage: tickPattern(idleLine),
-          backgroundSize: `${TICK_WIDTH}px 100%`,
-          backgroundRepeat: 'no-repeat',
-        }}
-      />
       {/* 淡竖分隔线贴刻度右缘 */}
-      <div className="absolute bottom-0 top-0 w-px bg-muted-foreground/15" style={{ left: TICK_LEFT + TICK_WIDTH + 2 }} />
-      {/* 常显节点淡杠：每条提问在全文中的位置；相邻过近时合并避免糊成一片 */}
-      {markerTops && markerTops.length > 0 && (() => {
-        const bars: number[] = []
-        for (const raw of markerTops) {
-          const top = Math.min(Math.max(Math.round(raw), 0), Math.max(0, trackH - 1))
-          if (bars.length === 0 || top - bars[bars.length - 1] >= 4) bars.push(top)
-        }
-        return bars.map((top, i) => (
-          <div
-            key={i}
-            className="absolute rounded-full"
-            style={{
-              left: TICK_LEFT,
-              width: TICK_WIDTH,
-              top,
-              height: 1.5,
-              background: 'hsl(var(--muted-foreground) / 0.35)',
-            }}
-          />
-        ))
-      })()}
-      {/* 亮 thumb 层：overflow 裁出视口区间，内部纹样与全局相位对齐 */}
-      <div
-        className="absolute overflow-hidden"
-        style={{
-          left: TICK_LEFT,
-          width: TICK_WIDTH,
-          top: thumbTop,
-          height: thumbH,
-          backgroundImage: tickPattern(activeLine),
-          backgroundPositionY: `${-thumbTop}px`,
-        }}
-      />
-      {/* 吸附节点亮杠：指示 hover 命中的提问在全文中的位置 */}
-      {markerTop != null && (
-        <div
-          className="pointer-events-none absolute rounded-full bg-primary shadow-[0_0_6px_hsl(var(--primary)/0.8)]"
-          style={{ left: TICK_LEFT - 2, top: Math.round(markerTop) - 1.5, width: TICK_WIDTH + 4, height: 3 }}
-        />
-      )}
+      <div className="absolute bottom-0 top-0 w-px bg-muted-foreground/15" style={{ right: TICK_RIGHT - 2 }} />
+      {/* 刻度横线列：flex 布局逐条收纳，每格定高（tickSpacing）保证刚性等距。
+          条贴窗口右缘，横线统一右对齐锚定——悬停正态加长时向左（内容一侧）伸出。
+          最长最亮的线始终是指针所在的那根，向两侧平滑收敛；
+          吸附到的提问节点以主题色标注 */}
+      <div className="absolute bottom-0 right-0 top-0 flex flex-col items-end" style={{ paddingRight: TICK_RIGHT }}>
+        {Array.from({ length: lineCount }, (_, i) => {
+          const isBright = i >= brightStart && i <= brightEnd
+          const isNode = nodeLineSet.has(i)
+          const isActiveNode = i === activeNodeLine
+          // 正态权重：中心（指针所在处）=1，向两侧平滑衰减
+          let depth = 0
+          if (pointerY != null) {
+            const d = i * tickSpacing + tickSpacing / 2 - pointerY
+            depth = Math.exp(-(d * d) / (2 * GAUSS_SIGMA * GAUSS_SIGMA))
+          }
+          return (
+            <div key={i} className="flex shrink-0 grow-0 items-start justify-start" style={{ height: tickSpacing }}>
+              <div
+                className="rounded-full transition-[background-color,width] duration-150"
+                style={{
+                  width: (isActiveNode || isBright ? TICK_WIDTH + 2 : TICK_WIDTH) + depth * GAUSS_EXTRA_WIDTH,
+                  height: 1.5,
+                  backgroundColor: isActiveNode
+                    ? `hsl(var(--primary) / ${Math.max(0.85, depth)})`
+                    : isBright || isNode
+                      ? `hsl(var(--foreground) / ${Math.max(isBright ? (hovered ? 0.9 : 0.65) : 0.5, depth * 0.92)})`
+                      : `hsl(var(--muted-foreground) / ${Math.max(hovered ? 0.45 : 0.26, depth * 0.8)})`,
+                }}
+              />
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -118,6 +118,21 @@
   }
 }
 
+/* 刻度尺滚动条的问答预览小卡片：淡入 + 轻微上浮 */
+@keyframes ruler-card-in {
+  from {
+    opacity: 0;
+    transform: translateY(-50%) translateX(6px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0) scale(1);
+  }
+}
+.ruler-card-enter > * {
+  animation: ruler-card-in 0.16s ease-out;
+}
+
 /* 自定义滚动条 */
 @layer components {
   .custom-scrollbar {


### PR DESCRIPTION
## 改动内容
- 将消息列表右侧滚动导航改为与用户消息一一对应的横条边栏
- 支持横条区域独立滚动、鼠标正态突出、点击跳转与问答预览
- 横条不足一屏时上下居中，间距收紧为 12px
- 始终为右下角三个导航按钮预留空间，避免底部横条被遮挡
- 横条边栏与三个导航按钮统一为鼠标移入右侧区域时显示
- 隐藏消息列表原生滚动条，并保留自动跟随与虚拟列表行为

## 验证
- `yarn build`
- `yarn test --run`（18 个测试文件，219 项测试全部通过）
- 推送前检查全部通过