### PR TITLE
feat(ui): 首次运行未配置对话模型时提供主页快速配置弹窗

### DIFF
--- a/crates/tiangong-config/src/config.rs
+++ b/crates/tiangong-config/src/config.rs
@@ -42,32 +42,9 @@ impl Default for ServerConfig {
     }
 }
 
-/// 获取用户 home 目录（与 app_state::repository::utils 保持一致）。
-fn user_home_dir() -> Option<PathBuf> {
-    if let Some(home) = std::env::var_os("HOME").filter(|v| !v.is_empty()) {
-        return Some(PathBuf::from(home));
-    }
-    if let Some(profile) = std::env::var_os("USERPROFILE").filter(|v| !v.is_empty()) {
-        return Some(PathBuf::from(profile));
-    }
-    let drive = std::env::var_os("HOMEDRIVE").filter(|v| !v.is_empty());
-    let path = std::env::var_os("HOMEPATH").filter(|v| !v.is_empty());
-    match (drive, path) {
-        (Some(drive), Some(path)) => {
-            let mut buf = PathBuf::from(drive);
-            buf.push(path);
-            Some(buf)
-        }
-        _ => None,
-    }
-}
-
 /// Server 配置文件路径：~/.tiangong/server.json
 pub fn server_config_path() -> PathBuf {
-    user_home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".tiangong")
-        .join("server.json")
+    crate::loader::default_tiangong_dir().join("server.json")
 }
 
 /// 从指定目录加载 Server 配置，文件不存在时返回默认值。

--- a/crates/tiangong-config/src/io.rs
+++ b/crates/tiangong-config/src/io.rs
@@ -37,7 +37,14 @@ pub fn user_home_dir() -> Option<PathBuf> {
 }
 
 /// 天工存储根目录（`~/.tiangong`）。
+///
+/// 设置 `TIANGONG_STORAGE_ROOT` 时使用其指向的目录；与
+/// `tiangong_plugin_runtime::sidecar::STORAGE_ROOT_ENV` 共用同一环境变量，
+/// 用于测试与多实例隔离。
 pub fn storage_root() -> PathBuf {
+    if let Some(root) = std::env::var_os("TIANGONG_STORAGE_ROOT").filter(|v| !v.is_empty()) {
+        return PathBuf::from(root);
+    }
     user_home_dir()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
         .join(".tiangong")

--- a/crates/tiangong-config/src/loader.rs
+++ b/crates/tiangong-config/src/loader.rs
@@ -71,7 +71,13 @@ impl AppConfigFile {
 }
 
 /// 获取默认配置目录（~/.tiangong/）
+///
+/// 设置 `TIANGONG_STORAGE_ROOT` 时使用其指向的目录（与 `io::storage_root`
+/// 一致，用于测试与多实例隔离）。
 pub fn default_tiangong_dir() -> PathBuf {
+    if let Some(root) = std::env::var_os("TIANGONG_STORAGE_ROOT").filter(|v| !v.is_empty()) {
+        return PathBuf::from(root);
+    }
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .unwrap_or_else(|_| ".".to_string());

--- a/crates/tiangong-config/src/logging.rs
+++ b/crates/tiangong-config/src/logging.rs
@@ -66,11 +66,7 @@ pub fn init_logging(options: LoggingOptions) -> Result<WorkerGuard> {
 }
 
 fn get_log_dir() -> Result<PathBuf> {
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map_err(|_| anyhow::anyhow!("无法获取用户主目录"))?;
-
-    Ok(PathBuf::from(home).join(".tiangong").join("logs"))
+    Ok(crate::loader::default_tiangong_dir().join("logs"))
 }
 
 #[cfg(test)]
@@ -80,6 +76,6 @@ mod tests {
     #[test]
     fn test_get_log_dir() {
         let log_dir = get_log_dir().unwrap();
-        assert!(log_dir.ends_with(".tiangong/logs"));
+        assert_eq!(log_dir.file_name().and_then(|n| n.to_str()), Some("logs"));
     }
 }

--- a/frontend/src/components/FirstRunModelSetup.tsx
+++ b/frontend/src/components/FirstRunModelSetup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Eye, EyeOff, Loader2, RefreshCw } from 'lucide-react';
 import { api } from '@/api/tauri';
 import type { ModelEntryView, ModelsConfigView, ProviderConfigView } from '@/api/tauri';
@@ -66,10 +66,15 @@ export function FirstRunModelSetup({ open, onOpenChange }: Props) {
   const [showApiKey, setShowApiKey] = useState(false);
   // 表单内联错误提示：不依赖全局 Toast Provider，首次运行场景自包含。
   const [error, setError] = useState<{ title: string; detail?: string } | null>(null);
+  // 模型列表请求代号：切换供应商或重新打开弹窗时递增，旧请求返回后直接丢弃，
+  // 避免把 A 供应商的模型写入 B 供应商的表单。
+  const fetchSeqRef = useRef(0);
 
   // 每次打开重置表单，避免残留上次的输入。
   useEffect(() => {
     if (!open) return;
+    fetchSeqRef.current += 1;
+    setFetchingModels(false);
     setProviderKey('DeepSeek');
     setIsCustomProvider(false);
     setCustomName('');
@@ -83,6 +88,8 @@ export function FirstRunModelSetup({ open, onOpenChange }: Props) {
 
   const selectPreset = (key: string) => {
     setError(null);
+    fetchSeqRef.current += 1;
+    setFetchingModels(false);
     setProviderKey(key);
     setIsCustomProvider(false);
     setCustomName('');
@@ -93,6 +100,8 @@ export function FirstRunModelSetup({ open, onOpenChange }: Props) {
 
   const selectCustom = () => {
     setError(null);
+    fetchSeqRef.current += 1;
+    setFetchingModels(false);
     setIsCustomProvider(true);
     setProviderKey('');
     setDraft({ base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai_chatcompletions' });
@@ -118,20 +127,26 @@ export function FirstRunModelSetup({ open, onOpenChange }: Props) {
       setError({ title: '请先填写 Base URL 和 API Key' });
       return;
     }
+    const seq = ++fetchSeqRef.current;
     setFetchingModels(true);
     try {
       const models = await api.fetchProviderModels(draft.base_url.trim(), draft.api_key.trim(), draft.timeout_ms, draft.protocol);
+      // 请求期间已切换供应商或重开弹窗：结果已过期，丢弃且不改状态。
+      if (seq !== fetchSeqRef.current) return;
       if (models.length === 0) {
         setError({ title: '该供应商未返回任何模型', detail: '可手动输入模型名称' });
       } else {
         setError(null);
+        // 手动输入的模型名不在返回列表中时清空，避免保存界面上不可见的模型。
+        setModelName((prev) => (prev.trim() !== '' && !models.includes(prev.trim()) ? '' : prev));
       }
       setAvailableModels(models);
     } catch (err) {
+      if (seq !== fetchSeqRef.current) return;
       setError({ title: '无法获取模型列表', detail: String(err) });
       setAvailableModels([]);
     } finally {
-      setFetchingModels(false);
+      if (seq === fetchSeqRef.current) setFetchingModels(false);
     }
   };
 

--- a/frontend/src/components/FirstRunModelSetup.tsx
+++ b/frontend/src/components/FirstRunModelSetup.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useState } from 'react';
+import { Eye, EyeOff, Loader2, RefreshCw } from 'lucide-react';
+import { api } from '@/api/tauri';
+import type { ModelEntryView, ModelsConfigView, ProviderConfigView } from '@/api/tauri';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './ui/select';
+
+/** 与设置页一致的预设供应商；快速配置从这里起步。 */
+const PRESET_PROVIDERS: Record<string, ProviderConfigView> = {
+  DeepSeek: { base_url: 'https://api.deepseek.com', api_key: '', timeout_ms: 300000, protocol: 'deepseek' },
+  智谱: { base_url: 'https://open.bigmodel.cn/api/paas/v4', api_key: '', timeout_ms: 300000, protocol: 'openai_chatcompletions' },
+};
+
+const PROTOCOL_DEFAULT_URLS: Record<string, string> = {
+  openai: 'https://api.openai.com/v1',
+  openai_chatcompletions: 'https://api.openai.com/v1',
+  anthropic: 'https://api.anthropic.com',
+};
+
+const PROTOCOL_OPTIONS = [
+  { value: 'openai', label: 'OpenAI Responses' },
+  { value: 'openai_chatcompletions', label: 'OpenAI Chat Completions' },
+  { value: 'anthropic', label: 'Anthropic' },
+];
+
+type Props = {
+  /** 是否显示快速配置窗口。 */
+  open: boolean;
+  /** 关闭/打开变化；关闭即跳过，不阻断其他功能。 */
+  onOpenChange: (open: boolean) => void;
+};
+
+/**
+ * 主页面首次运行模型快速配置弹窗：
+ * 未配置主对话模型（chat 路由）时引导用户一步完成供应商连接信息与模型选择，
+ * 提交时自动写入模型定义并配置 chat 路由，完成后即可直接发起对话。
+ */
+export function FirstRunModelSetup({ open, onOpenChange }: Props) {
+  const [saving, setSaving] = useState(false);
+  const [providerKey, setProviderKey] = useState<string>('DeepSeek');
+  const [isCustomProvider, setIsCustomProvider] = useState(false);
+  const [customName, setCustomName] = useState('');
+  const [draft, setDraft] = useState<ProviderConfigView>({ ...PRESET_PROVIDERS.DeepSeek });
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [fetchingModels, setFetchingModels] = useState(false);
+  const [modelName, setModelName] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  // 表单内联错误提示：不依赖全局 Toast Provider，首次运行场景自包含。
+  const [error, setError] = useState<{ title: string; detail?: string } | null>(null);
+
+  // 每次打开重置表单，避免残留上次的输入。
+  useEffect(() => {
+    if (!open) return;
+    setProviderKey('DeepSeek');
+    setIsCustomProvider(false);
+    setCustomName('');
+    setDraft({ ...PRESET_PROVIDERS.DeepSeek });
+    setAvailableModels([]);
+    setFetchingModels(false);
+    setModelName('');
+    setShowApiKey(false);
+    setError(null);
+  }, [open]);
+
+  const selectPreset = (key: string) => {
+    setError(null);
+    setProviderKey(key);
+    setIsCustomProvider(false);
+    setCustomName('');
+    setDraft({ ...(PRESET_PROVIDERS[key] ?? PRESET_PROVIDERS.DeepSeek) });
+    setAvailableModels([]);
+    setModelName('');
+  };
+
+  const selectCustom = () => {
+    setError(null);
+    setIsCustomProvider(true);
+    setProviderKey('');
+    setDraft({ base_url: '', api_key: '', timeout_ms: 300000, protocol: 'openai_chatcompletions' });
+    setAvailableModels([]);
+    setModelName('');
+  };
+
+  const handleProtocolChange = (protocol: string) => {
+    setDraft((prev) => ({ ...prev, protocol, base_url: PROTOCOL_DEFAULT_URLS[protocol] || '' }));
+  };
+
+  const fetchModels = async () => {
+    if (!draft.base_url.trim() || !draft.api_key.trim()) {
+      setError({ title: '请先填写 Base URL 和 API Key' });
+      return;
+    }
+    setFetchingModels(true);
+    try {
+      const models = await api.fetchProviderModels(draft.base_url.trim(), draft.api_key.trim(), draft.timeout_ms, draft.protocol);
+      if (models.length === 0) {
+        setError({ title: '该供应商未返回任何模型', detail: '可手动输入模型名称' });
+      } else {
+        setError(null);
+      }
+      setAvailableModels(models);
+    } catch (err) {
+      setError({ title: '无法获取模型列表', detail: String(err) });
+      setAvailableModels([]);
+    } finally {
+      setFetchingModels(false);
+    }
+  };
+
+  const submit = async () => {
+    const name = isCustomProvider ? customName.trim() : providerKey;
+    if (!name) {
+      setError({ title: '请为自定义供应商填写名称' });
+      return;
+    }
+    if (!draft.base_url.trim()) {
+      setError({ title: '请填写服务商接口地址（Base URL）' });
+      return;
+    }
+    if (!draft.api_key.trim()) {
+      setError({ title: '请填写 API Key' });
+      return;
+    }
+    if (!modelName.trim()) {
+      setError({ title: '请选择或输入模型名称' });
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      // 以服务端最新配置为基底合并，保留既有供应商/模型/其他路由。
+      const cfg: ModelsConfigView = await api.getModelsConfig();
+      cfg.providers = {
+        ...cfg.providers,
+        [name]: { ...draft, base_url: draft.base_url.trim(), api_key: draft.api_key.trim() },
+      };
+      let key = modelName.trim();
+      if (cfg.models[key]) key = `${name}-${key}`;
+      const entry: ModelEntryView = { provider: name, model: modelName.trim(), capabilities: ['chat'], options: {} };
+      // 补全上下文窗口默认值；失败不阻塞保存。
+      try {
+        const ctx = await api.resolveModelContextWindow(modelName.trim());
+        if (ctx > 0) entry.context_window = ctx;
+      } catch { /* ignore */ }
+      cfg.models = { ...cfg.models, [key]: { ...entry } };
+      // 自动配置主对话路由。
+      cfg.routing = { ...cfg.routing, chat: { ...entry } };
+      await api.setModelsConfig(cfg);
+      onOpenChange(false);
+    } catch (err) {
+      console.error('保存模型配置失败:', err);
+      setError({ title: '保存失败', detail: String(err) });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? null : onOpenChange(false))}>
+      <DialogContent className="max-w-md" overlayClassName="z-[90]" showCloseButton={!saving}>
+        <DialogHeader>
+          <DialogTitle>配置对话模型</DialogTitle>
+          <DialogDescription>
+            尚未配置主对话模型，暂时无法发起对话。填写下方信息即可完成配置；
+            更多能力路由可稍后在「设置 → 模型配置」中调整。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {/* 供应商选择 */}
+          <div>
+            <Label className="text-xs">供应商</Label>
+            <div className="flex flex-wrap gap-1.5 mt-1">
+              {Object.keys(PRESET_PROVIDERS).map((key) => (
+                <button
+                  key={key}
+                  type="button"
+                  className={`px-2.5 py-1 text-xs rounded border transition-colors ${
+                    !isCustomProvider && providerKey === key
+                      ? 'bg-primary/20 text-primary border-primary/40'
+                      : 'bg-secondary text-muted-foreground border-border hover:text-foreground'
+                  }`}
+                  onClick={() => selectPreset(key)}
+                >
+                  {key}
+                </button>
+              ))}
+              <button
+                type="button"
+                className={`px-2.5 py-1 text-xs rounded border transition-colors ${
+                  isCustomProvider
+                    ? 'bg-primary/20 text-primary border-primary/40'
+                    : 'bg-secondary text-muted-foreground border-border hover:text-foreground'
+                }`}
+                onClick={selectCustom}
+              >
+                自定义
+              </button>
+            </div>
+          </div>
+
+          {isCustomProvider && (
+            <div>
+              <Label className="text-xs">供应商名称</Label>
+              <Input
+                value={customName}
+                onChange={(e) => setCustomName(e.target.value)}
+                className="text-sm h-8 mt-1"
+                placeholder="例如 OpenAI、Moonshot"
+              />
+            </div>
+          )}
+
+          <div>
+            <Label className="text-xs">Base URL</Label>
+            <Input
+              value={draft.base_url}
+              onChange={(e) => setDraft({ ...draft, base_url: e.target.value })}
+              className="text-sm h-8 mt-1"
+              placeholder="https://api.openai.com/v1"
+            />
+          </div>
+
+          <div>
+            <Label className="text-xs">API Key</Label>
+            <div className="relative mt-1">
+              <Input
+                type={showApiKey ? 'text' : 'password'}
+                value={draft.api_key}
+                onChange={(e) => setDraft({ ...draft, api_key: e.target.value })}
+                className="text-sm h-8 pr-8"
+                placeholder="sk-... 或 ${ENV_VAR}"
+              />
+              <button
+                type="button"
+                onClick={() => setShowApiKey(!showApiKey)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                {showApiKey ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <Label className="text-xs">请求格式</Label>
+            <Select value={draft.protocol || 'openai_chatcompletions'} onValueChange={handleProtocolChange}>
+              <SelectTrigger className="text-sm h-8 mt-1">
+                <SelectValue placeholder="选择协议" />
+              </SelectTrigger>
+              <SelectContent>
+                {PROTOCOL_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between">
+              <Label className="text-xs">模型</Label>
+              <Button variant="ghost" size="sm" className="h-5 text-xs px-2" onClick={fetchModels} disabled={fetchingModels}>
+                {fetchingModels
+                  ? <><Loader2 className="w-3 h-3 mr-1 animate-spin" />获取中...</>
+                  : <><RefreshCw className="w-3 h-3 mr-1" />获取模型列表</>}
+              </Button>
+            </div>
+            {availableModels.length > 0 ? (
+              <Select value={modelName} onValueChange={setModelName}>
+                <SelectTrigger className="h-8 text-sm mt-1"><SelectValue placeholder="-- 选择模型 --" /></SelectTrigger>
+                <SelectContent>
+                  {availableModels.map((m) => <SelectItem key={m} value={m}>{m}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Input
+                value={modelName}
+                onChange={(e) => setModelName(e.target.value)}
+                className="text-sm h-8 mt-1"
+                placeholder="例如 deepseek-chat、glm-4.6"
+              />
+            )}
+          </div>
+        </div>
+
+        {error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2">
+            <p className="text-xs font-medium text-destructive">{error.title}</p>
+            {error.detail && <p className="mt-0.5 text-xs text-destructive/80 break-all">{error.detail}</p>}
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)} disabled={saving}>
+            稍后配置
+          </Button>
+          <Button size="sm" onClick={submit} disabled={saving}>
+            {saving && <Loader2 className="w-3 h-3 mr-1 animate-spin" />}
+            完成配置
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/FirstRunModelSetup.tsx
+++ b/frontend/src/components/FirstRunModelSetup.tsx
@@ -33,6 +33,9 @@ const PROTOCOL_DEFAULT_URLS: Record<string, string> = {
   anthropic: 'https://api.anthropic.com',
 };
 
+/** 连接信息固定的预设供应商：Base URL 与协议不可修改。 */
+const LOCKED_PRESET_PROVIDERS = new Set(['DeepSeek']);
+
 const PROTOCOL_OPTIONS = [
   { value: 'openai', label: 'OpenAI Responses' },
   { value: 'openai_chatcompletions', label: 'OpenAI Chat Completions' },
@@ -97,8 +100,17 @@ export function FirstRunModelSetup({ open, onOpenChange }: Props) {
     setModelName('');
   };
 
+  // 锁定供应商（如 DeepSeek）：Base URL 与协议固定为官方值。
+  const urlLocked = !isCustomProvider && LOCKED_PRESET_PROVIDERS.has(providerKey);
+
   const handleProtocolChange = (protocol: string) => {
-    setDraft((prev) => ({ ...prev, protocol, base_url: PROTOCOL_DEFAULT_URLS[protocol] || '' }));
+    setDraft((prev) => {
+      const oldDefault = PROTOCOL_DEFAULT_URLS[prev.protocol] || '';
+      const current = prev.base_url.trim();
+      // 仅当地址为空或仍等于旧协议默认地址时跟随协议更新，避免覆盖用户自填地址。
+      const keepUrl = current !== '' && current !== oldDefault;
+      return { ...prev, protocol, base_url: keepUrl ? prev.base_url : (PROTOCOL_DEFAULT_URLS[protocol] || '') };
+    });
   };
 
   const fetchModels = async () => {
@@ -234,6 +246,7 @@ export function FirstRunModelSetup({ open, onOpenChange }: Props) {
               onChange={(e) => setDraft({ ...draft, base_url: e.target.value })}
               className="text-sm h-8 mt-1"
               placeholder="https://api.openai.com/v1"
+              disabled={urlLocked}
             />
           </div>
 
@@ -259,16 +272,22 @@ export function FirstRunModelSetup({ open, onOpenChange }: Props) {
 
           <div>
             <Label className="text-xs">请求格式</Label>
-            <Select value={draft.protocol || 'openai_chatcompletions'} onValueChange={handleProtocolChange}>
-              <SelectTrigger className="text-sm h-8 mt-1">
-                <SelectValue placeholder="选择协议" />
-              </SelectTrigger>
-              <SelectContent>
-                {PROTOCOL_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            {urlLocked ? (
+              <div className="h-8 mt-1 px-3 flex items-center rounded-md border bg-muted/40 text-sm text-muted-foreground">
+                {providerKey} 官方协议（{draft.protocol}）
+              </div>
+            ) : (
+              <Select value={draft.protocol || 'openai_chatcompletions'} onValueChange={handleProtocolChange}>
+                <SelectTrigger className="text-sm h-8 mt-1">
+                  <SelectValue placeholder="选择协议" />
+                </SelectTrigger>
+                <SelectContent className="z-[95]">
+                  {PROTOCOL_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
           </div>
 
           <div>
@@ -283,7 +302,7 @@ export function FirstRunModelSetup({ open, onOpenChange }: Props) {
             {availableModels.length > 0 ? (
               <Select value={modelName} onValueChange={setModelName}>
                 <SelectTrigger className="h-8 text-sm mt-1"><SelectValue placeholder="-- 选择模型 --" /></SelectTrigger>
-                <SelectContent>
+                <SelectContent className="z-[95]">
                   {availableModels.map((m) => <SelectItem key={m} value={m}>{m}</SelectItem>)}
                 </SelectContent>
               </Select>

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1168,7 +1168,11 @@ function ProviderForm({
 }) {
   const handleProtocolChange = (protocol: string) => {
     const defaultUrl = PROTOCOL_DEFAULTS[protocol] || '';
-    setDraft({ ...draft, protocol, base_url: defaultUrl });
+    const oldDefault = PROTOCOL_DEFAULTS[draft.protocol] || '';
+    const current = draft.base_url.trim();
+    // 仅当地址为空或仍等于旧协议默认地址时跟随协议更新，避免覆盖用户自填地址。
+    const keepUrl = current !== '' && current !== oldDefault;
+    setDraft({ ...draft, protocol, base_url: keepUrl ? draft.base_url : defaultUrl });
   };
 
   return (

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -10,6 +10,7 @@ import {
 import { AppSidebar } from '@/components/AppSidebar';
 import { BackgroundPluginHost, type BackgroundPluginInstance } from '@/components/BackgroundPluginHost';
 import { DefaultPluginOnboarding } from '@/components/DefaultPluginOnboarding';
+import { FirstRunModelSetup } from '@/components/FirstRunModelSetup';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { LazyMessageList, LazyMessageInput, LazyStatusPanel } from '@/components/LazyComponents';
 import {
@@ -133,6 +134,8 @@ export function MainApp() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   // 首次启动推荐安装的缺失默认插件列表；为 null 时不显示引导对话框。
   const [onboardingMissing, setOnboardingMissing] = useState<AvailablePlugin[] | null>(null);
+  // 未配置主对话模型时弹出快速配置弹窗。
+  const [modelSetupOpen, setModelSetupOpen] = useState(false);
   const showWorkspacePanelRef = useRef(false);
   const workspaceTabKindRef = useRef<TabKind>('browser');
   const workspaceOpenRequestIdRef = useRef(0);
@@ -391,6 +394,14 @@ export function MainApp() {
         }
       })
       .catch((error) => console.warn('默认插件检测失败', error));
+
+    // 未配置主对话模型（chat 路由）时在主页面弹出快速配置引导；
+    // 独立 catch，检测失败不影响主初始化流程。
+    api.getModelsConfig()
+      .then((cfg) => {
+        if (!cfg.routing.chat) setModelSetupOpen(true);
+      })
+      .catch((error) => console.warn('模型配置检测失败', error));
 
     const flushStreamEvents = () => {
       streamEventTimerRef.current = null;
@@ -866,6 +877,11 @@ export function MainApp() {
         onComplete={() => {
           /* 安装后 registry 会热加载，Core 创建时按需感知已装插件，无需额外刷新 */
         }}
+      />
+
+      <FirstRunModelSetup
+        open={modelSetupOpen}
+        onOpenChange={setModelSetupOpen}
       />
     </SidebarProvider>
   );

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1655,10 +1655,7 @@ pub async fn synthesize_speech(
     let resp = output.response;
 
     // 将音频保存到临时文件，通过 asset 协议播放
-    let media_dir = user_home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".tiangong")
-        .join("media");
+    let media_dir = tiangong_config::io::storage_root().join("media");
     std::fs::create_dir_all(&media_dir).map_err(|e| format!("创建媒体目录失败：{e}"))?;
 
     let ext = match resp.mime_type.as_str() {
@@ -1747,10 +1744,7 @@ pub async fn transcribe_speech(
         .map_err(|e| format!("音频数据解码失败：{e}"))?;
 
     // 保存音频文件
-    let media_dir = user_home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".tiangong")
-        .join("media");
+    let media_dir = tiangong_config::io::storage_root().join("media");
     std::fs::create_dir_all(&media_dir).map_err(|e| format!("创建媒体目录失败：{e}"))?;
 
     let ext = match mime_type.as_str() {
@@ -3629,10 +3623,7 @@ pub fn is_server_running(config: &tiangong_server::config::ServerConfig) -> bool
 }
 
 fn server_pid_path() -> PathBuf {
-    user_home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".tiangong")
-        .join("server.pid")
+    tiangong_config::io::storage_root().join("server.pid")
 }
 
 fn server_pid_alive() -> bool {
@@ -3730,18 +3721,6 @@ pub fn connect_host(host: &str) -> String {
         "" | "0.0.0.0" | "::" => "127.0.0.1".to_string(),
         value => value.to_string(),
     }
-}
-
-/// 获取用户 home 目录
-fn user_home_dir() -> Option<PathBuf> {
-    if let Some(home) = std::env::var_os("HOME").filter(|v| !v.is_empty()) {
-        return Some(PathBuf::from(home));
-    }
-    if let Some(profile) = std::env::var_os("USERPROFILE").filter(|v| v != std::ffi::OsStr::new(""))
-    {
-        return Some(PathBuf::from(profile));
-    }
-    None
 }
 
 // ============================================================================

--- a/src-tauri/src/webview_host/manager.rs
+++ b/src-tauri/src/webview_host/manager.rs
@@ -3248,17 +3248,12 @@ fn persist_zoom(shared: &Arc<BrowserSharedState>) {
 }
 
 fn browser_data_directory(session_id: &str) -> PathBuf {
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .unwrap_or_else(|_| ".".to_string());
     // per-session data 目录隔离 cookie/storage；空 session_id 回退全局目录（兼容）
+    let base = tiangong_config::io::storage_root().join("browser-data");
     let dir = if session_id.is_empty() {
-        PathBuf::from(home).join(".tiangong").join("browser-data")
+        base
     } else {
-        PathBuf::from(home)
-            .join(".tiangong")
-            .join("browser-data")
-            .join(session_id)
+        base.join(session_id)
     };
     let _ = std::fs::create_dir_all(&dir);
     dir


### PR DESCRIPTION
## 变更内容

### 首次配置快速弹窗（新增）

- 主页面启动时检测能力路由缺少 `chat` 条目时，自动弹出「配置对话模型」modal，提供快速配置入口
- 弹窗内直接完成配置：供应商选择（DeepSeek / 智谱 / 自定义）、Base URL、API Key、请求格式、模型选择
- 支持从供应商拉取真实模型列表供选择；拉取失败或无返回时可手动输入模型名
- DeepSeek 锁定官方地址与 `deepseek` 协议：地址置灰、请求格式只读展示
- 提交时以服务端最新配置为基底合并写入供应商与模型定义，并自动将该模型配置为对话（`chat`）路由，完成后即可直接发起对话
- 已配置主对话模型的用户不再看到提示；可主动跳过，不阻断其他功能
- 错误内联展示于表单内，组件自包含不依赖全局 Toast Provider

### 竞态与边界修复

- 模型列表请求引入代号：切换供应商或重开弹窗时递增并复位获取中状态，迟到的旧响应直接丢弃，不再把 A 供应商的模型写入 B 供应商的表单
- 获取成功后校验已输入的模型名，不在返回列表中则清空，避免保存界面上不可见的模型
- 弹窗内 Select 下拉内容层级提升到遮罩之上，修复下拉无法展开的问题
- 切换请求格式时仅当地址为空或等于旧协议默认地址才跟随更新，不再覆盖用户自填的 Base URL（设置页 ProviderForm 与快速配置弹窗行为一致）

### 存储根目录环境变量支持

- `tiangong-config` 的 `storage_root` / `default_tiangong_dir` 支持 `TIANGONG_STORAGE_ROOT` 覆盖，与 `tiangong_plugin_runtime::sidecar::STORAGE_ROOT_ENV` 约定对齐
- server.json、日志目录收口到统一路径函数；src-tauri 中媒体目录、server.pid、浏览器历史与 browser-data 的硬编码路径全部改为使用 `tiangong_config::io::storage_root()`
- 未设置变量时行为与原来完全一致；用于测试与多实例隔离

## 测试情况

- [x] `yarn build`（tsc + vite）通过
- [x] 前端测试 18 个文件 219 个用例全部通过
- [x] `cargo check -p tiangong-app` 通过
- [x] `cargo clippy -p tiangong-config -p tiangong-bots --all-targets` 零警告
- [x] `cargo test -p tiangong-config` 17 个测试全部通过
- [x] pre-commit 钩子（含 cargo fmt）通过
- [x] Desktop 真实链路验证：隔离存储根下完成 DeepSeek 配置 → 自动路由 → 发起对话