### PR TITLE
fix(plugin): 修复升级按钮版本判断

### DIFF
--- a/frontend/src/__tests__/pluginVersion.test.ts
+++ b/frontend/src/__tests__/pluginVersion.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { isRemotePluginVersionNewer } from '@/lib/pluginVersion';
+
+describe('插件升级版本判断', () => {
+  it('版本一致时不提示升级', () => {
+    expect(isRemotePluginVersionNewer('0.1.2', '0.1.2')).toBe(false);
+  });
+
+  it('线上版本更高时提示升级', () => {
+    expect(isRemotePluginVersionNewer('0.1.2', '0.1.3')).toBe(true);
+  });
+
+  it('本地版本高于线上版本时不提示升级', () => {
+    expect(isRemotePluginVersionNewer('0.1.3', '0.1.2')).toBe(false);
+  });
+
+  it('按语义版本比较多位数字', () => {
+    expect(isRemotePluginVersionNewer('0.1.9', '0.1.10')).toBe(true);
+    expect(isRemotePluginVersionNewer('0.1.10', '0.1.9')).toBe(false);
+  });
+
+  it('正式版高于预发布版，构建信息不改变优先级', () => {
+    expect(isRemotePluginVersionNewer('1.0.0-beta.2', '1.0.0')).toBe(true);
+    expect(isRemotePluginVersionNewer('1.0.0+local', '1.0.0+remote')).toBe(false);
+  });
+
+  it('版本无效时不误提示升级', () => {
+    expect(isRemotePluginVersionNewer('dev', '0.1.2')).toBe(false);
+    expect(isRemotePluginVersionNewer('0.1.2', 'latest')).toBe(false);
+  });
+});

--- a/frontend/src/components/PluginManagerSettings.tsx
+++ b/frontend/src/components/PluginManagerSettings.tsx
@@ -23,6 +23,7 @@ import {
   type PluginStatus,
   type TrustedPublisherEntry,
 } from '@/api/tauri';
+import { isRemotePluginVersionNewer } from '@/lib/pluginVersion';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { DefaultPluginOnboarding } from './DefaultPluginOnboarding';
@@ -558,8 +559,10 @@ function InstalledPluginRow({
   const working = activeOperation?.pluginId === plugin.id;
   const healthy = plugin.state === 'loaded';
   const invalid = plugin.state === 'invalid';
-  const canUpgrade = Boolean(release?.update_available && release.supported);
   const currentVersion = plugin.loaded_version ?? plugin.manifest_version;
+  const canUpgrade = Boolean(
+    release?.supported && isRemotePluginVersionNewer(currentVersion, release.version),
+  );
   const sidecar = getSidecarPresentation(plugin);
   const StatusIcon = healthy ? CheckCircle2 : plugin.state === 'disabled' ? Circle : AlertCircle;
 

--- a/frontend/src/lib/pluginVersion.ts
+++ b/frontend/src/lib/pluginVersion.ts
@@ -1,0 +1,61 @@
+type SemverIdentifier = number | string;
+
+type ParsedSemver = {
+  core: [number, number, number];
+  prerelease: SemverIdentifier[];
+};
+
+const parseSemver = (value: string): ParsedSemver | null => {
+  const match = value.trim().match(
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/,
+  );
+  if (!match) return null;
+
+  const prerelease = match[4]
+    ? match[4].split('.').map((identifier): SemverIdentifier =>
+        /^\d+$/.test(identifier) ? Number(identifier) : identifier,
+      )
+    : [];
+
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease,
+  };
+};
+
+const comparePrerelease = (left: SemverIdentifier[], right: SemverIdentifier[]): number => {
+  if (left.length === 0 || right.length === 0) {
+    return left.length === right.length ? 0 : left.length === 0 ? 1 : -1;
+  }
+
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = left[index];
+    const rightIdentifier = right[index];
+    if (leftIdentifier === undefined || rightIdentifier === undefined) {
+      return leftIdentifier === rightIdentifier ? 0 : leftIdentifier === undefined ? -1 : 1;
+    }
+    if (leftIdentifier === rightIdentifier) continue;
+    if (typeof leftIdentifier === 'number' && typeof rightIdentifier === 'number') {
+      return leftIdentifier > rightIdentifier ? 1 : -1;
+    }
+    if (typeof leftIdentifier === 'number') return -1;
+    if (typeof rightIdentifier === 'number') return 1;
+    return leftIdentifier.localeCompare(rightIdentifier) > 0 ? 1 : -1;
+  }
+  return 0;
+};
+
+/** 仅当线上语义版本严格高于当前版本时返回 true。无效版本按不可升级处理。 */
+export const isRemotePluginVersionNewer = (current: string, remote: string): boolean => {
+  const currentVersion = parseSemver(current);
+  const remoteVersion = parseSemver(remote);
+  if (!currentVersion || !remoteVersion) return false;
+
+  for (let index = 0; index < currentVersion.core.length; index += 1) {
+    if (remoteVersion.core[index] === currentVersion.core[index]) continue;
+    return remoteVersion.core[index] > currentVersion.core[index];
+  }
+
+  return comparePrerelease(remoteVersion.prerelease, currentVersion.prerelease) > 0;
+};


### PR DESCRIPTION
## 变更内容
- 根据当前插件版本和线上版本的真实语义版本关系显示升级入口
- 版本一致或本地版本更高时隐藏升级标签、版本箭头和按钮
- 增加相等、线上更高、本地更高、多位数字、预发布和无效版本检查

## 验证
- `yarn build`
- `yarn test --pool=threads`（21 个文件、231 项测试通过）
- `yarn test -- src/__tests__/pluginVersion.test.ts`（6 项通过）