### PR TITLE
fix(frontend): 沙箱关闭状态按钮跳转沙箱管理页

### DIFF
--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -1350,7 +1350,7 @@ export function MessageInput({
                 )}
                 {sandboxDisabled === true && (
                   <button
-                    onClick={() => setPendingSettingsTab('agent')}
+                    onClick={() => setPendingSettingsTab('sandbox')}
                     className="flex items-center gap-1 text-red-500 transition-colors hover:text-red-400"
                     title="按需进程沙箱已关闭：终端、命令及其他按需 Sidecar 以完整用户权限启动，点击前往设置重新开启"
                   >


### PR DESCRIPTION
## 变更点

- 消息输入框下方"沙箱关"状态按钮点击后跳转的是设置页"智能体"标签（`agent`），而非"沙箱管理"标签（`sandbox`）
- 将跳转目标由 `agent` 改为 `sandbox`，与按钮提示文案"点击前往设置重新开启"一致，用户跳转后可直接操作"按需进程沙箱"开关

## 改动范围

- `frontend/src/components/MessageInput.tsx`：1 行（跳转目标）

## 测试情况

- `yarn build`（tsc + vite）通过
- 引用 MessageInput 的测试（extensionPanelStateMachine、mainAppSessionsRefresh）共 10 项全部通过
- pre-commit 检查全部通过