### PR TITLE
fix(ci): 按需运行解释器发布端到端

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
 
           check_all=false
           fallback_all=false
-          fallback_frontend=false
           scoped_change=false
           frontend=false
           interpreter_e2e=false
@@ -64,10 +63,6 @@ jobs:
                 ;;
               Cargo.toml|Cargo.lock|.github/actions/setup-rust/*)
                 fallback_all=true
-                ;;
-              .github/workflows/ci.yml)
-                fallback_all=true
-                fallback_frontend=true
                 ;;
             esac
             case "$file" in
@@ -89,9 +84,6 @@ jobs:
 
           if [[ "$fallback_all" == "true" && "$scoped_change" != "true" ]]; then
             check_all=true
-            if [[ "$fallback_frontend" == "true" ]]; then
-              frontend=true
-            fi
           fi
 
           workspace="$(pwd)/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       frontend: ${{ steps.resolve.outputs.frontend }}
+      interpreter_e2e: ${{ steps.resolve.outputs.interpreter_e2e }}
       matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
@@ -49,9 +50,11 @@ jobs:
           fallback_frontend=false
           scoped_change=false
           frontend=false
+          interpreter_e2e=false
           if [[ "$EVENT_NAME" != "pull_request" ]]; then
             check_all=true
             frontend=true
+            interpreter_e2e=true
           fi
 
           for file in "${files[@]}"; do
@@ -75,6 +78,11 @@ jobs:
             case "$file" in
               frontend/*)
                 frontend=true
+                ;;
+            esac
+            case "$file" in
+              plugins/tiangong-plugin-creator/*|xtask/*|.github/workflows/ci.yml|crates/tiangong-plugin-runtime/src/artifacts.rs|crates/tiangong-plugin-runtime/src/registry.rs|crates/tiangong-plugin-runtime/src/signature.rs|crates/tiangong-plugin-runtime/tests/official_catalog_e2e.rs)
+                interpreter_e2e=true
                 ;;
             esac
           done
@@ -129,8 +137,10 @@ jobs:
 
           echo "App crates: $affected"
           echo "Frontend: $frontend"
+          echo "Interpreter E2E: $interpreter_e2e"
           echo "matrix=$affected" >> "$GITHUB_OUTPUT"
           echo "frontend=$frontend" >> "$GITHUB_OUTPUT"
+          echo "interpreter_e2e=$interpreter_e2e" >> "$GITHUB_OUTPUT"
 
   rust-fmt:
     name: App Rust fmt
@@ -219,12 +229,14 @@ jobs:
           done < <(jq -r '.[]' <<< "$MATRIX")
           cargo nextest run "${packages[@]}" --no-tests pass
 
-  # 官方解释器发布链端到端（普通 CI 必跑）：Fresh Checkout 完整构建
+  # 官方解释器发布链端到端（相关发布链变更时运行）：Fresh Checkout 完整构建
   # plugin-creator（yarn build + xtask 组装 + 测试密钥签名 + 确定性归档 +
   # any 目录片段），随后经本地 http 目录服务真实走 目录发现 → 下载 → 解包 →
   # 官方验签（内容清单全树校验）→ 安装 → sidecar 调用 → 卸载。
   interpreter-release-e2e:
     name: Interpreter Release E2E
+    needs: changes
+    if: needs.changes.outputs.interpreter_e2e == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -258,10 +270,11 @@ jobs:
           test -f "${key_path}.pub"
           export TIANGONG_PLUGIN_SIGNING_PRIVATE_KEY_PATH="$key_path"
           cargo run -p xtask -- build-plugin plugin-creator
+          version="$(jq -er '.version' plugins/tiangong-plugin-creator/plugin.json)"
           # 断言发布产物齐备（测试必跑的先决条件）。
           test -f target/plugin-dist/plugins-index/fragments/plugin-creator-any.json
-          test -f "target/plugin-dist/plugins/plugin-creator/0.2.0/plugin-creator-0.2.0.tar.zst"
-          test -f target/plugin-dist/plugins/plugin-creator/0.2.0/release.json.sig
+          test -f "target/plugin-dist/plugins/plugin-creator/${version}/plugin-creator-${version}.tar.zst"
+          test -f "target/plugin-dist/plugins/plugin-creator/${version}/release.json.sig"
 
       - name: Run catalog install e2e
         env:

--- a/crates/tiangong-plugin-runtime/tests/official_catalog_e2e.rs
+++ b/crates/tiangong-plugin-runtime/tests/official_catalog_e2e.rs
@@ -16,6 +16,16 @@ use std::path::{Path, PathBuf};
 fn workspace_target_dist() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/plugin-dist")
 }
+fn plugin_creator_version() -> String {
+    let manifest: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../plugins/tiangong-plugin-creator/plugin.json"
+    ))
+    .expect("解析 Plugin Creator 清单");
+    manifest["version"]
+        .as_str()
+        .expect("Plugin Creator 清单缺少版本")
+        .to_string()
+}
 
 fn copy_tree(source: &Path, target: &Path) {
     std::fs::create_dir_all(target).unwrap();
@@ -37,8 +47,10 @@ fn 官方目录_测试密钥冒充官方被拒_三方签名完整链路与卸载
     let dist = std::env::var_os("TIANGONG_PLUGIN_E2E_DIST")
         .map(PathBuf::from)
         .unwrap_or_else(workspace_target_dist);
-    let archive = dist.join("plugins/plugin-creator/0.2.0/plugin-creator-0.2.0.tar.zst");
-    let release_json = dist.join("plugins/plugin-creator/0.2.0/release.json");
+    let version = plugin_creator_version();
+    let release_dir = dist.join(format!("plugins/plugin-creator/{version}"));
+    let archive = release_dir.join(format!("plugin-creator-{version}.tar.zst"));
+    let release_json = release_dir.join("release.json");
     if !archive.is_file() || !release_json.is_file() {
         let reason = format!(
             "缺少发布产物（archive={} release.json={}）",
@@ -130,7 +142,7 @@ fn 官方目录_测试密钥冒充官方被拒_三方签名完整链路与卸载
                     minisign::KeyPair::generate_unencrypted_keypair().expect("生成三方密钥");
                 let release_path = dist_copy
                     .path()
-                    .join("plugins/plugin-creator/0.2.0/release.json");
+                    .join(format!("plugins/plugin-creator/{version}/release.json"));
                 let mut release: serde_json::Value =
                     serde_json::from_slice(&std::fs::read(&release_path).unwrap()).unwrap();
                 release["publisher"] = serde_json::Value::String("acme-dev".to_string());
@@ -148,7 +160,7 @@ fn 官方目录_测试密钥冒充官方被拒_三方签名完整链路与卸载
                 std::fs::write(
                     dist_copy
                         .path()
-                        .join("plugins/plugin-creator/0.2.0/release.json.sig"),
+                        .join(format!("plugins/plugin-creator/{version}/release.json.sig")),
                     base64::engine::general_purpose::STANDARD.encode(signature.into_string()),
                 )
                 .unwrap();
@@ -170,7 +182,7 @@ fn 官方目录_测试密钥冒充官方被拒_三方签名完整链路与卸载
                     staged.path(),
                 )
                 .expect("三方签名插件安装");
-                assert_eq!(status.manifest_version, "0.2.0");
+                assert_eq!(status.manifest_version, version);
                 tiangong_plugin_runtime::registry::preload_installed_plugins(storage.path());
                 let response = tiangong_plugin_runtime::registry::invoke_sidecar(
                     storage.path(),


### PR DESCRIPTION
## 改动
- Interpreter Release E2E 只在解释器发布链相关文件变化时运行
- 手动运行 App CI 时仍会执行该 E2E
- 从 Plugin Creator 清单动态读取版本，移除 0.2.0 硬编码

## 验证
- `cargo test -p tiangong-plugin-runtime --test official_catalog_e2e --no-run`
- E2E 触发范围判定验证
- `cargo fmt -p tiangong-plugin-runtime -- --check`
- `git diff --check`