### PR TITLE
fix(frontend): 消息列表命令执行显示完整命令

### DIFF
--- a/frontend/src/components/message/toolDisplayModel.ts
+++ b/frontend/src/components/message/toolDisplayModel.ts
@@ -136,15 +136,32 @@ function squeezeToSingleLine(text: string): string {
     .join(" ");
 }
 
+/**
+ * terminal 数组参数组合为完整命令文本：shell 哨兵取脚本原文，
+ * exec 形态（[cmd, ...args]）空格连接全部部分，与后端 formatting.rs 的命令行对齐。
+ */
+function commandFromTerminalArgs(visible: unknown[]): string | null {
+  if (visible.length === 0) return null;
+  if (visible[0] === SHELL_SENTINEL) {
+    const script = visible[1];
+    return typeof script === "string" && script ? script : null;
+  }
+  const parts = visible
+    .filter((item): item is string => typeof item === "string" && item !== SHELL_SENTINEL)
+    .map((item) => squeezeToSingleLine(item))
+    .filter(Boolean);
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
 /** 从调用参数提取单行摘要（多行命令压缩去换行）；参数兼容位置数组与对象。 */
 function summaryFromArgs(variant: ToolVariant, args: unknown): string | null {
   if (args === undefined || args === null) return null;
 
   if (Array.isArray(args)) {
     const visible = filterCwdArgs(args);
-    if (variant === "terminal" && visible[0] === SHELL_SENTINEL) {
-      const script = typeof visible[1] === "string" ? visible[1] : "";
-      if (script) return clamp(squeezeToSingleLine(script), SUMMARY_MAX_CHARS);
+    if (variant === "terminal") {
+      const command = commandFromTerminalArgs(visible);
+      if (command) return clamp(squeezeToSingleLine(command), SUMMARY_MAX_CHARS);
       return null;
     }
     const first = visible.find((item) => typeof item === "string" && item !== SHELL_SENTINEL);
@@ -366,11 +383,11 @@ export function buildToolDisplayModel(msg: MessageItem, args?: unknown): ToolDis
   if (variant === "terminal") {
     const visibleArgs = Array.isArray(args) ? filterCwdArgs(args) : [];
     const command = (() => {
-      if (visibleArgs[0] === SHELL_SENTINEL && typeof visibleArgs[1] === "string") {
-        return visibleArgs[1];
+      if (Array.isArray(args)) {
+        return commandFromTerminalArgs(visibleArgs);
       }
       // 对象参数（run_shell {script} / run_command {cmd}）：取完整命令文本。
-      if (args && typeof args === "object" && !Array.isArray(args)) {
+      if (args && typeof args === "object") {
         const record = args as Record<string, unknown>;
         const script = record.script ?? record.cmd ?? record.command;
         if (typeof script === "string" && script) return script;

--- a/frontend/src/components/message/toolDisplayModel.ts
+++ b/frontend/src/components/message/toolDisplayModel.ts
@@ -137,20 +137,47 @@ function squeezeToSingleLine(text: string): string {
 }
 
 /**
- * terminal 数组参数组合为完整命令文本：shell 哨兵取脚本原文，
- * exec 形态（[cmd, ...args]）空格连接全部部分，与后端 formatting.rs 的命令行对齐。
+ * terminal 调用参数组合为完整命令文本：摘要与终端展开卡共用同一来源。
+ * 兼容三种形态：位置数组 [cmd, ...args]、对象 {cmd, args}（run_command 当前 schema）、
+ * 对象 {script | command}（run_shell 等）。shell 脚本保留多行原文；
+ * exec 形态空格连接全部部分，与后端 formatting.rs 的命令行对齐。
  */
-function commandFromTerminalArgs(visible: unknown[]): string | null {
-  if (visible.length === 0) return null;
-  if (visible[0] === SHELL_SENTINEL) {
-    const script = visible[1];
-    return typeof script === "string" && script ? script : null;
+function terminalCommandFromArgs(args: unknown): string | null {
+  if (args === undefined || args === null) return null;
+
+  if (Array.isArray(args)) {
+    const visible = filterCwdArgs(args);
+    if (visible.length === 0) return null;
+    if (visible[0] === SHELL_SENTINEL) {
+      const script = visible[1];
+      return typeof script === "string" && script ? script : null;
+    }
+    const parts = visible
+      .filter((item): item is string => typeof item === "string" && item !== SHELL_SENTINEL)
+      .map((item) => squeezeToSingleLine(item))
+      .filter(Boolean);
+    return parts.length > 0 ? parts.join(" ") : null;
   }
-  const parts = visible
-    .filter((item): item is string => typeof item === "string" && item !== SHELL_SENTINEL)
-    .map((item) => squeezeToSingleLine(item))
-    .filter(Boolean);
-  return parts.length > 0 ? parts.join(" ") : null;
+
+  if (typeof args === "object") {
+    const record = args as Record<string, unknown>;
+    // exec 对象形态：cmd 与参数列表拼接为完整命令，缺省 args 时命令即 cmd 本身。
+    if (typeof record.cmd === "string" && record.cmd) {
+      const parts = Array.isArray(record.args)
+        ? record.args
+            .filter((item): item is string => typeof item === "string")
+            .map((item) => squeezeToSingleLine(item))
+            .filter(Boolean)
+        : [];
+      return parts.length > 0 ? [record.cmd, ...parts].join(" ") : record.cmd;
+    }
+    const script = record.script ?? record.command;
+    if (typeof script === "string" && script) return script;
+    return null;
+  }
+
+  if (typeof args === "string" && args) return args;
+  return null;
 }
 
 /** 从调用参数提取单行摘要（多行命令压缩去换行）；参数兼容位置数组与对象。 */
@@ -160,7 +187,7 @@ function summaryFromArgs(variant: ToolVariant, args: unknown): string | null {
   if (Array.isArray(args)) {
     const visible = filterCwdArgs(args);
     if (variant === "terminal") {
-      const command = commandFromTerminalArgs(visible);
+      const command = terminalCommandFromArgs(visible);
       if (command) return clamp(squeezeToSingleLine(command), SUMMARY_MAX_CHARS);
       return null;
     }
@@ -171,6 +198,10 @@ function summaryFromArgs(variant: ToolVariant, args: unknown): string | null {
 
   if (typeof args === "object") {
     const record = args as Record<string, unknown>;
+    if (variant === "terminal") {
+      const command = terminalCommandFromArgs(record);
+      if (command) return clamp(squeezeToSingleLine(command), SUMMARY_MAX_CHARS);
+    }
     const keyPreference: Record<ToolVariant, readonly string[]> = {
       terminal: ["script", "cmd", "command", "description"],
       "file-read": ["path", "file_path", "url"],
@@ -381,19 +412,8 @@ export function buildToolDisplayModel(msg: MessageItem, args?: unknown): ToolDis
 
   let terminal: TerminalMaterial | null = null;
   if (variant === "terminal") {
-    const visibleArgs = Array.isArray(args) ? filterCwdArgs(args) : [];
-    const command = (() => {
-      if (Array.isArray(args)) {
-        return commandFromTerminalArgs(visibleArgs);
-      }
-      // 对象参数（run_shell {script} / run_command {cmd}）：取完整命令文本。
-      if (args && typeof args === "object") {
-        const record = args as Record<string, unknown>;
-        const script = record.script ?? record.cmd ?? record.command;
-        if (typeof script === "string" && script) return script;
-      }
-      return argSummary;
-    })();
+    // 展开卡命令与摘要共用 terminalCommandFromArgs，保证两处显示一致。
+    const command = terminalCommandFromArgs(args) ?? argSummary;
     terminal = { command: command ?? null, stdout: outputText, stderr: null };
   }
 


### PR DESCRIPTION
## 问题

消息列表中命令执行条目只显示程序名（如 `git`），完整命令（如 `git diff --stat`）不显示；展开后的终端卡同样不完整。

## 根因

摘要与终端卡命令从调用参数派生，而 `summaryFromArgs` 此前的处理：

- 数组形式 `[cmd, ...args]`：只取第一个字符串（程序名）
- 对象形式 `{cmd, args}`（**终端插件当前 schema 的主路径**）：只读 `cmd`，忽略 `args`

后端 trace 里的完整命令也被这份不完整的参数摘要遮蔽。

## 修复

新增统一的 `terminalCommandFromArgs`，覆盖三种参数形态，摘要与终端展开卡共用同一来源：

| 形态 | 显示 |
|---|---|
| `{cmd, args}`（主路径） | `git diff --stat` |
| `[cmd, ...args]` | `git diff --stat` |
| `{script}` / shell 哨兵 | 脚本原文（摘要压缩为单行） |

- 过滤 `__tiangong_cwd` 内部参数与 `cwd`/`timeout` 配置键，不泄漏工作目录
- 无命令结构的终端操作（terminal_send 等）回落原有键序兜底，行为不变
- 非 terminal 变体（read_file 显示路径等）不受影响

## 验证

- 模拟真实参数格式的 11 项场景验证全部通过（含对象格式主路径、摘要与展开卡一致性）
- 前端原有 219 项测试全部通过
- 生产构建（tsc + vite）通过