### PR TITLE
fix(browser): 保证工具调用事件顺序并简化插件调用状态

### DIFF
--- a/crates/tiangong-plugin-runtime/src/ts_tools.rs
+++ b/crates/tiangong-plugin-runtime/src/ts_tools.rs
@@ -350,12 +350,30 @@ fn validate_result(result: &TsToolResult) -> Result<()> {
     Ok(())
 }
 
+/// 发出 `tool.requested` 前必须在待处理表临界区内复查调用仍存在：
+/// 所有闭合路径都是「持锁移除表项、随后发出 tool.closed」，本函数把
+/// 复查与发出放进同一临界区后，同一调用只可能出现 requested → closed
+/// 顺序，绝不会在 closed 之后补发重放快照里的迟到 requested。
 fn emit_requested(plugin_id: &str, invocation: &TsToolInvocation) {
-    if let Ok(payload) = serde_json::to_string(invocation) {
-        crate::bridge::bridge_emit_to(plugin_id, "tool.requested", &payload);
-    } else {
+    let Ok(payload) = serde_json::to_string(invocation) else {
         tracing::warn!(plugin_id, "序列化 TS 工具调用事件失败");
+        return;
+    };
+    let Ok(pending) = pending_calls().lock() else {
+        return;
+    };
+    let still_pending = pending
+        .get(&invocation.invocation_id)
+        .is_some_and(|call| call.plugin_id == plugin_id);
+    if !still_pending {
+        tracing::debug!(
+            plugin_id,
+            invocation_id = %invocation.invocation_id,
+            "调用已闭合，跳过迟到的 tool.requested 重放"
+        );
+        return;
     }
+    crate::bridge::bridge_emit_to(plugin_id, "tool.requested", &payload);
 }
 
 fn emit_closed(plugin_id: &str, invocation_id: &str, status: TsToolCloseStatus) {

--- a/crates/tiangong-plugin-runtime/tests/tool_ui_launcher.rs
+++ b/crates/tiangong-plugin-runtime/tests/tool_ui_launcher.rs
@@ -348,6 +348,102 @@ fn ui_handler超过清单时限仍可正常返回() {
 }
 
 #[test]
+fn 调用闭合后重放不得补发requested() {
+    let _guard = REGISTRY_LOCK.lock().unwrap();
+    init_globals();
+    let root = tempfile::TempDir::new().unwrap();
+    stage_tool_plugin(root.path(), "tool-ui-replay-order");
+    let plugin = load_plugin(root.path(), "tool-ui-replay-order");
+    bridge_subscribe("tool-ui-replay-order", "tool.requested").unwrap();
+    bridge_subscribe("tool-ui-replay-order", "tool.closed").unwrap();
+
+    let count_requested = || {
+        event_hits()
+            .iter()
+            .filter(|(id, channel, _)| id == "tool-ui-replay-order" && channel == "tool.requested")
+            .count()
+    };
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(async {
+        let mut session = Session::new("重放顺序测试");
+        let call = ToolCall {
+            id: "call-replay-order".to_string(),
+            name: "demo_tool".to_string(),
+            arguments: serde_json::json!({}),
+        };
+        let task = tokio::spawn({
+            let plugin = plugin.clone();
+            async move { plugin.handle(&call, &mut session, "tester").await }
+        });
+        let invocation_id = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if let Some((_, _, payload)) = event_hits().iter().rev().find(|(id, channel, _)| {
+                    id == "tool-ui-replay-order" && channel == "tool.requested"
+                }) {
+                    let value: serde_json::Value = serde_json::from_str(payload).unwrap();
+                    return value["invocation_id"].as_str().unwrap().to_string();
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("工具请求应送达");
+        assert_eq!(count_requested(), 1, "首次投递只应有一次 requested");
+
+        // 闭合调用并等待 closed 事件与调用任务收尾。
+        bridge_call(
+            "tool-ui-replay-order",
+            "tool.resolve",
+            &serde_json::json!({
+                "invocation_id": invocation_id,
+                "status": "answered",
+                "result": {"ok": true, "summary": "done", "exit_code": 0}
+            })
+            .to_string(),
+        )
+        .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .expect("工具调用应正常闭合");
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let closed = event_hits().iter().any(|(id, channel, payload)| {
+                    id == "tool-ui-replay-order"
+                        && channel == "tool.closed"
+                        && serde_json::from_str::<serde_json::Value>(payload)
+                            .ok()
+                            .and_then(|value| value["invocation_id"].as_str().map(str::to_string))
+                            == Some(invocation_id.clone())
+                });
+                if closed {
+                    return;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("闭合事件应送达");
+
+        // 模拟新标签页挂载：退订后重新订阅触发 pending 重放。调用已闭合，
+        // 不得补发该调用的 tool.requested（closed 之后永不重放）。
+        bridge_unsubscribe("tool-ui-replay-order", "tool.requested").unwrap();
+        bridge_subscribe("tool-ui-replay-order", "tool.requested").unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert_eq!(
+            count_requested(),
+            1,
+            "调用闭合后的重放不得补发 tool.requested"
+        );
+    });
+
+    bridge_unsubscribe("tool-ui-replay-order", "tool.requested").unwrap();
+    bridge_unsubscribe("tool-ui-replay-order", "tool.closed").unwrap();
+}
+
+#[test]
 fn 插件经桥接调用app原语需声明权限且只能操作自己() {
     let _guard = REGISTRY_LOCK.lock().unwrap();
     init_globals();

--- a/frontend/src/api/tauri.ts
+++ b/frontend/src/api/tauri.ts
@@ -1235,6 +1235,10 @@ export const api = {
   listSlotContributions: (slot: string): Promise<SlotContributionEntry[]> =>
     invoke('list_slot_contributions', { slot }),
 
+  /// 同步当前会话实际挂载的 webview 插件标签。
+  setWebviewMountedTabs: (sessionId: string, tabIds: string[]): Promise<void> =>
+    invoke('set_webview_mounted_tabs', { sessionId, tabIds }),
+
   /// 列出拓展区 App（声明 extension.tab 贡献的插件，能力矩阵数据源）。
   listExtensionApps: (): Promise<AppEntry[]> =>
     invoke('list_extension_apps'),

--- a/frontend/src/components/TabsContainer.tsx
+++ b/frontend/src/components/TabsContainer.tsx
@@ -77,6 +77,12 @@ function isWebviewPluginTab(tab: TabState): boolean {
     && Boolean(tab.plugin_id && tab.contribution_id);
 }
 
+function mountedBrowserTabIds(tabs: TabState[]): string[] {
+  return tabs
+    .filter((tab) => isWebviewPluginTab(tab) && tab.plugin_id === 'browser')
+    .map((tab) => tab.id);
+}
+
 function webviewSessionId(sessionId: string): string {
   return sessionId || '__global__';
 }
@@ -156,6 +162,7 @@ export function TabsContainer({
   const isVisibleRef = useRef(isVisible);
   const lastInitialActivationKeyRef = useRef<string | null>(null);
   const mountedSessionIdRef = useRef('');
+  const mountedTabsSyncRef = useRef<Promise<void>>(Promise.resolve());
   /** tab 栏横向滚动容器：滚轮转横向滚动 + 活跃 tab 自动滚入可视区。 */
   const tabsScrollRef = useRef<HTMLDivElement>(null);
   const terminalSessionId = activeSessionId || newConversationId || '';
@@ -164,6 +171,14 @@ export function TabsContainer({
     () => tabs.find((tab) => tab.id === activeTabId) ?? tabs[0] ?? null,
     [activeTabId, tabs],
   );
+
+  const syncMountedBrowserTabs = useCallback((sessionId: string, tabIds: string[]) => {
+    const sync = mountedTabsSyncRef.current
+      .catch(() => {})
+      .then(() => api.setWebviewMountedTabs(sessionId, tabIds));
+    mountedTabsSyncRef.current = sync;
+    return sync;
+  }, []);
 
   const openWebviewPluginTab = useCallback(async (
     app: NonNullable<AppTabCommand['app']>,
@@ -230,7 +245,8 @@ export function TabsContainer({
     }
   }, [terminalSessionId]);
 
-  // tab 类型/插件 App 集合变化 → 通知宿主更新「已打开」绿点。
+  // tab 类型/插件 App 集合变化 → 通知宿主更新「已打开」绿点，并同步
+  // webview 页面实际挂载清单，页面事件只有命中该清单才允许进入会话。
   const onTabKindsChangedRef = useRef(onTabKindsChanged);
   onTabKindsChangedRef.current = onTabKindsChanged;
   const lastTabKindsRef = useRef<string>('');
@@ -241,11 +257,15 @@ export function TabsContainer({
         .filter((tab) => tab.kind === 'plugin' && tab.plugin_id && tab.contribution_id)
         .map((tab) => `${tab.plugin_id}:${tab.contribution_id}`),
     ));
-    const key = `${terminalSessionId}|${kinds.join(',')}|${pluginApps.join(',')}`;
+    const mountedWebviewTabIds = mountedBrowserTabIds(tabs);
+    const key = `${terminalSessionId}|${kinds.join(',')}|${pluginApps.join(',')}|${mountedWebviewTabIds.join(',')}`;
     if (key === lastTabKindsRef.current) return;
     lastTabKindsRef.current = key;
     onTabKindsChangedRef.current?.(kinds, pluginApps);
-  }, [tabs, terminalSessionId]);
+    if (terminalSessionId && mountedSessionIdRef.current === terminalSessionId) {
+      void syncMountedBrowserTabs(terminalSessionId, mountedWebviewTabIds).catch(console.error);
+    }
+  }, [syncMountedBrowserTabs, tabs, terminalSessionId]);
 
   useEffect(() => {
     onActiveKindChange?.(isVisible ? activeTab?.kind ?? null : null);
@@ -350,7 +370,10 @@ export function TabsContainer({
         .filter((tab) => tab.kind === 'plugin')
         .map((tab) => runPluginBeforeClose(tab.id)),
     );
-    if (previousSessionId) hideWebviewPluginTabs(closingTabs, previousSessionId);
+    if (previousSessionId) {
+      void syncMountedBrowserTabs(previousSessionId, []).catch(console.error);
+      hideWebviewPluginTabs(closingTabs, previousSessionId);
+    }
 
     tabsRef.current = [];
     activeTabIdRef.current = '';
@@ -359,7 +382,7 @@ export function TabsContainer({
     setReloadGenerations({});
     setSessionResetVersion((version) => version + 1);
     setActivationRetryVersion((version) => version + 1);
-  }, [hideWebviewPluginTabs, terminalSessionId]);
+  }, [hideWebviewPluginTabs, syncMountedBrowserTabs, terminalSessionId]);
 
   const activateOrCreateTab = useCallback(async (kind: TabKind) => {
     const sessionId = terminalSessionId;
@@ -428,10 +451,28 @@ export function TabsContainer({
     if (closedIndex === -1) return;
 
     const closingTab = currentTabs[closedIndex];
+    const closingBrowserTab = isWebviewPluginTab(closingTab) && closingTab.plugin_id === 'browser';
+    if (closingBrowserTab) {
+      const remainingMountedIds = mountedBrowserTabIds(
+        currentTabs.filter((tab) => tab.id !== tabId),
+      );
+      try {
+        await syncMountedBrowserTabs(terminalSessionId, remainingMountedIds);
+      } catch (error) {
+        console.error('撤销浏览器标签登记失败：', error);
+        return;
+      }
+    }
     if (closingTab.kind === 'plugin') {
       try {
         await runPluginBeforeClose(closingTab.id);
       } catch (error) {
+        if (closingBrowserTab) {
+          await syncMountedBrowserTabs(
+            terminalSessionId,
+            mountedBrowserTabIds(currentTabs),
+          ).catch(console.error);
+        }
         console.error('插件关闭前处理失败：', error);
         return;
       }
@@ -448,6 +489,12 @@ export function TabsContainer({
           { tab_id: closingTab.id },
         );
       } catch (error) {
+        if (closingBrowserTab) {
+          await syncMountedBrowserTabs(
+            terminalSessionId,
+            mountedBrowserTabIds(currentTabs),
+          ).catch(console.error);
+        }
         console.error('关闭 webview 插件标签失败：', error);
         return;
       }
@@ -494,7 +541,7 @@ export function TabsContainer({
       }
       return;
     }
-  }, [onClose, onShowMatrix, terminalSessionId]);
+  }, [onClose, onShowMatrix, syncMountedBrowserTabs, terminalSessionId]);
 
   const handleCloseWorkspace = useCallback(() => {
     hideWebviewPluginTabs(tabsRef.current);

--- a/plugins/tiangong-plugin-browser/package.json
+++ b/plugins/tiangong-plugin-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiangong-plugin-browser",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/plugins/tiangong-plugin-browser/package.json
+++ b/plugins/tiangong-plugin-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiangong-plugin-browser",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/plugins/tiangong-plugin-browser/plugin.json
+++ b/plugins/tiangong-plugin-browser/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "browser",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "entrypoints": [
     "desktop"
   ],

--- a/plugins/tiangong-plugin-browser/plugin.json
+++ b/plugins/tiangong-plugin-browser/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "browser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "entrypoints": [
     "desktop"
   ],

--- a/plugins/tiangong-plugin-browser/src/shell.ts
+++ b/plugins/tiangong-plugin-browser/src/shell.ts
@@ -4,7 +4,9 @@ import {
   getShadowHostRuntime,
   openExtensionApp,
   type HostBridge,
+  type ToolClosed,
   type ToolInvocation,
+  type ToolResolution,
 } from '@tiangong/plugin-sdk';
 import { tabsModel } from './tabs-model';
 
@@ -41,6 +43,9 @@ interface WebviewEvent {
   };
 }
 
+/** 进行中的工具调用状态：宿主取消/过期（tool.closed）后置 cancelled。 */
+const activeInvocations = new Map<string, { cancelled: boolean }>();
+
 function claimInvocation(invocationId: string): boolean {
   const sharedWindow = window as BrowserToolWindow;
   const claims = sharedWindow.__tiangongBrowserToolClaims
@@ -52,7 +57,24 @@ function claimInvocation(invocationId: string): boolean {
 
 function releaseInvocation(invocationId: string): void {
   const claims = (window as BrowserToolWindow).__tiangongBrowserToolClaims;
-  window.setTimeout(() => claims?.delete(invocationId), 5_000);
+  window.setTimeout(() => {
+    claims?.delete(invocationId);
+    activeInvocations.delete(invocationId);
+  }, 5_000);
+}
+
+/**
+ * 提交工具结果；调用已被宿主取消/过期时静默跳过。
+ * 宿主保证一次调用只能闭合一次，取消后提交的 resolve 会被拒绝，这里
+ * 提前短路，避免取消后仍执行有副作用或已失效的闭合。
+ */
+async function resolveActive(
+  tools: { resolve: (resolution: ToolResolution) => Promise<void> },
+  invocationId: string,
+  resolution: Omit<ToolResolution, 'invocation_id'>,
+): Promise<void> {
+  if (activeInvocations.get(invocationId)?.cancelled) return;
+  await tools.resolve({ invocation_id: invocationId, ...resolution });
 }
 
 /** 打开浏览器插件 App（app.open 宿主原语，聚焦本进程内的会话实例）。 */
@@ -128,10 +150,19 @@ async function main() {
   }
   const tools = createToolProvider(bridge);
 
+  // 宿主取消/过期闭合（tool.closed）：标记进行中的调用并立即释放 claim，
+  // 让其在 await 恢复后不再提交 resolve（宿主保证一次调用只能闭合一次）。
+  tools.onClosed((closed: ToolClosed) => {
+    const active = activeInvocations.get(closed.invocation_id);
+    if (active) active.cancelled = true;
+    (window as BrowserToolWindow).__tiangongBrowserToolClaims?.delete(closed.invocation_id);
+  });
+
   tools.onRequested((invocation: ToolInvocation) => {
     // multi 模式下每个浏览器顶部标签都会挂载一个页面。宿主事件会送达
     // 所有实例，按 invocation_id 只允许其中一个实例执行工具。
     if (!claimInvocation(invocation.invocation_id)) return;
+    activeInvocations.set(invocation.invocation_id, { cancelled: false });
     void (async () => {
       try {
         // browser_close（面板开关，app.* 原语）：带 tab_id 精确关闭一个
@@ -146,8 +177,7 @@ async function main() {
                 : { session_id: invocation.session_id, all: true },
             ),
           );
-          await tools.resolve({
-            invocation_id: invocation.invocation_id,
+          await resolveActive(tools, invocation.invocation_id, {
             status: 'answered',
             result: {
               ok: true,
@@ -159,8 +189,7 @@ async function main() {
         }
         const method = TOOL_METHOD[invocation.name];
         if (!method) {
-          await tools.resolve({
-            invocation_id: invocation.invocation_id,
+          await resolveActive(tools, invocation.invocation_id, {
             status: 'cancelled',
             result: { ok: false, summary: `未知工具 ${invocation.name}`, exit_code: 1 },
           });
@@ -186,8 +215,7 @@ async function main() {
             invocation.name === 'browser_open'
               ? `已在浏览器面板新标签打开：${target}`
               : `已导航到：${target}`;
-          await tools.resolve({
-            invocation_id: invocation.invocation_id,
+          await resolveActive(tools, invocation.invocation_id, {
             status: 'answered',
             result: { ok: true, summary, exit_code: 0 },
           });
@@ -252,14 +280,12 @@ async function main() {
             ? `webview 实例 ${parsed.view_id ?? '?'}，当前页：${active.title ?? active.url ?? '未知'}`
             : `webview 实例 ${parsed.view_id ?? '?'} 已就绪`;
         }
-        await tools.resolve({
-          invocation_id: invocation.invocation_id,
+        await resolveActive(tools, invocation.invocation_id, {
           status: 'answered',
           result: { ok: true, summary, exit_code: 0 },
         });
       } catch (error) {
-        await tools.resolve({
-          invocation_id: invocation.invocation_id,
+        await resolveActive(tools, invocation.invocation_id, {
           status: 'answered',
           result: { ok: false, summary: `webview 调用失败：${String(error)}`, exit_code: 1 },
         });

--- a/plugins/tiangong-plugin-browser/src/shell.ts
+++ b/plugins/tiangong-plugin-browser/src/shell.ts
@@ -32,6 +32,7 @@ const TOOL_METHOD: Record<string, string> = {
 
 type BrowserToolWindow = Window & {
   __tiangongBrowserToolClaims?: Set<string>;
+  __tiangongBrowserClosedInvocations?: Set<string>;
 };
 
 interface WebviewEvent {
@@ -46,7 +47,30 @@ interface WebviewEvent {
 /** 进行中的工具调用状态：宿主取消/过期（tool.closed）后置 cancelled。 */
 const activeInvocations = new Map<string, { cancelled: boolean }>();
 
+function sharedClosedInvocations(): Set<string> {
+  const sharedWindow = window as BrowserToolWindow;
+  return sharedWindow.__tiangongBrowserClosedInvocations
+    ?? (sharedWindow.__tiangongBrowserClosedInvocations = new Set());
+}
+
+function closeInvocation(invocationId: string): void {
+  sharedClosedInvocations().add(invocationId);
+}
+
+function isInvocationCancelled(invocationId: string): boolean {
+  return activeInvocations.get(invocationId)?.cancelled === true
+    || sharedClosedInvocations().has(invocationId);
+}
+
+class ToolResolutionError extends Error {
+  constructor(cause: unknown) {
+    super(`提交工具结果失败：${String(cause)}`);
+    this.name = 'ToolResolutionError';
+  }
+}
+
 function claimInvocation(invocationId: string): boolean {
+  if (sharedClosedInvocations().has(invocationId)) return false;
   const sharedWindow = window as BrowserToolWindow;
   const claims = sharedWindow.__tiangongBrowserToolClaims
     ?? (sharedWindow.__tiangongBrowserToolClaims = new Set());
@@ -73,8 +97,13 @@ async function resolveActive(
   invocationId: string,
   resolution: Omit<ToolResolution, 'invocation_id'>,
 ): Promise<void> {
-  if (activeInvocations.get(invocationId)?.cancelled) return;
-  await tools.resolve({ invocation_id: invocationId, ...resolution });
+  if (isInvocationCancelled(invocationId)) return;
+  try {
+    await tools.resolve({ invocation_id: invocationId, ...resolution });
+  } catch (error) {
+    if (isInvocationCancelled(invocationId)) return;
+    throw new ToolResolutionError(error);
+  }
 }
 
 /** 打开浏览器插件 App（app.open 宿主原语，聚焦本进程内的会话实例）。 */
@@ -150,12 +179,11 @@ async function main() {
   }
   const tools = createToolProvider(bridge);
 
-  // 宿主取消/过期闭合（tool.closed）：标记进行中的调用并立即释放 claim，
-  // 让其在 await 恢复后不再提交 resolve（宿主保证一次调用只能闭合一次）。
+  // 在当前应用生命周期保留闭合记录，拒绝宿主重放快照中晚于 tool.closed 到达的 requested。
   tools.onClosed((closed: ToolClosed) => {
     const active = activeInvocations.get(closed.invocation_id);
     if (active) active.cancelled = true;
-    (window as BrowserToolWindow).__tiangongBrowserToolClaims?.delete(closed.invocation_id);
+    closeInvocation(closed.invocation_id);
   });
 
   tools.onRequested((invocation: ToolInvocation) => {
@@ -168,6 +196,7 @@ async function main() {
         // browser_close（面板开关，app.* 原语）：带 tab_id 精确关闭一个
         // 页面，不带则收起整个浏览器面板（用户明确要求或任务完成时）。
         if (invocation.name === 'browser_close') {
+          if (isInvocationCancelled(invocation.invocation_id)) return;
           const args = (invocation.arguments ?? {}) as { tab_id?: string };
           await bridge.call(
             'app.close',
@@ -204,11 +233,13 @@ async function main() {
         ) {
           const target = (invocation.arguments as { url: string }).url;
           if (invocation.name === 'browser_open' || tabsModel.tabs.length === 0) {
+            if (isInvocationCancelled(invocation.invocation_id)) return;
             const opened = await tabsModel.newTab(target);
-            if (opened) {
+            if (opened && !isInvocationCancelled(invocation.invocation_id)) {
               void requestOpenInstance(bridge, invocation.session_id, opened.id);
             }
           } else {
+            if (isInvocationCancelled(invocation.invocation_id)) return;
             await tabsModel.navigate(target);
           }
           const summary =
@@ -224,6 +255,7 @@ async function main() {
         // 会话绑定（对齐终端插件）：Agent 打开/操作的页面归属发起对话，
         // 与该对话的浏览器面板是同一实例（插件×会话双维度隔离）。
         const invocationArgs = (invocation.arguments as Record<string, unknown>) ?? {};
+        if (isInvocationCancelled(invocation.invocation_id)) return;
         const showFetchPanel = invocation.name === 'web_fetch' && invocationArgs.open === true;
         const stopAppRegistration = invocation.name === 'web_fetch'
           ? registerNextNavigation(
@@ -246,6 +278,7 @@ async function main() {
         } finally {
           stopAppRegistration?.();
         }
+        if (isInvocationCancelled(invocation.invocation_id)) return;
         const parsed = JSON.parse(raw) as {
           view_id?: string;
           tabs?: Array<{ id?: string; url?: string; title?: string }>;
@@ -285,6 +318,11 @@ async function main() {
           result: { ok: true, summary, exit_code: 0 },
         });
       } catch (error) {
+        if (isInvocationCancelled(invocation.invocation_id)) return;
+        if (error instanceof ToolResolutionError) {
+          console.error(error.message);
+          return;
+        }
         await resolveActive(tools, invocation.invocation_id, {
           status: 'answered',
           result: { ok: false, summary: `webview 调用失败：${String(error)}`, exit_code: 1 },

--- a/plugins/tiangong-plugin-browser/src/shell.ts
+++ b/plugins/tiangong-plugin-browser/src/shell.ts
@@ -32,7 +32,6 @@ const TOOL_METHOD: Record<string, string> = {
 
 type BrowserToolWindow = Window & {
   __tiangongBrowserToolClaims?: Set<string>;
-  __tiangongBrowserClosedInvocations?: Set<string>;
 };
 
 interface WebviewEvent {
@@ -44,23 +43,13 @@ interface WebviewEvent {
   };
 }
 
-/** 进行中的工具调用状态：宿主取消/过期（tool.closed）后置 cancelled。 */
-const activeInvocations = new Map<string, { cancelled: boolean }>();
+/** 进行中的工具调用状态：收到 tool.closed（answered/cancelled/expired
+ * 均同）后置 closed。执行体持有对象引用，Map 提前清理后依然可读。 */
+type ActiveInvocation = {
+  closed: boolean;
+};
 
-function sharedClosedInvocations(): Set<string> {
-  const sharedWindow = window as BrowserToolWindow;
-  return sharedWindow.__tiangongBrowserClosedInvocations
-    ?? (sharedWindow.__tiangongBrowserClosedInvocations = new Set());
-}
-
-function closeInvocation(invocationId: string): void {
-  sharedClosedInvocations().add(invocationId);
-}
-
-function isInvocationCancelled(invocationId: string): boolean {
-  return activeInvocations.get(invocationId)?.cancelled === true
-    || sharedClosedInvocations().has(invocationId);
-}
+const activeInvocations = new Map<string, ActiveInvocation>();
 
 class ToolResolutionError extends Error {
   constructor(cause: unknown) {
@@ -70,7 +59,6 @@ class ToolResolutionError extends Error {
 }
 
 function claimInvocation(invocationId: string): boolean {
-  if (sharedClosedInvocations().has(invocationId)) return false;
   const sharedWindow = window as BrowserToolWindow;
   const claims = sharedWindow.__tiangongBrowserToolClaims
     ?? (sharedWindow.__tiangongBrowserToolClaims = new Set());
@@ -79,29 +67,28 @@ function claimInvocation(invocationId: string): boolean {
   return true;
 }
 
+/** 立即释放调用状态。finally 与 tool.closed 都会到达，必须幂等。 */
 function releaseInvocation(invocationId: string): void {
-  const claims = (window as BrowserToolWindow).__tiangongBrowserToolClaims;
-  window.setTimeout(() => {
-    claims?.delete(invocationId);
-    activeInvocations.delete(invocationId);
-  }, 5_000);
+  (window as BrowserToolWindow).__tiangongBrowserToolClaims?.delete(invocationId);
+  activeInvocations.delete(invocationId);
 }
 
 /**
- * 提交工具结果；调用已被宿主取消/过期时静默跳过。
- * 宿主保证一次调用只能闭合一次，取消后提交的 resolve 会被拒绝，这里
- * 提前短路，避免取消后仍执行有副作用或已失效的闭合。
+ * 提交工具结果；调用已闭合时静默跳过。宿主保证一次调用只能闭合一次，
+ * 闭合后提交的 resolve 会被拒绝，这里提前短路，避免取消后仍执行有副
+ * 作用或已失效的闭合。
  */
 async function resolveActive(
   tools: { resolve: (resolution: ToolResolution) => Promise<void> },
   invocationId: string,
+  state: ActiveInvocation,
   resolution: Omit<ToolResolution, 'invocation_id'>,
 ): Promise<void> {
-  if (isInvocationCancelled(invocationId)) return;
+  if (state.closed) return;
   try {
     await tools.resolve({ invocation_id: invocationId, ...resolution });
   } catch (error) {
-    if (isInvocationCancelled(invocationId)) return;
+    if (state.closed) return;
     throw new ToolResolutionError(error);
   }
 }
@@ -179,24 +166,27 @@ async function main() {
   }
   const tools = createToolProvider(bridge);
 
-  // 在当前应用生命周期保留闭合记录，拒绝宿主重放快照中晚于 tool.closed 到达的 requested。
+  // answered/cancelled/expired 都意味着调用已结束：标记后立即释放认领。
+  // 宿主保证同一调用只会出现 requested → closed，闭合后不再重放 requested，
+  // 因此无需定时器或永久闭合记录。
   tools.onClosed((closed: ToolClosed) => {
-    const active = activeInvocations.get(closed.invocation_id);
-    if (active) active.cancelled = true;
-    closeInvocation(closed.invocation_id);
+    const state = activeInvocations.get(closed.invocation_id);
+    if (state) state.closed = true;
+    releaseInvocation(closed.invocation_id);
   });
 
   tools.onRequested((invocation: ToolInvocation) => {
     // multi 模式下每个浏览器顶部标签都会挂载一个页面。宿主事件会送达
     // 所有实例，按 invocation_id 只允许其中一个实例执行工具。
     if (!claimInvocation(invocation.invocation_id)) return;
-    activeInvocations.set(invocation.invocation_id, { cancelled: false });
+    const state: ActiveInvocation = { closed: false };
+    activeInvocations.set(invocation.invocation_id, state);
     void (async () => {
       try {
         // browser_close（面板开关，app.* 原语）：带 tab_id 精确关闭一个
         // 页面，不带则收起整个浏览器面板（用户明确要求或任务完成时）。
         if (invocation.name === 'browser_close') {
-          if (isInvocationCancelled(invocation.invocation_id)) return;
+          if (state.closed) return;
           const args = (invocation.arguments ?? {}) as { tab_id?: string };
           await bridge.call(
             'app.close',
@@ -206,7 +196,7 @@ async function main() {
                 : { session_id: invocation.session_id, all: true },
             ),
           );
-          await resolveActive(tools, invocation.invocation_id, {
+          await resolveActive(tools, invocation.invocation_id, state, {
             status: 'answered',
             result: {
               ok: true,
@@ -218,7 +208,7 @@ async function main() {
         }
         const method = TOOL_METHOD[invocation.name];
         if (!method) {
-          await resolveActive(tools, invocation.invocation_id, {
+          await resolveActive(tools, invocation.invocation_id, state, {
             status: 'cancelled',
             result: { ok: false, summary: `未知工具 ${invocation.name}`, exit_code: 1 },
           });
@@ -233,20 +223,20 @@ async function main() {
         ) {
           const target = (invocation.arguments as { url: string }).url;
           if (invocation.name === 'browser_open' || tabsModel.tabs.length === 0) {
-            if (isInvocationCancelled(invocation.invocation_id)) return;
+            if (state.closed) return;
             const opened = await tabsModel.newTab(target);
-            if (opened && !isInvocationCancelled(invocation.invocation_id)) {
+            if (opened && !state.closed) {
               void requestOpenInstance(bridge, invocation.session_id, opened.id);
             }
           } else {
-            if (isInvocationCancelled(invocation.invocation_id)) return;
+            if (state.closed) return;
             await tabsModel.navigate(target);
           }
           const summary =
             invocation.name === 'browser_open'
               ? `已在浏览器面板新标签打开：${target}`
               : `已导航到：${target}`;
-          await resolveActive(tools, invocation.invocation_id, {
+          await resolveActive(tools, invocation.invocation_id, state, {
             status: 'answered',
             result: { ok: true, summary, exit_code: 0 },
           });
@@ -255,7 +245,7 @@ async function main() {
         // 会话绑定（对齐终端插件）：Agent 打开/操作的页面归属发起对话，
         // 与该对话的浏览器面板是同一实例（插件×会话双维度隔离）。
         const invocationArgs = (invocation.arguments as Record<string, unknown>) ?? {};
-        if (isInvocationCancelled(invocation.invocation_id)) return;
+        if (state.closed) return;
         const showFetchPanel = invocation.name === 'web_fetch' && invocationArgs.open === true;
         const stopAppRegistration = invocation.name === 'web_fetch'
           ? registerNextNavigation(
@@ -278,7 +268,7 @@ async function main() {
         } finally {
           stopAppRegistration?.();
         }
-        if (isInvocationCancelled(invocation.invocation_id)) return;
+        if (state.closed) return;
         const parsed = JSON.parse(raw) as {
           view_id?: string;
           tabs?: Array<{ id?: string; url?: string; title?: string }>;
@@ -313,17 +303,17 @@ async function main() {
             ? `webview 实例 ${parsed.view_id ?? '?'}，当前页：${active.title ?? active.url ?? '未知'}`
             : `webview 实例 ${parsed.view_id ?? '?'} 已就绪`;
         }
-        await resolveActive(tools, invocation.invocation_id, {
+        await resolveActive(tools, invocation.invocation_id, state, {
           status: 'answered',
           result: { ok: true, summary, exit_code: 0 },
         });
       } catch (error) {
-        if (isInvocationCancelled(invocation.invocation_id)) return;
+        if (state.closed) return;
         if (error instanceof ToolResolutionError) {
           console.error(error.message);
           return;
         }
-        await resolveActive(tools, invocation.invocation_id, {
+        await resolveActive(tools, invocation.invocation_id, state, {
           status: 'answered',
           result: { ok: false, summary: `webview 调用失败：${String(error)}`, exit_code: 1 },
         });

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -77,6 +77,8 @@ pub struct TiangongApp {
 pub struct ToolInjection {
     /// 注入到哪个 session（None = 当前活跃 session）。
     pub session_id: Option<String>,
+    /// 浏览器注入来源；消费前再次确认该页面仍有实际标签。
+    pub browser_source: Option<(String, String)>,
     /// 注入的工具数据。
     pub tool: Box<dyn tiangong_core::agent_input::ToolInput>,
 }
@@ -380,6 +382,19 @@ impl TiangongApp {
 
                 let tool_name = req.tool.tool_name().to_string();
 
+                if let Some((scope, tab_id)) = req.browser_source.as_ref() {
+                    let host_state = app_handle.state::<crate::webview_host::WebviewHostState>();
+                    let still_mounted = host_state
+                        .registry
+                        .existing_session_state(scope)
+                        .map(crate::webview_host::manager::BrowserManager::from_state)
+                        .is_some_and(|manager| manager.is_tab_mounted(tab_id));
+                    if !still_mounted {
+                        tracing::debug!(session_id, tab_id, "浏览器标签已关闭，跳过页面注入");
+                        continue;
+                    }
+                }
+
                 // 通过 app_handle 获取 TiangongApp
                 let app_state = app_handle.state::<TiangongApp>();
                 // 与发送、编辑和删除共享同一会话边界，覆盖快照读取、ensure、消费者
@@ -416,6 +431,19 @@ impl TiangongApp {
                         stream_rx,
                     );
                     tracing::info!(session_id, "消费者自动恢复 core");
+                }
+
+                if let Some((scope, tab_id)) = req.browser_source.as_ref() {
+                    let host_state = app_handle.state::<crate::webview_host::WebviewHostState>();
+                    let still_mounted = host_state
+                        .registry
+                        .existing_session_state(scope)
+                        .map(crate::webview_host::manager::BrowserManager::from_state)
+                        .is_some_and(|manager| manager.is_tab_mounted(tab_id));
+                    if !still_mounted {
+                        tracing::debug!(session_id, tab_id, "浏览器标签已关闭，跳过页面注入");
+                        continue;
+                    }
                 }
 
                 let core_sent = app_state

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4501,6 +4501,21 @@ pub async fn list_slot_contributions(
     ))
 }
 
+/// 同步拓展区中实际存在的 webview 插件标签，供页面事件注入校验。
+#[tauri::command]
+pub async fn set_webview_mounted_tabs(
+    session_id: String,
+    tab_ids: Vec<String>,
+    state: State<'_, crate::webview_host::WebviewHostState>,
+) -> Result<(), String> {
+    if session_id.trim().is_empty() {
+        return Err("会话 ID 不能为空".to_string());
+    }
+    let scope = format!("webview:browser:{session_id}");
+    state.manager_for(&scope).set_mounted_tabs(tab_ids);
+    Ok(())
+}
+
 /// 列出拓展区 App：声明 `extension.tab` 贡献的已启用插件（能力矩阵数据源）。
 #[tauri::command]
 pub async fn list_extension_apps(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -193,9 +193,9 @@ fn run_gui() {
                 else {
                     return;
                 };
-                if !tiangong_app::webview_host::manager::BrowserManager::from_state(source_state)
-                    .is_visible()
-                {
+                let source_manager =
+                    tiangong_app::webview_host::manager::BrowserManager::from_state(source_state);
+                if !source_manager.is_tab_mounted(&data.tab_id) {
                     return;
                 }
                 use tiangong_app::webview_host::page_fetcher::BrowserContent;
@@ -205,6 +205,7 @@ fn run_gui() {
                 };
                 let _ = tx1.send(tiangong_app::ToolInjection {
                     session_id: Some(target_session),
+                    browser_source: Some((data.session_id, data.tab_id)),
                     tool: Box::new(BrowserContent {
                         title: data.title,
                         url: data.url,
@@ -236,12 +237,13 @@ fn run_gui() {
                 else {
                     return;
                 };
-                if !tiangong_app::webview_host::manager::BrowserManager::from_state(source_state)
-                    .is_visible()
-                {
+                let source_manager =
+                    tiangong_app::webview_host::manager::BrowserManager::from_state(source_state);
+                if !source_manager.is_tab_mounted(&payload.tab_id) {
                     return;
                 }
                 let session_id = payload.session_id;
+                let source_tab_id = payload.tab_id;
                 let events = payload.events;
                 let total_count = events.len();
                 let Some((network_events, feedback)) = browser_events_to_feedback(events) else {
@@ -318,9 +320,20 @@ fn run_gui() {
                         debug!("浏览器网络事件来自非会话作用域，跳过注入");
                         return;
                     };
+                    let browser_state =
+                        app_handle.state::<tiangong_app::webview_host::WebviewHostState>();
+                    let mounted = browser_state
+                        .registry
+                        .existing_session_state(&session_id)
+                        .map(tiangong_app::webview_host::manager::BrowserManager::from_state)
+                        .is_some_and(|manager| manager.is_tab_mounted(&source_tab_id));
+                    if !mounted {
+                        return;
+                    }
                     let queued = injection_tx
                         .send(tiangong_app::ToolInjection {
                             session_id: Some(target_session.clone()),
+                            browser_source: Some((session_id.clone(), source_tab_id)),
                             tool: Box::new(BrowserContent {
                                 title,
                                 url: page_url.clone(),
@@ -834,6 +847,7 @@ fn run_gui() {
             tiangong_app::commands::plugin_open_view,
             tiangong_app::commands::plugin_call,
             tiangong_app::commands::list_slot_contributions,
+            tiangong_app::commands::set_webview_mounted_tabs,
             tiangong_app::commands::list_extension_apps,
             tiangong_app::commands::plugin_open_entry,
             tiangong_app::commands::plugin_read_entry_resource,

--- a/src-tauri/src/webview_host/manager.rs
+++ b/src-tauri/src/webview_host/manager.rs
@@ -1,6 +1,6 @@
 use tracing::{debug, warn};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
@@ -261,6 +261,8 @@ pub struct BrowserState {
     pub pending_events: Vec<BrowserEvent>,
     /// 标签列表
     pub tabs: Vec<BrowserTab>,
+    /// 前端拓展区中实际存在的浏览器标签。
+    pub mounted_tab_ids: HashSet<String>,
     /// 活跃标签 ID
     pub active_tab_id: Option<String>,
     /// 当前可见区域 (x, y, w, h)，用于标签切换时定位新 WebView
@@ -316,6 +318,7 @@ impl BrowserState {
             visible: Arc::new(std::sync::atomic::AtomicBool::new(true)),
             pending_events: Vec::new(),
             tabs: Vec::new(),
+            mounted_tab_ids: HashSet::new(),
             active_tab_id: None,
             browser_rect: (0.0, 0.0, 0.0, 0.0),
             shared,
@@ -359,6 +362,7 @@ impl BrowserManager {
                 visible: Arc::new(std::sync::atomic::AtomicBool::new(true)),
                 pending_events: Vec::new(),
                 tabs: Vec::new(),
+                mounted_tab_ids: HashSet::new(),
                 active_tab_id: None,
                 browser_rect: (0.0, 0.0, 0.0, 0.0),
                 shared,
@@ -410,6 +414,19 @@ impl BrowserManager {
             s.visible
                 .store(visible, std::sync::atomic::Ordering::Relaxed);
         }
+    }
+
+    pub fn set_mounted_tabs(&self, tab_ids: Vec<String>) {
+        if let Ok(mut state) = self.state.lock() {
+            state.mounted_tab_ids = tab_ids.into_iter().collect();
+        }
+    }
+
+    pub fn is_tab_mounted(&self, tab_id: &str) -> bool {
+        self.state
+            .lock()
+            .map(|state| state.mounted_tab_ids.contains(tab_id))
+            .unwrap_or(false)
     }
 
     /// 当前页面缩放比例（来自持久化状态）
@@ -1676,6 +1693,7 @@ impl BrowserManager {
                                     "browser:events",
                                     BrowserEventsEvent {
                                         session_id: session_id.clone(),
+                                        tab_id: active_tab_id_for_events,
                                         events,
                                     },
                                 );

--- a/src-tauri/src/webview_host/types.rs
+++ b/src-tauri/src/webview_host/types.rs
@@ -91,6 +91,7 @@ pub struct BrowserNavigationStateEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BrowserEventsEvent {
     pub session_id: String,
+    pub tab_id: String,
     pub events: Vec<BrowserEvent>,
 }
 


### PR DESCRIPTION
## 变更点

### Runtime（宿主，根因修复）
- `replay_pending` 原先持锁快照待处理列表后放锁再逐条发出 `tool.requested`，发出前不复查调用是否仍待处理：并发 resolve/取消会先移除表项并发出 `tool.closed`，新订阅者随后收到迟到的 `tool.requested`，被迫在每个 UI 插件侧各自维护防重表
- `emit_requested` 改为在待处理表临界区内复查调用仍存在才发出，发出动作与「移除表项 + 发出 closed」的临界区互斥；同一调用只可能出现 `requested → closed` 顺序，闭合后重放直接跳过（对所有 UI 插件生效）

### Browser 插件（0.1.1 → 0.1.2）
- 适配 SDK 0.1.1 取消闭合语义；阻止无标签页面注入会话（分支前两个提交）
- 删除应用级永久闭合记录与 5 秒延迟释放定时器：收到 `tool.closed`（answered/cancelled/expired 同等对待）标记局部状态对象后立即释放认领与活动表
- 执行体持有状态对象引用，Map 提前清理后依然可感知闭合；提交结果前后检查闭合状态，取消后不再执行副作用或补交 resolve

## 测试情况
- 集成测试 `tool_ui_launcher` 5 项全部通过（单线程），含新增用例「调用闭合后重放不得补发 requested」：闭合后模拟新标签页重新订阅触发重放，断言不补发
- `cargo check` / `cargo clippy --all-targets`（tiangong-plugin-runtime）无警告
- 插件 `yarn build`（vue-tsc 类型检查 + vite 打包）通过；`xtask validate-plugin browser` 通过
- pre-push 钩子全绿（cargo check / clippy / nextest / 前端 build + test）
- 多浏览器标签同订阅只有一个执行的 claim 场景无自动化测试基建，建议合并前真实应用开多标签实测一次