### PR TITLE
fix(windows): 隐藏沙箱后台终端窗口

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11772,7 +11772,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-sandbox"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -11791,6 +11791,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
+ "tiangong-toolkit",
  "tokio",
  "windows-sys 0.61.2",
 ]

--- a/crates/tiangong-plugin-runtime/src/launcher_update.rs
+++ b/crates/tiangong-plugin-runtime/src/launcher_update.rs
@@ -160,8 +160,9 @@ pub fn installed_version(storage_root: &Path) -> Option<String> {
     verify_launcher_self_check(&launcher).ok()
 }
 fn verify_launcher_self_check(binary: &Path) -> Result<String> {
-    let output = std::process::Command::new(binary)
-        .arg("--self-check")
+    let mut command = std::process::Command::new(binary);
+    command.arg("--self-check");
+    let output = tiangong_toolkit::configure_no_window(&mut command)
         .output()
         .with_context(|| format!("运行 Sandbox 自检失败: {}", binary.display()))?;
     if !output.status.success() && output.status.code() != Some(79) {

--- a/crates/tiangong-plugin-runtime/src/sidecar/stdio.rs
+++ b/crates/tiangong-plugin-runtime/src/sidecar/stdio.rs
@@ -1229,6 +1229,8 @@ fn apply_user_environment_policy(command: &mut Command, config: &SidecarConfig) 
 }
 
 fn configure_process_lifecycle(command: &mut Command) -> Result<()> {
+    #[cfg(windows)]
+    tiangong_toolkit::configure_no_window(command);
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;

--- a/crates/tiangong-sandbox/Cargo.toml
+++ b/crates/tiangong-sandbox/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tiangong-sandbox"
 # Launcher 独立版本序列（不随 workspace/App 版本）：在线更新按此序列
 # 判定新旧与防降级，App 发版不要求 Launcher 同步改动。
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Command 工具的宿主强制操作系统沙箱套壳"
@@ -29,6 +29,7 @@ minisign-verify = { workspace = true }
 reqwest = { workspace = true, features = ["json", "stream", "rustls"] }
 semver = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+tiangong-toolkit = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 dunce = { workspace = true }

--- a/crates/tiangong-sandbox/README.md
+++ b/crates/tiangong-sandbox/README.md
@@ -25,14 +25,14 @@ Sandbox 不决定宿主的存储布局。安装目录由 App、服务或其他�
 
 正式版由独立发布流程构建、签名并发布到官方 OSS。推荐先读取 [最新版本清单](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/latest.json)，清单包含当前版本、协议版本、各平台下载地址、SHA-256 和签名地址。
 
-当前正式版为 `0.1.2`：
+当前正式版为 `0.1.3`：
 
 | 平台 | 程序 | minisign 签名 |
 | --- | --- | --- |
-| macOS Apple Silicon | [tiangong-sb-darwin-aarch64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-darwin-aarch64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-darwin-aarch64.sig) |
-| macOS Intel | [tiangong-sb-darwin-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-darwin-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-darwin-x86_64.sig) |
-| Linux x86_64 | [tiangong-sb-linux-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-linux-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-linux-x86_64.sig) |
-| Windows x86_64 | [tiangong-sb-windows-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-windows-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.2/tiangong-sb-windows-x86_64.sig) |
+| macOS Apple Silicon | [tiangong-sb-darwin-aarch64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.3/tiangong-sb-darwin-aarch64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.3/tiangong-sb-darwin-aarch64.sig) |
+| macOS Intel | [tiangong-sb-darwin-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.3/tiangong-sb-darwin-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.3/tiangong-sb-darwin-x86_64.sig) |
+| Linux x86_64 | [tiangong-sb-linux-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.3/tiangong-sb-linux-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.3/tiangong-sb-linux-x86_64.sig) |
+| Windows x86_64 | [tiangong-sb-windows-x86_64](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.3/tiangong-sb-windows-x86_64) | [签名](https://silent-tiangong.oss-cn-hangzhou.aliyuncs.com/sandbox/0.1.3/tiangong-sb-windows-x86_64.sig) |
 
 手动下载后，将程序重命名为 `tiangong-sandbox`（Windows 为 `tiangong-sandbox.exe`），签名放在同目录并命名为程序名加 `.sig`。macOS 和 Linux 还需要添加执行权限：
 

--- a/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
+++ b/crates/tiangong-sandbox/src/bin/tiangong-sandbox.rs
@@ -1262,12 +1262,14 @@ fn reachable_network_address() -> Result<String> {
 
 #[cfg(windows)]
 fn create_directory_junction(target: &Path, link: &Path) -> Result<bool> {
-    let status = std::process::Command::new("cmd.exe")
+    let mut command = std::process::Command::new("cmd.exe");
+    command
         .args(["/D", "/C", "mklink", "/J"])
         .arg(link)
         .arg(target)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let status = tiangong_toolkit::configure_no_window(&mut command)
         .status()
         .context("创建 Windows 自检 Junction 失败")?;
     Ok(status.success())
@@ -1337,14 +1339,15 @@ fn run_windows_file_probe(raw: &str) -> i32 {
         std::fs::File::create(&file_stderr_path),
     ) {
         (Ok(stdin), Ok(stdout), Ok(stderr)) => {
-            std::process::Command::new(&request.workspace_executable)
+            let mut command = std::process::Command::new(&request.workspace_executable);
+            command
                 .arg("--windows-self-check-child-probe")
                 .arg(&child_request)
                 .current_dir(&request.workspace)
                 .stdin(std::process::Stdio::from(stdin))
                 .stdout(std::process::Stdio::from(stdout))
-                .stderr(std::process::Stdio::from(stderr))
-                .status()
+                .stderr(std::process::Stdio::from(stderr));
+            tiangong_toolkit::configure_no_window(&mut command).status()
         }
         (stdin, stdout, stderr) => {
             eprintln!(
@@ -1369,15 +1372,16 @@ fn run_windows_file_probe(raw: &str) -> i32 {
     const PIPE_TOKEN: &str = "tiangong-sandbox-pipe-input";
     const STDOUT_TOKEN: &str = "tiangong-sandbox-pipe-stdout";
     const STDERR_TOKEN: &str = "tiangong-sandbox-pipe-stderr";
-    let piped_child = std::process::Command::new(&request.workspace_executable)
+    let mut piped_command = std::process::Command::new(&request.workspace_executable);
+    piped_command
         .arg("--windows-self-check-child-probe")
         .arg(&child_request)
         .arg(PIPE_TOKEN)
         .current_dir(&request.workspace)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn();
+        .stderr(std::process::Stdio::piped());
+    let piped_child = tiangong_toolkit::configure_no_window(&mut piped_command).spawn();
     let pipe_stdio_ok = match piped_child {
         Ok(mut child) => {
             let input_written = child
@@ -1549,10 +1553,9 @@ fn run_windows_process_limit_probe() -> i32 {
     let Ok(program) = std::env::current_exe() else {
         return 3;
     };
-    match std::process::Command::new(program)
-        .args(["--self-check-network-probe", "invalid"])
-        .spawn()
-    {
+    let mut command = std::process::Command::new(program);
+    command.args(["--self-check-network-probe", "invalid"]);
+    match tiangong_toolkit::configure_no_window(&mut command).spawn() {
         Err(_) => 0,
         Ok(mut child) => {
             let _ = child.wait();
@@ -1604,11 +1607,11 @@ fn run_windows_tree_probe(raw: &str) -> i32 {
     if std::fs::write(&request.parent_pid_path, std::process::id().to_string()).is_err() {
         return 3;
     }
-    let child = match std::process::Command::new(&request.executable)
+    let mut command = std::process::Command::new(&request.executable);
+    command
         .arg("--windows-self-check-idle-probe")
-        .current_dir(&request.workspace)
-        .spawn()
-    {
+        .current_dir(&request.workspace);
+    let child = match tiangong_toolkit::configure_no_window(&mut command).spawn() {
         Ok(child) => child,
         Err(_) => return 4,
     };
@@ -1839,8 +1842,9 @@ fn windows_stop_event_cleanup_probe(root: &Path, current_exe: &Path) -> Result<b
 #[cfg(windows)]
 fn windows_host_exit_cleanup_probe(root: &Path, current_exe: &Path) -> Result<bool> {
     let fixture = WindowsTreeFixture::new(root, current_exe, "host-exit")?;
-    let mut host = std::process::Command::new(current_exe)
-        .arg("--windows-self-check-idle-probe")
+    let mut command = std::process::Command::new(current_exe);
+    command.arg("--windows-self-check-idle-probe");
+    let mut host = tiangong_toolkit::configure_no_window(&mut command)
         .spawn()
         .context("启动 Windows 生命周期宿主探针失败")?;
     let host_pid = host.id();
@@ -1907,14 +1911,15 @@ fn windows_concurrent_cleanup_probe(root: &Path, current_exe: &Path) -> Result<b
             let stdin = std::fs::File::open(&input_path)?;
             let stdout = std::fs::File::create(&stdout_path)?;
             let stderr = std::fs::File::create(&stderr_path)?;
-            Ok(std::process::Command::new(current_exe)
+            let mut command = std::process::Command::new(current_exe);
+            command
                 .arg("--windows-self-check-lifecycle-worker")
                 .arg(&worker_root)
                 .arg(format!("worker-{index}"))
                 .stdin(std::process::Stdio::from(stdin))
                 .stdout(std::process::Stdio::from(stdout))
-                .stderr(std::process::Stdio::from(stderr))
-                .spawn()?)
+                .stderr(std::process::Stdio::from(stderr));
+            Ok(tiangong_toolkit::configure_no_window(&mut command).spawn()?)
         })();
         match child {
             Ok(child) => workers.push((child, stdout_path, stderr_path)),

--- a/crates/tiangong-sandbox/src/installed.rs
+++ b/crates/tiangong-sandbox/src/installed.rs
@@ -38,8 +38,9 @@ pub fn verify_signature_with_public_key(program: &Path, public_key_b64: &str) ->
 /// 官方验签后执行真实自检，并返回产品版本。
 pub fn verify_official_install(program: &Path) -> Result<String> {
     verify_official_signature(program)?;
-    let output = std::process::Command::new(program)
-        .arg("--self-check")
+    let mut command = std::process::Command::new(program);
+    command.arg("--self-check");
+    let output = tiangong_toolkit::configure_no_window(&mut command)
         .output()
         .with_context(|| format!("运行 Sandbox 自检失败: {}", program.display()))?;
     if !output.status.success() && output.status.code() != Some(79) {

--- a/crates/tiangong-sandbox/src/sandbox/windows.rs
+++ b/crates/tiangong-sandbox/src/sandbox/windows.rs
@@ -56,14 +56,15 @@ use windows_sys::Win32::System::JobObjects::{
     QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
 };
 use windows_sys::Win32::System::Threading::{
-    CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateMutexW, CreateProcessAsUserW,
-    DeleteProcThreadAttributeList, EXTENDED_STARTUPINFO_PRESENT, GetCurrentProcess,
-    GetExitCodeProcess, GetProcessMitigationPolicy, INFINITE, InitializeProcThreadAttributeList,
-    OpenEventW, OpenProcess, OpenProcessToken, PROC_THREAD_ATTRIBUTE_CHILD_PROCESS_POLICY,
-    PROC_THREAD_ATTRIBUTE_HANDLE_LIST, PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
-    PROCESS_INFORMATION, PROCESS_SYNCHRONIZE, ProcessChildProcessPolicy, ReleaseMutex,
-    ResumeThread, STARTF_USESTDHANDLES, STARTUPINFOEXW, SYNCHRONIZATION_SYNCHRONIZE,
-    TerminateProcess, UpdateProcThreadAttribute, WaitForMultipleObjects, WaitForSingleObject,
+    CREATE_NO_WINDOW, CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateMutexW,
+    CreateProcessAsUserW, DeleteProcThreadAttributeList, EXTENDED_STARTUPINFO_PRESENT,
+    GetCurrentProcess, GetExitCodeProcess, GetProcessMitigationPolicy, INFINITE,
+    InitializeProcThreadAttributeList, OpenEventW, OpenProcess, OpenProcessToken,
+    PROC_THREAD_ATTRIBUTE_CHILD_PROCESS_POLICY, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+    PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES, PROCESS_INFORMATION, PROCESS_SYNCHRONIZE,
+    ProcessChildProcessPolicy, ReleaseMutex, ResumeThread, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+    SYNCHRONIZATION_SYNCHRONIZE, TerminateProcess, UpdateProcThreadAttribute,
+    WaitForMultipleObjects, WaitForSingleObject,
 };
 use windows_sys::Win32::System::WindowsProgramming::PROCESS_CREATION_CHILD_PROCESS_OVERRIDE;
 
@@ -922,7 +923,10 @@ fn run_restricted_process(
             std::ptr::null(),
             std::ptr::null(),
             1,
-            EXTENDED_STARTUPINFO_PRESENT | CREATE_SUSPENDED | CREATE_UNICODE_ENVIRONMENT,
+            EXTENDED_STARTUPINFO_PRESENT
+                | CREATE_SUSPENDED
+                | CREATE_UNICODE_ENVIRONMENT
+                | CREATE_NO_WINDOW,
             std::ptr::null(),
             cwd.as_ptr(),
             (&raw const startup.StartupInfo),

--- a/crates/tiangong-sandbox/src/update.rs
+++ b/crates/tiangong-sandbox/src/update.rs
@@ -415,8 +415,9 @@ fn verify_signature(binary: &Path, signature: &Path, pubkey_b64: &str) -> Result
 }
 
 fn verify_candidate_self_check(binary: &Path, manifest: &UpdateManifest) -> Result<()> {
-    let output = std::process::Command::new(binary)
-        .arg("--self-check")
+    let mut command = std::process::Command::new(binary);
+    command.arg("--self-check");
+    let output = tiangong_toolkit::configure_no_window(&mut command)
         .output()
         .with_context(|| format!("运行候选 Sandbox 自检失败: {}", binary.display()))?;
     if !output.status.success() && output.status.code() != Some(79) {
@@ -438,9 +439,9 @@ fn verify_candidate_self_check(binary: &Path, manifest: &UpdateManifest) -> Resu
 
 fn trusted_target_version(binary: &Path, signature: &Path, pubkey_b64: &str) -> Result<Version> {
     verify_signature(binary, signature, pubkey_b64)?;
-    let output = std::process::Command::new(binary)
-        .arg("--self-check")
-        .output()?;
+    let mut command = std::process::Command::new(binary);
+    command.arg("--self-check");
+    let output = tiangong_toolkit::configure_no_window(&mut command).output()?;
     if !output.status.success() && output.status.code() != Some(79) {
         bail!("已安装 Sandbox 自检失败");
     }


### PR DESCRIPTION
## 问题

Windows 下沙箱后台进程（自检、探针、sidecar 生命周期、Launcher 自检等）在启动时会弹出可见的终端窗口，干扰用户。

## 改动

- 新增统一入口 `tiangong_toolkit::configure_no_window`，为所有 Windows 后台子进程设置 `CREATE_NO_WINDOW` 标志，隐藏控制台窗口。
- 沙箱 `CreateProcessAsUserW` 的创建标志增加 `CREATE_NO_WINDOW`，从进程创建源头隐藏窗口。
- 覆盖以下场景：
  - 沙箱自检 / 探针子进程（junction、file probe、process limit、tree、host exit、concurrent cleanup 等）
  - Launcher 自检（`launcher_update.rs`、`installed.rs`、`update.rs`）
  - sidecar 进程生命周期（`stdio.rs`）
- 沙箱版本 `0.1.2` → `0.1.3`，同步更新 README 与 Cargo.lock。

## 验证

- [ ] `cargo check` 通过
- [ ] Windows 下沙箱后台进程不再弹出终端窗口
