### PR TITLE
refactor(core): 会话标题移出 system prompt 保持 KV cache 前缀稳定

### DIFF
--- a/crates/tiangong-core/src/prompt/sections.rs
+++ b/crates/tiangong-core/src/prompt/sections.rs
@@ -27,7 +27,7 @@ impl SystemPromptConfig {
 /// 构建完整的 system prompt 消息
 ///
 /// 组装顺序：插件段（含产品身份 / 通用规则 / 自定义指令 / 各能力说明）
-/// → 环境段（会话标题 / 工作目录 / 文件根）→ 摘要段。
+/// → 环境段（工作目录 / 文件根）→ 摘要段。
 /// 返回 `Message { role: System }`，由 `build_provider_messages()` 提取到 system prompt。
 pub fn build_full_system_prompt(session: &Session, config: &SystemPromptConfig) -> Message {
     let mut parts = Vec::new();
@@ -49,11 +49,14 @@ pub fn build_full_system_prompt(session: &Session, config: &SystemPromptConfig) 
     assemble_system_message(parts)
 }
 
-/// 收集环境段（会话标题、工作目录、文件根）
+/// 收集环境段（工作目录、文件根）
+///
+/// 会话标题不进入 system prompt：标题随 lite 自动起名 / 用户改名变化，
+/// 拼进 prompt 会在每次变化后破坏 KV cache 前缀（system prompt 是请求最前缀，
+/// 一变则其后全部对话历史缓存作废）。
 fn collect_environment_parts(session: &Session) -> Vec<String> {
     let mut parts = Vec::new();
     let workspace = session_working_directory(session);
-    parts.push(format!("当前会话：{}", session.title));
     parts.push(format!("当前工作目录：{}", workspace));
     // 允许文件操作目录：工作空间 + 应用存储根（由 toolkit 硬编码为始终允许）。
     parts.push(format!(
@@ -129,8 +132,9 @@ mod tests {
         let msg = build_full_system_prompt(&session, &config);
         assert_eq!(msg.role, MessageRole::System);
         let text = msg.content.first().unwrap().as_text().unwrap_or_default();
-        assert!(text.contains("当前会话：测试会话"));
         assert!(text.contains("当前工作目录"));
+        // 标题不进入 system prompt（保持 KV cache 前缀稳定）
+        assert!(!text.contains("测试会话"));
     }
 
     #[test]

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -1046,7 +1046,7 @@ impl Session {
 
     /// 重建 system prompt 消息
     ///
-    /// 从 session 数据（title, cwd, context_summary）和外部配置构建完整的 system prompt，
+    /// 从 session 数据（cwd, context_summary）和外部配置构建完整的 system prompt，
     /// 存为 `Message { role: System }`，供 `context()` 返回。
     ///
     /// 应在以下时机调用：

--- a/crates/tiangong-core/tests/context_integration.rs
+++ b/crates/tiangong-core/tests/context_integration.rs
@@ -121,8 +121,8 @@ fn new_path_system_prompt_includes_all_sections() {
     assert!(text.contains("通用规则段"), "应包含通用规则段");
     assert!(text.contains("自定义指令段"), "应包含自定义指令段");
     // 环境段
-    assert!(text.contains("当前会话"), "应包含会话标题");
     assert!(text.contains("当前工作目录"), "应包含工作目录");
+    assert!(!text.contains("测试会话"), "会话标题不应进入 system prompt");
     // 各能力插件段落
     assert!(text.contains("test-skill"), "应包含 Skills 列表");
     assert!(text.contains("团队协作"), "应包含团队协作");

--- a/crates/tiangong-core/tests/prompt_assembly_integration.rs
+++ b/crates/tiangong-core/tests/prompt_assembly_integration.rs
@@ -3,7 +3,7 @@
 //! 验证插件注册后 system prompt 的组装顺序：
 //! - 多个插件的 PromptSectionProvider 按注册顺序追加
 //! - 产品文案插件注册在最前时，身份 / 规则段排在 prompt 开头
-//! - 插件段后接环境段（会话标题 / 工作目录 / 文件根）与摘要段
+//! - 插件段后接环境段（工作目录 / 文件根）与摘要段
 //! - 空白段落被过滤；无插件时仍能构建合法 prompt
 
 use std::sync::Arc;
@@ -114,7 +114,7 @@ fn product_copy_precedes_capability_sections() {
 
     // 产品身份段应出现在 prompt 最前面的区域（在环境段之前）
     let id_idx = text.find("【产品身份】").expect("应包含产品身份段");
-    let env_idx = text.find("当前会话").expect("应包含环境段");
+    let env_idx = text.find("当前工作目录").expect("应包含环境段");
     assert!(
         id_idx < env_idx,
         "产品身份段应排在环境段之前（保证在 prompt 开头）"
@@ -134,7 +134,7 @@ fn environment_and_summary_sections_appended_after_plugins() {
 
     // 顺序：插件段 → 环境段 → 摘要段
     let plugin_idx = text.find("【产品身份】").unwrap();
-    let env_idx = text.find("当前会话：环境摘要测试").unwrap();
+    let env_idx = text.find("当前工作目录").unwrap();
     let summary_idx = text.find("此前对话摘要").unwrap();
 
     assert!(plugin_idx < env_idx, "插件段应在环境段前");
@@ -168,9 +168,13 @@ fn empty_plugins_still_produces_valid_prompt() {
     let session = Session::new("空插件测试");
     let text = build_prompt_text(&engine, &session);
 
-    // 无插件段时，prompt 仍应包含环境段，是合法的非空 system prompt
-    assert!(text.contains("当前会话：空插件测试"));
+    // 无插件段时，prompt 仍应包含环境段，是合法的非空 system prompt；
+    // 标题不进入 system prompt（保持 KV cache 前缀稳定）。
     assert!(text.contains("当前工作目录"));
+    assert!(
+        !text.contains("空插件测试"),
+        "会话标题不应进入 system prompt"
+    );
     assert!(!text.trim().is_empty(), "空插件时 prompt 不应为空");
 }
 
@@ -195,7 +199,7 @@ fn plugin_sections_appear_between_identity_and_environment() {
         "【通用规则】",
         "【能力】技能摘要",
         "有效段",
-        "当前会话",
+        "当前工作目录",
         "此前对话摘要",
     ]
     .iter()


### PR DESCRIPTION
## 变更点

- 删除 system prompt 环境段中的「当前会话：{标题}」一行（`crates/tiangong-core/src/prompt/sections.rs`）
- 标题随 lite 自动起名 / 用户改名变化，而 system prompt 是每次请求的最前缀：标题一变，其后全部对话历史的 KV cache（前缀缓存）整体作废
- 标题对模型的信息价值有限，移出后 system prompt 在会话生命周期内保持稳定
- 同步更新单元测试与两个集成测试：改为断言标题**不**出现在 system prompt 中，并清理相关文档注释

## 背景

本分支源于 KV cache 失效原因分析。结论：对话过程中非预期的前缀失效源主要是 system prompt 中的动态内容（标题、memory 三级注入、TS 插件动态段）与 tools 集合变化；压缩时刻的前缀断裂属压缩语义的必然代价（memory/index 可追溯，无需优化）。本 PR 落地其中收益明确的一项：标题移出 system prompt。

## 测试情况

- `cargo check -p tiangong-core` 通过
- prompt 单元测试 4 项、`prompt_assembly_integration` 6 项、`context_integration` 6 项全部通过
- tiangong-core 全量 lib 测试 93 项通过（`--test-threads=1`）