### PR TITLE
fix(plugin): 升级判定忽略部署残留的 staging 目录

### DIFF
--- a/crates/tiangong-plugin-runtime/src/artifacts.rs
+++ b/crates/tiangong-plugin-runtime/src/artifacts.rs
@@ -963,6 +963,12 @@ fn installed_plugin_states(storage_root: &Path) -> HashMap<String, InstalledPlug
         .filter_map(Result::ok)
         .filter_map(|entry| {
             let manifest = PluginManifest::load(&entry.path().join(MANIFEST_FILE)).ok()?;
+            // 只认目录名与清单 ID 一致的正式目录：本地部署中断残留的
+            // `.{id}-staging-{pid}` 同样带清单，混入会以同 ID 覆盖正式目录
+            // 的版本，让升级判定与安装校验读到的"当前版本"不一致。
+            if *entry.file_name() != *manifest.id {
+                return None;
+            }
             let enabled = !entry.path().join(DISABLED_MARKER_FILE).is_file();
             Some((
                 manifest.id,
@@ -1108,6 +1114,32 @@ mod tests {
                 .is_file()
         );
         assert!(!staged.path().join("templates/ui-app/node_modules").exists());
+    }
+
+    /// 升级判定只认目录名与清单 ID 一致的正式目录：本地部署中断残留的
+    /// `.{id}-staging-{pid}` 带同 ID 清单，不得覆盖正式目录的版本。
+    #[test]
+    fn installed_plugin_states_忽略staging残留目录() {
+        let root = tempfile::tempdir().expect("临时目录");
+        let plugins = root.path().join("plugins");
+        std::fs::create_dir_all(plugins.join("demo")).expect("正式目录");
+        std::fs::write(
+            plugins.join("demo").join(MANIFEST_FILE),
+            r#"{"schema_version":2,"id":"demo","version":"0.3.2","permissions":[],"capabilities":{"prompt":true}}"#,
+        )
+        .expect("正式清单");
+        std::fs::create_dir_all(plugins.join(".demo-staging-123")).expect("残留目录");
+        std::fs::write(
+            plugins.join(".demo-staging-123").join(MANIFEST_FILE),
+            r#"{"schema_version":2,"id":"demo","version":"0.3.1","permissions":[],"capabilities":{"prompt":true}}"#,
+        )
+        .expect("残留清单");
+
+        let states = installed_plugin_states(root.path());
+        assert_eq!(
+            states.get("demo").expect("正式插件应被识别").version,
+            "0.3.2"
+        );
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -613,7 +613,19 @@ fn build_plugin(config: &PluginConfig) -> io::Result<()> {
     std::fs::create_dir_all(&plugins_dir)?;
     let staging = plugins_dir.join(format!(".{}-staging-{}", config.id, std::process::id()));
     let destination = plugins_dir.join(config.id);
-    remove_dir_if_exists(&staging)?;
+    // 部署中断会留下旧 staging（含清单，会被 App 误读为已装版本），
+    // 每次部署前清掉同插件的全部历史 staging（含本进程旧目录）。
+    let staging_prefix = format!(".{}-staging-", config.id);
+    for entry in std::fs::read_dir(&plugins_dir)? {
+        let entry = entry?;
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with(&staging_prefix)
+        {
+            remove_dir_if_exists(&entry.path())?;
+        }
+    }
     std::fs::create_dir_all(&staging)?;
 
     if let (Some(wasm), Some(wasm_artifact)) = (&wasm, config.wasm_artifact) {


### PR DESCRIPTION
## 问题

App 启动时反复出现告警：

```
插件自动升级失败，下次启动重试 plugin_id="screenshot-input" error=插件 screenshot-input 可安装版本 0.3.2 不高于当前版本 0.3.2
```

## 根因

`xtask deploy` 中断会在 `plugins/` 下残留 `.{id}-staging-{pid}` 目录（含同 ID 清单）。`installed_plugin_states` 扫描时不区分目录名，残留目录与正式目录以同一清单 ID 写入 HashMap，后者覆盖前者且遍历顺序不受控——本机实测残留（0.3.1）覆盖了正式目录（0.3.2），导致：

- 升级判定读到“当前版本 0.3.1”，判定有更新并下载 0.3.2；
- 安装校验直读正式目录读到 0.3.2，同版本且不允许重装，被拒；
- 每次启动重复“下载→被拒→告警”循环。

本机日志已完整还原时间线：9-01 21:52 部署中断留下两个 staging 残留 → 9-02 01:06 经残留恢复路径装上 0.3.2 → 之后每次启动触发幽灵升级。

## 变更

- `installed_plugin_states` 只认目录名与清单 ID 一致的正式目录（与安装校验 `find_installed_plugin` 的目录规则对齐）
- `xtask deploy` 部署前清理同插件的全部历史 staging 残留（含本进程旧目录）
- 补充回归测试 `installed_plugin_states_忽略staging残留目录`

## 测试

- `cargo test -p tiangong-plugin-runtime --lib -- --test-threads=1`：131 通过
- `cargo clippy -p tiangong-plugin-runtime -p xtask`：无警告