### PR TITLE
fix(sandbox): 使用正确的发布签名密钥

### DIFF
--- a/.github/workflows/publish-sandbox.yml
+++ b/.github/workflows/publish-sandbox.yml
@@ -111,13 +111,13 @@ jobs:
       - name: Verify signing key present
         shell: bash
         run: |
-          test -n "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" || \
-            { echo "::error::缺少官方签名私钥 secret"; exit 1; }
+          test -n "${{ secrets.TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY }}" || \
+            { echo "::error::缺少 TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY（必须匹配 Sandbox 内置官方公钥）"; exit 1; }
           key="$RUNNER_TEMP/launcher-release.key"
-          printf '%s' "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" > "$key"
+          printf '%s' "${{ secrets.TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY }}" > "$key"
           echo "TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PATH=$key" >> "$GITHUB_ENV"
-          if [ -n "${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}" ]; then
-            echo "TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PASSWORD=${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}" >> "$GITHUB_ENV"
+          if [ -n "${{ secrets.TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PASSWORD }}" ]; then
+            echo "TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PASSWORD=${{ secrets.TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PASSWORD }}" >> "$GITHUB_ENV"
           fi
 
       - name: Build and sign launcher artifact

--- a/docs/sandbox-self-management.md
+++ b/docs/sandbox-self-management.md
@@ -72,8 +72,8 @@ sandbox/v0.1.0
 
 1. 合并本分支到 main，并确认 Sandbox CI 全部通过。
 2. 确认 GitHub Secrets：
-   - `TAURI_SIGNING_PRIVATE_KEY`
-   - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`（私钥无密码时可空）
+   - `TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY`
+   - `TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PASSWORD`（私钥无密码时可空）
    - `ALIYUN_OSS_ACCESS_KEY_ID`
    - `ALIYUN_OSS_ACCESS_KEY_SECRET`
 3. 确认官方私钥能被仓库内置公钥验证。


### PR DESCRIPTION
## 问题

首次试发布的四个平台均在官方公钥验签阶段失败。发布工作流误用了 `TAURI_SIGNING_PRIVATE_KEY`，该密钥用于应用更新签名，与 Sandbox 内置 minisign 官方公钥不匹配。

## 修复

- Sandbox 发布改用 `TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY`
- 密码改用对应的 `TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PASSWORD`
- 缺失密钥时给出明确错误
- 同步 Sandbox 发布说明

当前 Sandbox 内置公钥与插件官方公钥相同，因此首版应使用现有插件官方签名私钥。未来独立轮换 Sandbox 密钥时，再同步引入专用 Secret 和新的内置公钥。

## 验证

- 发布工作流 YAML 解析通过
- `cargo fmt --all -- --check`
- `cargo test --locked -p xtask -- --test-threads=1`
- `git diff --check`
- 核对首次发布四平台失败日志，均为同一公钥不匹配问题