### PR TITLE
fix(plugins): fs 读文件误报"目标不是文件"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11215,7 +11215,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-fs-protocol"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -11223,7 +11223,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-fs-sidecar"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11215,7 +11215,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-fs-protocol"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -11223,7 +11223,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-fs-sidecar"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/plugins/tiangong-plugin-fs/plugin.json
+++ b/plugins/tiangong-plugin-fs/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "fs",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "wasm": {
     "binary": "tiangong_plugin_fs_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-fs/plugin.json
+++ b/plugins/tiangong-plugin-fs/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "fs",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "wasm": {
     "binary": "tiangong_plugin_fs_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-fs/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-fs/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-fs-protocol"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-fs/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-fs/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-fs-protocol"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-fs/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-fs/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-fs-sidecar"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "Apache-2.0"
 description = "Fs 独立 sidecar 进程（承载文件读写、进程级锁表、路径解析与沙箱策略）"

--- a/plugins/tiangong-plugin-fs/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-fs/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-fs-sidecar"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "Apache-2.0"
 description = "Fs 独立 sidecar 进程（承载文件读写、进程级锁表、路径解析与沙箱策略）"

--- a/plugins/tiangong-plugin-fs/sidecar/src/handlers.rs
+++ b/plugins/tiangong-plugin-fs/sidecar/src/handlers.rs
@@ -45,9 +45,7 @@ pub fn handle_list_dir(req: ListDirRequest, policy: &dyn PathPolicy) -> FsToolRe
         let base = base_of(&req.access)?;
         let path = req.path.as_deref().unwrap_or(".");
         let full_path = policy.resolve_read(path, &base)?;
-        if !full_path.is_dir() {
-            return Err(anyhow!("目标不是目录：{}", full_path.display()));
-        }
+        ensure_dir_target(&full_path)?;
         let mut items = Vec::new();
         for entry in fs::read_dir(&full_path)
             .with_context(|| format!("读取目录失败：{}", full_path.display()))?
@@ -84,9 +82,7 @@ pub fn handle_tree_dir(req: TreeDirRequest, policy: &dyn PathPolicy) -> FsToolRe
             req.max_depth.min(MAX_TREE_MAX_DEPTH)
         };
         let full_path = policy.resolve_read(path, &base)?;
-        if !full_path.is_dir() {
-            return Err(anyhow!("目标不是目录：{}", full_path.display()));
-        }
+        ensure_dir_target(&full_path)?;
         let rel = shared::display_rel_path_with(&full_path, &base);
         let mut lines = vec![if rel == "." {
             "./".to_string()
@@ -428,6 +424,19 @@ fn finalize_write(
 }
 
 // ── 辅助函数 ─────────────────────────────────────────────────
+
+/// 目录类读工具的目标判定：区分目录不存在 / 目标不是目录 / 无法访问
+/// （信任模式解析对不存在路径静默放行，不能依赖单一 is_dir 判定）。
+fn ensure_dir_target(full_path: &Path) -> Result<()> {
+    match fs::metadata(full_path) {
+        Ok(meta) if meta.is_dir() => Ok(()),
+        Ok(_) => Err(anyhow!("目标不是目录：{}", full_path.display())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(anyhow!("目录不存在：{}", full_path.display()))
+        }
+        Err(e) => Err(anyhow!("无法访问目标目录：{}（{e}）", full_path.display())),
+    }
+}
 
 fn error_response(tool: &str, e: anyhow::Error) -> FsToolResponse {
     let summary = format!("{tool} 失败：{e}");
@@ -802,6 +811,47 @@ mod tests {
             workspace: Some(root.to_string_lossy().into_owned()),
             full_trust: false,
         }
+    }
+
+    #[test]
+    fn list_dir_missing_path_reports_not_found() {
+        let root = tempfile::tempdir().unwrap();
+
+        let response = handle_list_dir(
+            ListDirRequest {
+                path: Some("docs".to_string()),
+                access: access(root.path()),
+            },
+            &TrustModePathPolicy::new(true),
+        );
+
+        assert!(!response.ok);
+        assert!(
+            response.stderr.contains("目录不存在"),
+            "stderr={}",
+            response.stderr
+        );
+    }
+
+    #[test]
+    fn list_dir_file_target_reports_not_dir() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("README.md"), "hi\n").unwrap();
+
+        let response = handle_list_dir(
+            ListDirRequest {
+                path: Some("README.md".to_string()),
+                access: access(root.path()),
+            },
+            &TrustModePathPolicy::new(true),
+        );
+
+        assert!(!response.ok);
+        assert!(
+            response.stderr.contains("目标不是目录"),
+            "stderr={}",
+            response.stderr
+        );
     }
 
     #[test]

--- a/plugins/tiangong-plugin-fs/sidecar/src/handlers.rs
+++ b/plugins/tiangong-plugin-fs/sidecar/src/handlers.rs
@@ -132,8 +132,17 @@ pub fn handle_read_file(req: ReadFileRequest, policy: &dyn PathPolicy) -> FsTool
             req.max_lines.clamp(1, MAX_READ_MAX_LINES)
         };
         let full_path = policy.resolve_read(&req.path, &base)?;
-        if !full_path.is_file() {
-            return Err(anyhow!("目标不是文件：{}", full_path.display()));
+        // 信任模式解析对不存在路径静默放行，这里必须区分"不存在"与"类型不对"，
+        // 否则文件缺失会被误报成"目标不是文件"，误导调用方反复重试。
+        match fs::metadata(&full_path) {
+            Ok(meta) if meta.is_file() => {}
+            Ok(_) => return Err(anyhow!("目标不是文件：{}", full_path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(anyhow!("文件不存在：{}", full_path.display()));
+            }
+            Err(e) => {
+                return Err(anyhow!("无法访问目标文件：{}（{e}）", full_path.display()));
+            }
         }
         let content = fs::read_to_string(&full_path)
             .with_context(|| format!("读取文件失败：{}", full_path.display()))?;
@@ -793,6 +802,67 @@ mod tests {
             workspace: Some(root.to_string_lossy().into_owned()),
             full_trust: false,
         }
+    }
+
+    #[test]
+    fn read_file_missing_path_reports_not_found() {
+        let root = tempfile::tempdir().unwrap();
+
+        let response = handle_read_file(
+            ReadFileRequest {
+                path: "docs/requirements.md".to_string(),
+                access: access(root.path()),
+                ..Default::default()
+            },
+            &TrustModePathPolicy::new(true),
+        );
+
+        assert!(!response.ok);
+        assert!(
+            response.stderr.contains("文件不存在"),
+            "stderr={}",
+            response.stderr
+        );
+    }
+
+    #[test]
+    fn read_file_directory_target_reports_not_file() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("docs")).unwrap();
+
+        let response = handle_read_file(
+            ReadFileRequest {
+                path: "docs".to_string(),
+                access: access(root.path()),
+                ..Default::default()
+            },
+            &TrustModePathPolicy::new(true),
+        );
+
+        assert!(!response.ok);
+        assert!(
+            response.stderr.contains("目标不是文件"),
+            "stderr={}",
+            response.stderr
+        );
+    }
+
+    #[test]
+    fn read_file_reads_markdown_content() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("README.md"), "第一行\n第二行\n").unwrap();
+
+        let response = handle_read_file(
+            ReadFileRequest {
+                path: "README.md".to_string(),
+                access: access(root.path()),
+                ..Default::default()
+            },
+            &TrustModePathPolicy::new(true),
+        );
+
+        assert!(response.ok, "{}", response.stderr);
+        assert!(response.stdout.contains("第一行"));
     }
 
     #[test]


### PR DESCRIPTION
## 变更点

- **read_file 修复**：完全信任模式下，`resolve_workspace_path_trusted_with` 对不存在路径静默放行，随后统一的 `is_file()` 判定把一切失败（文件不存在、访问被拒）都误报成"目标不是文件"。改为基于 `fs::metadata` 三分支判定：文件不存在 / 目标不是文件 / 无法访问（附具体原因），分别报错。
- **list_dir / tree_dir 同类修复**：目录不存在与"目标不是目录"同样混报，抽出 `ensure_dir_target` 统一区分。
- **版本升级**：fs 插件 0.1.4 → 0.1.6（plugin.json / protocol / sidecar 三处同步）。

## 背景

应用日志中 read_file 反复报"目标不是文件"的路径（PLAN.md、TODO.md、docs/requirements.md 等）均为不存在的 md 文件，误导调用方（agent）以为目标是非普通文件而反复重试。另存在被沙箱禁读的真实文件（如 ~/.tiangong/server.json）同样被误报，修复后会正确报"无法访问"。

## 测试情况

- 新增 5 个测试：read_file 读不存在的 md / 读目录 / 正常读 md；list_dir 列不存在目录 / 列文件。
- `cargo test -p tiangong-plugin-fs-sidecar` 19 项全绿；`cargo clippy` 干净；`xtask validate-plugin fs` 通过。