### PR TITLE
feat(sandbox): 设置中提供命令沙箱用户开关

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,9 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           matrix: ${{ needs.changes.outputs.matrix }}
+      - name: Prepare sandbox launcher artifact
+        if: contains(fromJSON(needs.changes.outputs.matrix), 'tiangong-app')
+        run: cargo run --locked -p xtask -- prepare-sandbox
       - name: Check crates
         env:
           MATRIX: ${{ needs.changes.outputs.matrix }}
@@ -195,6 +198,9 @@ jobs:
         with:
           matrix: ${{ needs.changes.outputs.matrix }}
           components: clippy
+      - name: Prepare sandbox launcher artifact
+        if: contains(fromJSON(needs.changes.outputs.matrix), 'tiangong-app')
+        run: cargo run --locked -p xtask -- prepare-sandbox
       - name: Lint crates
         env:
           MATRIX: ${{ needs.changes.outputs.matrix }}
@@ -217,6 +223,9 @@ jobs:
         with:
           matrix: ${{ needs.changes.outputs.matrix }}
           install-nextest: true
+      - name: Prepare sandbox launcher artifact
+        if: contains(fromJSON(needs.changes.outputs.matrix), 'tiangong-app')
+        run: cargo run --locked -p xtask -- prepare-sandbox
       - name: Test crates
         env:
           MATRIX: ${{ needs.changes.outputs.matrix }}
@@ -316,6 +325,8 @@ jobs:
             patchelf
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Prepare sandbox launcher artifact
+        run: cargo run --locked -p xtask -- prepare-sandbox
       - name: Check Tauri shell
         run: cargo check --manifest-path src-tauri/Cargo.toml
 

--- a/crates/tiangong-config/src/config.rs
+++ b/crates/tiangong-config/src/config.rs
@@ -133,6 +133,8 @@ pub struct TiangongConfig {
     // ===== 应用层配置 =====
     /// 默认工作目录
     pub workspace_dir: String,
+    /// 用户显式关闭命令沙箱（全局；关闭时 command 以完整用户权限直跑）
+    pub sandbox_disabled: bool,
     /// Server 配置
     pub server: ServerConfig,
 }
@@ -145,6 +147,7 @@ impl Default for TiangongConfig {
             default_trust_mode: TrustMode::default(),
             custom_system_prompt: String::new(),
             workspace_dir: crate::loader::default_workspace_dir(),
+            sandbox_disabled: false,
             server: ServerConfig::default(),
         }
     }

--- a/crates/tiangong-config/src/io.rs
+++ b/crates/tiangong-config/src/io.rs
@@ -63,6 +63,8 @@ pub fn custom_prompt_path() -> PathBuf {
 struct AppConfigFile<'a> {
     default_trust_mode: TrustMode,
     workspace_dir: &'a str,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    sandbox_disabled: bool,
 }
 
 /// 保存应用长期配置到 `app.json`。
@@ -73,6 +75,7 @@ pub fn save_app_config_at(
     dir: &Path,
     default_trust_mode: TrustMode,
     workspace_dir: &str,
+    sandbox_disabled: bool,
 ) -> Result<()> {
     let path = dir.join("app.json");
     if let Some(parent) = path.parent() {
@@ -82,6 +85,7 @@ pub fn save_app_config_at(
     let content = serde_json::to_string_pretty(&AppConfigFile {
         default_trust_mode,
         workspace_dir,
+        sandbox_disabled,
     })
     .context("序列化应用配置失败")?;
     std::fs::write(&path, content)
@@ -294,6 +298,35 @@ mod tests {
     use tiangong_llm::models_config::{
         ModelCapability, ModelEntry, ModelsConfig, ProviderConfig, RoutingSlot,
     };
+
+    /// 命令沙箱开关持久化：关闭状态写入 app.json 并能读回；
+    /// 默认开启时序列化省略该字段（旧版文件兼容）。
+    #[test]
+    fn app_config_roundtrips_sandbox_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        save_app_config_at(
+            dir.path(),
+            TrustMode::default(),
+            dir.path().to_str().unwrap(),
+            true,
+        )
+        .unwrap();
+        assert!(crate::loader::load_tiangong_config_from_dir(dir.path()).sandbox_disabled);
+
+        save_app_config_at(
+            dir.path(),
+            TrustMode::default(),
+            dir.path().to_str().unwrap(),
+            false,
+        )
+        .unwrap();
+        let raw = std::fs::read_to_string(dir.path().join("app.json")).unwrap();
+        assert!(
+            !raw.contains("sandbox_disabled"),
+            "默认开启时不应写入字段: {raw}"
+        );
+        assert!(!crate::loader::load_tiangong_config_from_dir(dir.path()).sandbox_disabled);
+    }
 
     /// save_models_config_at 应把 routing 中未注册到 models 的条目自动补入 models。
     #[test]

--- a/crates/tiangong-config/src/loader.rs
+++ b/crates/tiangong-config/src/loader.rs
@@ -26,6 +26,8 @@ struct AppConfigFile {
     #[serde(default)]
     default_trust_mode: Option<TrustMode>,
     #[serde(default)]
+    sandbox_disabled: bool,
+    #[serde(default)]
     custom_system_prompt: String,
     #[serde(default)]
     agent_config: Option<LegacyAgentConfig>,
@@ -129,6 +131,7 @@ pub fn load_tiangong_config_from_dir(dir: &Path) -> TiangongConfig {
         default_trust_mode: app.resolved_default_trust_mode(),
         custom_system_prompt,
         workspace_dir,
+        sandbox_disabled: app.sandbox_disabled,
         server,
     }
 }

--- a/crates/tiangong-config/src/registry.rs
+++ b/crates/tiangong-config/src/registry.rs
@@ -63,6 +63,15 @@ pub fn try_models() -> Option<tiangong_llm::models_config::ModelsConfig> {
         .map(|config| config.models)
 }
 
+/// 读取用户"命令沙箱"开关；尚未初始化配置时返回 None（调用方按开启处理）。
+pub fn try_sandbox_disabled() -> Option<bool> {
+    config_cell()
+        .read()
+        .ok()
+        .and_then(|guard| guard.clone())
+        .map(|config| config.sandbox_disabled)
+}
+
 /// 可靠更新模型配置：先写盘成功，再更新兼容副本并返回新的完整配置。
 ///
 /// 处理顺序：
@@ -108,7 +117,12 @@ impl TiangongConfig {
         } else {
             crate::io::save_custom_prompt_at(&prompt_path, &self.custom_system_prompt)?;
         }
-        crate::io::save_app_config_at(dir, self.default_trust_mode, &self.workspace_dir)?;
+        crate::io::save_app_config_at(
+            dir,
+            self.default_trust_mode,
+            &self.workspace_dir,
+            self.sandbox_disabled,
+        )?;
         Ok(())
     }
 }

--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -2604,7 +2604,14 @@ fn sidecar_connection_inner(
     if installed.manifest.id == "command" && !official_signed {
         bail!("command 插件必须由官方发布者签名");
     }
-    let host_policy = tiangong_sandbox::host_policy::resolve(&installed.manifest.id);
+    // 用户全局"命令沙箱"开关（设置页）：关闭时 command 以完整用户权限直跑。
+    // 配置读取失败按默认开启处理（fail-safe 向保护方向）。
+    let sandbox_disabled = tiangong_config::registry::try_sandbox_disabled().unwrap_or(false);
+    if sandbox_disabled && installed.manifest.id == "command" {
+        tracing::warn!("命令沙箱已被用户设置关闭：command 将以完整用户权限执行");
+    }
+    let host_policy =
+        tiangong_sandbox::host_policy::resolve(&installed.manifest.id, sandbox_disabled);
     let use_stdio = interpreter.is_some()
         || host_policy.transport == tiangong_sandbox::host_policy::SidecarTransport::Stdio;
 

--- a/crates/tiangong-plugin-runtime/src/sidecar/command.rs
+++ b/crates/tiangong-plugin-runtime/src/sidecar/command.rs
@@ -37,8 +37,9 @@ pub struct EphemeralCommandConnection {
 }
 
 impl EphemeralCommandConnection {
-    pub fn new(mut template: SidecarConfig) -> Self {
-        template.sandbox = true;
+    /// `template.sandbox` 由唯一生产构造点（registry 策略表，含用户
+    /// "命令沙箱"开关）显式决定，封套不再暗改——测试构造时需显式设置。
+    pub fn new(template: SidecarConfig) -> Self {
         Self {
             template,
             exec_env: Mutex::new(BTreeMap::new()),

--- a/crates/tiangong-plugin-runtime/src/sidecar/stdio.rs
+++ b/crates/tiangong-plugin-runtime/src/sidecar/stdio.rs
@@ -391,11 +391,16 @@ impl StdioSidecarConnection {
             .env(
                 SANDBOX_MEMORY_LIMIT_ENV,
                 resource_limits.max_memory_bytes.to_string(),
-            )
-            .env(
+            );
+        // 进程数上限（RLIMIT_NPROC）按真实用户全局计数：无沙箱直跑时与
+        // 宿主既有进程共享配额，进程数较多的环境（CI runner、桌面）会令
+        // 命令 fork 直接失败（Cannot fork）。仅在沙箱链路保持既有注入。
+        if launch_policy.is_some() {
+            command.env(
                 SANDBOX_PROCESS_LIMIT_ENV,
                 resource_limits.max_processes.to_string(),
             );
+        }
         if let Some(temp_dir) = &self.config.sandbox_temp_dir {
             if !temp_dir.is_absolute() || !temp_dir.is_dir() {
                 bail!("sidecar 专用临时目录无效: {}", temp_dir.display());

--- a/crates/tiangong-plugin-runtime/src/sidecar/stdio.rs
+++ b/crates/tiangong-plugin-runtime/src/sidecar/stdio.rs
@@ -377,21 +377,25 @@ impl StdioSidecarConnection {
             .env(PLUGIN_ENDPOINT_ENV, &self.config.endpoint)
             .env(PLUGIN_DATA_DIR_ENV, &self.config.data_dir)
             .env(PROCESS_GROUP_ENV, "1");
-        if let Some(policy) = &launch_policy {
-            command
-                .env(
-                    SANDBOX_CPU_LIMIT_ENV,
-                    policy.resource_limits.max_cpu_time_seconds.to_string(),
-                )
-                .env(
-                    SANDBOX_MEMORY_LIMIT_ENV,
-                    policy.resource_limits.max_memory_bytes.to_string(),
-                )
-                .env(
-                    SANDBOX_PROCESS_LIMIT_ENV,
-                    policy.resource_limits.max_processes.to_string(),
-                );
-        }
+        // 资源上限不依赖沙箱：无沙箱直跑（用户关闭命令沙箱）时也注入，
+        // sidecar 层 rlimit 照常自愿生效，防止关闭沙箱后命令失控烧机器。
+        let resource_limits = launch_policy
+            .as_ref()
+            .map(|policy| policy.resource_limits)
+            .unwrap_or_default();
+        command
+            .env(
+                SANDBOX_CPU_LIMIT_ENV,
+                resource_limits.max_cpu_time_seconds.to_string(),
+            )
+            .env(
+                SANDBOX_MEMORY_LIMIT_ENV,
+                resource_limits.max_memory_bytes.to_string(),
+            )
+            .env(
+                SANDBOX_PROCESS_LIMIT_ENV,
+                resource_limits.max_processes.to_string(),
+            );
         if let Some(temp_dir) = &self.config.sandbox_temp_dir {
             if !temp_dir.is_absolute() || !temp_dir.is_dir() {
                 bail!("sidecar 专用临时目录无效: {}", temp_dir.display());

--- a/crates/tiangong-plugin-runtime/tests/ephemeral_route.rs
+++ b/crates/tiangong-plugin-runtime/tests/ephemeral_route.rs
@@ -123,7 +123,22 @@ fn sandbox_fixture() -> Option<SandboxFixture> {
 fn sandbox_fixture_with_limits(
     limits: Option<tiangong_sandbox::SandboxResourceLimits>,
 ) -> Option<SandboxFixture> {
-    if !sandbox_binaries_ready() {
+    sandbox_fixture_configured(true, limits)
+}
+
+/// `sandbox=false` 模拟用户在设置中关闭命令沙箱：不经 Launcher 直跑，
+/// 不依赖平台沙箱可用性（嵌套受限环境也可真实执行）。
+#[cfg(any(unix, windows))]
+fn sandbox_fixture_configured(
+    sandbox: bool,
+    limits: Option<tiangong_sandbox::SandboxResourceLimits>,
+) -> Option<SandboxFixture> {
+    if sandbox {
+        if !sandbox_binaries_ready() {
+            return None;
+        }
+    } else if command_sidecar_binary().is_none() {
+        eprintln!("跳过无沙箱测试：target/debug/tiangong-command-sidecar 尚未构建");
         return None;
     }
     let root = tempfile::tempdir().unwrap();
@@ -174,6 +189,7 @@ fn sandbox_fixture_with_limits(
     )
     .with_protocols(PROTOCOL_VERSION, COMMAND_PROTOCOL_VERSION)
     .with_timeouts(Duration::from_secs(15), Duration::from_secs(90))
+    .with_sandbox(sandbox)
     .with_sandbox_program_root(Some(plugin_root))
     .with_sandbox_denied_read_paths(vec![ssh_dir, aws_dir, trust_db.clone()])
     .with_sandbox_resource_limits(limits);
@@ -405,6 +421,35 @@ fn real_launcher_enforces_workspace_and_dedicated_temp() {
     let response: serde_json::Value = serde_json::from_str(&raw).unwrap();
     assert_eq!(response["ok"], false, "工作区外写入必须失败: {raw}");
     assert!(!fixture.outside.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn sandbox_disabled_runs_command_without_launcher() {
+    let _serial = REAL_SANDBOX_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // 模拟用户在设置中关闭命令沙箱：直跑链路（不经 Launcher），
+    // 命令真实执行成功；环境净化与资源上限注入仍然保留。
+    let Some(fixture) = sandbox_fixture_configured(false, None) else {
+        return;
+    };
+
+    let raw = fixture
+        .connection
+        .invoke_with_context(
+            RUN_SHELL_OPERATION,
+            &shell_request(
+                "printf direct > ran.txt && test -n \"$TMPDIR\" && printf '%s' ok".to_string(),
+                &fixture.workspace,
+            ),
+            &invocation_context(&fixture.workspace, "sandbox-disabled"),
+        )
+        .expect("无沙箱 command 执行失败");
+    let response: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(response["ok"], true, "关闭沙箱后命令应真实执行: {raw}");
+    assert_eq!(response["stdout"].as_str().unwrap_or_default(), "ok");
+    assert!(fixture.workspace.join("ran.txt").is_file());
 }
 
 #[cfg(unix)]

--- a/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
+++ b/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
@@ -235,9 +235,12 @@ fn apply_unix_resource_limits(
             // 以宏在调用点展开让 libc 常量类型自然匹配。
             macro_rules! apply {
                 ($resource:expr, $value:expr) => {{
+                    // 硬限略高于软限：软限到期发 SIGXCPU（默认终止，可归因），
+                    // 无视它的进程由硬限 SIGKILL 兜底；软硬同值时 Linux 会
+                    // 直接 SIGKILL，终止原因无法与外部强杀区分。
                     let wanted = libc::rlimit {
                         rlim_cur: ($value) as libc::rlim_t,
-                        rlim_max: ($value) as libc::rlim_t,
+                        rlim_max: ($value).saturating_add(1) as libc::rlim_t,
                     };
                     if libc::setrlimit($resource, &wanted) == 0 {
                         Ok(())

--- a/crates/tiangong-sandbox/src/host_policy.rs
+++ b/crates/tiangong-sandbox/src/host_policy.rs
@@ -27,10 +27,14 @@ pub struct HostExecutionPolicy {
 }
 
 /// 解析插件的宿主执行策略。
-pub fn resolve(plugin_id: &str) -> HostExecutionPolicy {
+///
+/// `sandbox_disabled` 为用户全局设置（设置页"命令沙箱"开关）：仅影响
+/// command 的沙箱决策；其他插件的存量 TCP 行为不受影响。开关由宿主
+/// 读取配置传入，策略表本身不读全局状态。
+pub fn resolve(plugin_id: &str, sandbox_disabled: bool) -> HostExecutionPolicy {
     if plugin_id == "command" {
         return HostExecutionPolicy {
-            sandbox: true,
+            sandbox: !sandbox_disabled,
             allow_network: false,
             transport: SidecarTransport::Stdio,
         };
@@ -42,11 +46,11 @@ pub fn resolve(plugin_id: &str) -> HostExecutionPolicy {
     }
 }
 
-/// 策略表快照（审计与测试用）。
+/// 策略表快照（审计与测试用）；沙箱开关默认开启。
 pub fn catalog_snapshot() -> BTreeMap<String, HostExecutionPolicy> {
     ["command"]
         .iter()
-        .map(|id| ((*id).to_string(), resolve(id)))
+        .map(|id| ((*id).to_string(), resolve(id, false)))
         .collect()
 }
 
@@ -56,7 +60,7 @@ mod tests {
 
     #[test]
     fn command_is_the_only_sandboxed_official_plugin() {
-        let policy = resolve("command");
+        let policy = resolve("command", false);
         assert!(policy.sandbox);
         assert_eq!(policy.transport, SidecarTransport::Stdio);
         // 其它官方插件按存量默认（TCP、不沙箱），逐批迁移归独立分支。
@@ -69,9 +73,20 @@ mod tests {
             "terminal",
             "index",
         ] {
-            let policy = resolve(id);
+            let policy = resolve(id, false);
             assert!(!policy.sandbox, "{id} 本分支不沙箱化");
             assert_eq!(policy.transport, SidecarTransport::Tcp, "{id} 保持存量 TCP");
         }
+    }
+
+    #[test]
+    fn user_setting_disables_only_command_sandbox() {
+        let policy = resolve("command", true);
+        assert!(!policy.sandbox, "用户关闭后 command 不再走沙箱");
+        assert_eq!(policy.transport, SidecarTransport::Stdio);
+        // 开关不影响其他插件的存量策略。
+        let other = resolve("fetch", true);
+        assert!(!other.sandbox);
+        assert_eq!(other.transport, SidecarTransport::Tcp);
     }
 }

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -788,6 +788,12 @@ export const api = {
   setDefaultTrustMode: (mode: string): Promise<void> =>
     invoke('set_default_trust_mode', { mode }),
 
+  getSandboxDisabled: (): Promise<boolean> =>
+    invoke('get_sandbox_disabled'),
+
+  setSandboxDisabled: (disabled: boolean): Promise<void> =>
+    invoke('set_sandbox_disabled', { disabled }),
+
 
   getReasoningEffort: (sessionId?: string): Promise<string> =>
     invoke('get_reasoning_effort', { sessionId }),

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -3,7 +3,7 @@ import type { SetStateAction } from 'react';
 import { selectCurrentInputCacheKey, selectCurrentInputCache, useStore } from '@/store/useStore';
 import { MentionEditor, type MentionEditorHandle } from './MentionEditor';
 import { Button } from './ui/button';
-import { Send, Square, FolderOpen, Wrench, Cpu, Mic, Loader2, Keyboard, MessageSquarePlus, ShieldCheck, ShieldOff, Circle, Paperclip, X, Users, Brain, Clock } from 'lucide-react';
+import { Send, Square, FolderOpen, Wrench, Cpu, Mic, Loader2, Keyboard, MessageSquarePlus, ShieldCheck, ShieldOff, Circle, Paperclip, X, Users, Brain, Clock, Unlock } from 'lucide-react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
 import type { DragDropEvent } from '@tauri-apps/api/webview';
@@ -66,6 +66,9 @@ export function MessageInput({
   const isSending = inputCache.is_sending;
   const setInputCacheText = useStore((state) => state.setInputCacheText);
   const setInputCacheAttachments = useStore((state) => state.setInputCacheAttachments);
+  const sandboxDisabled = useStore((state) => state.sandboxDisabled);
+  const loadSandboxDisabled = useStore((state) => state.loadSandboxDisabled);
+  const setPendingSettingsTab = useStore((state) => state.setPendingSettingsTab);
   const sendMessage = useStore((state) => state.sendMessage);
   const appendMessage = useStore((state) => state.appendMessage);
   const enqueueInputMessage = useStore((state) => state.enqueueInputMessage);
@@ -176,6 +179,13 @@ export function MessageInput({
       cancelled = true;
     };
   }, [activeSessionId]);
+
+  // 命令沙箱开关（全局）：状态图标来源；null 表示尚未加载。
+  useEffect(() => {
+    if (sandboxDisabled === null) {
+      void loadSandboxDisabled();
+    }
+  }, [sandboxDisabled, loadSandboxDisabled]);
 
   const toggleTrustMode = async () => {
     const newMode = trustMode === 'full_trust' ? 'supervised' : 'full_trust';
@@ -1207,6 +1217,16 @@ export function MessageInput({
                       </>
                     )}
                   </div>
+                )}
+                {sandboxDisabled === true && (
+                  <button
+                    onClick={() => setPendingSettingsTab('agent')}
+                    className="flex items-center gap-1 text-red-500 transition-colors hover:text-red-400"
+                    title="命令沙箱已关闭：命令以完整用户权限运行，点击前往设置重新开启"
+                  >
+                    <Unlock className="w-3 h-3" />
+                    <span>沙箱关</span>
+                  </button>
                 )}
                 <button
                   onClick={toggleTrustMode}

--- a/frontend/src/components/SettingsDialog.tsx
+++ b/frontend/src/components/SettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './ui/dialog';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
@@ -246,10 +246,17 @@ export function SettingsDialog() {
 function AgentSettings({ onSaveStatusChange }: { onSaveStatusChange: (status: SaveStatus) => void }) {
   const [defaultTrustMode, setDefaultTrustMode] = useState('full_trust');
   const { showError } = useToast();
-  const { workspaceDir, setWorkspaceDir } = useStore();
+  const { workspaceDir, setWorkspaceDir, sandboxDisabled, loadSandboxDisabled, setSandboxDisabled } = useStore();
   const [editWorkspaceDir, setEditWorkspaceDir] = useState(workspaceDir);
   const [isSavingWorkspace, setIsSavingWorkspace] = useState(false);
   const { showSuccess } = useToast();
+  const [confirmDisableSandbox, setConfirmDisableSandbox] = useState(false);
+
+  useEffect(() => {
+    if (sandboxDisabled === null) {
+      void loadSandboxDisabled();
+    }
+  }, [sandboxDisabled, loadSandboxDisabled]);
 
   useEffect(() => {
     setEditWorkspaceDir(workspaceDir);
@@ -277,6 +284,25 @@ function AgentSettings({ onSaveStatusChange }: { onSaveStatusChange: (status: Sa
       console.error('保存默认审核模式失败:', error);
       onSaveStatusChange('error');
       showError('保存失败', '无法保存默认审核模式');
+    }
+  };
+
+  const handleSandboxToggle = async (disabled: boolean) => {
+    onSaveStatusChange('saving');
+    try {
+      await setSandboxDisabled(disabled);
+      onSaveStatusChange('saved');
+      showSuccess(
+        disabled ? '命令沙箱已关闭' : '命令沙箱已开启',
+        disabled
+          ? '命令将以完整用户权限运行，输入区会显示警告标识'
+          : '命令恢复工作区、联网与凭据限制',
+      );
+      setTimeout(() => onSaveStatusChange('idle'), 2000);
+    } catch (error) {
+      console.error('设置命令沙箱开关失败:', error);
+      onSaveStatusChange('error');
+      showError('保存失败', '无法保存命令沙箱开关');
     }
   };
 
@@ -333,6 +359,30 @@ function AgentSettings({ onSaveStatusChange }: { onSaveStatusChange: (status: Sa
         </div>
 
         <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <Label>命令沙箱</Label>
+              <p className="text-xs text-muted-foreground max-w-md">
+                开启后命令只能写入当前工作区、默认禁止联网、无法读取你的凭据。
+                关闭后命令将以你的完整用户权限运行，输入区会持续显示警告标识。
+              </p>
+            </div>
+            <Switch
+              checked={sandboxDisabled !== true}
+              disabled={sandboxDisabled === null}
+              onCheckedChange={(enabled) => {
+                if (enabled) {
+                  void handleSandboxToggle(false);
+                } else {
+                  setConfirmDisableSandbox(true);
+                }
+              }}
+              aria-label="命令沙箱"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
           <Label htmlFor="workspacePath">默认工作区目录</Label>
           <div className="flex gap-2">
             <Input
@@ -366,6 +416,30 @@ function AgentSettings({ onSaveStatusChange }: { onSaveStatusChange: (status: Sa
         </div>
       </div>
 
+      {/* 关闭命令沙箱的警示确认 */}
+      <Dialog open={confirmDisableSandbox} onOpenChange={(open) => !open && setConfirmDisableSandbox(false)}>
+        <DialogContent className="mx-4 w-[calc(100%-2rem)] max-w-md">
+          <DialogHeader>
+            <DialogTitle>关闭命令沙箱？</DialogTitle>
+            <DialogDescription>
+              关闭后，Agent 执行的命令将以你的完整用户权限运行：可以读写任意文件、
+              访问网络和你的凭据，不再受工作区与联网限制。仅在你明确需要时短期关闭，
+              并在完成后重新开启。输入区会持续显示"沙箱关"警告标识。
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDisableSandbox(false)}>
+              取消
+            </Button>
+            <Button variant="destructive" onClick={() => {
+              setConfirmDisableSandbox(false);
+              void handleSandboxToggle(true);
+            }}>
+              关闭沙箱
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -960,6 +960,11 @@ export interface AppState {
   setSessionCwd: (cwd: string) => Promise<void>;
   setWorkspaceDir: (workspaceDir: string) => Promise<void>;
 
+  /** 用户"命令沙箱"开关（全局）：null 表示尚未从宿主加载。 */
+  sandboxDisabled: boolean | null;
+  loadSandboxDisabled: () => Promise<void>;
+  setSandboxDisabled: (disabled: boolean) => Promise<void>;
+
   loadMcpServers: () => Promise<void>;
 
   setSelectedAgentTab: (tab: string | null) => void;
@@ -1002,6 +1007,7 @@ export const useStore = create<AppState>((set, get) => ({
   setUpdateAvailable: (info) => set({ updateAvailable: info }),
   pendingSettingsTab: null,
   setPendingSettingsTab: (tab) => set({ pendingSettingsTab: tab }),
+  sandboxDisabled: null,
   reasoningEffort: 'medium',
   reasoningEffortPerSession: {},
   setReasoningEffort: (effort: string) => {
@@ -1980,6 +1986,27 @@ export const useStore = create<AppState>((set, get) => ({
       set({ workspaceDir });
     } catch (error) {
       console.error('设置工作空间失败:', error);
+      throw error;
+    }
+  },
+
+  // 加载用户"命令沙箱"开关（设置页与输入区状态图标共用）
+  loadSandboxDisabled: async () => {
+    try {
+      const disabled = await api.getSandboxDisabled();
+      set({ sandboxDisabled: disabled });
+    } catch (error) {
+      console.error('加载命令沙箱开关失败:', error);
+    }
+  },
+
+  // 写入用户"命令沙箱"开关并同步宿主配置
+  setSandboxDisabled: async (disabled: boolean) => {
+    try {
+      await api.setSandboxDisabled(disabled);
+      set({ sandboxDisabled: disabled });
+    } catch (error) {
+      console.error('设置命令沙箱开关失败:', error);
       throw error;
     }
   },

--- a/plugins/tiangong-plugin-command/sidecar/src/exec.rs
+++ b/plugins/tiangong-plugin-command/sidecar/src/exec.rs
@@ -233,9 +233,11 @@ fn configure_command_lifecycle(command: &mut Command) -> Result<()> {
             use std::os::unix::process::CommandExt;
             command.pre_exec(move || {
                 if let Some(limit) = cpu_limit {
+                    // 硬限略高于软限：软限 SIGXCPU 先行可归因，硬限 SIGKILL
+                    // 兜底（软硬同值时 Linux 直接 SIGKILL，Launcher 层同理）。
                     let limit = libc::rlimit {
                         rlim_cur: limit as libc::rlim_t,
-                        rlim_max: limit as libc::rlim_t,
+                        rlim_max: limit.saturating_add(1) as libc::rlim_t,
                     };
                     if libc::setrlimit(libc::RLIMIT_CPU, &limit) != 0 {
                         return Err(std::io::Error::last_os_error());

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1464,6 +1464,40 @@ pub async fn set_default_trust_mode(
 }
 
 #[tauri::command]
+pub async fn get_sandbox_disabled(state: State<'_, TiangongApp>) -> Result<bool, String> {
+    state
+        .with_state_read(|core_state| Ok(core_state.config.sandbox_disabled))
+        .await
+}
+
+#[tauri::command]
+pub async fn set_sandbox_disabled(
+    disabled: bool,
+    state: State<'_, TiangongApp>,
+) -> Result<(), String> {
+    let mut config = state
+        .with_state_read(|core_state| Ok(core_state.config.clone()))
+        .await?;
+    if config.sandbox_disabled == disabled {
+        return Ok(());
+    }
+    config.sandbox_disabled = disabled;
+    tiangong_config::registry::update(config.clone()).map_err(|error| error.to_string())?;
+    state
+        .with_state(|core_state| {
+            core_state.config = config;
+            Ok(())
+        })
+        .await?;
+    if disabled {
+        tracing::warn!("用户已在设置中关闭命令沙箱：command 将以完整用户权限执行");
+    } else {
+        tracing::info!("用户已重新开启命令沙箱");
+    }
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn get_reasoning_effort(
     session_id: Option<String>,
     state: State<'_, TiangongApp>,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -841,6 +841,8 @@ fn run_gui() {
             tiangong_app::commands::set_trust_mode,
             tiangong_app::commands::get_default_trust_mode,
             tiangong_app::commands::set_default_trust_mode,
+            tiangong_app::commands::get_sandbox_disabled,
+            tiangong_app::commands::set_sandbox_disabled,
             tiangong_app::commands::get_reasoning_effort,
             tiangong_app::commands::set_reasoning_effort,
             tiangong_app::commands::get_provider_balance,


### PR DESCRIPTION
## 概述

按用户需求在设置中提供全局"命令沙箱"开关（默认开启）。这是用户显式设置且全程可视化的能力，与静默降级无关；沙箱平台能力不可用时的拒绝执行语义不变。

## 行为

- **设置页**（智能体分区）：开关默认开启；关闭时弹出警示确认（命令将以完整用户权限运行、可读写任意文件与网络、建议仅短期关闭，destructive 确认按钮）；重新开启直接生效。
- **状态图标**：关闭期间输入区信任标识左侧常显红色 `Unlock` "沙箱关"（悬停说明 + 点击跳转设置智能体页）；开启时不显示。
- **警示日志**：宿主在每次 command 调用与设置变更时输出 warn 日志（审计信号）。
- **资源保护保留**：CPU/内存上限注入不依赖沙箱，无沙箱直跑时照常生效，防命令失控烧机器。
- **持久化**：app.json `sandbox_disabled`（默认开启不写字段，旧配置完全兼容）；配置读取失败按开启处理（fail-safe 向保护方向）。

## 实现要点

- `host_policy::resolve` 参数化 `sandbox_disabled`（仅影响 command，其他插件策略不变）；registry 组合配置并告警。
- `EphemeralCommandConnection` 不再硬编码强制 sandbox，由唯一生产构造点（registry 策略表）显式决定。
- `get_sandbox_disabled` / `set_sandbox_disabled` Tauri 命令（照 default_trust_mode 模式：落盘 + 内存热更 + 状态同步）。
- 新增无沙箱直跑真实链路测试（不依赖沙箱环境，任何机器真实执行）。

## 附带修复（已单独提交并 cherry-pick 到 #441）

- Launcher rlimit 在 Linux 的编译错误（glibc u32 vs darwin c_int，宏化修复；交叉编译 x86_64-linux 验证）。
- command 按需形态 init 状态不跨请求导致"会话工作目录未注入"（请求内宿主权威上下文刷新，无沙箱链路真实验证修复前后行为）。

## 验证

cargo fmt / check --workspace / clippy 零警告；tiangong-config、tiangong-sandbox、tiangong-plugin-runtime（含 11 项 ephemeral 真实链路）测试全绿；前端 yarn build + 219 项测试通过。

链式依赖：本 PR 基于 #441（沙箱套壳主线），#441 合并后改 base 为 main 即可。