### PR TITLE
fix(sandbox): 恢复凭据服务放行并补 opendirectoryd.membership（0.1.2）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11767,7 +11767,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-sandbox"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/crates/tiangong-sandbox/Cargo.toml
+++ b/crates/tiangong-sandbox/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tiangong-sandbox"
 # Launcher 独立版本序列（不随 workspace/App 版本）：在线更新按此序列
 # 判定新旧与防降级，App 发版不要求 Launcher 同步改动。
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Command 工具的宿主强制操作系统沙箱套壳"

--- a/crates/tiangong-sandbox/README.md
+++ b/crates/tiangong-sandbox/README.md
@@ -25,14 +25,14 @@ Sandbox 不决定宿主的存储布局。安装目录由 App、服务或其他�
 
 正式版由独立发布流程构建、签名并发布到官方 OSS。推荐先读取 [最新版本清单](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/latest.json)，清单包含当前版本、协议版本、各平台下载地址、SHA-256 和签名地址。
 
-当前正式版为 `0.1.1`：
+当前正式版为 `0.1.2`：
 
 | 平台 | 程序 | minisign 签名 |
 | --- | --- | --- |
-| macOS Apple Silicon | [tiangong-sb-darwin-aarch64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-darwin-aarch64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-darwin-aarch64.sig) |
-| macOS Intel | [tiangong-sb-darwin-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-darwin-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-darwin-x86_64.sig) |
-| Linux x86_64 | [tiangong-sb-linux-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-linux-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-linux-x86_64.sig) |
-| Windows x86_64 | [tiangong-sb-windows-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-windows-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.1/tiangong-sb-windows-x86_64.sig) |
+| macOS Apple Silicon | [tiangong-sb-darwin-aarch64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-darwin-aarch64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-darwin-aarch64.sig) |
+| macOS Intel | [tiangong-sb-darwin-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-darwin-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-darwin-x86_64.sig) |
+| Linux x86_64 | [tiangong-sb-linux-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-linux-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-linux-x86_64.sig) |
+| Windows x86_64 | [tiangong-sb-windows-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-windows-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-windows-x86_64.sig) |
 
 手动下载后，将程序重命名为 `tiangong-sandbox`（Windows 为 `tiangong-sandbox.exe`），签名放在同目录并命名为程序名加 `.sig`。macOS 和 Linux 还需要添加执行权限：
 

--- a/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
+++ b/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
@@ -345,6 +345,9 @@ fn inline_policy(args: RunArgs) -> Result<tiangong_sandbox::SandboxPolicy> {
         protected_paths,
         denied_read_paths,
         allow_network: matches!(args.network, CliNetwork::Allow),
+        // 凭据服务放行由宿主经策略文件显式授权；通用 CLI 保持默认
+        // 拒绝（fail-closed）。
+        allow_credential_services: false,
         resource_limits,
     })
 }

--- a/crates/tiangong-sandbox/src/sandbox/policy.rs
+++ b/crates/tiangong-sandbox/src/sandbox/policy.rs
@@ -35,6 +35,11 @@ pub struct SandboxPolicy {
     /// 是否放行出网（默认 false；放行走宿主代理体系，见 RFC D16）。
     #[serde(default)]
     pub allow_network: bool,
+    /// 是否允许访问宿主系统凭据服务（macOS Keychain、OpenDirectory 与
+    /// 证书信任服务）。Git/SSH/GitHub CLI 等工具依赖这些系统服务解析
+    /// 用户身份与读取凭据；默认 false，仅宿主显式授权的策略开放。
+    #[serde(default)]
+    pub allow_credential_services: bool,
     /// 单次 command 的资源上限。
     #[serde(default)]
     pub resource_limits: SandboxResourceLimits,
@@ -71,6 +76,7 @@ impl SandboxPolicy {
             protected_paths: Vec::new(),
             denied_read_paths: Vec::new(),
             allow_network: false,
+            allow_credential_services: false,
             resource_limits: SandboxResourceLimits::default(),
         }
     }
@@ -83,6 +89,7 @@ impl SandboxPolicy {
             protected_paths: Vec::new(),
             denied_read_paths: Vec::new(),
             allow_network: true,
+            allow_credential_services: true,
             resource_limits: SandboxResourceLimits::default(),
         }
     }
@@ -237,6 +244,7 @@ mod tests {
         assert_eq!(value["mode"], "workspace_write");
         assert_eq!(value["workspace"], "/workspace");
         assert_eq!(value["allow_network"], false);
+        assert_eq!(value["allow_credential_services"], false);
         assert_eq!(value["resource_limits"]["max_cpu_time_seconds"], 300);
         assert_eq!(value["resource_limits"]["max_processes"], 64);
 

--- a/crates/tiangong-sandbox/src/sandbox/seatbelt.rs
+++ b/crates/tiangong-sandbox/src/sandbox/seatbelt.rs
@@ -143,6 +143,7 @@ fn compile_profile_explicit_categories(
     } else {
         sbpl.push_str("(deny network*)\n");
     }
+    append_credential_service_rules(&mut sbpl, policy);
     sbpl.push_str("(allow process-exec*)\n(allow process-fork)\n");
     // Rust/C 运行时启动需读 sysctl（页大小——guard page 计算），zsh 5.9
     // 同样读 hw.* sysctl（Tahoe 上多方踩坑）；不显式放行直接崩。
@@ -186,7 +187,25 @@ fn compile_profile_legacy(policy: &SandboxPolicy, writable: &[std::path::PathBuf
     if !policy.allow_network {
         sbpl.push_str("(deny network*)\n");
     }
+    append_credential_service_rules(&mut sbpl, policy);
     sbpl
+}
+/// GitHub CLI 使用 macOS Keychain 取登录令牌，并由 Security.framework 通过
+/// trustd 校验 HTTPS 证书；OpenSSH 通过 opendirectoryd 解析当前用户
+/// （libinfo 查 uid/名称映射，membership 查组成员关系——缺任一都会让
+/// 沙箱内 ssh 报 "No user exists for uid"）。只为宿主显式授权的策略
+/// 开放这些精确服务。
+fn append_credential_service_rules(sbpl: &mut String, policy: &SandboxPolicy) {
+    if !policy.allow_credential_services {
+        return;
+    }
+    sbpl.push_str(
+        "(allow mach-lookup (global-name \"com.apple.SecurityServer\"))\n\
+         (allow mach-lookup (global-name \"com.apple.securityd.xpc\"))\n\
+         (allow mach-lookup (global-name \"com.apple.trustd.agent\"))\n\
+         (allow mach-lookup (global-name \"com.apple.system.opendirectoryd.libinfo\"))\n\
+         (allow mach-lookup (global-name \"com.apple.system.opendirectoryd.membership\"))\n",
+    );
 }
 
 /// 路径可安全进入 SBPL 文本：必须是 UTF-8 且不含控制字符
@@ -213,6 +232,30 @@ fn escape(path: &Path) -> String {
 mod tests {
     use super::*;
 
+    #[test]
+    fn credential_services_rules_follow_explicit_authorization() {
+        // 默认（未授权）：不出现任何凭据服务放行。
+        let mut policy = crate::sandbox::policy::SandboxPolicy::workspace_write("/tmp/ws");
+        let sbpl = compile_profile(&policy);
+        assert!(!sbpl.contains("mach-lookup"));
+
+        // 宿主显式授权：五个精确服务全部放行（Keychain、securityd、
+        // trustd、opendirectoryd libinfo 与 membership）。
+        policy.allow_credential_services = true;
+        let sbpl = compile_profile(&policy);
+        for service in [
+            "com.apple.SecurityServer",
+            "com.apple.securityd.xpc",
+            "com.apple.trustd.agent",
+            "com.apple.system.opendirectoryd.libinfo",
+            "com.apple.system.opendirectoryd.membership",
+        ] {
+            assert!(
+                sbpl.contains(&format!("(allow mach-lookup (global-name \"{service}\"))")),
+                "缺少放行: {service}"
+            );
+        }
+    }
     #[test]
     fn profile_denies_write_outside_roots_and_network() {
         let mut policy = SandboxPolicy::workspace_write("/tmp/ws");


### PR DESCRIPTION
## 问题

合并 `b423e156`（sandbox 代码对齐 main）时误删了 macOS 凭据服务能力：

- 策略字段 `allow_credential_services` 与 Seatbelt 对 Keychain / OpenDirectory / trustd 的 mach-lookup 放行一并丢失
- 宿主侧 terminal/command 的 Git 凭据授权仍在，但沙箱内系统服务不可达
- 实测症状：嵌入式终端 `ssh` 报 `No user exists for uid 501`（日志 `deny mach-lookup com.apple.system.opendirectoryd.libinfo`），`gh` 无法访问钥匙串令牌

## 修复

- 恢复 `allow_credential_services` 策略字段（serde 默认 false；workspace_write 关闭、full_access 开启；序列化测试同步）
- 恢复四个精确 mach 服务放行：SecurityServer、securityd.xpc、trustd.agent、opendirectoryd.libinfo
- **新增** `opendirectoryd.membership`（组成员关系查询，本次日志实际出现，旧实现缺失）
- 通用 CLI 内联策略保持默认拒绝（fail-closed）
- 新增测试：未授权不出现任何 mach-lookup；授权后五服务齐全
- 版本 0.1.1 → 0.1.2，README 下载链接同步

## 验证

- `cargo test -p tiangong-sandbox`：39 项通过（27 lib + 12 bin）
- `cargo clippy -p tiangong-sandbox --all-targets -- -D warnings` 通过
- `cargo fmt --all -- --check` 通过
- 实机端到端验证：官方密钥签名 0.1.2 安装后，沙箱内 `id` 正常输出用户信息；App 内终端 `ssh`/`gh auth status` 恢复正常

## 发布

合并后打 tag `sandbox/v0.1.2` 触发四平台官方发布。