### PR TITLE
test(sandbox): 独立宿主执行回归与三平台真实验证

### DIFF
--- a/.github/workflows/sandbox-ci.yml
+++ b/.github/workflows/sandbox-ci.yml
@@ -81,7 +81,19 @@ jobs:
       - name: Lint sandbox crate
         run: cargo clippy --locked -p tiangong-sandbox --all-targets -- -D warnings
       - name: Test sandbox crate
-        run: cargo test --locked -p tiangong-sandbox
+        run: |
+          cargo test --locked -p tiangong-sandbox --lib --bins
+          cargo test --locked -p tiangong-sandbox --test launcher_execution
+      - name: Test Launcher execution contract
+        timeout-minutes: 10
+        run: |
+          set -o pipefail
+          cargo test --locked -p tiangong-sandbox --test launcher_execution -- --ignored --test-threads=1 --nocapture 2>&1 | tee "$RUNNER_TEMP/launcher-execution.log"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: launcher-execution-linux
+          path: ${{ runner.temp }}/launcher-execution.log
       - name: Build Launcher
         run: cargo build --locked -p tiangong-sandbox --release
       - name: Verify Launcher self-check (bwrap)
@@ -117,7 +129,20 @@ jobs:
       - name: Lint sandbox crate
         run: cargo clippy --locked -p tiangong-sandbox --all-targets -- -D warnings
       - name: Test sandbox crate
-        run: cargo test --locked -p tiangong-sandbox
+        run: |
+          cargo test --locked -p tiangong-sandbox --lib --bins
+          cargo test --locked -p tiangong-sandbox --test launcher_execution
+      - name: Test Launcher execution contract
+        timeout-minutes: 10
+        run: |
+          set -o pipefail
+          # CI runner 本身是测试宿主；绝不通过天工沙箱工具嵌套执行本组测试。
+          cargo test --locked -p tiangong-sandbox --test launcher_execution -- --ignored --test-threads=1 --nocapture 2>&1 | tee "$RUNNER_TEMP/launcher-execution.log"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: launcher-execution-macos
+          path: ${{ runner.temp }}/launcher-execution.log
       - name: Verify Launcher self-check (Seatbelt)
         run: |
           # macOS 托管环境可能无法嵌套 Seatbelt：0=真实验证通过，
@@ -145,7 +170,29 @@ jobs:
       - name: Lint sandbox crate
         run: cargo clippy --locked -p tiangong-sandbox --all-targets -- -D warnings
       - name: Test sandbox crate
-        run: cargo test --locked -p tiangong-sandbox
+        run: |
+          cargo test --locked -p tiangong-sandbox --lib --bins
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cargo test --locked -p tiangong-sandbox --test launcher_execution
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Prepare standalone Node probe
+        shell: pwsh
+        run: |
+          Copy-Item (Get-Command node.exe).Source "$env:RUNNER_TEMP\sandbox-node.exe"
+          "SANDBOX_TEST_NODE=$env:RUNNER_TEMP\sandbox-node.exe" >> $env:GITHUB_ENV
+      - name: Test Launcher execution contract
+        shell: pwsh
+        timeout-minutes: 10
+        run: |
+          cargo test --locked -p tiangong-sandbox --test launcher_execution -- --ignored --test-threads=1 --nocapture 2>&1 | Tee-Object "$env:RUNNER_TEMP\launcher-execution.log"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: launcher-execution-windows
+          path: ${{ runner.temp }}/launcher-execution.log
       - name: Verify Launcher self-check (AppContainer)
         shell: pwsh
         run: |

--- a/crates/tiangong-sandbox/README.md
+++ b/crates/tiangong-sandbox/README.md
@@ -171,3 +171,27 @@ cargo clippy --locked -p tiangong-sandbox --all-targets -- -D warnings
 ## 许可证
 
 Apache-2.0
+
+### 独立宿主执行测试（issue #485）
+
+`tests/launcher_execution.rs` 不依赖 Runtime/sidecar SDK。默认测试只执行策略拒绝及宿主测试辅助逻辑；真实隔离用例标记为 `ignored`，避免在天工命令工具的沙箱内嵌套执行。
+必须从**沙箱外**原生终端或 CI runner 显式运行：
+
+```bash
+cargo test --locked -p tiangong-sandbox --test launcher_execution -- --ignored --test-threads=1 --nocapture
+```
+
+Windows 需安装 Node 22，并将独立 `node.exe` 的绝对路径设置为 `SANDBOX_TEST_NODE`；Sandbox CI 已自动准备。CI 显式启用用例后任何失败都直接失败，不以环境探测失败后返回制造成功。受限环境未运行不等于功能验证通过。
+
+取消/超时由外部测试宿主执行：Unix 关闭本次调用独占的进程组，通过继承通信端全部关闭确认后台进程结束；Windows 通过停止事件通知 Launcher 终止 Job，再清理 ACL 和临时身份。并发取消不得影响另一次任务。
+
+| 覆盖项 | 验证边界 |
+| --- | --- |
+| 敏感读取、越界写、网络、路径逃逸 | Launcher 真实自检报告，每项断言 |
+| 工作区、专用 Temp、敏感只读豁免 | Unix CLI 文件操作；Windows CLI 授权及私有 Temp，专用 Temp 由自检覆盖 |
+| CPU、内存 | Unix CPU 读回/实际超限、Linux 内存读回/实际分配；Windows Job 自检 |
+| 取消、超时、并发隔离 | Unix 外部宿主进程组；Windows 生命周期自检 |
+| 宿主异常退出 | Windows 现有 Job 自检；macOS SDK 的 kqueue 路径不属于独立 Launcher，不在此伪造实现 |
+| 进程数限制 | Windows Job 自检；当前 Linux Launcher 未施加该限制，保留独立待办，不用目标自己 setrlimit 代替 Launcher 验证 |
+
+此测试组不表示 issue #485 的所有能力已完成，也不改变 Launcher 生产代码。平台 CI 未运行时不得宣称三平台真实隔离通过。

--- a/crates/tiangong-sandbox/tests/launcher_execution.rs
+++ b/crates/tiangong-sandbox/tests/launcher_execution.rs
@@ -1,0 +1,597 @@
+//! issue #485：制品级黑盒测试。仅使用 Launcher CLI，不依赖 Runtime。
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use tiangong_sandbox::SandboxPolicy;
+
+static SERIAL: Mutex<()> = Mutex::new(());
+const LAUNCHER: &str = env!("CARGO_BIN_EXE_tiangong-sandbox");
+
+struct Process {
+    child: Child,
+    stdout: PathBuf,
+    stderr: PathBuf,
+    #[cfg(windows)]
+    stop_event: WindowsStopEvent,
+    #[cfg(unix)]
+    liveness: std::os::unix::net::UnixStream,
+}
+impl Process {
+    fn spawn(command: &mut Command, directory: &Path) -> Self {
+        let id = scru128::new().to_string();
+        let stdout = directory.join(format!("{id}.stdout"));
+        let stderr = directory.join(format!("{id}.stderr"));
+        command
+            .stdin(Stdio::null())
+            .stdout(fs::File::create(&stdout).unwrap())
+            .stderr(fs::File::create(&stderr).unwrap());
+        #[cfg(unix)]
+        let (liveness, inherited) = std::os::unix::net::UnixStream::pair().unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            liveness.set_nonblocking(true).unwrap();
+            // stdin 由 Launcher 原样传给目标及后台子进程；宿主持有另一端，
+            // EOF 用来确认整棵测试进程树退出，而不依赖心跳或进程名扫描。
+            let fd: std::os::fd::OwnedFd = inherited.into();
+            command.stdin(Stdio::from(fd)).process_group(0);
+        }
+
+        #[cfg(windows)]
+        let stop_event = WindowsStopEvent::new(command);
+        let child = command.spawn().unwrap();
+        command.stdin(Stdio::null());
+        Self {
+            child,
+            stdout,
+            stderr,
+            #[cfg(unix)]
+            liveness,
+            #[cfg(windows)]
+            stop_event,
+        }
+    }
+    fn wait(&mut self, timeout: Duration) -> ExitStatus {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = self.child.try_wait().unwrap() {
+                return status;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "Launcher 超时，{}",
+                self.diagnostics()
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+    fn output(&self) -> String {
+        fs::read_to_string(&self.stdout).unwrap()
+    }
+    fn diagnostics(&self) -> String {
+        format!(
+            "stdout={}\nstderr={}",
+            self.output(),
+            fs::read_to_string(&self.stderr).unwrap()
+        )
+    }
+}
+impl Process {
+    #[cfg(unix)]
+    fn stop(&mut self) -> std::io::Result<()> {
+        // 当前对象由沙箱外宿主持有。只向本调用的独立进程组发送终止信号。
+        if unsafe { libc::kill(-(self.child.id() as i32), libc::SIGKILL) } != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+    #[cfg(unix)]
+    fn assert_tree_closed(&mut self) {
+        use std::io::Read;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match self.liveness.read(&mut [0u8; 1]) {
+                Ok(0) => return,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                other => panic!("进程树存活探针异常: {other:?}"),
+            }
+            assert!(
+                Instant::now() < deadline,
+                "任务关闭后仍有进程持有继承描述符"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+}
+impl Drop for Process {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Err(error) = self.stop() {
+            eprintln!("测试宿主关闭任务失败: {error}");
+        }
+        #[cfg(windows)]
+        {
+            self.stop_event.signal();
+            // 正常路径由 Launcher 终止 Job 后回滚 ACL/容器身份，不直接杀首进程。
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while matches!(self.child.try_wait(), Ok(None)) && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+        let _ = self.child.kill();
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while matches!(self.child.try_wait(), Ok(None)) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+}
+#[cfg(windows)]
+struct WindowsStopEvent(std::os::windows::io::OwnedHandle);
+#[cfg(windows)]
+impl WindowsStopEvent {
+    fn new(command: &mut Command) -> Self {
+        use std::os::windows::io::FromRawHandle;
+        let name = format!("Local\\TiangongSandboxTest.{}", scru128::new());
+        let wide: Vec<u16> = name.encode_utf16().chain([0]).collect();
+        let handle = unsafe {
+            windows_sys::Win32::System::Threading::CreateEventW(
+                std::ptr::null(),
+                1,
+                0,
+                wide.as_ptr(),
+            )
+        };
+        assert!(
+            !handle.is_null(),
+            "创建宿主停止事件失败: {}",
+            std::io::Error::last_os_error()
+        );
+        command
+            .env(tiangong_sandbox::WINDOWS_STOP_EVENT_ENV, name)
+            .env(
+                tiangong_sandbox::HOST_PID_ENV,
+                std::process::id().to_string(),
+            );
+        Self(unsafe { std::os::windows::io::OwnedHandle::from_raw_handle(handle) })
+    }
+    fn signal(&self) {
+        use std::os::windows::io::AsRawHandle;
+        if unsafe { windows_sys::Win32::System::Threading::SetEvent(self.0.as_raw_handle()) } == 0 {
+            eprintln!("宿主通知停止失败: {}", std::io::Error::last_os_error());
+        }
+    }
+}
+struct Fixture {
+    root: tempfile::TempDir,
+    workspace: PathBuf,
+    temp: PathBuf,
+    outside: PathBuf,
+}
+impl Fixture {
+    fn new() -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let canonical = tiangong_sandbox::canonicalize_path(root.path()).unwrap();
+        let workspace = canonical.join("workspace");
+        let temp = canonical.join("private-temp");
+        let outside = canonical.join("outside");
+        for path in [&workspace, &temp, &outside] {
+            fs::create_dir(path).unwrap();
+        }
+        Self {
+            root,
+            workspace,
+            temp,
+            outside,
+        }
+    }
+    fn policy(&self) -> SandboxPolicy {
+        let mut policy = SandboxPolicy::workspace_write(&self.workspace);
+        policy.extra_writable.push(self.temp.clone());
+        policy
+    }
+    fn command(&self, policy: &SandboxPolicy) -> Command {
+        let path = self.root.path().join(format!("{}.json", scru128::new()));
+        fs::write(&path, serde_json::to_vec(policy).unwrap()).unwrap();
+        let mut command = Command::new(LAUNCHER);
+        command.args(["run", "--policy"]).arg(path).arg("--");
+        command
+            .env_remove(tiangong_sandbox::HOST_PID_ENV)
+            .env_remove(tiangong_sandbox::WINDOWS_STOP_EVENT_ENV)
+            .env_remove(tiangong_sandbox::POLICY_ENV);
+        command
+    }
+    #[cfg(unix)]
+    fn shell(&self, policy: &SandboxPolicy, script: &str) -> Process {
+        Process::spawn(
+            self.command(policy).args(["/bin/bash", "-c", script]),
+            self.root.path(),
+        )
+    }
+}
+
+#[cfg(unix)]
+fn quote(path: &Path) -> String {
+    format!("'{}'", path.to_str().unwrap().replace('\'', "'\\''"))
+}
+
+#[test]
+fn launcher_rejects_unsafe_policy_without_running_target() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let fixture = Fixture::new();
+    let mut policy = fixture.policy();
+    policy.mode = tiangong_sandbox::SandboxMode::FullAccess;
+    let mut command = fixture.command(&policy);
+    #[cfg(unix)]
+    command.args(["/bin/sh", "-c", "echo TARGET_RAN"]);
+    #[cfg(windows)]
+    command.args(["cmd.exe", "/D", "/C", "echo TARGET_RAN"]);
+    let mut process = Process::spawn(&mut command, fixture.root.path());
+    assert_eq!(
+        process.wait(Duration::from_secs(10)).code(),
+        Some(78),
+        "{}",
+        process.diagnostics()
+    );
+    assert!(!process.output().contains("TARGET_RAN"));
+}
+
+#[test]
+#[ignore = "必须由沙箱外宿主运行：cargo test --test launcher_execution -- --ignored --test-threads=1"]
+fn launcher_attack_matrix_and_resource_self_check() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let root = tempfile::tempdir().unwrap();
+    let mut process = Process::spawn(Command::new(LAUNCHER).arg("--self-check"), root.path());
+    assert!(
+        process.wait(Duration::from_secs(180)).success(),
+        "{}",
+        process.diagnostics()
+    );
+    let report: serde_json::Value = serde_json::from_str(&process.output()).unwrap();
+    for field in [
+        "workspace_write",
+        "outside_write_blocked",
+        "outside_delete_blocked",
+        "outside_config_write_blocked",
+        "git_metadata_write",
+        "network_blocked",
+        "sensitive_read_blocked",
+        "symlink_escape_blocked",
+        "path_traversal_blocked",
+    ] {
+        assert_eq!(report[field], true, "{field}: {report}");
+    }
+    #[cfg(windows)]
+    for field in [
+        "outside_read_blocked",
+        "dedicated_temp_write",
+        "network_allowed",
+        "child_restrictions_inherited",
+        "resource_limits_applied",
+        "process_limit_enforced",
+        "memory_limit_enforced",
+        "cpu_limit_enforced",
+        "hardlink_escape_blocked",
+        "temporary_acl_cleaned",
+        "temporary_identity_cleaned",
+    ] {
+        assert_eq!(report[field], true, "{field}: {report}");
+    }
+    eprintln!("Launcher 自检报告: {report}");
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "必须由沙箱外宿主运行：cargo test --test launcher_execution -- --ignored --test-threads=1"]
+fn cli_workspace_temp_and_sensitive_authorization() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let f = Fixture::new();
+    let secret = f.workspace.join("credentials");
+    fs::write(&secret, "secret").unwrap();
+    let mut policy = f.policy();
+    policy.denied_read_paths.push(secret.clone());
+    policy.protected_paths.push(secret.clone());
+    let script = format!(
+        "set -eu; for d in {} {}; do printf one > \"$d/file\"; test \"$(cat \"$d/file\")\" = one; printf two >> \"$d/file\"; test \"$(cat \"$d/file\")\" = onetwo; rm \"$d/file\"; done; if cat {} ; then exit 21; fi; if echo bad > {}/escape; then exit 22; fi; echo BOUNDARIES_OK",
+        quote(&f.workspace),
+        quote(&f.temp),
+        quote(&secret),
+        quote(&f.outside)
+    );
+    let mut process = f.shell(&policy, &script);
+    assert!(
+        process.wait(Duration::from_secs(15)).success(),
+        "{}",
+        process.diagnostics()
+    );
+    assert!(process.output().contains("BOUNDARIES_OK"));
+    assert!(!f.outside.join("escape").exists());
+    // 模拟宿主已验证身份后的策略豁免，不在沙箱内伪造宿主身份。
+    policy.denied_read_paths.clear();
+    let script = format!(
+        "set -eu; test \"$(cat {})\" = secret; if echo changed > {}; then exit 23; fi; echo AUTHORIZED_READ_ONLY",
+        quote(&secret),
+        quote(&secret)
+    );
+    let mut process = f.shell(&policy, &script);
+    assert!(
+        process.wait(Duration::from_secs(15)).success(),
+        "{}",
+        process.diagnostics()
+    );
+    assert!(process.output().contains("AUTHORIZED_READ_ONLY"));
+    assert_eq!(fs::read_to_string(secret).unwrap(), "secret");
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "必须由沙箱外宿主运行：cargo test --test launcher_execution -- --ignored --test-threads=1"]
+fn cli_cpu_limit_readback_and_busy_loop_termination() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let f = Fixture::new();
+    let mut policy = f.policy();
+    policy.resource_limits.max_cpu_time_seconds = 2;
+    let mut readback = f.shell(&policy, "ulimit -t");
+    assert!(
+        readback.wait(Duration::from_secs(10)).success(),
+        "{}",
+        readback.diagnostics()
+    );
+    assert_eq!(readback.output().trim(), "2");
+    let mut busy = f.shell(&policy, "echo CPU_READY; while :; do :; done");
+    let status = busy.wait(Duration::from_secs(20));
+    assert!(
+        busy.output().contains("CPU_READY"),
+        "{}",
+        busy.diagnostics()
+    );
+    use std::os::unix::process::ExitStatusExt;
+    assert!(
+        matches!(status.signal(), Some(libc::SIGXCPU | libc::SIGKILL))
+            || matches!(status.code(), Some(137 | 152)),
+        "CPU 未被限制: {status}, {}",
+        busy.diagnostics()
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+#[ignore = "必须由沙箱外宿主运行：cargo test --test launcher_execution -- --ignored --test-threads=1"]
+fn cli_memory_limit_readback_and_enforcement() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let f = Fixture::new();
+    let mut policy = f.policy();
+    policy.resource_limits.max_memory_bytes = 256 * 1024 * 1024;
+    let mut readback = f.shell(&policy, "ulimit -v");
+    assert!(
+        readback.wait(Duration::from_secs(15)).success(),
+        "{}",
+        readback.diagnostics()
+    );
+    let values = readback.output();
+    let values: Vec<_> = values.lines().collect();
+    assert_eq!(values[0], "262144");
+    // 有界分配：不是 OOM 炸弹，最多尝试超出 256 MiB 的单次分配。
+    let mut memory = Process::spawn(f.command(&policy).args(["python3", "-c",
+        "import sys\ntry: bytearray(512*1024*1024)\nexcept MemoryError: print('MEMORY_BLOCKED'); sys.exit(0)\nsys.exit(24)"]), f.root.path());
+    assert!(
+        memory.wait(Duration::from_secs(15)).success(),
+        "{}",
+        memory.diagnostics()
+    );
+    assert!(memory.output().contains("MEMORY_BLOCKED"));
+}
+#[cfg(windows)]
+#[test]
+#[ignore = "必须由沙箱外宿主运行：cargo test --test launcher_execution -- --ignored --test-threads=1"]
+fn windows_timeout_cancel_host_crash_and_concurrent_cleanup() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let root = tempfile::tempdir().unwrap();
+    let mut process = Process::spawn(
+        Command::new(LAUNCHER).arg("--windows-lifecycle-self-check"),
+        root.path(),
+    );
+    assert!(
+        process.wait(Duration::from_secs(180)).success(),
+        "{}",
+        process.diagnostics()
+    );
+    let report: serde_json::Value = serde_json::from_str(&process.output()).unwrap();
+    for field in [
+        "timeout_cleanup",
+        "stop_event_cleanup",
+        "host_exit_cleanup",
+        "process_tree_cleanup",
+        "concurrent_cleanup",
+    ] {
+        assert_eq!(report[field], true, "{field}: {report}");
+    }
+    eprintln!("Windows 生命周期报告: {report}");
+}
+
+#[cfg(unix)]
+fn wait_marker(path: &Path, process: &mut Process) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !path.exists() {
+        assert!(
+            process.child.try_wait().unwrap().is_none(),
+            "目标提前退出: {}",
+            process.diagnostics()
+        );
+        assert!(
+            Instant::now() < deadline,
+            "未收到进程树就绪标记: {}",
+            process.diagnostics()
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "必须由沙箱外宿主运行：cargo test --test launcher_execution -- --ignored --test-threads=1"]
+fn cli_cancel_and_timeout_stop_entire_process_group() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let f = Fixture::new();
+    for label in ["cancel", "timeout"] {
+        let marker = f.workspace.join(label);
+        let heartbeat = f.workspace.join(format!("{label}-heartbeat"));
+        let script = format!(
+            "(while :; do echo tick >> {}; sleep 0.05; done) <&0 & echo ready > {}; wait",
+            quote(&heartbeat),
+            quote(&marker)
+        );
+        let mut process = f.shell(&f.policy(), &script);
+        wait_marker(&marker, &mut process);
+        if label == "timeout" {
+            let deadline = Instant::now() + Duration::from_millis(200);
+            while Instant::now() < deadline {
+                assert!(
+                    process.child.try_wait().unwrap().is_none(),
+                    "超时前任务意外退出"
+                );
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+        process.stop().expect("沙箱外宿主关闭任务");
+        assert!(!process.wait(Duration::from_secs(5)).success());
+        process.assert_tree_closed();
+        std::thread::sleep(Duration::from_millis(150));
+        let before = fs::read(&heartbeat).unwrap_or_default();
+        std::thread::sleep(Duration::from_millis(250));
+        assert_eq!(
+            before,
+            fs::read(&heartbeat).unwrap_or_default(),
+            "{label} 后后台进程仍在写入"
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+#[ignore = "必须由沙箱外宿主运行：cargo test --test launcher_execution -- --ignored --test-threads=1"]
+fn windows_cli_node_private_temp_roundtrip_and_identity_isolation() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let f = Fixture::new();
+    let node =
+        std::env::var_os("SANDBOX_TEST_NODE").expect("Windows CI 必须准备 SANDBOX_TEST_NODE");
+    let script = "const fs=require('fs'),os=require('os'),path=require('path'); const dir=os.tmpdir(); const p=path.join(dir,'probe.txt'); fs.writeFileSync(p,'one'); if(fs.readFileSync(p,'utf8')!=='one')process.exit(20); fs.appendFileSync(p,'two'); if(fs.readFileSync(p,'utf8')!=='onetwo')process.exit(21); fs.unlinkSync(p); if(fs.existsSync(p))process.exit(22); console.log(JSON.stringify({dir}));";
+    let mut directories = Vec::new();
+    for _ in 0..2 {
+        let mut command = f.command(&f.policy());
+        command.arg(&node).args([
+            "--preserve-symlinks",
+            "--preserve-symlinks-main",
+            "-e",
+            script,
+        ]);
+        let mut process = Process::spawn(&mut command, f.root.path());
+        assert!(
+            process.wait(Duration::from_secs(30)).success(),
+            "{}",
+            process.diagnostics()
+        );
+        let result: serde_json::Value = serde_json::from_str(process.output().trim()).unwrap();
+        let directory = result["dir"]
+            .as_str()
+            .unwrap()
+            .replace('\\', "/")
+            .to_lowercase();
+        assert!(
+            directory.contains("/packages/tiangongsandbox.") && directory.ends_with("/ac/temp"),
+            "非私有临时目录: {directory}"
+        );
+        directories.push(directory);
+    }
+    assert_ne!(directories[0], directories[1]);
+}
+
+#[cfg(windows)]
+#[test]
+#[ignore = "必须由沙箱外宿主运行：cargo test --test launcher_execution -- --ignored --test-threads=1"]
+fn windows_cli_sensitive_read_exemption_preserves_write_denial() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let f = Fixture::new();
+    let node = std::env::var_os("SANDBOX_TEST_NODE").expect("Windows CI 必须准备 Node");
+    let secret = f.workspace.join("credentials.txt");
+    fs::write(&secret, "secret").unwrap();
+    let mut policy = f.policy();
+    policy.protected_paths.push(secret.clone());
+    policy.denied_read_paths.push(secret.clone());
+    for allowed in [false, true] {
+        if allowed {
+            policy.denied_read_paths.clear();
+        }
+        let script = "const fs=require('fs');const [secret,outside,allowed]=process.argv.slice(1);let read=false;try{read=fs.readFileSync(secret,'utf8')==='secret'}catch(e){if(!['EACCES','EPERM'].includes(e.code))throw e}if(read!==(allowed==='true'))process.exit(20);for(const p of [secret,outside]){try{fs.writeFileSync(p,'bad');process.exit(21)}catch(e){if(!['EACCES','EPERM'].includes(e.code))throw e}}console.log('BOUNDARIES_OK')";
+        let mut command = f.command(&policy);
+        command
+            .arg(&node)
+            .args(["-e", script])
+            .arg(&secret)
+            .arg(f.outside.join("escape"))
+            .arg(allowed.to_string());
+        let mut process = Process::spawn(&mut command, f.root.path());
+        assert!(
+            process.wait(Duration::from_secs(30)).success(),
+            "{}",
+            process.diagnostics()
+        );
+        assert!(process.output().contains("BOUNDARIES_OK"));
+        assert_eq!(fs::read_to_string(&secret).unwrap(), "secret");
+        assert!(!f.outside.join("escape").exists());
+    }
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "必须由沙箱外宿主运行：cargo test --test launcher_execution -- --ignored --test-threads=1"]
+fn cli_concurrent_cancellation_does_not_stop_other_invocation() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let f = Fixture::new();
+    let first = f.workspace.join("first");
+    let second = f.workspace.join("second");
+    let script = |marker: &Path| {
+        format!(
+            "echo ready > {}; while :; do sleep 0.05; done",
+            quote(marker)
+        )
+    };
+    let mut cancelled = f.shell(&f.policy(), &script(&first));
+    let mut survivor = f.shell(&f.policy(), &script(&second));
+    wait_marker(&first, &mut cancelled);
+    wait_marker(&second, &mut survivor);
+    cancelled.stop().expect("沙箱外宿主取消指定调用");
+    assert!(!cancelled.wait(Duration::from_secs(5)).success());
+    cancelled.assert_tree_closed();
+    std::thread::sleep(Duration::from_millis(150));
+    assert!(
+        survivor.child.try_wait().unwrap().is_none(),
+        "取消影响了另一调用"
+    );
+    survivor.stop().expect("沙箱外宿主清理剩余调用");
+    assert!(!survivor.wait(Duration::from_secs(5)).success());
+    survivor.assert_tree_closed();
+}
+
+// 不施加沙箱、不发送 kill：验证测试宿主的描述符归属和有限回收逻辑。
+#[cfg(unix)]
+#[test]
+fn host_liveness_probe_waits_for_descendant_exit() {
+    use std::io::Read;
+    let root = tempfile::tempdir().unwrap();
+    let mut process = Process::spawn(
+        Command::new("/bin/sh").args(["-c", "(sleep 1) <&0 & exit 0"]),
+        root.path(),
+    );
+    assert!(process.wait(Duration::from_secs(5)).success());
+    assert!(
+        matches!(process.liveness.read(&mut [0u8; 1]), Err(e) if e.kind() == std::io::ErrorKind::WouldBlock),
+        "首进程退出不应误判后台子进程也已退出"
+    );
+    process.assert_tree_closed();
+}

--- a/crates/tiangong-sandbox/tests/launcher_execution.rs
+++ b/crates/tiangong-sandbox/tests/launcher_execution.rs
@@ -442,7 +442,7 @@ fn cli_cancel_and_timeout_stop_entire_process_group() {
         let marker = f.workspace.join(label);
         let heartbeat = f.workspace.join(format!("{label}-heartbeat"));
         let script = format!(
-            "(while :; do echo tick >> {}; sleep 0.05; done) <&0 & echo ready > {}; wait",
+            "exec 9<&0; (while :; do echo tick >> {}; sleep 0.05; done) <&9 & echo ready > {}; wait",
             quote(&heartbeat),
             quote(&marker)
         );
@@ -582,10 +582,10 @@ fn cli_concurrent_cancellation_does_not_stop_other_invocation() {
 #[cfg(unix)]
 #[test]
 fn host_liveness_probe_waits_for_descendant_exit() {
-    use std::io::Read;
+    use std::io::{Read, Write};
     let root = tempfile::tempdir().unwrap();
     let mut process = Process::spawn(
-        Command::new("/bin/sh").args(["-c", "(sleep 1) <&0 & exit 0"]),
+        Command::new("/bin/sh").args(["-c", "exec 9<&0; (read token <&9) <&9 & exit 0"]),
         root.path(),
     );
     assert!(process.wait(Duration::from_secs(5)).success());
@@ -593,5 +593,7 @@ fn host_liveness_probe_waits_for_descendant_exit() {
         matches!(process.liveness.read(&mut [0u8; 1]), Err(e) if e.kind() == std::io::ErrorKind::WouldBlock),
         "首进程退出不应误判后台子进程也已退出"
     );
+    // 显式释放后台进程，不依赖 sleep 时长或 CI 调度速度。
+    process.liveness.write_all(b"stop\n").unwrap();
     process.assert_tree_closed();
 }


### PR DESCRIPTION
## 关联
Related to #485（不自动关闭：未覆盖项见下）
基于已合并 Windows 修复 PR #489 的 main。

## 变更
- 新增直接调用 Launcher CLI 的独立集成测试，不反向依赖 Runtime/sidecar SDK。
- 取消和超时由沙箱外测试宿主关闭对应任务，检查后台进程继承通信端回收、并发取消隔离。
- Windows 验证已有 Job 生命周期自检、私有 Temp 文件读写删除与不同身份隔离、敏感只读授权；清理由停止事件通知 Launcher。
- 覆盖攻击矩阵、Unix CPU 限制、Linux 内存限制、工作区/专用 Temp 边界。
- 默认明确 ignored 真实用例；Sandbox CI 三平台通过 --ignored 显式串行执行，失败直接失败并保存日志。
- 没有改动 Launcher 生产代码，没有添加额外 macOS 监视器或 Linux 限额逻辑。

## 本地已验证
- 严格 Clippy、格式检查、CI actionlint 通过。
- 默认集成测试 2 通过、5 ignored（macOS），不把未运行当作真实隔离通过。
- 库/二进制测试命令通过。
- commit/push hooks 的 cargo check、clippy、nextest 通过。

## 真实平台验收
等待本 PR 的 Sandbox CI：必须检查 Linux、macOS、Windows 的 Test Launcher execution contract 步骤实际执行成功，不能仅看默认测试或跳过状态。

## 未覆盖边界
- macOS SDK 的 kqueue 宿主崩溃回收不属于独立 Launcher，不在本 PR 伪造实现。
- Linux Launcher 当前未施加进程数限制，不能用目标自行 setrlimit 代替 Launcher 验证；保留 #485 后续跟踪。
- 本地受限工具环境不适合嵌套真实沙箱，真实验收交给 CI。