### PR TITLE
fix(memory): 阻止动态记忆与成员状态改写系统提示

### DIFF
--- a/crates/plugins/tiangong-plugin-agent-team/src/adapter.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/adapter.rs
@@ -94,7 +94,7 @@ impl ToolOverrideHandler for AgentTeamPlugin {
 
 impl PromptSectionProvider for AgentTeamPlugin {
     fn prompt_sections(&self) -> Vec<String> {
-        vec![format!(
+        vec![String::from(
             "团队协作能力（默认不创建子 Agent）：\n\
              - create_agent 会启动一个全新的独立成员，它必须跑完自己的整轮后才能返回结果，开销显著。\n\
              - **默认不要主动 create_agent**：单轮即可完成的任务一律自己处理。仅在用户明确要求并行、\n\
@@ -103,8 +103,8 @@ impl PromptSectionProvider for AgentTeamPlugin {
              - send_message 向指定成员发送消息，并等待其跑完整轮后返回；发给 main 时仅投递、不等待。\n\
              - 用户输入中的 @role 应调用 send_message，@all 应调用 broadcast_message；不要解析或改写 @ 消息。\n\
              - 子 Agent 只能向 main 异步报告；同级之间的等待只允许沿创建顺序向后。\n\
-             - 执行命令时必须前台运行并设置有限超时。\n{}",
-            self.coordinator.roster_prompt()
+             - 执行命令时必须前台运行并设置有限超时。\n\
+             - 团队成员信息以创建、解散工具的结果和会话消息为准。"
         )]
     }
 }
@@ -202,6 +202,42 @@ mod tests {
     use crate::test_support::storage_test_guard;
 
     const SLOW_SESSION_END_SAFETY_LIMIT: Duration = Duration::from_secs(10);
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn membership_changes_do_not_rewrite_system_prompt() {
+        let _guard = crate::test_support::storage_test_guard_async().await;
+        let storage = tempfile::tempdir().unwrap();
+        let plugin = super::AgentTeamPlugin::new(storage.path().to_path_buf(), Arc::new(Vec::new));
+        let mut session = Session::new("team prompt");
+        session.cwd = storage.path().to_string_lossy().into_owned();
+        plugin.coordinator.initialize(&mut session);
+        let before = plugin.prompt_sections();
+        let call = tiangong_core::model::ToolCall {
+            id: "create".into(),
+            name: crate::constants::TOOL_CREATE_AGENT.into(),
+            arguments: json!({"role":"dev","label":"Developer","system_prompt":"检查结果"}),
+        };
+        let result = plugin.coordinator.create_agent(&call, &mut session);
+        assert!(result.ok, "{}", result.stderr);
+        assert_eq!(before, plugin.prompt_sections());
+        assert!(session
+            .messages
+            .iter()
+            .any(|message| message.text_content().contains("已加入团队")));
+        let call = tiangong_core::model::ToolCall {
+            id: "dismiss".into(),
+            name: crate::constants::TOOL_DISMISS_AGENT.into(),
+            arguments: json!({"role":"dev"}),
+        };
+        let result = plugin
+            .coordinator
+            .prepare_dismiss_agent(&call, &mut session)
+            .unwrap()
+            .finish()
+            .await;
+        assert!(result.ok, "{}", result.stderr);
+        assert_eq!(before, plugin.prompt_sections());
+    }
 
     struct SlowSessionEndedState {
         started: AtomicBool,

--- a/crates/plugins/tiangong-plugin-agent-team/src/coordinator.rs
+++ b/crates/plugins/tiangong-plugin-agent-team/src/coordinator.rs
@@ -593,24 +593,6 @@ impl Coordinator {
         }
     }
 
-    pub(crate) fn roster_prompt(&self) -> String {
-        let records = self.alive_records();
-        if records.is_empty() {
-            return "当前团队尚无子 Agent。".to_string();
-        }
-        let roster = records
-            .into_iter()
-            .map(|record| {
-                format!(
-                    "- @{}：{}（Session ID={}）",
-                    record.descriptor.role, record.descriptor.label, record.descriptor.agent_id
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-        format!("当前团队成员：\n{roster}")
-    }
-
     fn start_record(
         self: &Arc<Self>,
         parent: &Session,

--- a/crates/tiangong-core/src/tool_override.rs
+++ b/crates/tiangong-core/src/tool_override.rs
@@ -41,6 +41,8 @@ pub trait ToolSpecProvider: Send + Sync + 'static {
 ///
 /// Plugin 通过此机制向 system prompt 注入规则段落（如终端交互引导、浏览器使用规范等）。
 /// 段落会按 plugin 注册顺序追加到 system prompt 中。
+/// 相同配置下必须保持稳定，不应包含当前时间、轮次、自动提取的记忆或成员状态。
+/// 动态信息应经工具结果或追加消息进入上下文，避免改写已发送的请求前缀。
 pub trait PromptSectionProvider: Send + Sync + 'static {
     /// 返回该 plugin 暴露的所有 prompt 段落（每段会作为独立块拼接到 system prompt）。
     /// 默认返回空，不注入 prompt 的插件无需覆写。

--- a/crates/tiangong-plugin-runtime/tests/load_and_call.rs
+++ b/crates/tiangong-plugin-runtime/tests/load_and_call.rs
@@ -577,8 +577,7 @@ fn prompt_sections_without_handle_returns_empty() {
 }
 
 #[test]
-fn set_workspace_and_prompt_sections_flow() {
-    // set_workspace → on_session_ready → prompt_sections 完整流程。
+fn new_turns_do_not_load_memory_into_system_prompt() {
     let sidecar = Arc::new(MockMemorySidecar::default());
     let Some(wasm) = wasm_or_skip() else {
         return;
@@ -597,9 +596,37 @@ fn set_workspace_and_prompt_sections_flow() {
     let mut session = test_session();
     <WasmPluginAdapter as Plugin>::on_session_ready(&adapter, &mut session);
 
-    // prompt_sections 应能正常调用（返回注入段落或空）。
-    let _sections = <WasmPluginAdapter as PromptSectionProvider>::prompt_sections(&adapter);
-    assert!(sidecar.called("load_injection"));
+    session.system_prompt_message = Some(tiangong_types::Message::new(
+        tiangong_types::MessageRole::System,
+        "旧版自动注入的 Session Memory 和更新时间",
+    ));
+    let mut previous_prompt = None;
+    for turn in 0..3 {
+        session.append_message(tiangong_types::MessageRole::User, format!("继续 {turn}"));
+        let start = session.messages.len() - 1;
+        <WasmPluginAdapter as Plugin>::on_turn_started(&adapter, &mut session, start);
+        let sections = <WasmPluginAdapter as PromptSectionProvider>::prompt_sections(&adapter);
+        assert!(
+            sections.is_empty(),
+            "记忆只能经 handler 返回，不能拼入系统提示"
+        );
+        session.rebuild_system_prompt(
+            &tiangong_core::prompt::SystemPromptConfig::from_plugin_sections(sections),
+        );
+        let prompt = session.system_prompt_message.as_ref().unwrap();
+        assert!(!prompt.text_content().contains("Session Memory"));
+        let serialized_prompt = serde_json::to_vec(prompt).unwrap();
+        if let Some(previous) = &previous_prompt {
+            assert_eq!(
+                previous, &serialized_prompt,
+                "重新加载和追加消息不应重建系统提示"
+            );
+        }
+        previous_prompt = Some(serialized_prompt);
+        assert!(!sidecar.called("load_injection"));
+        assert!(!sidecar.called("recall_context"));
+        session = serde_json::from_slice(&serde_json::to_vec(&session).unwrap()).unwrap();
+    }
 }
 
 #[test]

--- a/crates/tiangong-plugin-runtime/tests/m0_slot_bridge.rs
+++ b/crates/tiangong-plugin-runtime/tests/m0_slot_bridge.rs
@@ -96,6 +96,19 @@ fn v1_插件经_slot_与宿主桥接完成设置页闭环() {
 
     let root = tempfile::TempDir::new().unwrap();
     stage_plugins(root.path());
+    // 此处验证旧清单结构兼容性，版本仍须匹配当前实际构建的 WASM。
+    let config = tiangong_plugin_runtime::PluginRuntimeConfig::default();
+    let loader = tiangong_plugin_runtime::WasmPluginLoader::new(&config).unwrap();
+    for id in ["prompt", "memory"] {
+        let dir = root.path().join("plugins").join(id);
+        let manifest_path = dir.join("plugin.json");
+        let mut manifest: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        let binary = manifest["wasm"]["binary"].as_str().unwrap();
+        let mut component = loader.load(&dir.join(binary), &config).unwrap();
+        manifest["version"] = component.describe().unwrap().version.into();
+        std::fs::write(manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+    }
 
     // ── 1. v1 清单按旧规则解析并加载 ──
     let loaded = preload_installed_plugins(root.path());

--- a/crates/tiangong-plugin-runtime/tests/v2_manifest_contribution.rs
+++ b/crates/tiangong-plugin-runtime/tests/v2_manifest_contribution.rs
@@ -158,7 +158,19 @@ fn stage_extension_tab_plugin(root: &std::path::Path, manifest: &str) {
         dir.join("tiangong_plugin_memory_wasm.wasm"),
     )
     .unwrap();
-    std::fs::write(dir.join("plugin.json"), manifest).unwrap();
+    // UI 贡献测试使用当前构建的组件，不应因夹具写死旧版本而退化为未加载状态。
+    let config = tiangong_plugin_runtime::PluginRuntimeConfig::default();
+    let loader = tiangong_plugin_runtime::WasmPluginLoader::new(&config).unwrap();
+    let mut component = loader
+        .load(&dir.join("tiangong_plugin_memory_wasm.wasm"), &config)
+        .unwrap();
+    let mut manifest: serde_json::Value = serde_json::from_str(manifest).unwrap();
+    manifest["version"] = component.describe().unwrap().version.into();
+    std::fs::write(
+        dir.join("plugin.json"),
+        serde_json::to_vec(&manifest).unwrap(),
+    )
+    .unwrap();
     std::fs::write(
         dir.join("app").join("index.html"),
         "<html><body>board</body></html>",

--- a/plugins/tiangong-plugin-memory/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-memory/wasm/src/lib.rs
@@ -23,7 +23,6 @@ use bindings::exports::tiangong::plugin::plugin_ui::{
 };
 use serde::Deserialize;
 use tiangong_plugin_memory_protocol::control::Reconfigure;
-use tiangong_plugin_memory_protocol::injection::{LoadInjection, LoadInjectionRequest};
 use tiangong_plugin_memory_protocol::recall::{
     Recall, RecallContext, RecallContextRequest, RecallQuery, RecallRequest,
 };
@@ -52,14 +51,11 @@ struct RecallToolArguments {
 }
 
 /// 全局状态缓存（WASM 单线程，RefCell 安全）。
-/// 存放 prompt_sections 拉注入所需的 session_id 和 workspace，
-/// 以及 handle-tool 构建召回 context 所需的上一个 PluginSession 快照。
+/// 存放 handle-tool 构建召回 context 所需的上一个 PluginSession 快照。
 mod state {
     use std::cell::RefCell;
 
     struct PluginState {
-        session_id: Option<String>,
-        workspace: Option<String>,
         /// 上一次 on_turn_started / on_session_ready 收到的 PluginSession 快照。
         last_session: Option<tiangong_types::PluginSession>,
         /// 本轮是否已经召回过（每轮只召回一次）。
@@ -70,47 +66,20 @@ mod state {
 
     thread_local! {
         static STATE: RefCell<PluginState> = const { RefCell::new(PluginState {
-            session_id: None,
-            workspace: None,
             last_session: None,
             recall_attempted: false,
             turn_count: 0,
         }) };
     }
 
-    #[allow(dead_code)]
-    pub fn set_session_id(id: Option<String>) {
-        STATE.with(|s| s.borrow_mut().session_id = id);
-    }
-
-    pub fn set_workspace(ws: Option<String>) {
-        STATE.with(|s| s.borrow_mut().workspace = ws);
-    }
-
     pub fn set_last_session(session: tiangong_types::PluginSession) {
         STATE.with(|s| {
-            s.borrow_mut().session_id = Some(session.id.clone());
             s.borrow_mut().last_session = Some(session);
         });
     }
 
     pub fn last_session() -> Option<tiangong_types::PluginSession> {
         STATE.with(|s| s.borrow().last_session.clone())
-    }
-
-    pub fn session_id() -> Option<String> {
-        STATE.with(|s| s.borrow().session_id.clone())
-    }
-
-    pub fn workspace_id() -> Option<String> {
-        STATE.with(|s| {
-            s.borrow().workspace.as_ref().and_then(|ws| {
-                ws.rsplit('/')
-                    .next()
-                    .filter(|n| !n.is_empty())
-                    .map(String::from)
-            })
-        })
     }
 
     /// 标记本轮已召回。
@@ -198,21 +167,8 @@ impl Guest for Component {
     }
 
     fn prompt_sections() -> Result<Vec<String>, PluginError> {
-        // 读缓存的状态，经 request 拉取三级记忆注入。
-        let session_id = state::session_id().unwrap_or_default();
-        let workspace_id = state::workspace_id();
-        let request = LoadInjectionRequest {
-            session_id,
-            workspace_id,
-        };
-        let sections = match sidecar_client::invoke::<LoadInjection>(&request) {
-            Ok(response) => response.items,
-            Err(_) => {
-                // sidecar 不可用时返回空（不注入），不阻断 prompt 装配。
-                Vec::new()
-            }
-        };
-        Ok(sections)
+        // 记忆只通过 recall_memory 的工具结果进入上下文，后台整理不得改写系统提示。
+        Ok(Vec::new())
     }
 
     fn handle_tool(call: ToolCall) -> Result<ToolResult, PluginError> {
@@ -346,8 +302,7 @@ impl Guest for Component {
         Ok(())
     }
 
-    fn set_workspace(workspace: Option<String>, _full_trust: bool) -> Result<(), PluginError> {
-        state::set_workspace(workspace);
+    fn set_workspace(_workspace: Option<String>, _full_trust: bool) -> Result<(), PluginError> {
         Ok(())
     }
 
@@ -364,7 +319,7 @@ impl Guest for Component {
     // session 的所有修改权始终在 Core，WASM/ sidecar 绝不回写。
 
     fn on_session_ready(session_json: String) -> Result<(), PluginError> {
-        // 会话就绪：缓存 PluginSession 供 handle-tool 构建 context 和 prompt_sections 拉注入。
+        // 会话就绪：缓存 PluginSession 供 handle-tool 构建回忆 context。
         if let Ok(session) = serde_json::from_str::<tiangong_types::PluginSession>(&session_json) {
             state::set_last_session(session);
         }


### PR DESCRIPTION
每轮对话结束后，memory 会更新会话记忆及其时间戳；下一轮启动时，插件又通过 prompt_sections 自动把最新记忆放入 system prompt。即使记忆正文没变，仅时间变化也会改写请求前缀，使大量旧上下文无法命中缓存，并绕过 Agent 主动调用 recall_memory 的策略。

本次修改：

- memory 的 prompt_sections 不再读取或返回记忆，记忆内容只通过 recall_memory handler 的工具结果进入上下文；后台记忆整理及 UI 查询保留。
- 移除仅供自动注入使用的会话、工作区缓存。
- 检查其他插件后发现，内置 Agent Team 也会把动态成员名单放入 system prompt；改为固定说明。成员创建、解散已有可恢复的会话消息，继续作为成员信息来源。
- 明确插件提示契约：相同配置下保持稳定，时间、轮次、记忆和成员状态经工具结果或追加消息表达。
- 修正 UI 贡献与设置页桥接测试夹具写死插件旧版本的问题，使用实际组件版本，避免新版 WASM 被版本校验拒绝而退化成未加载状态。

其他插件审查结果：WASM 能力插件返回固定说明或空提示；Coding 的工作区与信任模式、附件分析的模型能力、Prompt 的用户配置、Skill 的已安装技能目录属于显式环境/配置变化。Skill 列表已有固定排序。Browser、Terminal、Interaction、Creator 的声明式提示为静态文案。本次不冻结这些配置，避免配置修改失效。

验证：

- 实际构建 memory WASM：cargo build -p tiangong-plugin-memory-wasm --target wasm32-wasip2。
- 真实 WASM 集成测试 15 项通过，覆盖无 handler 不加载记忆、主动回忆返回工具结果、轮后及周期记忆整理。
- 补充旧会话回归：清除旧版自动记忆提示后，连续三轮用户消息及序列化重新加载保持系统消息逐字节一致。
- Core 101 项、Agent Team 12 项通过；团队成员创建、解散不改写提示，成员消息仍保留。
- Core、Runtime、Agent Team 和 memory WASM 全目标严格 Clippy 通过。
- 构建 prompt WASM 后，设置页桥接与三项 UI 贡献测试通过。

升级到修复后的插件时，旧会话首次清除自动记忆提示会改变一次前缀；后续不再因记忆整理而反复变化。更改模型、插件或用户配置仍可能使缓存失效；上游实际命中率由服务端决定。此次未修改用户的本地安装或会话文件。
