### PR TITLE
fix(ui): 输入框粘贴内容支持 Ctrl+Z 撤销

### DIFF
--- a/frontend/src/components/MentionEditor.tsx
+++ b/frontend/src/components/MentionEditor.tsx
@@ -34,6 +34,11 @@ import { cn } from '@/lib/utils';
 // 序列化时剥离（见 stripZwsp）。这是 Slack/Notion/ProseMirror 的通用做法。
 const ZWSP = '\u200b';
 
+// execCommand('insertHTML') 的内容按 HTML 解析，粘贴文本必须先转义
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 export interface MentionEditorHandle {
   /** 聚焦编辑器并把光标置于文本末尾 */
   focus(): void;
@@ -719,11 +724,44 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
     };
 
     // 仅插入文本与换行节点，避免富文本样式污染，同时保留多行粘贴语义。
+    // 优先走 execCommand('insertHTML')：Range.insertNode 这类脚本 DOM 变更
+    // 不进入浏览器原生撤销栈，Ctrl+Z 撤不掉粘贴内容、只能撤销键盘输入；
+    // execCommand 的事务会入栈，且 undo/redo 以 historyUndo/historyRedo
+    // 触发 input 事件，外部受控 value 能随之同步。
     function insertPlainText(text: string) {
       const root = rootRef.current;
       const selection = window.getSelection();
       if (!root || !selection) return;
 
+      const lines = normalizePastedText(text).split('\n');
+      if (lines.length === 1 && lines[0] === '') return;
+
+      if (selection.rangeCount === 0
+        || !root.contains(selection.getRangeAt(0).commonAncestorContainer)) {
+        restoreCaretEnd();
+      }
+      root.focus();
+
+      let inserted = false;
+      try {
+        inserted = document.execCommand(
+          'insertHTML',
+          false,
+          lines.map((line) => escapeHtml(line)).join('<br>'),
+        );
+      } catch {
+        inserted = false;
+      }
+      if (inserted) {
+        if (hasChip()) {
+          normalizeSentinels();
+          normalizeMentionBoundaries();
+        }
+        commit();
+        return;
+      }
+
+      // WebView 不支持 execCommand 时退回直接 DOM 插入（撤销栈不可用，行为同旧实现）
       const range = selection.rangeCount > 0
         ? selection.getRangeAt(0)
         : document.createRange();
@@ -734,7 +772,6 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
       range.deleteContents();
 
       const fragment = document.createDocumentFragment();
-      const lines = normalizePastedText(text).split('\n');
       lines.forEach((line, index) => {
         if (index > 0) fragment.appendChild(document.createElement('br'));
         if (line) fragment.appendChild(document.createTextNode(line));


### PR DESCRIPTION
## 问题

输入框粘贴文本后按 Ctrl+Z，只能撤销之前手动输入的内容，粘贴的内容撤销不掉。

## 根因

`MentionEditor` 的粘贴路径先 `preventDefault` 再用 `Range.insertNode` 直接改 DOM。脚本发起的 DOM 变更不进入浏览器原生撤销栈，撤销栈里只有键盘输入的事务，因此粘贴内容无法被撤销。

## 变更点

- `insertPlainText` 优先改走 `execCommand('insertHTML')` 编辑事务，使粘贴进入浏览器原生撤销栈；HTML 由自己构造（粘贴文本转义 + `<br>` 换行），结构与传统路径一致，无富文本污染
- undo/redo 会以 `historyUndo`/`historyRedo` 触发 input 事件，受控 value 随之同步，不会出现撤销后被旧值重建覆盖
- WebView 不支持 `execCommand` 的环境（如测试用的 jsdom）保留原直接 DOM 插入路径，行为与旧实现一致
- 空文本粘贴不再清空当前选区（原实现会误删选中内容）

## 验证

- WKWebView 真实环境实测：多行/空行/行中插入/覆盖选区插入的结构与序列化均正确；粘贴后 Ctrl+Z 整体撤销、再 Ctrl+Z 撤销之前的手动输入、Ctrl+Shift+Z 重做，栈序正确，React 受控值全程同步
- 挂载真实 `MentionEditor` 组件（vite dev 源码模块）在真实 WebView 中跑通「键盘输入 → 粘贴多行 → Ctrl+Z → Ctrl+Z」全流程，DOM 与受控状态均符合预期
- 前端 225 项测试全部通过；`yarn build`（tsc + vite）通过

## 说明

- 附件（图片/文件）粘贴不进入文本撤销栈，仍由附件栏"移除附件"按钮负责，与主流聊天输入框行为一致（已在会话中确认暂不处理）
- 手动输入贴近 @ 提及标签的边界路径（`applyValue` 重建）本就不在浏览器撤销栈内，属既有行为，本次未动