### PR TITLE
chore(memory): 发布 memory 插件 v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11453,7 +11453,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -11461,7 +11461,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/plugins/tiangong-plugin-memory/plugin.json
+++ b/plugins/tiangong-plugin-memory/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "memory",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "wasm": {
     "binary": "tiangong_plugin_memory_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-memory/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "Apache-2.0"
 description = "Memory System 独立 sidecar 进程（承载 SQLite/tantivy/lancedb 原生运行）"


### PR DESCRIPTION
## 变更

- 将 memory 插件版本升级至 0.1.6
- 同步协议、sidecar 与 Cargo.lock 版本
- 发布已合并的系统提示稳定性修复

## 验证

- `cargo fmt --all -- --check`
- `cargo run --locked -p xtask -- validate-plugin memory`
- `cargo check --locked -p tiangong-plugin-memory-protocol -p tiangong-plugin-memory-sidecar`
- `cargo check --locked -p tiangong-plugin-memory-wasm --target wasm32-wasip2`
- 对上述组件执行 `cargo clippy -- -D warnings`
- 推送前 changed crates 检查、Clippy 与 nextest 全部通过