### PR TITLE
feat(sandbox): 完成 P1 通用化与宿主自选安装目录

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11767,7 +11767,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-sandbox"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11771,6 +11771,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
+ "clap",
  "dunce",
  "fs2",
  "futures-util",

--- a/crates/tiangong-sandbox/Cargo.toml
+++ b/crates/tiangong-sandbox/Cargo.toml
@@ -21,6 +21,7 @@ libc = { workspace = true }
 tempfile = { workspace = true }
 scru128 = { workspace = true }
 base64 = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 futures-util = { workspace = true }
 fs2 = { workspace = true }
 minisign-verify = { workspace = true }

--- a/crates/tiangong-sandbox/Cargo.toml
+++ b/crates/tiangong-sandbox/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Command 工具的宿主强制操作系统沙箱套壳"
+readme = "README.md"
 
 [[bin]]
 name = "tiangong-sandbox"

--- a/crates/tiangong-sandbox/Cargo.toml
+++ b/crates/tiangong-sandbox/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tiangong-sandbox"
 # Launcher 独立版本序列（不随 workspace/App 版本）：在线更新按此序列
 # 判定新旧与防降级，App 发版不要求 Launcher 同步改动。
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Command 工具的宿主强制操作系统沙箱套壳"

--- a/crates/tiangong-sandbox/README.md
+++ b/crates/tiangong-sandbox/README.md
@@ -1,0 +1,139 @@
+# tiangong-sandbox
+
+`tiangong-sandbox` 是一个可独立使用的操作系统沙箱 Launcher。调用方提供策略和目标命令，Launcher 验证请求后使用当前平台的隔离能力启动目标进程；隔离能力不可用、策略非法或目标不可信时会明确拒绝执行，不会退回普通进程。
+
+## 平台实现
+
+- macOS：Seatbelt（`sandbox-exec`）
+- Linux：bubblewrap（`bwrap`）
+- Windows：AppContainer 与 Job Object
+
+目标进程创建的子进程会继承相同约束。不同平台的底层能力有所区别，但策略入口和失败关闭原则保持一致。
+
+## 安装目录
+
+Sandbox 不决定宿主的存储布局。安装目录由 App、服务或其他调用方选择，目录内文件名约定为：
+
+```text
+<宿主选择的目录>/tiangong-sandbox[.exe]
+<宿主选择的目录>/tiangong-sandbox[.exe].sig
+```
+
+库提供程序定位、签名验证和自检能力，但不会自动拼接天工的存储根或 `sandbox` 目录。
+
+## 快速使用
+
+### 直接在命令行中设置策略
+
+```bash
+tiangong-sandbox run \
+  --mode workspace-write \
+  --workspace /absolute/workspace \
+  --writable /absolute/run-temp \
+  --protect /absolute/workspace/protected \
+  --deny-read /home/user/.ssh \
+  --network deny \
+  --max-cpu-seconds 300 \
+  --max-memory-bytes 2147483648 \
+  --max-processes 64 \
+  -- command arg1 arg2
+```
+
+参数说明：
+
+- `--mode`：`read-only` 或 `workspace-write`，默认 `workspace-write`；不允许 `full-access`。
+- `--workspace`：主工作区，直接策略形式必须提供绝对路径。
+- `--writable`：额外可写绝对路径，可以重复。
+- `--protect`：即使位于可写范围内也保持只读的绝对路径，可以重复。
+- `--deny-read`：禁止读取的绝对路径，可以重复。
+- `--network`：`allow` 或 `deny`，默认 `deny`。
+- `--max-cpu-seconds`：CPU 时间上限，必须大于零。
+- `--max-memory-bytes`：内存上限，必须大于零。
+- `--max-processes`：进程数量上限，必须大于零。
+- `--`：策略参数与目标命令的分隔符。
+
+未设置资源参数时，默认限制为 300 秒 CPU 时间、2 GiB 内存和 64 个进程。
+
+### 使用策略文件
+
+```bash
+tiangong-sandbox run --policy /absolute/policy.json -- command arg1 arg2
+```
+
+`--policy` 不能与直接策略参数混用。策略文件使用 `SandboxPolicy` JSON：
+
+```json
+{
+  "mode": "workspace_write",
+  "workspace": "/absolute/workspace",
+  "extra_writable": ["/absolute/run-temp"],
+  "protected_paths": ["/absolute/workspace/protected"],
+  "denied_read_paths": ["/home/user/.ssh"],
+  "allow_network": false,
+  "resource_limits": {
+    "max_cpu_time_seconds": 300,
+    "max_memory_bytes": 2147483648,
+    "max_processes": 64
+  }
+}
+```
+
+## 默认安全行为
+
+- 网络默认禁止。
+- `workspace-write` 只允许写入工作区和显式指定的额外可写路径。
+- `read-only` 不提供可写根。
+- `full-access` 请求会被 Launcher 拒绝。
+- 命令、工作区及策略路径必须通过形态和绝对路径检查。
+- 目标程序会校验普通文件形态、摘要和平台权限。
+- 平台沙箱不可用时拒绝执行，不静默降级。
+- 敏感路径不会由通用核心隐式猜测；宿主应通过 `protected_paths` 和 `denied_read_paths` 明确传入。crate 另提供可选的常见凭据与天工宿主预设。
+
+## 宿主协议
+
+除 `run` 命令外，宿主也可以使用 Launcher 请求协议：
+
+- Unix：通过继承的文件描述符 3 传入长度前缀 JSON 帧。
+- Windows：通过一次性环境信封传入请求，并可关联宿主进程和停止事件。
+
+请求包含独立的协议版本和策略 Schema。版本不兼容时 Launcher 会拒绝启动。目标校验默认使用路径、摘要和权限；需要天工插件清单比对时，宿主可以显式选择对应校验方式。
+
+## 签名、自检与更新
+
+检查当前平台能力和协议信息：
+
+```bash
+tiangong-sandbox --self-check
+```
+
+检查和安装官方更新：
+
+```bash
+tiangong-sandbox check-update
+tiangong-sandbox update
+tiangong-sandbox update --root /absolute/install-directory
+```
+
+默认更新链使用 crate 内置的官方公钥。第三方宿主可以显式提供自己的 HTTPS 更新清单和 minisign 公钥，但环境变量不能静默替换信任根。天工生产验证入口始终只接受内置官方公钥，并在验签后执行真实自检。
+
+## 构建与验证
+
+在仓库根目录执行：
+
+```bash
+cargo build --locked -p tiangong-sandbox --bin tiangong-sandbox
+cargo check --locked -p tiangong-sandbox --all-targets
+cargo test --locked -p tiangong-sandbox
+cargo clippy --locked -p tiangong-sandbox --all-targets -- -D warnings
+```
+
+真实隔离测试需要当前环境允许应用对应平台的沙箱。已经处于受限沙箱中的开发环境可能无法再次嵌套，此时 Launcher 会报告平台不可用并拒绝执行。
+
+## 设计资料
+
+- [Sandbox 通用化与宿主安装目录](../../docs/sandbox-direct-storage.md)
+- [Sandbox 自管理与首版发布](../../docs/sandbox-self-management.md)
+
+## 许可证
+
+Apache-2.0

--- a/crates/tiangong-sandbox/README.md
+++ b/crates/tiangong-sandbox/README.md
@@ -21,6 +21,74 @@ Sandbox 不决定宿主的存储布局。安装目录由 App、服务或其他�
 
 库提供程序定位、签名验证和自检能力，但不会自动拼接天工的存储根或 `sandbox` 目录。
 
+## 正式版本下载
+
+正式版由独立发布流程构建、签名并发布到官方 OSS。推荐先读取 [最新版本清单](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/latest.json)，清单包含当前版本、协议版本、各平台下载地址、SHA-256 和签名地址。
+
+当前正式版为 `0.1.0`：
+
+| 平台 | 程序 | minisign 签名 |
+| --- | --- | --- |
+| macOS Apple Silicon | [tiangong-sb-darwin-aarch64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-aarch64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-aarch64.sig) |
+| macOS Intel | [tiangong-sb-darwin-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-x86_64.sig) |
+| Linux x86_64 | [tiangong-sb-linux-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-linux-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-linux-x86_64.sig) |
+| Windows x86_64 | [tiangong-sb-windows-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-windows-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-windows-x86_64.sig) |
+
+手动下载后，将程序重命名为 `tiangong-sandbox`（Windows 为 `tiangong-sandbox.exe`），签名放在同目录并命名为程序名加 `.sig`。macOS 和 Linux 还需要添加执行权限：
+
+```bash
+chmod +x tiangong-sandbox
+./tiangong-sandbox --self-check
+```
+
+版本源码与发布记录可在 [silent-rs/silent-Tiangong](https://github.com/silent-rs/silent-Tiangong) 查看。正式二进制以官方最新版本清单及其签名为准。
+
+### 包管理器支持计划
+
+目前正式版通过官方 OSS 和内置自更新能力发布，尚未提供包管理器安装命令。后续计划逐步增加：
+
+- macOS：Homebrew Formula；
+- Debian / Ubuntu：APT 仓库与 `.deb`；
+- Fedora / RHEL 系：RPM 仓库；
+- Windows：WinGet，并评估 Chocolatey / Scoop；
+- Rust 用户：评估 crates.io 安装入口。
+
+包管理器发布仍需复用同一套版本、SHA-256、minisign 验签和 `--self-check` 门禁。在对应仓库和自动发布流程上线前，不应使用尚未发布的 `brew install`、`apt install` 等命令。
+
+## 正式版本下载
+
+正式版由独立发布流程构建、签名并发布到官方 OSS。推荐先读取 [最新版本清单](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/latest.json)，清单包含当前版本、协议版本、各平台下载地址、SHA-256 和签名地址。
+
+当前正式版为 `0.1.0`：
+
+| 平台 | 程序 | minisign 签名 |
+| --- | --- | --- |
+| macOS Apple Silicon | [tiangong-sb-darwin-aarch64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-aarch64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-aarch64.sig) |
+| macOS Intel | [tiangong-sb-darwin-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-x86_64.sig) |
+| Linux x86_64 | [tiangong-sb-linux-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-linux-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-linux-x86_64.sig) |
+| Windows x86_64 | [tiangong-sb-windows-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-windows-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-windows-x86_64.sig) |
+
+手动下载后，将程序重命名为 `tiangong-sandbox`（Windows 为 `tiangong-sandbox.exe`），签名放在同目录并命名为程序名加 `.sig`。macOS 和 Linux 还需要添加执行权限：
+
+```bash
+chmod +x tiangong-sandbox
+./tiangong-sandbox --self-check
+```
+
+版本源码与发布记录可在 [silent-rs/silent-Tiangong](https://github.com/silent-rs/silent-Tiangong) 查看。正式二进制以官方最新版本清单及其签名为准。
+
+### 包管理器支持计划
+
+目前正式版通过官方 OSS 和内置自更新能力发布，尚未提供包管理器安装命令。后续计划逐步增加：
+
+- macOS：Homebrew Formula；
+- Debian / Ubuntu：APT 仓库与 `.deb`；
+- Fedora / RHEL 系：RPM 仓库；
+- Windows：WinGet，并评估 Chocolatey / Scoop；
+- Rust 用户：评估 crates.io 安装入口。
+
+包管理器发布仍需复用同一套版本、SHA-256、minisign 验签和 `--self-check` 门禁。在对应仓库和自动发布流程上线前，不应使用尚未发布的 `brew install`、`apt install` 等命令。
+
 ## 快速使用
 
 ### 直接在命令行中设置策略

--- a/crates/tiangong-sandbox/README.md
+++ b/crates/tiangong-sandbox/README.md
@@ -25,48 +25,14 @@ Sandbox 不决定宿主的存储布局。安装目录由 App、服务或其他�
 
 正式版由独立发布流程构建、签名并发布到官方 OSS。推荐先读取 [最新版本清单](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/latest.json)，清单包含当前版本、协议版本、各平台下载地址、SHA-256 和签名地址。
 
-当前正式版为 `0.1.0`：
+当前正式版为 `0.1.1`：
 
 | 平台 | 程序 | minisign 签名 |
 | --- | --- | --- |
-| macOS Apple Silicon | [tiangong-sb-darwin-aarch64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-aarch64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-aarch64.sig) |
-| macOS Intel | [tiangong-sb-darwin-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-x86_64.sig) |
-| Linux x86_64 | [tiangong-sb-linux-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-linux-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-linux-x86_64.sig) |
-| Windows x86_64 | [tiangong-sb-windows-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-windows-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-windows-x86_64.sig) |
-
-手动下载后，将程序重命名为 `tiangong-sandbox`（Windows 为 `tiangong-sandbox.exe`），签名放在同目录并命名为程序名加 `.sig`。macOS 和 Linux 还需要添加执行权限：
-
-```bash
-chmod +x tiangong-sandbox
-./tiangong-sandbox --self-check
-```
-
-版本源码与发布记录可在 [silent-rs/silent-Tiangong](https://github.com/silent-rs/silent-Tiangong) 查看。正式二进制以官方最新版本清单及其签名为准。
-
-### 包管理器支持计划
-
-目前正式版通过官方 OSS 和内置自更新能力发布，尚未提供包管理器安装命令。后续计划逐步增加：
-
-- macOS：Homebrew Formula；
-- Debian / Ubuntu：APT 仓库与 `.deb`；
-- Fedora / RHEL 系：RPM 仓库；
-- Windows：WinGet，并评估 Chocolatey / Scoop；
-- Rust 用户：评估 crates.io 安装入口。
-
-包管理器发布仍需复用同一套版本、SHA-256、minisign 验签和 `--self-check` 门禁。在对应仓库和自动发布流程上线前，不应使用尚未发布的 `brew install`、`apt install` 等命令。
-
-## 正式版本下载
-
-正式版由独立发布流程构建、签名并发布到官方 OSS。推荐先读取 [最新版本清单](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/latest.json)，清单包含当前版本、协议版本、各平台下载地址、SHA-256 和签名地址。
-
-当前正式版为 `0.1.0`：
-
-| 平台 | 程序 | minisign 签名 |
-| --- | --- | --- |
-| macOS Apple Silicon | [tiangong-sb-darwin-aarch64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-aarch64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-aarch64.sig) |
-| macOS Intel | [tiangong-sb-darwin-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-darwin-x86_64.sig) |
-| Linux x86_64 | [tiangong-sb-linux-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-linux-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-linux-x86_64.sig) |
-| Windows x86_64 | [tiangong-sb-windows-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-windows-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.0/tiangong-sb-windows-x86_64.sig) |
+| macOS Apple Silicon | [tiangong-sb-darwin-aarch64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-darwin-aarch64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-darwin-aarch64.sig) |
+| macOS Intel | [tiangong-sb-darwin-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-darwin-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-darwin-x86_64.sig) |
+| Linux x86_64 | [tiangong-sb-linux-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-linux-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-linux-x86_64.sig) |
+| Windows x86_64 | [tiangong-sb-windows-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-windows-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-windows-x86_64.sig) |
 
 手动下载后，将程序重命名为 `tiangong-sandbox`（Windows 为 `tiangong-sandbox.exe`），签名放在同目录并命名为程序名加 `.sig`。macOS 和 Linux 还需要添加执行权限：
 

--- a/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
+++ b/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
@@ -59,17 +59,27 @@ struct LaunchRequest {
     protocol_version: u32,
     policy_schema: u32,
     policy: tiangong_sandbox::SandboxPolicy,
+    #[serde(default)]
     plugin_id: String,
     program: String,
     program_root: String,
     program_sha256: String,
     #[serde(default)]
     args: Vec<String>,
-    /// 解释器形态：目标程序是宿主白名单解析的解释器（node/python），
-    /// 入口脚本与参数在 args 中。此时目标不在插件目录内、无插件清单，
-    /// 校验退化为路径形态 + 摘要 + 权限。
+    /// 目标校验方式。缺省为通用摘要校验；天工插件宿主可显式要求清单比对。
+    #[serde(default)]
+    target_validation: TargetValidation,
+    /// 旧协议兼容字段；新宿主应使用 target_validation。
     #[serde(default)]
     interpreter: bool,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum TargetValidation {
+    #[default]
+    DigestOnly,
+    PluginManifest,
 }
 
 fn main() {
@@ -83,7 +93,7 @@ fn main() {
     }
     if matches!(args.first().map(String::as_str), Some("--help" | "help")) {
         println!(
-            "tiangong-sandbox {}\n\nUSAGE:\n  tiangong-sandbox --self-check\n  tiangong-sandbox check-update [--manifest-url <https-url>]\n  tiangong-sandbox update [--manifest-url <https-url>]\n  tiangong-sandbox update --root <absolute-dir> [--manifest-url <https-url>]",
+            "tiangong-sandbox {}\n\nUSAGE:\n  tiangong-sandbox --self-check\n  tiangong-sandbox run --policy <policy.json> -- <command> [args...]\n  tiangong-sandbox check-update [--manifest-url <https-url>] [--public-key <file>]\n  tiangong-sandbox update [--manifest-url <https-url>] [--public-key <file>]\n  tiangong-sandbox update --root <absolute-dir> [--manifest-url <https-url>] [--public-key <file>]",
             env!("CARGO_PKG_VERSION")
         );
         return;
@@ -91,6 +101,13 @@ fn main() {
     #[cfg(windows)]
     if args.first().map(String::as_str) == Some("complete-update") {
         if let Err(error) = run_windows_update_completer(&args) {
+            eprintln!("{}", serde_json::json!({ "error": format!("{error:#}") }));
+            std::process::exit(EXIT_SANDBOX_UNAVAILABLE);
+        }
+        return;
+    }
+    if args.first().map(String::as_str) == Some("run") {
+        if let Err(error) = run_policy_file(&args) {
             eprintln!("{}", serde_json::json!({ "error": format!("{error:#}") }));
             std::process::exit(EXIT_SANDBOX_UNAVAILABLE);
         }
@@ -177,10 +194,56 @@ fn main() {
     }
 }
 
+fn run_policy_file(args: &[String]) -> Result<()> {
+    if args.get(1).map(String::as_str) != Some("--policy") {
+        bail!("用法: run --policy <policy.json> -- <command> [args...]");
+    }
+    let policy_path = Path::new(args.get(2).context("--policy 缺少值")?);
+    if args.get(3).map(String::as_str) != Some("--") {
+        bail!("策略文件与命令之间必须使用 -- 分隔");
+    }
+    let program = Path::new(args.get(4).context("缺少要执行的命令")?);
+    let program = if program.is_absolute() {
+        program.to_path_buf()
+    } else if program.components().count() > 1 {
+        std::env::current_dir()?.join(program)
+    } else {
+        resolve_command_in_path(program).context("无法在 PATH 中解析命令")?
+    };
+    let program = std::fs::canonicalize(&program)
+        .with_context(|| format!("解析命令失败: {}", program.display()))?;
+    let program_root = program.parent().context("命令缺少父目录")?.to_path_buf();
+    let policy: tiangong_sandbox::SandboxPolicy = serde_json::from_slice(
+        &std::fs::read(policy_path)
+            .with_context(|| format!("读取策略文件失败: {}", policy_path.display()))?,
+    )
+    .context("解析策略文件失败")?;
+    let request = LaunchRequest {
+        protocol_version: PROTOCOL_VERSION,
+        policy_schema: POLICY_SCHEMA,
+        policy,
+        plugin_id: String::new(),
+        program: program.display().to_string(),
+        program_root: program_root.display().to_string(),
+        program_sha256: sha256_file(&program)?,
+        args: args[5..].to_vec(),
+        target_validation: TargetValidation::DigestOnly,
+        interpreter: false,
+    };
+    execute_request(request, false)
+}
+
+fn resolve_command_in_path(program: &Path) -> Option<PathBuf> {
+    std::env::split_paths(&std::env::var_os("PATH")?)
+        .map(|directory| directory.join(program))
+        .find(|candidate| candidate.is_file())
+}
+
 fn run_self_update(args: &[String]) -> Result<()> {
     let command = args.first().map(String::as_str).context("缺少升级命令")?;
     let mut root = None;
     let mut manifest = tiangong_sandbox::update::DEFAULT_MANIFEST_URL.to_string();
+    let mut public_key = None;
     let mut index = 1;
     while index < args.len() {
         match args[index].as_str() {
@@ -192,6 +255,13 @@ fn run_self_update(args: &[String]) -> Result<()> {
                 index += 1;
                 manifest = args.get(index).context("--manifest-url 缺少值")?.clone();
             }
+            "--public-key" => {
+                index += 1;
+                public_key = Some(
+                    std::fs::read_to_string(args.get(index).context("--public-key 缺少值")?)
+                        .context("读取更新公钥失败")?,
+                );
+            }
             unknown => bail!("未知升级参数: {unknown}"),
         }
         index += 1;
@@ -200,7 +270,11 @@ fn run_self_update(args: &[String]) -> Result<()> {
         .enable_all()
         .build()
         .context("创建 Sandbox 升级运行时失败")?;
-    let updater = tiangong_sandbox::update::SelfUpdater::new(manifest)?;
+    let updater = if let Some(public_key) = public_key {
+        tiangong_sandbox::update::SelfUpdater::with_public_key(manifest, public_key)?
+    } else {
+        tiangong_sandbox::update::SelfUpdater::new(manifest)?
+    };
     let status = runtime.block_on(async {
         match (command, root) {
             ("check-update", None) => updater.check().await,
@@ -235,7 +309,10 @@ fn run_windows_update_completer(args: &[String]) -> Result<()> {
 }
 
 fn run_launch() -> Result<()> {
-    let request = read_request()?;
+    execute_request(read_request()?, true)
+}
+
+fn execute_request(request: LaunchRequest, inherited_request: bool) -> Result<()> {
     if request.protocol_version != PROTOCOL_VERSION {
         bail!(
             "Launcher 协议版本不匹配: expected={PROTOCOL_VERSION}, actual={}",
@@ -257,11 +334,13 @@ fn run_launch() -> Result<()> {
     #[cfg(windows)]
     {
         let host_pid = std::env::var(tiangong_sandbox::HOST_PID_ENV)
-            .context("读取 Windows 宿主进程 ID 失败")?
-            .parse::<u32>()
-            .context("Windows 宿主进程 ID 无效")?;
-        let stop_event = std::env::var(tiangong_sandbox::WINDOWS_STOP_EVENT_ENV)
-            .context("读取 Windows Sandbox 停止事件失败")?;
+            .ok()
+            .map(|value| value.parse::<u32>().context("Windows 宿主进程 ID 无效"))
+            .transpose()?;
+        let stop_event = std::env::var(tiangong_sandbox::WINDOWS_STOP_EVENT_ENV).ok();
+        if inherited_request && (host_pid.is_none() || stop_event.is_none()) {
+            bail!("Windows 宿主生命周期信息缺失");
+        }
         // Launcher 是一次性单线程进程；移除信封后再继承环境，目标无法读取
         // 策略正文或停止事件名称。
         unsafe {
@@ -277,8 +356,8 @@ fn run_launch() -> Result<()> {
                 program_root: &program_root,
                 args: &request.args,
                 policy: &request.policy,
-                host_pid: Some(host_pid),
-                stop_event_name: Some(&stop_event),
+                host_pid,
+                stop_event_name: stop_event.as_deref(),
                 timeout: None,
             },
         )?;
@@ -313,7 +392,9 @@ fn run_launch() -> Result<()> {
     apply_unix_resource_limits(&mut command, &request.policy.resource_limits);
     #[cfg(unix)]
     unsafe {
-        libc::close(POLICY_FD);
+        if inherited_request {
+            libc::close(POLICY_FD);
+        }
         Err(command.exec().into())
     }
     #[cfg(not(any(unix, windows)))]
@@ -465,9 +546,8 @@ fn validate_target(request: &LaunchRequest) -> Result<PathBuf> {
         bail!("目标程序不在插件权威目录内");
     }
 
-    // 解释器形态：目标是宿主白名单解析的解释器程序（入口脚本在 args），
-    // 无插件清单可比对；校验到路径形态与摘要即止。
-    if request.interpreter {
+    // 通用缺省只校验路径形态、摘要与权限。旧 interpreter 字段保持兼容。
+    if request.target_validation == TargetValidation::DigestOnly || request.interpreter {
         let actual_sha256 = sha256_file(&canonical_program)?;
         if !request.program_sha256.eq_ignore_ascii_case(&actual_sha256) {
             bail!("目标程序摘要不匹配");
@@ -2059,6 +2139,7 @@ mod tests {
             program_root: root.display().to_string(),
             program_sha256: String::new(),
             args: Vec::new(),
+            target_validation: TargetValidation::PluginManifest,
             interpreter: false,
         }
     }
@@ -2100,6 +2181,39 @@ mod tests {
         // 无清单比对所需的完整字段时，错误应指向清单链路而非白名单。
         let error = validate_target(&req).unwrap_err();
         assert!(!error.to_string().contains("只允许启动"));
+    }
+
+    #[test]
+    fn missing_target_validation_defaults_to_digest_only() {
+        let value = serde_json::json!({
+            "protocol_version": PROTOCOL_VERSION,
+            "policy_schema": POLICY_SCHEMA,
+            "policy": tiangong_sandbox::SandboxPolicy::workspace_write("/workspace"),
+            "program": "/bin/sh",
+            "program_root": "/bin",
+            "program_sha256": "00"
+        });
+        let request: LaunchRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(request.target_validation, TargetValidation::DigestOnly);
+    }
+
+    #[test]
+    fn digest_only_target_does_not_require_plugin_manifest() {
+        let fixture = tempfile::tempdir().unwrap();
+        let program = fixture.path().join("program");
+        std::fs::write(&program, "stub").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let mut req = request(fixture.path(), &program);
+        req.target_validation = TargetValidation::DigestOnly;
+        req.program_sha256 = sha256_file(&program).unwrap();
+        assert_eq!(
+            validate_target(&req).unwrap(),
+            std::fs::canonicalize(program).unwrap()
+        );
     }
 
     #[test]

--- a/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
+++ b/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
@@ -33,6 +33,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use clap::{Parser, ValueEnum};
 use serde::Deserialize;
 #[cfg(windows)]
 use serde::Serialize;
@@ -93,7 +94,7 @@ fn main() {
     }
     if matches!(args.first().map(String::as_str), Some("--help" | "help")) {
         println!(
-            "tiangong-sandbox {}\n\nUSAGE:\n  tiangong-sandbox --self-check\n  tiangong-sandbox run --policy <policy.json> -- <command> [args...]\n  tiangong-sandbox check-update [--manifest-url <https-url>] [--public-key <file>]\n  tiangong-sandbox update [--manifest-url <https-url>] [--public-key <file>]\n  tiangong-sandbox update --root <absolute-dir> [--manifest-url <https-url>] [--public-key <file>]",
+            "tiangong-sandbox {}\n\nUSAGE:\n  tiangong-sandbox --self-check\n  tiangong-sandbox run --policy <policy.json> -- <command> [args...]\n  tiangong-sandbox run --workspace <absolute-dir> [policy-options] -- <command> [args...]\n  tiangong-sandbox check-update [--manifest-url <https-url>] [--public-key <file>]\n  tiangong-sandbox update [--manifest-url <https-url>] [--public-key <file>]\n  tiangong-sandbox update --root <absolute-dir> [--manifest-url <https-url>] [--public-key <file>]",
             env!("CARGO_PKG_VERSION")
         );
         return;
@@ -195,14 +196,8 @@ fn main() {
 }
 
 fn run_policy_file(args: &[String]) -> Result<()> {
-    if args.get(1).map(String::as_str) != Some("--policy") {
-        bail!("用法: run --policy <policy.json> -- <command> [args...]");
-    }
-    let policy_path = Path::new(args.get(2).context("--policy 缺少值")?);
-    if args.get(3).map(String::as_str) != Some("--") {
-        bail!("策略文件与命令之间必须使用 -- 分隔");
-    }
-    let program = Path::new(args.get(4).context("缺少要执行的命令")?);
+    let parsed = parse_run_args(args)?;
+    let program = Path::new(&parsed.command[0]);
     let program = if program.is_absolute() {
         program.to_path_buf()
     } else if program.components().count() > 1 {
@@ -213,24 +208,159 @@ fn run_policy_file(args: &[String]) -> Result<()> {
     let program = std::fs::canonicalize(&program)
         .with_context(|| format!("解析命令失败: {}", program.display()))?;
     let program_root = program.parent().context("命令缺少父目录")?.to_path_buf();
-    let policy: tiangong_sandbox::SandboxPolicy = serde_json::from_slice(
-        &std::fs::read(policy_path)
-            .with_context(|| format!("读取策略文件失败: {}", policy_path.display()))?,
-    )
-    .context("解析策略文件失败")?;
     let request = LaunchRequest {
         protocol_version: PROTOCOL_VERSION,
         policy_schema: POLICY_SCHEMA,
-        policy,
+        policy: parsed.policy,
         plugin_id: String::new(),
         program: program.display().to_string(),
         program_root: program_root.display().to_string(),
         program_sha256: sha256_file(&program)?,
-        args: args[5..].to_vec(),
+        args: parsed.command[1..].to_vec(),
         target_validation: TargetValidation::DigestOnly,
         interpreter: false,
     };
     execute_request(request, false)
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "tiangong-sandbox run",
+    disable_version_flag = true,
+    about = "使用策略文件或直接策略参数执行受限命令"
+)]
+struct RunArgs {
+    /// SandboxPolicy JSON 文件；不能与直接策略参数同时使用。
+    #[arg(long, value_name = "FILE", conflicts_with_all = INLINE_POLICY_ARGS)]
+    policy: Option<PathBuf>,
+    /// 沙箱模式，默认 workspace-write。
+    #[arg(long, value_enum, default_value_t = CliSandboxMode::WorkspaceWrite)]
+    mode: CliSandboxMode,
+    /// 主工作区绝对路径；直接策略参数形式必须提供。
+    #[arg(long, value_name = "ABSOLUTE_DIR", required_unless_present = "policy")]
+    workspace: Option<PathBuf>,
+    /// 额外可写绝对路径，可重复。
+    #[arg(long, value_name = "ABSOLUTE_PATH")]
+    writable: Vec<PathBuf>,
+    /// 即使位于可写根内也保持只读的绝对路径，可重复。
+    #[arg(long, value_name = "ABSOLUTE_PATH")]
+    protect: Vec<PathBuf>,
+    /// 禁止读取的绝对路径，可重复。
+    #[arg(long, value_name = "ABSOLUTE_PATH")]
+    deny_read: Vec<PathBuf>,
+    /// 网络权限，默认 deny。
+    #[arg(long, value_enum, default_value_t = CliNetwork::Deny)]
+    network: CliNetwork,
+    /// CPU 时间上限（秒）。
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+    max_cpu_seconds: Option<u64>,
+    /// 内存上限（字节）。
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+    max_memory_bytes: Option<u64>,
+    /// 进程数量上限。
+    #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
+    max_processes: Option<u32>,
+    /// `--` 后要执行的命令及参数。
+    #[arg(last = true, required = true, num_args = 1.., allow_hyphen_values = true)]
+    command: Vec<String>,
+}
+
+const INLINE_POLICY_ARGS: &[&str] = &[
+    "mode",
+    "workspace",
+    "writable",
+    "protect",
+    "deny_read",
+    "network",
+    "max_cpu_seconds",
+    "max_memory_bytes",
+    "max_processes",
+];
+
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+enum CliSandboxMode {
+    ReadOnly,
+    #[default]
+    WorkspaceWrite,
+}
+
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+enum CliNetwork {
+    Allow,
+    #[default]
+    Deny,
+}
+
+fn parse_run_args(args: &[String]) -> Result<ParsedRun> {
+    let parsed = RunArgs::try_parse_from(
+        std::iter::once("tiangong-sandbox run").chain(args.iter().skip(1).map(String::as_str)),
+    )
+    .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+    let command = parsed.command.clone();
+    let policy = if let Some(policy_path) = parsed.policy.as_ref() {
+        serde_json::from_slice(
+            &std::fs::read(policy_path)
+                .with_context(|| format!("读取策略文件失败: {}", policy_path.display()))?,
+        )
+        .context("解析策略文件失败")?
+    } else {
+        inline_policy(parsed)?
+    };
+    Ok(ParsedRun { policy, command })
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ParsedRun {
+    policy: tiangong_sandbox::SandboxPolicy,
+    command: Vec<String>,
+}
+
+fn inline_policy(args: RunArgs) -> Result<tiangong_sandbox::SandboxPolicy> {
+    let workspace = absolute_cli_path(
+        args.workspace
+            .as_deref()
+            .context("直接策略参数必须提供 --workspace <absolute-dir>")?,
+        "--workspace",
+    )?;
+    let extra_writable = absolute_cli_paths(args.writable, "--writable")?;
+    let protected_paths = absolute_cli_paths(args.protect, "--protect")?;
+    let denied_read_paths = absolute_cli_paths(args.deny_read, "--deny-read")?;
+    let mut resource_limits = tiangong_sandbox::SandboxResourceLimits::default();
+    if let Some(value) = args.max_cpu_seconds {
+        resource_limits.max_cpu_time_seconds = value;
+    }
+    if let Some(value) = args.max_memory_bytes {
+        resource_limits.max_memory_bytes = value;
+    }
+    if let Some(value) = args.max_processes {
+        resource_limits.max_processes = value;
+    }
+    Ok(tiangong_sandbox::SandboxPolicy {
+        mode: match args.mode {
+            CliSandboxMode::ReadOnly => tiangong_sandbox::SandboxMode::ReadOnly,
+            CliSandboxMode::WorkspaceWrite => tiangong_sandbox::SandboxMode::WorkspaceWrite,
+        },
+        workspace,
+        extra_writable,
+        protected_paths,
+        denied_read_paths,
+        allow_network: matches!(args.network, CliNetwork::Allow),
+        resource_limits,
+    })
+}
+
+fn absolute_cli_paths(values: Vec<PathBuf>, option: &str) -> Result<Vec<PathBuf>> {
+    values
+        .into_iter()
+        .map(|path| absolute_cli_path(&path, option))
+        .collect()
+}
+
+fn absolute_cli_path(value: &Path, option: &str) -> Result<PathBuf> {
+    if !value.is_absolute() {
+        bail!("{option} 必须使用绝对路径: {}", value.display());
+    }
+    Ok(value.to_path_buf())
 }
 
 fn resolve_command_in_path(program: &Path) -> Option<PathBuf> {
@@ -2181,6 +2311,124 @@ mod tests {
         // 无清单比对所需的完整字段时，错误应指向清单链路而非白名单。
         let error = validate_target(&req).unwrap_err();
         assert!(!error.to_string().contains("只允许启动"));
+    }
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn inline_policy_parses_all_options() {
+        let parsed = parse_run_args(&strings(&[
+            "run",
+            "--mode",
+            "workspace-write",
+            "--workspace",
+            "/workspace",
+            "--writable",
+            "/tmp/run",
+            "--writable",
+            "/tmp/cache",
+            "--protect",
+            "/workspace/protected",
+            "--deny-read",
+            "/home/user/.ssh",
+            "--network",
+            "allow",
+            "--max-cpu-seconds",
+            "12",
+            "--max-memory-bytes",
+            "4096",
+            "--max-processes",
+            "8",
+            "--",
+            "echo",
+            "ok",
+        ]))
+        .unwrap();
+        assert_eq!(
+            parsed.policy.mode,
+            tiangong_sandbox::SandboxMode::WorkspaceWrite
+        );
+        assert_eq!(parsed.policy.workspace, PathBuf::from("/workspace"));
+        assert_eq!(
+            parsed.policy.extra_writable,
+            vec![PathBuf::from("/tmp/run"), PathBuf::from("/tmp/cache")]
+        );
+        assert_eq!(
+            parsed.policy.protected_paths,
+            vec![PathBuf::from("/workspace/protected")]
+        );
+        assert_eq!(
+            parsed.policy.denied_read_paths,
+            vec![PathBuf::from("/home/user/.ssh")]
+        );
+        assert!(parsed.policy.allow_network);
+        assert_eq!(parsed.policy.resource_limits.max_cpu_time_seconds, 12);
+        assert_eq!(parsed.policy.resource_limits.max_memory_bytes, 4096);
+        assert_eq!(parsed.policy.resource_limits.max_processes, 8);
+        assert_eq!(parsed.command, strings(&["echo", "ok"]));
+    }
+
+    #[test]
+    fn inline_policy_defaults_are_fail_closed() {
+        let parsed = parse_run_args(&strings(&[
+            "run",
+            "--workspace",
+            "/workspace",
+            "--",
+            "/bin/true",
+        ]))
+        .unwrap();
+        assert_eq!(
+            parsed.policy.mode,
+            tiangong_sandbox::SandboxMode::WorkspaceWrite
+        );
+        assert!(!parsed.policy.allow_network);
+        assert_eq!(
+            parsed.policy.resource_limits,
+            tiangong_sandbox::SandboxResourceLimits::default()
+        );
+    }
+
+    #[test]
+    fn policy_file_and_inline_options_are_mutually_exclusive() {
+        let error = parse_run_args(&strings(&[
+            "run",
+            "--policy",
+            "/tmp/policy.json",
+            "--workspace",
+            "/workspace",
+            "--",
+            "/bin/true",
+        ]))
+        .unwrap_err();
+        assert!(error.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn inline_policy_rejects_relative_paths_and_zero_limits() {
+        let relative = parse_run_args(&strings(&[
+            "run",
+            "--workspace",
+            "relative",
+            "--",
+            "/bin/true",
+        ]))
+        .unwrap_err();
+        assert!(relative.to_string().contains("必须使用绝对路径"));
+
+        let zero = parse_run_args(&strings(&[
+            "run",
+            "--workspace",
+            "/workspace",
+            "--max-processes",
+            "0",
+            "--",
+            "/bin/true",
+        ]))
+        .unwrap_err();
+        assert!(zero.to_string().contains("not in 1..="));
     }
 
     #[test]

--- a/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
+++ b/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
@@ -2317,22 +2317,32 @@ mod tests {
         values.iter().map(|value| (*value).to_string()).collect()
     }
 
+    /// 将 Unix 风格路径转换为当前平台的绝对路径，Windows 上补盘符前缀。
+    fn platform_path(unix: &str) -> PathBuf {
+        if cfg!(windows) {
+            PathBuf::from(format!("C:{}", unix.replace('/', "\\")))
+        } else {
+            PathBuf::from(unix)
+        }
+    }
     #[test]
     fn inline_policy_parses_all_options() {
-        let parsed = parse_run_args(&strings(&[
-            "run",
-            "--mode",
-            "workspace-write",
-            "--workspace",
-            "/workspace",
-            "--writable",
-            "/tmp/run",
-            "--writable",
-            "/tmp/cache",
-            "--protect",
-            "/workspace/protected",
-            "--deny-read",
-            "/home/user/.ssh",
+        let workspace = platform_path("/workspace");
+        let extra_run = platform_path("/tmp/run");
+        let extra_cache = platform_path("/tmp/cache");
+        let protected = platform_path("/workspace/protected");
+        let denied = platform_path("/home/user/.ssh");
+        let mut args = strings(&["run", "--mode", "workspace-write", "--workspace"]);
+        args.push(workspace.display().to_string());
+        args.push("--writable".to_string());
+        args.push(extra_run.display().to_string());
+        args.push("--writable".to_string());
+        args.push(extra_cache.display().to_string());
+        args.push("--protect".to_string());
+        args.push(protected.display().to_string());
+        args.push("--deny-read".to_string());
+        args.push(denied.display().to_string());
+        args.extend(strings(&[
             "--network",
             "allow",
             "--max-cpu-seconds",
@@ -2344,42 +2354,29 @@ mod tests {
             "--",
             "echo",
             "ok",
-        ]))
-        .unwrap();
+        ]));
+        let parsed = parse_run_args(&args).unwrap();
         assert_eq!(
             parsed.policy.mode,
             tiangong_sandbox::SandboxMode::WorkspaceWrite
         );
-        assert_eq!(parsed.policy.workspace, PathBuf::from("/workspace"));
-        assert_eq!(
-            parsed.policy.extra_writable,
-            vec![PathBuf::from("/tmp/run"), PathBuf::from("/tmp/cache")]
-        );
-        assert_eq!(
-            parsed.policy.protected_paths,
-            vec![PathBuf::from("/workspace/protected")]
-        );
-        assert_eq!(
-            parsed.policy.denied_read_paths,
-            vec![PathBuf::from("/home/user/.ssh")]
-        );
+        assert_eq!(parsed.policy.workspace, workspace);
+        assert_eq!(parsed.policy.extra_writable, vec![extra_run, extra_cache]);
+        assert_eq!(parsed.policy.protected_paths, vec![protected]);
+        assert_eq!(parsed.policy.denied_read_paths, vec![denied]);
         assert!(parsed.policy.allow_network);
         assert_eq!(parsed.policy.resource_limits.max_cpu_time_seconds, 12);
         assert_eq!(parsed.policy.resource_limits.max_memory_bytes, 4096);
         assert_eq!(parsed.policy.resource_limits.max_processes, 8);
         assert_eq!(parsed.command, strings(&["echo", "ok"]));
     }
-
     #[test]
     fn inline_policy_defaults_are_fail_closed() {
-        let parsed = parse_run_args(&strings(&[
-            "run",
-            "--workspace",
-            "/workspace",
-            "--",
-            "/bin/true",
-        ]))
-        .unwrap();
+        let workspace = platform_path("/workspace");
+        let mut args = strings(&["run", "--workspace"]);
+        args.push(workspace.display().to_string());
+        args.extend(strings(&["--", "/bin/true"]));
+        let parsed = parse_run_args(&args).unwrap();
         assert_eq!(
             parsed.policy.mode,
             tiangong_sandbox::SandboxMode::WorkspaceWrite
@@ -2390,7 +2387,6 @@ mod tests {
             tiangong_sandbox::SandboxResourceLimits::default()
         );
     }
-
     #[test]
     fn policy_file_and_inline_options_are_mutually_exclusive() {
         let error = parse_run_args(&strings(&[

--- a/crates/tiangong-sandbox/src/installed.rs
+++ b/crates/tiangong-sandbox/src/installed.rs
@@ -1,4 +1,4 @@
-//! 已安装 Sandbox 的官方签名与自检验证。
+//! 已安装 Sandbox 的签名与自检验证。
 //!
 //! 生产 Sandbox 只信任本 crate 内置的独立官方公钥，不接受插件用户密钥、
 //! 第三方插件公钥或任何运行时配置覆盖。
@@ -13,21 +13,26 @@ const OFFICIAL_PUBKEY_B64: &str = include_str!("official-pubkey.b64");
 
 /// 验证固定路径程序的普通文件形态与官方 minisign 签名。
 pub fn verify_official_signature(program: &Path) -> Result<()> {
+    verify_signature_with_public_key(program, OFFICIAL_PUBKEY_B64)
+}
+
+/// 使用宿主显式提供的 base64 minisign 公钥验证程序。
+pub fn verify_signature_with_public_key(program: &Path, public_key_b64: &str) -> Result<()> {
     ensure_regular_file(program, "Sandbox 程序")?;
     let signature_path = crate::launcher_manager::signature_path(program);
     ensure_regular_file(&signature_path, "Sandbox 签名")?;
     let public_text = base64::engine::general_purpose::STANDARD
-        .decode(OFFICIAL_PUBKEY_B64.trim())
-        .context("解析 Sandbox 官方公钥失败")?;
+        .decode(public_key_b64.trim())
+        .context("解析 Sandbox 公钥失败")?;
     let public =
-        PublicKey::decode(&String::from_utf8(public_text)?).context("解析 Sandbox 官方公钥失败")?;
+        PublicKey::decode(&String::from_utf8(public_text)?).context("解析 Sandbox 公钥失败")?;
     let signature_text = base64::engine::general_purpose::STANDARD
         .decode(std::fs::read_to_string(&signature_path)?.trim())?;
     let signature =
         Signature::decode(&String::from_utf8(signature_text)?).context("解析 Sandbox 签名失败")?;
     public
         .verify(&std::fs::read(program)?, &signature, false)
-        .context("Sandbox 官方签名验证不通过")
+        .context("Sandbox 签名验证不通过")
 }
 
 /// 官方验签后执行真实自检，并返回产品版本。

--- a/crates/tiangong-sandbox/src/installed.rs
+++ b/crates/tiangong-sandbox/src/installed.rs
@@ -1,0 +1,92 @@
+//! 已安装 Sandbox 的官方签名与自检验证。
+//!
+//! 生产 Sandbox 只信任本 crate 内置的独立官方公钥，不接受插件用户密钥、
+//! 第三方插件公钥或任何运行时配置覆盖。
+
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use base64::Engine as _;
+use minisign_verify::{PublicKey, Signature};
+
+const OFFICIAL_PUBKEY_B64: &str = include_str!("official-pubkey.b64");
+
+/// 验证固定路径程序的普通文件形态与官方 minisign 签名。
+pub fn verify_official_signature(program: &Path) -> Result<()> {
+    ensure_regular_file(program, "Sandbox 程序")?;
+    let signature_path = crate::launcher_manager::signature_path(program);
+    ensure_regular_file(&signature_path, "Sandbox 签名")?;
+    let public_text = base64::engine::general_purpose::STANDARD
+        .decode(OFFICIAL_PUBKEY_B64.trim())
+        .context("解析 Sandbox 官方公钥失败")?;
+    let public =
+        PublicKey::decode(&String::from_utf8(public_text)?).context("解析 Sandbox 官方公钥失败")?;
+    let signature_text = base64::engine::general_purpose::STANDARD
+        .decode(std::fs::read_to_string(&signature_path)?.trim())?;
+    let signature =
+        Signature::decode(&String::from_utf8(signature_text)?).context("解析 Sandbox 签名失败")?;
+    public
+        .verify(&std::fs::read(program)?, &signature, false)
+        .context("Sandbox 官方签名验证不通过")
+}
+
+/// 官方验签后执行真实自检，并返回产品版本。
+pub fn verify_official_install(program: &Path) -> Result<String> {
+    verify_official_signature(program)?;
+    let output = std::process::Command::new(program)
+        .arg("--self-check")
+        .output()
+        .with_context(|| format!("运行 Sandbox 自检失败: {}", program.display()))?;
+    if !output.status.success() && output.status.code() != Some(79) {
+        bail!(
+            "Sandbox 自检失败（退出码 {}）：{}",
+            output.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).context("解析 Sandbox 自检报告失败")?;
+    if report["protocol_version"].as_u64() != Some(u64::from(crate::LAUNCHER_PROTOCOL_VERSION))
+        || report["policy_schema"].as_u64() != Some(u64::from(crate::LAUNCHER_POLICY_SCHEMA))
+    {
+        bail!("Sandbox 自报协议或策略 Schema 与宿主不兼容");
+    }
+    report["product_version"]
+        .as_str()
+        .filter(|version| !version.is_empty())
+        .map(ToOwned::to_owned)
+        .context("Sandbox 自检报告缺少产品版本")
+}
+
+fn ensure_regular_file(path: &Path, label: &str) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("{label}不存在: {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        bail!("{label}必须是普通文件: {}", path.display());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_program_is_rejected_before_signature_read() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("target");
+        let link = root.path().join("tiangong-sandbox");
+        std::fs::write(&target, b"sandbox").unwrap();
+        std::os::unix::fs::symlink(target, &link).unwrap();
+        assert!(verify_official_signature(&link).is_err());
+    }
+
+    #[test]
+    fn unsigned_program_is_rejected() {
+        let root = tempfile::tempdir().unwrap();
+        let program = root.path().join("tiangong-sandbox");
+        std::fs::write(&program, b"sandbox").unwrap();
+        assert!(verify_official_signature(&program).is_err());
+    }
+}

--- a/crates/tiangong-sandbox/src/launcher_manager.rs
+++ b/crates/tiangong-sandbox/src/launcher_manager.rs
@@ -1,13 +1,9 @@
-//! App 集成侧的 Sandbox 程序定位。
+//! Sandbox 程序定位。
 //!
-//! 生产布局固定为 `<storage_root>/sandbox/tiangong-sandbox[.exe]` 及同目录
-//! 伴生签名。版本由程序自身 `--self-check` 报告，不再通过版本目录或
-//! active/pending 指针表达。调试构建仍优先使用宿主同目录的本地构建。
+//! 安装目录完全由宿主决定；本模块只约定目录内的程序名与伴生签名名，
+//! 不认识天工的存储根或目录布局。
 
 use std::path::{Path, PathBuf};
-
-/// storage_root 下的 Sandbox 安装目录。
-pub const LAUNCHER_DIR: &str = "sandbox";
 
 pub fn builtin_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -17,12 +13,8 @@ pub fn launcher_file_name() -> String {
     format!("tiangong-sandbox{}", std::env::consts::EXE_SUFFIX)
 }
 
-pub fn install_directory(storage_root: &Path) -> PathBuf {
-    storage_root.join(LAUNCHER_DIR)
-}
-
-pub fn installed_sandbox(storage_root: &Path) -> PathBuf {
-    install_directory(storage_root).join(launcher_file_name())
+pub fn installed_program(directory: &Path) -> PathBuf {
+    directory.join(launcher_file_name())
 }
 
 pub fn signature_path(program: &Path) -> PathBuf {
@@ -36,19 +28,15 @@ pub fn signature_path(program: &Path) -> PathBuf {
 }
 
 /// 返回值仍需由调用方逐次验签与自检。
-pub fn resolve_sandbox_binary(storage_root: &Path) -> Option<PathBuf> {
-    select_sandbox_binary(regular_installed_sandbox(storage_root), builtin_sandbox())
+pub fn resolve_installed_program(directory: &Path) -> Option<PathBuf> {
+    regular_installed_program(directory)
 }
 
-fn select_sandbox_binary(installed: Option<PathBuf>, local: Option<PathBuf>) -> Option<PathBuf> {
-    installed.or(local)
-}
-
-fn regular_installed_sandbox(storage_root: &Path) -> Option<PathBuf> {
-    if !storage_root.is_absolute() {
+fn regular_installed_program(directory: &Path) -> Option<PathBuf> {
+    if !directory.is_absolute() {
         return None;
     }
-    let program = installed_sandbox(storage_root);
+    let program = installed_program(directory);
     let program_meta = std::fs::symlink_metadata(&program).ok()?;
     if !program_meta.is_file() || program_meta.file_type().is_symlink() {
         return None;
@@ -60,7 +48,8 @@ fn regular_installed_sandbox(storage_root: &Path) -> Option<PathBuf> {
     Some(program)
 }
 
-fn builtin_sandbox() -> Option<PathBuf> {
+/// 查找当前宿主程序同目录的 Sandbox。是否采用该布局由宿主决定。
+pub fn sibling_program() -> Option<PathBuf> {
     let current_exe = std::env::current_exe().ok()?;
     let directory = current_exe.parent()?;
     let direct = directory.join(launcher_file_name());
@@ -82,51 +71,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn installed_layout_is_flat() {
-        let root = Path::new("/storage");
+    fn install_directory_is_owned_by_host() {
+        let directory = Path::new("/host/chosen/location");
         assert_eq!(
-            installed_sandbox(root),
-            root.join("sandbox").join(launcher_file_name())
-        );
-        assert!(
-            !installed_sandbox(root)
-                .to_string_lossy()
-                .contains("versions")
+            installed_program(directory),
+            directory.join(launcher_file_name())
         );
     }
 
     #[test]
     fn resolver_requires_program_and_signature() {
         let root = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(install_directory(root.path())).unwrap();
-        let program = installed_sandbox(root.path());
+        let directory = root.path().join("chosen");
+        std::fs::create_dir_all(&directory).unwrap();
+        let program = installed_program(&directory);
         std::fs::write(&program, b"sandbox").unwrap();
-        assert!(regular_installed_sandbox(root.path()).is_none());
+        assert!(resolve_installed_program(&directory).is_none());
         std::fs::write(signature_path(&program), b"signature").unwrap();
-        assert_eq!(regular_installed_sandbox(root.path()), Some(program));
+        assert_eq!(resolve_installed_program(&directory), Some(program));
     }
 
     #[cfg(unix)]
     #[test]
     fn resolver_rejects_symlink_program() {
         let root = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(install_directory(root.path())).unwrap();
+        let directory = root.path().join("chosen");
+        std::fs::create_dir_all(&directory).unwrap();
         let target = root.path().join("target");
         std::fs::write(&target, b"sandbox").unwrap();
-        let program = installed_sandbox(root.path());
+        let program = installed_program(&directory);
         std::os::unix::fs::symlink(target, &program).unwrap();
         std::fs::write(signature_path(&program), b"signature").unwrap();
-        assert!(regular_installed_sandbox(root.path()).is_none());
-    }
-
-    #[cfg(debug_assertions)]
-    #[test]
-    fn debug_build_prefers_installed_program() {
-        let local = PathBuf::from("/debug/tiangong-sandbox");
-        let installed = PathBuf::from("/storage/sandbox/tiangong-sandbox");
-        assert_eq!(
-            select_sandbox_binary(Some(installed.clone()), Some(local)),
-            Some(installed)
-        );
+        assert!(resolve_installed_program(&directory).is_none());
     }
 }

--- a/crates/tiangong-sandbox/src/launcher_manager.rs
+++ b/crates/tiangong-sandbox/src/launcher_manager.rs
@@ -1,0 +1,132 @@
+//! App 集成侧的 Sandbox 程序定位。
+//!
+//! 生产布局固定为 `<storage_root>/sandbox/tiangong-sandbox[.exe]` 及同目录
+//! 伴生签名。版本由程序自身 `--self-check` 报告，不再通过版本目录或
+//! active/pending 指针表达。调试构建仍优先使用宿主同目录的本地构建。
+
+use std::path::{Path, PathBuf};
+
+/// storage_root 下的 Sandbox 安装目录。
+pub const LAUNCHER_DIR: &str = "sandbox";
+
+pub fn builtin_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+pub fn launcher_file_name() -> String {
+    format!("tiangong-sandbox{}", std::env::consts::EXE_SUFFIX)
+}
+
+pub fn install_directory(storage_root: &Path) -> PathBuf {
+    storage_root.join(LAUNCHER_DIR)
+}
+
+pub fn installed_sandbox(storage_root: &Path) -> PathBuf {
+    install_directory(storage_root).join(launcher_file_name())
+}
+
+pub fn signature_path(program: &Path) -> PathBuf {
+    program.with_file_name(format!(
+        "{}.sig",
+        program
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+    ))
+}
+
+/// 返回值仍需由调用方逐次验签与自检。
+pub fn resolve_sandbox_binary(storage_root: &Path) -> Option<PathBuf> {
+    select_sandbox_binary(regular_installed_sandbox(storage_root), builtin_sandbox())
+}
+
+fn select_sandbox_binary(installed: Option<PathBuf>, local: Option<PathBuf>) -> Option<PathBuf> {
+    installed.or(local)
+}
+
+fn regular_installed_sandbox(storage_root: &Path) -> Option<PathBuf> {
+    if !storage_root.is_absolute() {
+        return None;
+    }
+    let program = installed_sandbox(storage_root);
+    let program_meta = std::fs::symlink_metadata(&program).ok()?;
+    if !program_meta.is_file() || program_meta.file_type().is_symlink() {
+        return None;
+    }
+    let signature_meta = std::fs::symlink_metadata(signature_path(&program)).ok()?;
+    if !signature_meta.is_file() || signature_meta.file_type().is_symlink() {
+        return None;
+    }
+    Some(program)
+}
+
+fn builtin_sandbox() -> Option<PathBuf> {
+    let current_exe = std::env::current_exe().ok()?;
+    let directory = current_exe.parent()?;
+    let direct = directory.join(launcher_file_name());
+    if direct.is_file() {
+        return Some(direct);
+    }
+    #[cfg(debug_assertions)]
+    if directory.file_name().is_some_and(|name| name == "deps") {
+        let debug_binary = directory.parent()?.join(launcher_file_name());
+        if debug_binary.is_file() {
+            return Some(debug_binary);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn installed_layout_is_flat() {
+        let root = Path::new("/storage");
+        assert_eq!(
+            installed_sandbox(root),
+            root.join("sandbox").join(launcher_file_name())
+        );
+        assert!(
+            !installed_sandbox(root)
+                .to_string_lossy()
+                .contains("versions")
+        );
+    }
+
+    #[test]
+    fn resolver_requires_program_and_signature() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(install_directory(root.path())).unwrap();
+        let program = installed_sandbox(root.path());
+        std::fs::write(&program, b"sandbox").unwrap();
+        assert!(regular_installed_sandbox(root.path()).is_none());
+        std::fs::write(signature_path(&program), b"signature").unwrap();
+        assert_eq!(regular_installed_sandbox(root.path()), Some(program));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolver_rejects_symlink_program() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(install_directory(root.path())).unwrap();
+        let target = root.path().join("target");
+        std::fs::write(&target, b"sandbox").unwrap();
+        let program = installed_sandbox(root.path());
+        std::os::unix::fs::symlink(target, &program).unwrap();
+        std::fs::write(signature_path(&program), b"signature").unwrap();
+        assert!(regular_installed_sandbox(root.path()).is_none());
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn debug_build_prefers_installed_program() {
+        let local = PathBuf::from("/debug/tiangong-sandbox");
+        let installed = PathBuf::from("/storage/sandbox/tiangong-sandbox");
+        assert_eq!(
+            select_sandbox_binary(Some(installed.clone()), Some(local)),
+            Some(installed)
+        );
+    }
+}

--- a/crates/tiangong-sandbox/src/lib.rs
+++ b/crates/tiangong-sandbox/src/lib.rs
@@ -9,6 +9,8 @@
 //! - 工作区快照恢复 → feature/workspace-snapshots
 //! - 无沙箱审批升级 → feature/sandbox-escalation
 
+pub mod installed;
+pub mod launcher_manager;
 mod path;
 pub mod sandbox;
 pub mod update;

--- a/crates/tiangong-sandbox/src/sandbox/mod.rs
+++ b/crates/tiangong-sandbox/src/sandbox/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod bwrap;
 pub mod policy;
+pub mod presets;
 pub mod seatbelt;
 #[cfg(windows)]
 pub mod windows;

--- a/crates/tiangong-sandbox/src/sandbox/policy.rs
+++ b/crates/tiangong-sandbox/src/sandbox/policy.rs
@@ -24,6 +24,7 @@ pub struct SandboxPolicy {
     /// 会话工作区（WorkspaceWrite 模式下的主可写根）。
     pub workspace: PathBuf,
     /// 额外可写根（插件数据目录等）。
+    #[serde(default)]
     pub extra_writable: Vec<PathBuf>,
     /// 即使位于可写根内也保持只读的宿主敏感路径。
     #[serde(default)]
@@ -32,6 +33,7 @@ pub struct SandboxPolicy {
     #[serde(default)]
     pub denied_read_paths: Vec<PathBuf>,
     /// 是否放行出网（默认 false；放行走宿主代理体系，见 RFC D16）。
+    #[serde(default)]
     pub allow_network: bool,
     /// 单次 command 的资源上限。
     #[serde(default)]
@@ -82,21 +84,6 @@ impl SandboxPolicy {
             denied_read_paths: Vec::new(),
             allow_network: true,
             resource_limits: SandboxResourceLimits::default(),
-        }
-    }
-
-    /// 加入宿主权威的默认敏感读取拒绝项。
-    ///
-    /// 覆盖常见凭据位置：SSH/AWS/GPG/Kubernetes/Docker/Azure/GCP/GitHub CLI
-    /// 与 `.netrc`。天工数据根下的配置、密钥与信任件同样拒绝读取。
-    pub fn protect_user_credentials(&mut self, storage_root: &Path) {
-        if let Some(home) = user_home_dir() {
-            for path in home_credential_relative_paths() {
-                self.denied_read_paths.push(home.join(path));
-            }
-        }
-        for path in protected_storage_relative_paths() {
-            self.denied_read_paths.push(storage_root.join(path));
         }
     }
 
@@ -161,74 +148,6 @@ impl SandboxPolicy {
         paths.dedup();
         paths
     }
-}
-
-/// 当前用户家目录（绝对路径，解析失败返回 None）。
-pub fn user_home_dir() -> Option<PathBuf> {
-    #[cfg(windows)]
-    let value = std::env::var_os("USERPROFILE")
-        .map(PathBuf::from)
-        .or_else(|| {
-            let drive = std::env::var_os("HOMEDRIVE")?;
-            let path = std::env::var_os("HOMEPATH")?;
-            Some(PathBuf::from(drive).join(path))
-        });
-    #[cfg(not(windows))]
-    let value = std::env::var_os("HOME").map(PathBuf::from);
-    value.filter(|path| path.is_absolute())
-}
-
-/// 家目录下必须保持只读的凭据相对路径清单：沙箱禁读（deny-read）与
-/// 家目录作工作区时的写保护（protected）共用同一份权威清单。
-pub fn home_credential_relative_paths() -> [&'static str; 9] {
-    [
-        ".ssh",
-        ".aws",
-        ".gnupg",
-        ".kube",
-        ".docker",
-        ".azure",
-        ".config/gcloud",
-        ".config/gh",
-        ".netrc",
-    ]
-}
-
-/// 家目录下凭据路径的绝对形态（家目录不可解析时为空）。
-pub fn home_credential_paths() -> Vec<PathBuf> {
-    let Some(home) = user_home_dir() else {
-        return Vec::new();
-    };
-    home_credential_relative_paths()
-        .iter()
-        .map(|path| home.join(path))
-        .collect()
-}
-
-/// storage_root 下对 sidecar 读写双禁的配置与信任件（相对路径段）：
-/// 模型/服务/MCP/应用配置（app.json 含沙箱开关本身）、签名密钥与信任
-/// 库、以及 Launcher 目录（沙箱防"被约束者"的核心——沙箱内进程必须
-/// 够不到 Launcher 与信任锚，防替换逃逸）。其余存储目录整体开放可写。
-pub fn protected_storage_relative_paths() -> [&'static str; 7] {
-    [
-        "keys",
-        "trust.db",
-        "mcp.json",
-        "models.json",
-        "server.json",
-        "app.json",
-        "sandbox",
-    ]
-}
-
-/// protected_paths 用的绝对清单：存储配置件 + 家目录凭据（读写双禁）。
-pub fn protected_paths_for(storage_root: &Path) -> Vec<PathBuf> {
-    let mut paths: Vec<PathBuf> = protected_storage_relative_paths()
-        .iter()
-        .map(|path| storage_root.join(path))
-        .collect();
-    paths.extend(home_credential_paths());
-    paths
 }
 
 /// 规范化路径：能解析则用真实路径（macOS 上 `/var` → `/private/var`），
@@ -339,31 +258,5 @@ mod tests {
                 .read_only_roots()
                 .contains(&canonical_or_keep(&git_file))
         );
-    }
-
-    #[test]
-    fn credential_protection_covers_common_secret_locations() {
-        let root = tempfile::tempdir().unwrap();
-        let mut policy = SandboxPolicy::workspace_write("/workspace");
-        policy.protect_user_credentials(root.path());
-        let denied = policy.denied_read_roots();
-
-        // 用户目录凭据位置。
-        if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
-            for path in [".ssh", ".aws", ".gnupg", ".kube", ".docker", ".netrc"] {
-                assert!(
-                    denied.contains(&canonical_or_keep(&home.join(path))),
-                    "应拒绝读取 {}",
-                    path
-                );
-            }
-        }
-        // 天工数据根内的密钥与凭据文件。
-        for path in ["keys", "trust.db", "mcp.json", "models.json"] {
-            assert!(
-                denied.contains(&canonical_or_keep(&root.path().join(path))),
-                "应拒绝读取数据根内 {path}"
-            );
-        }
     }
 }

--- a/crates/tiangong-sandbox/src/sandbox/presets.rs
+++ b/crates/tiangong-sandbox/src/sandbox/presets.rs
@@ -1,0 +1,81 @@
+//! 可选的宿主策略预设。
+//!
+//! 通用核心不会自动加入任何路径；宿主可采用这些预设，也可完全传入自己的
+//! `protected_paths` 与 `denied_read_paths`。
+
+use std::path::{Path, PathBuf};
+
+use super::policy::SandboxPolicy;
+
+/// 常见用户凭据位置。是否禁止读取由宿主决定。
+pub fn common_credential_paths() -> Vec<PathBuf> {
+    let Some(home) = user_home_dir() else {
+        return Vec::new();
+    };
+    [
+        ".ssh",
+        ".aws",
+        ".gnupg",
+        ".kube",
+        ".docker",
+        ".azure",
+        ".config/gcloud",
+        ".config/gh",
+        ".netrc",
+    ]
+    .iter()
+    .map(|path| home.join(path))
+    .collect()
+}
+
+/// 天工 App 的敏感路径预设。`storage_root` 与其中的 `sandbox` 目录均由 App
+/// 选择；Sandbox 核心不推导该布局。
+pub fn apply_tiangong(policy: &mut SandboxPolicy, storage_root: &Path) {
+    policy.denied_read_paths.extend(common_credential_paths());
+    policy.denied_read_paths.extend(
+        [
+            "keys",
+            "trust.db",
+            "mcp.json",
+            "models.json",
+            "server.json",
+            "app.json",
+            "sandbox",
+        ]
+        .iter()
+        .map(|path| storage_root.join(path)),
+    );
+}
+
+fn user_home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    let value = std::env::var_os("USERPROFILE")
+        .map(PathBuf::from)
+        .or_else(|| {
+            let drive = std::env::var_os("HOMEDRIVE")?;
+            let path = std::env::var_os("HOMEPATH")?;
+            Some(PathBuf::from(drive).join(path))
+        });
+    #[cfg(not(windows))]
+    let value = std::env::var_os("HOME").map(PathBuf::from);
+    value.filter(|path| path.is_absolute())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tiangong_preset_is_explicit() {
+        let root = tempfile::tempdir().unwrap();
+        let mut policy = SandboxPolicy::workspace_write("/workspace");
+        assert!(policy.denied_read_paths.is_empty());
+        apply_tiangong(&mut policy, root.path());
+        assert!(policy.denied_read_paths.contains(&root.path().join("keys")));
+        assert!(
+            policy
+                .denied_read_paths
+                .contains(&root.path().join("sandbox"))
+        );
+    }
+}

--- a/crates/tiangong-sandbox/src/update.rs
+++ b/crates/tiangong-sandbox/src/update.rs
@@ -89,6 +89,14 @@ pub struct SelfUpdater {
 
 impl SelfUpdater {
     pub fn new(manifest_url: impl Into<String>) -> Result<Self> {
+        Self::with_public_key(manifest_url, OFFICIAL_PUBKEY_B64)
+    }
+
+    /// 使用调用方显式选择的更新端点和信任根。不会读取环境变量。
+    pub fn with_public_key(
+        manifest_url: impl Into<String>,
+        public_key_b64: impl Into<String>,
+    ) -> Result<Self> {
         let manifest_url = manifest_url.into();
         validate_https_url(&manifest_url, "更新清单")?;
         let client = reqwest::Client::builder()
@@ -100,15 +108,13 @@ impl SelfUpdater {
         Ok(Self {
             client,
             manifest_url,
-            official_pubkey_b64: OFFICIAL_PUBKEY_B64.trim().to_string(),
+            official_pubkey_b64: public_key_b64.into().trim().to_string(),
         })
     }
 
     #[cfg(all(test, not(windows)))]
     fn with_test_pubkey(manifest_url: impl Into<String>, pubkey_b64: String) -> Result<Self> {
-        let mut updater = Self::new(manifest_url)?;
-        updater.official_pubkey_b64 = pubkey_b64;
-        Ok(updater)
+        Self::with_public_key(manifest_url, pubkey_b64)
     }
 
     /// 只检查官方更新，不读写安装目录。

--- a/crates/tiangong-sandbox/src/update.rs
+++ b/crates/tiangong-sandbox/src/update.rs
@@ -910,7 +910,7 @@ mod tests {
         assert_eq!(
             status,
             UpdateStatus::Updated {
-                previous: "0.1.0".into(),
+                previous: env!("CARGO_PKG_VERSION").into(),
                 version: "0.2.0".into(),
                 path: current.clone(),
             }

--- a/docs/sandbox-direct-storage.md
+++ b/docs/sandbox-direct-storage.md
@@ -7,17 +7,30 @@
 ## 需求
 
 1. Sandbox 不认识天工的 `storage_root`，安装目录完全由宿主决定。库只负责在宿主传入的目录中定位 `tiangong-sandbox[.exe]` 和伴生签名。
-2. 增加通用命令：
+2. 提供策略文件和直接命令行参数两种通用执行形式：
 
 ```text
 tiangong-sandbox run --policy <policy.json> -- <command> [args...]
+
+tiangong-sandbox run \
+  --mode workspace-write \
+  --workspace /absolute/workspace \
+  --writable /absolute/run-temp \
+  --protect /absolute/workspace/protected \
+  --deny-read /home/user/.ssh \
+  --network deny \
+  --max-cpu-seconds 300 \
+  --max-memory-bytes 2147483648 \
+  --max-processes 64 \
+  -- <command> [args...]
 ```
 
-3. 策略文件直接使用 `SandboxPolicy` JSON。保护路径、禁读路径、额外可写路径和网络权限全部由宿主传入。
-4. 目标程序默认执行路径、摘要、文件类型和权限校验，不要求 `plugin.json`。天工插件宿主可以显式启用插件清单比对。
-5. 常见凭据和天工数据文件清单是可选预设，不是通用策略的隐式默认值。
-6. 更新端点和 minisign 信任根可由调用方通过显式参数配置；不允许环境变量静默替换生产信任根。
-7. 天工生产安装验证入口仍只接受 crate 内置官方公钥，并在验签后执行自检。
+3. `--writable`、`--protect` 和 `--deny-read` 可以重复。直接参数缺省使用 `workspace-write`、禁止网络和默认资源上限，并且必须提供绝对路径的 `--workspace`。
+4. `--policy` 与直接策略参数互斥，不做隐式合并或覆盖。策略文件直接使用 `SandboxPolicy` JSON。保护路径、禁读路径、额外可写路径和网络权限全部由宿主传入。
+5. 目标程序默认执行路径、摘要、文件类型和权限校验，不要求 `plugin.json`。天工插件宿主可以显式启用插件清单比对。
+6. 常见凭据和天工数据文件清单是可选预设，不是通用策略的隐式默认值。
+7. 更新端点和 minisign 信任根可由调用方通过显式参数配置；不允许环境变量静默替换生产信任根。
+8. 天工生产安装验证入口仍只接受 crate 内置官方公钥，并在验签后执行自检。
 
 ## 兼容性
 
@@ -52,7 +65,7 @@ tiangong-sandbox run --policy <policy.json> -- <command> [args...]
 ## 完成标准
 
 - 宿主可自行选择任意绝对安装目录。
-- 无天工插件清单时可用策略文件执行普通命令。
+- 无天工插件清单时可用策略文件或直接命令行策略执行普通命令。
 - 越界写和禁读行为仍由三平台现有沙箱实现强制执行。
 - 天工生产官方根与第三方显式信任根入口分离。
 - Sandbox crate 构建、测试和严格检查通过。

--- a/docs/sandbox-direct-storage.md
+++ b/docs/sandbox-direct-storage.md
@@ -1,28 +1,58 @@
-# Sandbox 直存与生产信任边界
+# Sandbox 通用化与宿主安装目录
+
+## 目标
+
+按照 issue #458 的 P1 范围，让 Sandbox 可以脱离天工插件上下文独立使用，同时保持天工生产信任边界不降低。
 
 ## 需求
 
-1. 天工存储根下的 Sandbox 使用固定直存布局：
+1. Sandbox 不认识天工的 `storage_root`，安装目录完全由宿主决定。库只负责在宿主传入的目录中定位 `tiangong-sandbox[.exe]` 和伴生签名。
+2. 增加通用命令：
 
 ```text
-<storage>/sandbox/tiangong-sandbox[.exe]
-<storage>/sandbox/tiangong-sandbox[.exe].sig
+tiangong-sandbox run --policy <policy.json> -- <command> [args...]
 ```
 
-2. 不创建 `active`、`pending` 或 `versions/<版本>/` 仓库；版本由程序 `--self-check` 自报。
-3. 定位阶段只接受普通程序与普通签名文件，拒绝符号链接。
-4. 生产 Sandbox 必须通过 `tiangong-sandbox` crate 内置的独立官方公钥验签；插件用户密钥和第三方插件信任根不得参与。
-5. 官方验签后必须执行真实自检，并确认协议与策略 Schema 与当前宿主一致。
-6. Sandbox 下载、首次安装和自更新继续复用现有 `SelfUpdater`，不在本分支实现 App 前端、Tauri 命令或 Sidecar 接线。
+3. 策略文件直接使用 `SandboxPolicy` JSON。保护路径、禁读路径、额外可写路径和网络权限全部由宿主传入。
+4. 目标程序默认执行路径、摘要、文件类型和权限校验，不要求 `plugin.json`。天工插件宿主可以显式启用插件清单比对。
+5. 常见凭据和天工数据文件清单是可选预设，不是通用策略的隐式默认值。
+6. 更新端点和 minisign 信任根可由调用方通过显式参数配置；不允许环境变量静默替换生产信任根。
+7. 天工生产安装验证入口仍只接受 crate 内置官方公钥，并在验签后执行自检。
+
+## 兼容性
+
+- fd3 / Windows 信封协议继续可用。
+- 新增的目标校验字段缺省为通用摘要校验；旧 `interpreter` 字段继续兼容。
+- 策略中新增默认值，旧策略缺少额外可写、保护/禁读、网络和资源限制字段时仍可解析。
+
+## 策略示例
+
+```json
+{
+  "mode": "workspace_write",
+  "workspace": "/absolute/workspace",
+  "extra_writable": ["/absolute/run-temp"],
+  "protected_paths": ["/absolute/workspace/protected"],
+  "denied_read_paths": ["/home/user/.ssh"],
+  "allow_network": false,
+  "resource_limits": {
+    "max_cpu_time_seconds": 300,
+    "max_memory_bytes": 2147483648,
+    "max_processes": 64
+  }
+}
+```
 
 ## 非目标
 
-1. 不迁移旧版本目录；离线迁移另行处理。
-2. 不增加最低产品版本门槛；由后续兼容任务处理。
-3. 不修改终端跨会话路由、Sidecar 策略、设置页和启动准备页。
+1. 不执行 P2 的独立仓库、中性产品命名或公共宿主集成 crate 拆分。
+2. 不迁移旧版本目录，不增加最低产品版本门槛。
+3. 不修改终端跨会话路由、设置页和启动准备页。
 
 ## 完成标准
 
-- 直存路径解析和符号链接拒绝有测试覆盖。
-- 用户插件密钥无法验证生产 Sandbox；生产验证入口只使用 Sandbox 官方根。
-- Sandbox crate 格式、构建、测试和严格 lint 通过。
+- 宿主可自行选择任意绝对安装目录。
+- 无天工插件清单时可用策略文件执行普通命令。
+- 越界写和禁读行为仍由三平台现有沙箱实现强制执行。
+- 天工生产官方根与第三方显式信任根入口分离。
+- Sandbox crate 构建、测试和严格检查通过。

--- a/docs/sandbox-direct-storage.md
+++ b/docs/sandbox-direct-storage.md
@@ -1,0 +1,28 @@
+# Sandbox 直存与生产信任边界
+
+## 需求
+
+1. 天工存储根下的 Sandbox 使用固定直存布局：
+
+```text
+<storage>/sandbox/tiangong-sandbox[.exe]
+<storage>/sandbox/tiangong-sandbox[.exe].sig
+```
+
+2. 不创建 `active`、`pending` 或 `versions/<版本>/` 仓库；版本由程序 `--self-check` 自报。
+3. 定位阶段只接受普通程序与普通签名文件，拒绝符号链接。
+4. 生产 Sandbox 必须通过 `tiangong-sandbox` crate 内置的独立官方公钥验签；插件用户密钥和第三方插件信任根不得参与。
+5. 官方验签后必须执行真实自检，并确认协议与策略 Schema 与当前宿主一致。
+6. Sandbox 下载、首次安装和自更新继续复用现有 `SelfUpdater`，不在本分支实现 App 前端、Tauri 命令或 Sidecar 接线。
+
+## 非目标
+
+1. 不迁移旧版本目录；离线迁移另行处理。
+2. 不增加最低产品版本门槛；由后续兼容任务处理。
+3. 不修改终端跨会话路由、Sidecar 策略、设置页和启动准备页。
+
+## 完成标准
+
+- 直存路径解析和符号链接拒绝有测试覆盖。
+- 用户插件密钥无法验证生产 Sandbox；生产验证入口只使用 Sandbox 官方根。
+- Sandbox crate 格式、构建、测试和严格 lint 通过。

--- a/docs/sandbox-self-management.md
+++ b/docs/sandbox-self-management.md
@@ -30,7 +30,7 @@ https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/latest.json
 <目录>/tiangong-sandbox[.exe].sig
 ```
 
-不会创建 `sandbox/versions/active` 版本仓库。`--manifest-url` 仅用于受控测试；生产使用 HTTPS，测试构建只允许本机回环 HTTP。
+不会创建 `sandbox/versions/active` 版本仓库。App 集成使用 `<storage>/sandbox/` 作为安装目录，生产启动验签只认 Sandbox 独立官方根；详见 `docs/sandbox-direct-storage.md`。`--manifest-url` 仅用于受控测试；生产使用 HTTPS，测试构建只允许本机回环 HTTP。
 
 ## 安全门禁
 


### PR DESCRIPTION
## 变更内容

- Sandbox 安装目录改为完全由宿主决定，不再认识或拼接天工 `storage_root/sandbox`
- 按 issue #458 完成 P1 通用化，增加 `run --policy <json> -- <command>` 独立执行入口
- 使用 clap 支持直接在命令行配置工作区、读写保护、网络和资源限制
- 目标插件清单校验改为显式可选，通用场景默认执行路径、摘要与权限校验
- 将天工敏感路径清单移为显式宿主预设，通用策略不再隐式注入
- 更新端点与信任根支持显式配置，同时保持天工生产入口只接受官方根
- 添加 Sandbox README、正式版本下载链接及 Homebrew/APT 等后续发布计划

## 验证

- `cargo check --locked -p tiangong-sandbox --all-targets`
- `cargo test --locked -p tiangong-sandbox`
- `cargo clippy --locked -p tiangong-sandbox --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- 实际验证策略文件、直接命令行参数、互斥参数和非法路径拒绝
- 推送前仓库检查：cargo check、clippy、nextest 全部通过

Closes #458