### PR TITLE
fix(core): 支持未完成标记继续执行

### DIFF
--- a/crates/tiangong-core/src/react/execute.rs
+++ b/crates/tiangong-core/src/react/execute.rs
@@ -603,12 +603,23 @@ pub(super) fn persist_streamed_react_message(
     emit_session_message_upsert(ctx, pending_msg_id);
 }
 
+const NEED_MORE_WORK_MARKER: &str = "[NEED_MORE_WORK]";
+
 /// ReAct 文本回复的后续去向。
 enum ReactTextDisposition {
     /// 有效最终答复：提交（PendingFinish）。
     Complete,
+    /// 模型明确声明仍有工作：保留为过程消息并继续请求模型。
+    Continue,
     /// 无效输出（空回复/合成占位符）：明确失败。
     InvalidOutput,
+}
+
+/// 与前端展示层保持一致：忽略开头空白、大小写不敏感，并按标记前缀识别。
+fn is_need_more_work_text(text: &str) -> bool {
+    text.trim_start()
+        .get(..NEED_MORE_WORK_MARKER.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(NEED_MORE_WORK_MARKER))
 }
 
 fn handle_react_text_response(
@@ -657,10 +668,13 @@ fn handle_react_text_response(
 
     // 附件内容不进入模型请求（模型看不见），自然会调用读取插件处理——
     // 工具使用由模型基于上下文自主决策（Agent 的根基），Loop 不做义务门控。
-    if response.text.trim().is_empty() {
-        return ReactTextDisposition::InvalidOutput;
+    if is_need_more_work_text(&response.text) {
+        ReactTextDisposition::Continue
+    } else if response.text.trim().is_empty() {
+        ReactTextDisposition::InvalidOutput
+    } else {
+        ReactTextDisposition::Complete
     }
-    ReactTextDisposition::Complete
 }
 
 fn finish_react_text(
@@ -688,6 +702,7 @@ fn finish_react_text(
                 state.accumulated_usage.clone(),
             ))
         }
+        ReactTextDisposition::Continue => ExecutionPhase::NeedModel,
         ReactTextDisposition::InvalidOutput => {
             // 模型未产生有效输出：明确失败，不把空回复发布为最终答复。
             let reason = "模型未产生有效回复".to_string();

--- a/crates/tiangong-core/src/react/execute_tests.rs
+++ b/crates/tiangong-core/src/react/execute_tests.rs
@@ -440,6 +440,47 @@ async fn completes_with_direct_text_answer() {
     );
 }
 
+/// `[NEED_MORE_WORK]` 与前端采用相同的宽松前缀规则：忽略前导空白和大小写，
+/// 命中后保留该过程消息并继续请求模型，直到得到普通最终回复。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn need_more_work_marker_continues_model_loop() {
+    let server = MockServer::start().await;
+    mount_sse(
+        &server,
+        vec![
+            text_delta_chunk("\n  [need_more_work]还有检查需要完成。"),
+            usage_chunk(10, 4),
+        ],
+    )
+    .await;
+    mount_sse(
+        &server,
+        vec![text_delta_chunk("所有检查均已完成。"), usage_chunk(12, 3)],
+    )
+    .await;
+
+    let mut harness = TestHarness::new(&server, Vec::new(), HashMap::new());
+    let result = execute_turn(&mut harness.ctx, &mut harness.cmd_rx).await;
+
+    assert!(matches!(result.outcome, TurnExecutionOutcome::Success));
+    assert_eq!(result.usage.total_tokens, 29, "两次模型请求的用量都应累计");
+    let assistant_messages = harness
+        .ctx
+        .session
+        .messages
+        .iter()
+        .filter(|message| message.role == MessageRole::Assistant)
+        .collect::<Vec<_>>();
+    assert!(assistant_messages.iter().any(|message| {
+        message.phase == crate::session::MessagePhase::React
+            && message.text_content().contains("[need_more_work]")
+    }));
+    assert!(assistant_messages.iter().any(|message| {
+        message.phase == crate::session::MessagePhase::Summary
+            && message.text_content() == "所有检查均已完成。"
+    }));
+}
+
 /// 请求前压缩保留模型可见的续接消息：上一 turn 观测压力超阈值，下一 turn
 /// 在发起模型请求前压缩（ALR-303），摘要与 resume 持久化到磁盘。
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/frontend/src/__tests__/summaryStatusMarker.test.ts
+++ b/frontend/src/__tests__/summaryStatusMarker.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '@/api/tauri';
+import { displayTextContent, isNeedMoreWorkMessage } from '@/components/message/utils';
+
+function assistantMessage(text: string): Message {
+  return {
+    id: 'assistant-marker-test',
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    reasoning_content: '',
+    phase: 'react',
+    created_at: '2026-09-01 00:00:00',
+  };
+}
+
+describe('助手状态标记', () => {
+  it('按前导空白、忽略大小写的前缀规则识别 NEED_MORE_WORK', () => {
+    expect(isNeedMoreWorkMessage(assistantMessage('\n  [need_more_work]继续执行'))).toBe(true);
+  });
+
+  it('ASK_USER 不再作为控制标记剥离', () => {
+    expect(displayTextContent(assistantMessage('[ASK_USER] 请确认'))).toBe('[ASK_USER] 请确认');
+  });
+});

--- a/frontend/src/components/message/AgentTurn.tsx
+++ b/frontend/src/components/message/AgentTurn.tsx
@@ -278,7 +278,7 @@ function AgentTurnView({
           const { msg, isStreaming } = frag;
           const visibleText = displayTextContent(msg);
           const isReactPhase = msg.phase === "react";
-          // 流式输出无条件剥离状态标记（[DONE]/[NEED_MORE_WORK]/[ASK_USER] 等），
+          // 流式输出无条件剥离状态标记（[DONE]/[NEED_MORE_WORK]），
           // 即使后端 phase 尚未传播到也兜底，避免标记泄漏到界面。
           const visibleStreamingContent = stripSummaryStatusMarker(streamingContent);
           const agentReply = !isStreaming ? parseAgentReply(visibleText) : null;

--- a/frontend/src/components/message/utils.ts
+++ b/frontend/src/components/message/utils.ts
@@ -67,10 +67,10 @@ export function msgReasoning(message: MessageItem): string {
 }
 
 /** 总结阶段的状态标记，需在前端展示时剥离。 */
-const SUMMARY_STATUS_MARKERS = ["[DONE]", "[ASK_USER]", "[NEED_MORE_WORK]"];
+const SUMMARY_STATUS_MARKERS = ["[DONE]", "[NEED_MORE_WORK]"];
 const NEED_MORE_WORK_MARKER = "[NEED_MORE_WORK]";
 
-/** 剥离总结阶段回复首行的状态标记（[DONE]/[ASK_USER]/[NEED_MORE_WORK]）。 */
+/** 剥离总结阶段回复首行的状态标记（[DONE]/[NEED_MORE_WORK]）。 */
 export function stripSummaryStatusMarker(text: string): string {
   const trimmed = text.trimStart();
   for (const marker of SUMMARY_STATUS_MARKERS) {
@@ -88,12 +88,12 @@ export function isNeedMoreWorkMessage(message: MessageItem): boolean {
 /**
  * 获取消息的可展示文本：无条件剥离总结阶段首行状态标记。
  *
- * `[DONE]`/`[ASK_USER]`/`[NEED_MORE_WORK]` 是 summary 阶段提示词要求 LLM 首行输出的
+ * `[DONE]`/`[NEED_MORE_WORK]` 是 summary 阶段提示词要求 LLM 首行输出的
  * 完成度信号，属于控制标记而非正文。后端不应为显示而篡改正文（否则会污染后续喂回 LLM
  * 的上下文），剥离职责落在显示层。不依赖 `message.phase`，保证任何情况下都正确显示。
  *
  * 注意：`[NEED_MORE_WORK]` 在 AgentTurn 的分组逻辑中已被单独拦截为 thinking 片段，
- * 不会走到这里；此处主要处理 `[DONE]`/`[ASK_USER]`。
+ * 不会走到这里；此处主要处理 `[DONE]`。
  */
 export function displayTextContent(message: MessageItem): string {
   return stripSummaryStatusMarker(textContent(message));


### PR DESCRIPTION
## 改动
- Core 按前端现有规则识别助手回复开头的 `[NEED_MORE_WORK]`
- 命中后保留过程消息并继续模型循环，不再把该回复作为本轮最终答复
- 前端移除 `[ASK_USER]` 控制标记支持，征询统一由交互工具承担
- 增加 Core 与前端回归测试

## 验证
- `cargo fmt --all -- --check`
- `cargo check -p tiangong-core --all-targets`
- `cargo clippy -p tiangong-core --all-targets -- -D warnings`
- `cargo test -p tiangong-core --lib -- --test-threads=1`（93 项通过）
- `yarn test`
- `yarn build`
- 推送前仓库检查全部通过