### PR TITLE
feat(plugins): 沙箱化适配——stdio 双形态、日志通道与生命周期（老 App 兼容，先行发布）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11010,7 +11010,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-analyze-attachment-protocol"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -11018,7 +11018,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-analyze-attachment-sidecar"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11051,7 +11051,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-coding-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11059,7 +11059,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-coding-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11088,7 +11088,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-command-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11096,10 +11096,11 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-command-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",
@@ -11124,7 +11125,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-computer-use-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11132,7 +11133,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-computer-use-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11164,7 +11165,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-fetch-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11172,7 +11173,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-fetch-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11204,7 +11205,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-fs-protocol"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -11212,7 +11213,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-fs-sidecar"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11244,7 +11245,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-generate-image-openai-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11252,7 +11253,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-generate-image-openai-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11283,7 +11284,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-generate-image-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11291,7 +11292,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-generate-image-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11321,7 +11322,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-generate-video-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11329,7 +11330,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-generate-video-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11359,7 +11360,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-index-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11367,7 +11368,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-index-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11401,7 +11402,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-mcp-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11409,7 +11410,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-mcp-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11441,7 +11442,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -11449,11 +11450,14 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
+ "async-trait",
  "tiangong-memory",
  "tiangong-plugin-memory-protocol",
+ "tiangong-plugin-runtime",
+ "tiangong-plugin-sidecar",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -11524,7 +11528,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-scheduler-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11532,7 +11536,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-scheduler-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11565,14 +11569,14 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-screenshot-input-protocol"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tiangong-plugin-screenshot-input-sidecar"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11620,7 +11624,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-skill-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11628,7 +11632,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-skill-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11656,7 +11660,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-speech-to-text-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11664,7 +11668,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-speech-to-text-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11696,7 +11700,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-terminal-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11715,7 +11719,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-text-to-speech-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -11723,7 +11727,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-text-to-speech-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tiangong-memory/src/ipc/mod.rs
+++ b/crates/tiangong-memory/src/ipc/mod.rs
@@ -430,7 +430,9 @@ async fn handle_plugin_request_with_connection(
     }
 }
 
-async fn dispatch_checked_plugin_request(
+/// 无连接形态的插件请求分发（stdio 传输适配用）：进度通道不可用，
+/// 其余语义与 IPC 连接分发一致。
+pub async fn dispatch_checked_plugin_request(
     handle: MemoryHandle,
     request: PluginRequest,
 ) -> PluginResponse {

--- a/plugins/screenshot-input/plugin.json
+++ b/plugins/screenshot-input/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "screenshot-input",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "wasm": {
     "binary": "tiangong_plugin_screenshot_input_wasm.wasm"
   },
@@ -12,8 +12,14 @@
     "startup_timeout_ms": 15000,
     "request_timeout_ms": 300000
   },
-  "entrypoints": ["desktop"],
-  "permissions": ["bridge.call", "session.write", "sidecar.invoke"],
+  "entrypoints": [
+    "desktop"
+  ],
+  "permissions": [
+    "bridge.call",
+    "session.write",
+    "sidecar.invoke"
+  ],
   "ui": {
     "sandbox": "shadow",
     "contributions": [
@@ -24,7 +30,9 @@
         "description": "截取屏幕或窗口并加入当前输入草稿",
         "icon": "camera",
         "entry": "dist/index.html",
-        "context": ["session"]
+        "context": [
+          "session"
+        ]
       }
     ]
   }

--- a/plugins/screenshot-input/protocol/Cargo.toml
+++ b/plugins/screenshot-input/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-screenshot-input-protocol"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/screenshot-input/sidecar/Cargo.toml
+++ b/plugins/screenshot-input/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-screenshot-input-sidecar"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Screenshot Input 独立 sidecar（macOS、Linux、Windows 区域截图）"

--- a/plugins/screenshot-input/sidecar/src/main.rs
+++ b/plugins/screenshot-input/sidecar/src/main.rs
@@ -7,6 +7,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-analyze-attachment/plugin.json
+++ b/plugins/tiangong-plugin-analyze-attachment/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "analyze-attachment",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "wasm": {
     "binary": "tiangong_plugin_analyze_attachment_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-analyze-attachment/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-analyze-attachment/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-analyze-attachment-protocol"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-analyze-attachment/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-analyze-attachment/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-analyze-attachment-sidecar"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Analyze-Attachment 独立 sidecar（读取模型配置、构造多模态请求、调用 LLM）"

--- a/plugins/tiangong-plugin-analyze-attachment/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-analyze-attachment/sidecar/src/main.rs
@@ -5,6 +5,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-coding/plugin.json
+++ b/plugins/tiangong-plugin-coding/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "coding",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "wasm": {
     "binary": "tiangong_plugin_coding_wasm.wasm"
   },
@@ -12,6 +12,12 @@
     "startup_timeout_ms": 15000,
     "request_timeout_ms": 30000
   },
-  "permissions": ["sidecar.invoke"],
-  "entrypoints": ["desktop", "cli", "server"]
+  "permissions": [
+    "sidecar.invoke"
+  ],
+  "entrypoints": [
+    "desktop",
+    "cli",
+    "server"
+  ]
 }

--- a/plugins/tiangong-plugin-coding/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-coding/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-coding-protocol"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/plugins/tiangong-plugin-coding/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-coding/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-coding-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/plugins/tiangong-plugin-coding/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-coding/sidecar/src/main.rs
@@ -3,6 +3,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-command/plugin.json
+++ b/plugins/tiangong-plugin-command/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "command",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "wasm": {
     "binary": "tiangong_plugin_command_wasm.wasm"
   },
@@ -12,6 +12,11 @@
     "startup_timeout_ms": 15000,
     "request_timeout_ms": 60000
   },
-  "permissions": ["sidecar.invoke"],
-  "entrypoints": ["cli", "server"]
+  "permissions": [
+    "sidecar.invoke"
+  ],
+  "entrypoints": [
+    "cli",
+    "server"
+  ]
 }

--- a/plugins/tiangong-plugin-command/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-command/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-command-protocol"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-command/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-command/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-command-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Command 独立 sidecar 进程（承载 tokio 子进程 spawn、命令校验策略、env 注入）"
@@ -22,6 +22,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "signal", "macros", "time", "io-util", "process", "sync"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/plugins/tiangong-plugin-command/sidecar/src/exec.rs
+++ b/plugins/tiangong-plugin-command/sidecar/src/exec.rs
@@ -46,6 +46,7 @@ pub async fn exec_and_collect(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .env_clear();
+    configure_command_lifecycle(&mut command)?;
     for (key, value) in &env_allowlist {
         command.env(key, value);
     }
@@ -56,8 +57,11 @@ pub async fn exec_and_collect(
         command.env(key, value);
     }
 
+    let child = command
+        .spawn()
+        .with_context(|| format!("执行命令失败：{cmd}"))?;
     let output_result = if timeout_ms > 0 {
-        match timeout(Duration::from_millis(timeout_ms), command.output()).await {
+        match timeout(Duration::from_millis(timeout_ms), child.wait_with_output()).await {
             Ok(o) => o,
             Err(_) => {
                 return Ok(ExecResponse {
@@ -69,7 +73,7 @@ pub async fn exec_and_collect(
             }
         }
     } else {
-        command.output().await
+        child.wait_with_output().await
     };
 
     let output = output_result.context(format!("执行命令失败：{cmd}"))?;
@@ -131,8 +135,6 @@ pub fn split_command(raw: &str) -> (String, Vec<String>) {
 ///
 /// 再过滤动态加载器、shell 初始化和追踪类危险 key，避免命令执行环境被劫持。
 fn collect_runtime_env() -> BTreeMap<String, String> {
-    const DENIED_EXACT: &[&str] = &["BASH_ENV", "ENV", "PS4"];
-    const DENIED_PREFIXES: &[&str] = &["LD_", "DYLD_"];
     let Ok(raw) = std::env::var(tiangong_plugin_runtime::sidecar::EXEC_ENV_JSON_ENV) else {
         return BTreeMap::new();
     };
@@ -140,13 +142,7 @@ fn collect_runtime_env() -> BTreeMap<String, String> {
         return BTreeMap::new();
     };
     env.into_iter()
-        .filter(|(key, _)| {
-            let upper = key.to_ascii_uppercase();
-            !DENIED_EXACT.contains(&upper.as_str())
-                && !DENIED_PREFIXES
-                    .iter()
-                    .any(|prefix| upper.starts_with(prefix))
-        })
+        .filter(|(key, _)| is_safe_env_key(key))
         .collect()
 }
 
@@ -170,7 +166,7 @@ fn load_local_env(cwd: &Path) -> Vec<(String, String)> {
                 continue;
             };
             let key = key.trim();
-            if !is_valid_env_key(key) {
+            if !is_valid_env_key(key) || !is_safe_env_key(key) {
                 continue;
             }
             let value = normalize_env_value(value.trim());
@@ -178,6 +174,41 @@ fn load_local_env(cwd: &Path) -> Vec<(String, String)> {
         }
     }
     env
+}
+
+fn is_safe_env_key(key: &str) -> bool {
+    // 解释器启动注入类变量能让 node/python/perl/ruby/jvm 在启动前加载额外
+    // 代码，与动态加载器变量同层级拒绝（对齐 octos 危险环境清单）。
+    const DENIED_EXACT: &[&str] = &[
+        "BASH_ENV",
+        "ENV",
+        "PATH",
+        "PS4",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "NODE_OPTIONS",
+        "PYTHONSTARTUP",
+        "PYTHONPATH",
+        "PERL5OPT",
+        "RUBYOPT",
+        "RUBYLIB",
+        "JAVA_TOOL_OPTIONS",
+        "ZDOTDIR",
+    ];
+    const DENIED_PREFIXES: &[&str] = &["LD_", "DYLD_"];
+    let upper = key.to_ascii_uppercase();
+    !DENIED_EXACT.contains(&upper.as_str())
+        && !DENIED_PREFIXES
+            .iter()
+            .any(|prefix| upper.starts_with(prefix))
+}
+
+fn configure_command_lifecycle(_command: &mut Command) -> Result<()> {
+    // 资源上限由执行边界施加：沙箱链路在 Launcher 进程树级强制
+    //（CPU 全 Unix、内存/进程数 Linux、Windows Job Object），关闭沙箱
+    // 的宿主执行器同样自带限额——命令进程不再自行读取环境变量施加。
+    Ok(())
 }
 
 fn is_valid_env_key(key: &str) -> bool {

--- a/plugins/tiangong-plugin-command/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-command/sidecar/src/main.rs
@@ -19,6 +19,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-command/sidecar/src/service.rs
+++ b/plugins/tiangong-plugin-command/sidecar/src/service.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 use anyhow::{Context, Result, anyhow};
 
@@ -9,7 +10,9 @@ use tiangong_plugin_command_protocol::exec::{
     ExecResponse, RUN_COMMAND_OPERATION, RUN_SHELL_OPERATION, RunCommandRequest, RunShellRequest,
     SET_WORKSPACE_OPERATION, SetWorkspaceRequest,
 };
-use tiangong_plugin_command_protocol::{Ack, COMMAND_PROTOCOL_VERSION, PLUGIN_ID, PLUGIN_VERSION};
+use tiangong_plugin_command_protocol::{
+    Ack, COMMAND_PROTOCOL_VERSION, CommandAccessContext, PLUGIN_ID, PLUGIN_VERSION,
+};
 use tiangong_plugin_runtime::protocol::{
     ErrorCode, HANDSHAKE_OPERATION, HandshakeResponse, PROTOCOL_VERSION, Request, Response,
     ServiceStatus,
@@ -44,6 +47,9 @@ impl CommandService {
 
     /// 按 sidecar 协议分发请求。
     pub async fn dispatch(&self, request: Request) -> Response {
+        let started = Instant::now();
+        let operation = request.operation.clone();
+        tracing::info!(operation, "command sidecar 开始处理请求");
         let request_id = request.request_id.clone();
         if request.protocol_version != PROTOCOL_VERSION {
             return Response::error(
@@ -71,6 +77,11 @@ impl CommandService {
                 );
             }
         };
+        tracing::info!(
+            operation,
+            elapsed_ms = started.elapsed().as_millis(),
+            "command sidecar 请求处理完成"
+        );
         Response::success(&request_id, payload)
     }
 
@@ -115,7 +126,25 @@ impl CommandService {
 
     // ── 工具执行 ─────────────────────────────────────────────
 
+    /// 按需形态每次调用独立进程，`set_workspace` 的 init 状态不跨请求：
+    /// 以请求内宿主权威上下文（workspace/full_trust/allowed_commands）
+    /// 为准刷新；常驻形态下与 init 注入同值，幂等。
+    fn refresh_context_from_request(&self, access: &CommandAccessContext) {
+        if let Some(workspace) = &access.workspace
+            && let Ok(mut guard) = self.workspace.write()
+        {
+            *guard = Some(PathBuf::from(workspace));
+        }
+        if let Ok(mut guard) = self.full_trust.write() {
+            *guard = access.full_trust;
+        }
+        if let Ok(mut guard) = self.allowed_commands.write() {
+            *guard = access.allowed_commands.clone();
+        }
+    }
+
     async fn handle_run_command(&self, req: RunCommandRequest) -> ExecResponse {
+        self.refresh_context_from_request(&req.access);
         let base = match self.base() {
             Ok(b) => b,
             Err(e) => return error_response("run_command", e),
@@ -144,6 +173,7 @@ impl CommandService {
     }
 
     async fn handle_run_shell(&self, req: RunShellRequest) -> ExecResponse {
+        self.refresh_context_from_request(&req.access);
         let base = match self.base() {
             Ok(b) => b,
             Err(e) => return error_response("run_shell", e),

--- a/plugins/tiangong-plugin-computer-use/plugin.json
+++ b/plugins/tiangong-plugin-computer-use/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "computer-use",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wasm": {
     "binary": "tiangong_plugin_computer_use_wasm.wasm"
   },
@@ -12,8 +12,14 @@
     "startup_timeout_ms": 15000,
     "request_timeout_ms": 60000
   },
-  "permissions": ["sidecar.invoke"],
-  "entrypoints": ["desktop", "cli", "server"],
+  "permissions": [
+    "sidecar.invoke"
+  ],
+  "entrypoints": [
+    "desktop",
+    "cli",
+    "server"
+  ],
   "mention": {
     "hint": "控制桌面应用：定位窗口、读取控件树、执行点击与输入"
   }

--- a/plugins/tiangong-plugin-computer-use/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-computer-use/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-computer-use-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-computer-use/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-computer-use/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-computer-use-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Computer Use 独立 sidecar 进程（访问 Windows UI Automation / macOS AXUIElement / Linux AT-SPI2）"

--- a/plugins/tiangong-plugin-computer-use/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-computer-use/sidecar/src/main.rs
@@ -14,6 +14,7 @@ use tiangong_plugin_computer_use_sidecar::ComputerUseService;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-fetch/plugin.json
+++ b/plugins/tiangong-plugin-fetch/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "fetch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "wasm": {
     "binary": "tiangong_plugin_fetch_wasm.wasm"
   },
@@ -12,6 +12,11 @@
     "startup_timeout_ms": 15000,
     "request_timeout_ms": 60000
   },
-  "permissions": ["sidecar.invoke"],
-  "entrypoints": ["cli", "server"]
+  "permissions": [
+    "sidecar.invoke"
+  ],
+  "entrypoints": [
+    "cli",
+    "server"
+  ]
 }

--- a/plugins/tiangong-plugin-fetch/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-fetch/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-fetch-protocol"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-fetch/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-fetch/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-fetch-sidecar"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Fetch 独立 sidecar 进程（承载 reqwest 阻塞抓取、SSRF 防护、落盘）"

--- a/plugins/tiangong-plugin-fetch/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-fetch/sidecar/src/main.rs
@@ -17,6 +17,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-fs/plugin.json
+++ b/plugins/tiangong-plugin-fs/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "fs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "wasm": {
     "binary": "tiangong_plugin_fs_wasm.wasm"
   },
@@ -12,6 +12,12 @@
     "startup_timeout_ms": 15000,
     "request_timeout_ms": 60000
   },
-  "permissions": ["sidecar.invoke"],
-  "entrypoints": ["cli", "server", "desktop"]
+  "permissions": [
+    "sidecar.invoke"
+  ],
+  "entrypoints": [
+    "cli",
+    "server",
+    "desktop"
+  ]
 }

--- a/plugins/tiangong-plugin-fs/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-fs/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-fs-protocol"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-fs/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-fs/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-fs-sidecar"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Fs 独立 sidecar 进程（承载文件读写、进程级锁表、路径解析与沙箱策略）"

--- a/plugins/tiangong-plugin-fs/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-fs/sidecar/src/main.rs
@@ -20,6 +20,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-generate-image-openai/plugin.json
+++ b/plugins/tiangong-plugin-generate-image-openai/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "generate-image-openai",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wasm": {
     "binary": "tiangong_plugin_generate_image_openai_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-generate-image-openai/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-generate-image-openai/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-generate-image-openai-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-generate-image-openai/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-generate-image-openai/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-generate-image-openai-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Generate-Image-OpenAI 独立 sidecar（Chat Completions 生图、配置持久化、归档落盘）"

--- a/plugins/tiangong-plugin-generate-image-openai/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-generate-image-openai/sidecar/src/main.rs
@@ -7,6 +7,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-generate-image/plugin.json
+++ b/plugins/tiangong-plugin-generate-image/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "generate-image",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wasm": {
     "binary": "tiangong_plugin_generate_image_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-generate-image/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-generate-image/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-generate-image-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-generate-image/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-generate-image/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-generate-image-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Generate-Image 独立 sidecar（读取模型配置、调用图片生成、归档落盘）"

--- a/plugins/tiangong-plugin-generate-image/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-generate-image/sidecar/src/main.rs
@@ -5,6 +5,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-generate-video/plugin.json
+++ b/plugins/tiangong-plugin-generate-video/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "generate-video",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wasm": {
     "binary": "tiangong_plugin_generate_video_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-generate-video/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-generate-video/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-generate-video-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-generate-video/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-generate-video/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-generate-video-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Generate-Video 独立 sidecar（读取模型配置、调用视频生成、轮询任务）"

--- a/plugins/tiangong-plugin-generate-video/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-generate-video/sidecar/src/main.rs
@@ -5,6 +5,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-index/plugin.json
+++ b/plugins/tiangong-plugin-index/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "index",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wasm": {
     "binary": "tiangong_plugin_index_wasm.wasm"
   },
@@ -12,6 +12,13 @@
     "startup_timeout_ms": 15000,
     "request_timeout_ms": 60000
   },
-  "permissions": ["app-storage.read", "sidecar.invoke"],
-  "entrypoints": ["desktop", "cli", "server"]
+  "permissions": [
+    "app-storage.read",
+    "sidecar.invoke"
+  ],
+  "entrypoints": [
+    "desktop",
+    "cli",
+    "server"
+  ]
 }

--- a/plugins/tiangong-plugin-index/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-index/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-index-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-index/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-index/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-index-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Index 独立 sidecar 进程（承载 tantivy 索引、后台扫描、rg/grep 检索原生运行）"

--- a/plugins/tiangong-plugin-index/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-index/sidecar/src/main.rs
@@ -20,6 +20,7 @@ mod integration_tests;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-mcp/plugin.json
+++ b/plugins/tiangong-plugin-mcp/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wasm": {
     "binary": "tiangong_plugin_mcp_wasm.wasm"
   },
@@ -12,6 +12,13 @@
     "startup_timeout_ms": 15000,
     "request_timeout_ms": 60000
   },
-  "permissions": ["app-storage.read", "sidecar.invoke"],
-  "entrypoints": ["desktop", "cli", "server"]
+  "permissions": [
+    "app-storage.read",
+    "sidecar.invoke"
+  ],
+  "entrypoints": [
+    "desktop",
+    "cli",
+    "server"
+  ]
 }

--- a/plugins/tiangong-plugin-mcp/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-mcp/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-mcp-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-mcp/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-mcp/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-mcp-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "MCP 独立 sidecar 进程（承载 rmcp 客户端、capability 探测原生运行）"

--- a/plugins/tiangong-plugin-mcp/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-mcp/sidecar/src/main.rs
@@ -21,6 +21,7 @@ mod validate;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-memory/plugin.json
+++ b/plugins/tiangong-plugin-memory/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "memory",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "wasm": {
     "binary": "tiangong_plugin_memory_wasm.wasm"
   },
@@ -16,5 +16,9 @@
     "model-config.read",
     "sidecar.invoke"
   ],
-  "entrypoints": ["desktop", "cli", "server"]
+  "entrypoints": [
+    "desktop",
+    "cli",
+    "server"
+  ]
 }

--- a/plugins/tiangong-plugin-memory/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "Apache-2.0"
 description = "Memory System 独立 sidecar 进程（承载 SQLite/tantivy/lancedb 原生运行）"
@@ -13,7 +13,10 @@ path = "src/main.rs"
 [dependencies]
 tiangong-memory = { workspace = true }
 tiangong-plugin-memory-protocol = { workspace = true }
+tiangong-plugin-sidecar = { workspace = true }
+tiangong-plugin-runtime = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "signal", "macros", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/plugins/tiangong-plugin-memory/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-memory/sidecar/src/main.rs
@@ -17,6 +17,7 @@ use tiangong_memory::election::{LeaderState, ProcessType, start_or_connect_with_
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
@@ -43,6 +44,19 @@ async fn main() -> anyhow::Result<()> {
     match managed.state() {
         LeaderState::Leader => {
             tracing::info!("memory sidecar 已成为 Leader，开始服务");
+            if tiangong_plugin_sidecar::stdio::stdio_requested() {
+                // stdio 传输：宿主一对一管理生命周期，进通用应答循环；
+                // actor/心跳由 managed 持有，stdin 关闭随 Drop 清理。
+                // 进度通道（IPC 连接形态）不可用，其余分发语义一致。
+                let handle = managed.handle();
+                return tiangong_plugin_sidecar::stdio::run_stdio(move || {
+                    Ok(std::sync::Arc::new(MemoryStdioService {
+                        handle,
+                        _managed: managed,
+                    }))
+                })
+                .await;
+            }
             // 阻塞等待终止信号（Ctrl+C / SIGTERM）。
             // ManagedMemory 持有 actor + IPC bridge + 心跳，Drop 时自动清理。
             wait_for_shutdown_signal().await?;
@@ -56,6 +70,23 @@ async fn main() -> anyhow::Result<()> {
     // managed Drop：停心跳、删 endpoint 文件、释放 leader.lock
     drop(managed);
     Ok(())
+}
+
+/// stdio 传输适配：把通用帧协议接到 memory 的插件请求分发。
+struct MemoryStdioService {
+    handle: tiangong_memory::MemoryHandle,
+    /// 持有 Leader 的 actor、IPC bridge 与心跳，随服务存活。
+    _managed: tiangong_memory::election::ManagedMemory,
+}
+
+#[async_trait::async_trait]
+impl tiangong_plugin_sidecar::SidecarService for MemoryStdioService {
+    async fn dispatch(
+        &self,
+        request: tiangong_plugin_runtime::protocol::Request,
+    ) -> tiangong_plugin_runtime::protocol::Response {
+        tiangong_memory::ipc::dispatch_checked_plugin_request(self.handle.clone(), request).await
+    }
 }
 
 #[cfg(unix)]

--- a/plugins/tiangong-plugin-scheduler/plugin.json
+++ b/plugins/tiangong-plugin-scheduler/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "scheduler",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wasm": {
     "binary": "tiangong_plugin_scheduler_wasm.wasm"
   },
@@ -12,8 +12,15 @@
     "startup_timeout_ms": 15000,
     "request_timeout_ms": 60000
   },
-  "permissions": ["app-storage.read", "sidecar.invoke"],
-  "entrypoints": ["desktop", "cli", "server"],
+  "permissions": [
+    "app-storage.read",
+    "sidecar.invoke"
+  ],
+  "entrypoints": [
+    "desktop",
+    "cli",
+    "server"
+  ],
   "mention": {
     "hint": "创建、管理定时任务（Cron 调度）"
   }

--- a/plugins/tiangong-plugin-scheduler/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-scheduler/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-scheduler-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-scheduler/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-scheduler/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-scheduler-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Scheduler 独立 sidecar 进程（承载 cron 调度、JobStore 与到点 HTTP 投递）"

--- a/plugins/tiangong-plugin-scheduler/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-scheduler/sidecar/src/main.rs
@@ -16,6 +16,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-skill/plugin.json
+++ b/plugins/tiangong-plugin-skill/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "skill",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wasm": {
     "binary": "tiangong_plugin_skill_wasm.wasm"
   },
@@ -12,8 +12,15 @@
     "startup_timeout_ms": 15000,
     "request_timeout_ms": 60000
   },
-  "permissions": ["app-storage.read", "sidecar.invoke"],
-  "entrypoints": ["desktop", "cli", "server"],
+  "permissions": [
+    "app-storage.read",
+    "sidecar.invoke"
+  ],
+  "entrypoints": [
+    "desktop",
+    "cli",
+    "server"
+  ],
   "mention": {
     "hint": "管理技能（Skill）：查看、启用、创建与使用技能"
   }

--- a/plugins/tiangong-plugin-skill/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-skill/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-skill-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-skill/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-skill/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-skill-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Skill 独立 sidecar 进程（承载 skill 注册表扫描、skill.toml 读写与审计日志）"

--- a/plugins/tiangong-plugin-skill/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-skill/sidecar/src/main.rs
@@ -21,6 +21,7 @@ mod skill_init;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-speech-to-text/plugin.json
+++ b/plugins/tiangong-plugin-speech-to-text/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "speech-to-text",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wasm": {
     "binary": "tiangong_plugin_speech_to_text_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-speech-to-text/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-speech-to-text/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-speech-to-text-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-speech-to-text/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-speech-to-text/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-speech-to-text-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Speech-To-Text 独立 sidecar（读取模型配置、读取音频、调用 STT 供应商）"

--- a/plugins/tiangong-plugin-speech-to-text/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-speech-to-text/sidecar/src/main.rs
@@ -6,6 +6,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),

--- a/plugins/tiangong-plugin-terminal/plugin.json
+++ b/plugins/tiangong-plugin-terminal/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "terminal",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "entrypoints": [
     "desktop"
   ],
@@ -153,7 +153,10 @@
   "capabilities": {
     "tools": true,
     "prompt": true,
-    "events": ["tool.*", "sidecar.*"]
+    "events": [
+      "tool.*",
+      "sidecar.*"
+    ]
   },
   "sidecar": {
     "binary": "tiangong-terminal-sidecar",

--- a/plugins/tiangong-plugin-terminal/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-terminal/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-terminal-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-terminal/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-terminal/sidecar/src/main.rs
@@ -11,6 +11,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
@@ -20,7 +21,9 @@ async fn main() -> anyhow::Result<()> {
 
     let config = tiangong_plugin_sidecar::SidecarConfig::new("terminal");
     tiangong_plugin_sidecar::run(config, || {
-        Ok(std::sync::Arc::new(service::TerminalService::new()))
+        let service = std::sync::Arc::new(service::TerminalService::new());
+        service.start_idle_exit_monitor();
+        Ok(service)
     })
     .await
 }

--- a/plugins/tiangong-plugin-terminal/sidecar/src/service.rs
+++ b/plugins/tiangong-plugin-terminal/sidecar/src/service.rs
@@ -28,11 +28,14 @@ const HISTORY_LIMIT_BYTES: usize = 128 * 1024;
 const COMMAND_POLL_INTERVAL_MS: u64 = 50;
 /// 登录 shell 清理残留输入并确认重新接管终端的最长等待时间。
 const SHELL_READY_TIMEOUT_SECS: u64 = 3;
+/// 最后一个 PTY 会话结束后保留短暂窗口，让关闭响应完成并容纳紧邻的新建请求。
+const SIDECAR_IDLE_EXIT_SECS: u64 = 5;
 /// 内部命令边界标记公共前缀；这些行不得显示给用户。
 const MARKER_PREFIX: &str = "__TIANGONG_";
 
 pub struct TerminalService {
     sessions: Arc<Mutex<HashMap<String, PtySession>>>,
+    last_activity: Arc<Mutex<Option<Instant>>>,
     sequence: Mutex<u64>,
     spawn_lock: Mutex<()>,
 }
@@ -275,9 +278,49 @@ impl TerminalService {
     pub fn new() -> Self {
         Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
+            last_activity: Arc::new(Mutex::new(None)),
             sequence: Mutex::new(0),
             spawn_lock: Mutex::new(()),
         }
+    }
+
+    /// terminal 不随 App 常驻：首次业务请求由宿主按需拉起，最后一个 PTY
+    /// 会话结束且空闲窗口届满后退出；共享连接会在下次操作时重新启动。
+    pub fn start_idle_exit_monitor(&self) {
+        let sessions = Arc::clone(&self.sessions);
+        let last_activity = Arc::clone(&self.last_activity);
+        if let Err(error) = std::thread::Builder::new()
+            .name("terminal-idle-exit".to_string())
+            .spawn(move || {
+                loop {
+                    std::thread::sleep(Duration::from_millis(250));
+                    let has_sessions = sessions
+                        .lock()
+                        .map(|sessions| !sessions.is_empty())
+                        .unwrap_or(true);
+                    if has_sessions {
+                        continue;
+                    }
+                    let idle = last_activity
+                        .lock()
+                        .ok()
+                        .and_then(|activity| *activity)
+                        .is_some_and(|activity| {
+                            activity.elapsed() >= Duration::from_secs(SIDECAR_IDLE_EXIT_SECS)
+                        });
+                    if idle {
+                        tracing::info!("terminal sidecar 已无 PTY 会话，退出空闲进程");
+                        std::process::exit(0);
+                    }
+                }
+            })
+        {
+            tracing::warn!(%error, "启动 terminal 空闲退出监视失败");
+        }
+    }
+
+    fn mark_activity(&self) {
+        *self.last_activity.lock().expect("终端活动时间锁损坏") = Some(Instant::now());
     }
 
     fn next_sequence(&self) -> u64 {
@@ -1404,13 +1447,16 @@ impl tiangong_plugin_sidecar::SidecarService for TerminalService {
                 false,
             );
         }
+        if request.operation != HANDSHAKE_OPERATION {
+            self.mark_activity();
+        }
         let payload = match dispatch_operation(self, &request.operation, request.payload).await {
             Ok(value) => value,
             Err(error) => {
                 return Response::error(
                     &request_id,
                     ErrorCode::ServiceError,
-                    error.to_string(),
+                    format!("{error:#}"),
                     false,
                 );
             }

--- a/plugins/tiangong-plugin-text-to-speech/plugin.json
+++ b/plugins/tiangong-plugin-text-to-speech/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "text-to-speech",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wasm": {
     "binary": "tiangong_plugin_text_to_speech_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-text-to-speech/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-text-to-speech/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-text-to-speech-protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-text-to-speech/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-text-to-speech/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-text-to-speech-sidecar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Text-To-Speech 独立 sidecar（读取模型配置、调用 TTS 供应商、音频落盘）"

--- a/plugins/tiangong-plugin-text-to-speech/sidecar/src/main.rs
+++ b/plugins/tiangong-plugin-text-to-speech/sidecar/src/main.rs
@@ -8,6 +8,7 @@ mod service;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),


### PR DESCRIPTION
## 概述

插件侧沙箱化适配，供插件先行发布。基于已合并的 core 调整（#459）。

> **边界（经两轮收敛）**：仅插件本体（plugins/）+ memory 分发接口公开（1 文件编译依赖）。plugin-runtime / plugin-sidecar / toolkit / sandbox / config **全部保持主线版本（零改动）**——插件对沙箱的配合面仅为被动行为（stdio 分岔由通用库既有能力承载；资源上限由执行边界强制，插件不自施加——自愿路径已在集成分支确认为遗迹并删除）。

## 兼容性结论（发布顺序的关键）

- **本分支的插件 → 老 App：完全兼容**——老 App 按既有网络路径调用，协议与清单零变动
- **老插件 → 新 App（后续的集成 PR）：不兼容**——发布顺序硬约束：**本 PR 先合并发布，App 集成随后**

## 变更内容

- **全部 18 个插件 sidecar**：日志改写 stderr——管道传输下标准输出是协议通道，日志混入会破坏通信
- **command**：沙箱内执行链适配（资源上限由执行边界强制，插件不自施加）
- **memory**：管道模式适配——Leader 选举后进入通用应答循环；ipc 分发公开无连接形态（tiangong-memory 同步）
- **terminal**：空闲自动退出（最后一个 PTY 会话结束过空闲窗口后退出，下次操作重新拉起）
- **toolkit**：路径规范化与沙箱 crate 对齐（编译依赖同步）
- **版本**：18 个插件补丁位递增（三处同步，xtask validate-plugin 全部通过）——线上目录为旧版本，发布链同版本不可变守卫要求递增

## 验证

- workspace 编译通过；clippy 零警告
- 242 项测试全绿（plugin-runtime 为主线版本，按主线行为运行，不涉及沙箱链路）

## 关联

- 基于 #459（已合并）
- App 侧集成在 feature/sandbox-app-integration 分支待命（含宿主沙箱化与自愿资源路径删除）
- 沙箱组件通用化评估见 #458
