### PR TITLE
fix(core): 沿用完整对话前缀生成并持久化摘要

### DIFF
--- a/crates/tiangong-core/src/context/compressor.rs
+++ b/crates/tiangong-core/src/context/compressor.rs
@@ -1,4 +1,7 @@
-use crate::model::{ModelRequest, SingleProviderClient, StopReason, TokenUsage};
+use crate::model::{
+    ModelRequest, ReasoningEffort, SingleProviderClient, StopReason, TokenUsage, ToolChoice,
+    ToolSpec,
+};
 use crate::session::{Message, MessagePhase, MessageRole, Session};
 
 /// 判断消息是否为可压缩的有效消息。
@@ -12,6 +15,8 @@ pub(crate) fn is_compressible(message: &Message) -> bool {
 pub struct ContextCompressor {
     session: Session,
     client: SingleProviderClient,
+    tools: Vec<ToolSpec>,
+    reasoning_effort: ReasoningEffort,
 }
 
 #[derive(Debug, Clone)]
@@ -54,8 +59,18 @@ impl std::fmt::Display for CompressionError {
 impl std::error::Error for CompressionError {}
 
 impl ContextCompressor {
-    pub fn new(session: Session, client: SingleProviderClient) -> Self {
-        Self { session, client }
+    pub fn new(
+        session: Session,
+        client: SingleProviderClient,
+        tools: Vec<ToolSpec>,
+        reasoning_effort: ReasoningEffort,
+    ) -> Self {
+        Self {
+            session,
+            client,
+            tools,
+            reasoning_effort,
+        }
     }
 
     pub fn has_pending_messages(&self) -> bool {
@@ -87,13 +102,24 @@ impl ContextCompressor {
         }
 
         let boundary_message_id = self.session.messages[split_point - 1].id.clone();
-        let request = Self::summary_request(&self.session, split_point, max_output_tokens);
+        let request = Self::summary_request(
+            &self.session,
+            split_point,
+            max_output_tokens,
+            self.reasoning_effort,
+        );
         let response = self
             .client
-            .complete_async(&request)
+            .complete_async_with_tools(&request, &self.tools, Some(ToolChoice::None))
             .await
             .map_err(|error| CompressionError::new(error.to_string()))?;
         let usage = response.usage.clone();
+        if !response.tool_calls.is_empty() || !response.invalid_tool_calls.is_empty() {
+            return Err(CompressionError::with_usage(
+                "上下文压缩返回了工具调用，拒绝提交摘要",
+                usage,
+            ));
+        }
         if response.stop_reason == Some(StopReason::MaxTokens) {
             return Err(CompressionError::with_usage(
                 "上下文压缩输出达到最大 token 限制，拒绝提交截断摘要",
@@ -116,36 +142,29 @@ impl ContextCompressor {
         session: &Session,
         split_point: usize,
         max_output_tokens: u32,
+        reasoning_effort: ReasoningEffort,
     ) -> ModelRequest {
         let split_point = split_point.min(session.messages.len());
-        let start = session.summary_up_to.min(split_point);
-        let mut context = Vec::with_capacity((split_point - start) + 2);
-        if let Some(system) = session.system_prompt_message.as_ref() {
-            context.push(system.clone());
-        }
-        context.extend(
-            session.messages[start..split_point]
-                .iter()
-                .filter(|message| {
-                    is_compressible(message) || message.phase == MessagePhase::CompressedResume
-                })
-                .cloned(),
-        );
+        let mut context = session.context();
         context.push(Message::new(
             MessageRole::User,
-            Self::compress_instruction(session, max_output_tokens),
+            Self::compress_instruction(session, split_point, max_output_tokens),
         ));
 
         ModelRequest {
             session_id: Some(session.id.clone()),
             user_input: String::new(),
             context,
-            reasoning_effort: crate::model::ReasoningEffort::None,
+            reasoning_effort,
             max_output_tokens: Some(max_output_tokens),
         }
     }
 
-    fn compress_instruction(session: &Session, max_output_tokens: u32) -> String {
+    fn compress_instruction(
+        session: &Session,
+        split_point: usize,
+        max_output_tokens: u32,
+    ) -> String {
         let existing_summary = session
             .context_summary
             .as_deref()
@@ -156,8 +175,17 @@ impl ContextCompressor {
         } else {
             ""
         };
+        // 边界说明仅追加在请求末尾，不向原历史插入标记或重复整段工具输出。
+        let boundary = session.messages[..split_point].iter().rev().find(|message| {
+            message.role != MessageRole::System && message.role != MessageRole::Notice
+        }).map(|message| {
+            let tail: String = message.text_content().chars().rev().take(512).collect::<Vec<_>>().into_iter().rev().collect();
+            serde_json::json!({"role":message.role,"tool_call_id":message.tool_call_id,"tool_call_ids":message.tool_calls.iter().map(|call|&call.id).collect::<Vec<_>>(),"text_end":tail})
+        }).unwrap_or(serde_json::Value::Null);
         format!(
             "请压缩以上对话历史。{merge_hint}\
+             以上完整上下文供你理解任务。摘要截止于最后一条符合以下边界描述的历史消息（包含该消息）：{boundary}。\n\
+             边界之后的消息将原样保留，只供参考，不要重复写入摘要。不要调用工具。\n\
              总输出不得超过 {max_output_tokens} tokens，请在达到预算前主动结束。\n\
              保留关键事实、决策、路径、错误和重要结果，删除重复内容、过程性描述和无效工具输出。\n\
              不要回答用户，严格按以下格式输出：\n\n\
@@ -213,8 +241,10 @@ mod tests {
         session.system_prompt_message = Some(Message::new(MessageRole::System, "系统提示"));
         session.messages = vec![user("你好"), assistant("你好，有什么可以帮你？")];
 
-        let request = ContextCompressor::summary_request(&session, 2, 10_000);
+        let request =
+            ContextCompressor::summary_request(&session, 2, 10_000, ReasoningEffort::High);
         assert_eq!(request.session_id.as_deref(), Some(session.id.as_str()));
+        assert_eq!(request.reasoning_effort, ReasoningEffort::High);
 
         assert_eq!(request.max_output_tokens, Some(10_000));
         assert_eq!(request.context.len(), 4);
@@ -231,7 +261,7 @@ mod tests {
         let mut session = Session::new("test");
         session.context_summary = Some("不应重复出现的旧摘要正文".to_string());
 
-        let instruction = ContextCompressor::compress_instruction(&session, 50_000);
+        let instruction = ContextCompressor::compress_instruction(&session, 0, 50_000);
 
         assert!(instruction.contains("系统提示中已经包含此前对话摘要"));
         assert!(!instruction.contains("不应重复出现的旧摘要正文"));
@@ -247,7 +277,8 @@ mod tests {
         resume.phase = MessagePhase::CompressedResume;
         session.messages = vec![resume, assistant("后续交互")];
 
-        let request = ContextCompressor::summary_request(&session, 2, 10_000);
+        let request =
+            ContextCompressor::summary_request(&session, 2, 10_000, ReasoningEffort::None);
 
         assert_eq!(request.context[1].role, MessageRole::User);
         assert_eq!(request.context[1].phase, MessagePhase::CompressedResume);

--- a/crates/tiangong-core/src/core/integration_tests.rs
+++ b/crates/tiangong-core/src/core/integration_tests.rs
@@ -482,8 +482,12 @@ async fn high_pressure_triggers_pre_request_compression() {
 
     let compression = chat_request_at(&server, 1).await;
     assert!(compression.any_message_contains("AUTO-COMPRESS-FIRST"));
-    assert!(!compression.any_message_contains("AUTO-COMPRESS-SECOND"));
-    assert!(compression.defined_tools().is_empty());
+    assert!(compression.any_message_contains("AUTO-COMPRESS-SECOND"));
+    assert_eq!(
+        compression.defined_tools(),
+        chat_request_at(&server, 0).await.defined_tools()
+    );
+    assert!(!compression.allows_tool_calls());
     assert!(
         !compression.is_stream(),
         "压缩沿生产接口使用非流式 completion"

--- a/crates/tiangong-core/src/react/compression.rs
+++ b/crates/tiangong-core/src/react/compression.rs
@@ -89,7 +89,12 @@ impl ContextCompression {
         notify_started(ctx);
         Self {
             task: start_task(
-                ContextCompressor::new(ctx.session.clone(), ctx.client.clone()),
+                ContextCompressor::new(
+                    ctx.session.clone(),
+                    ctx.client.clone(),
+                    ctx.tools.clone(),
+                    ctx.agent_config.reasoning_effort,
+                ),
                 organizer,
                 observed_tokens,
                 compression_split_point(&ctx.session),
@@ -233,7 +238,12 @@ pub(crate) async fn run_manual_context_compression(
     let observed_tokens = ctx.session.current_tokens;
     let organizer = ContextOrganizer::new(ctx.context_limit);
 
-    let compressor = ContextCompressor::new(ctx.session.clone(), ctx.client.clone());
+    let compressor = ContextCompressor::new(
+        ctx.session.clone(),
+        ctx.client.clone(),
+        ctx.tools.clone(),
+        ctx.agent_config.reasoning_effort,
+    );
     if !compressor.has_pending_messages() {
         notify_result(&ctx, ContextCompressAction::Noop);
         return None;
@@ -650,7 +660,7 @@ mod tests {
             session.append_message(MessageRole::User, format!("{round}问题"));
             session.append_message(MessageRole::Assistant, format!("{round}回答"));
         }
-        let (mut ctx, _root) = test_context(session);
+        let (mut ctx, root) = test_context(session);
 
         // 模拟压缩分割点：保留第三轮（最近交互），折叠前两轮。
         let update = update_for(&ctx.session, 0, "前两轮摘要", 4);
@@ -658,6 +668,18 @@ mod tests {
 
         assert_eq!(ctx.session.context_summary.as_deref(), Some("前两轮摘要"));
         assert_eq!(ctx.session.summary_up_to, 4);
+        let saved_prompt = serde_json::to_vec(&ctx.session.system_prompt_message).unwrap();
+        let mut restored = Session::load_from_storage(root.path(), &ctx.session.id).unwrap();
+        assert_eq!(restored.context_summary, ctx.session.context_summary);
+        assert_eq!(restored.summary_up_to, ctx.session.summary_up_to);
+        for question in ["继续", "再核对一次"] {
+            restored.append_message(MessageRole::User, question);
+            rebuild_system_prompt_for_session(&mut restored, &ctx.plugins);
+            assert_eq!(
+                serde_json::to_vec(&restored.system_prompt_message).unwrap(),
+                saved_prompt
+            );
+        }
         let context = ctx.session.context();
         assert_eq!(context[0].role, MessageRole::System);
         assert_eq!(context[1].text_content(), "第三轮问题");

--- a/crates/tiangong-core/src/react/context_cache_tests.rs
+++ b/crates/tiangong-core/src/react/context_cache_tests.rs
@@ -1,6 +1,154 @@
 use super::*;
 use serde_json::{Value, json};
 
+#[tokio::test]
+async fn compression_request_preserves_full_prefix_tools_and_reasoning() {
+    use crate::context::compressor::ContextCompressor;
+    for protocol in [
+        ProviderProtocol::OpenAi,
+        ProviderProtocol::OpenAiChatCompletions,
+    ] {
+        let server = MockServer::builder().start().await;
+        let mut harness = TestHarness::new_with_protocol(
+            &server,
+            protocol,
+            vec![tool_spec("read_file")],
+            HashMap::new(),
+            Vec::new(),
+        );
+        harness.ctx.agent_config.reasoning_effort = crate::model::ReasoningEffort::High;
+        harness.ctx.session.messages.push(Message::with_reasoning(
+            MessageRole::Assistant,
+            "先前结论",
+            "保留这段历史思考",
+        ));
+        harness
+            .ctx
+            .session
+            .append_message(MessageRole::User, "最新问题仍需原样保留");
+        let before_session = serde_json::to_vec(&harness.ctx.session).unwrap();
+        if protocol == ProviderProtocol::OpenAi {
+            mount_responses(&server, vec![answer("正常回复")], 0, true).await;
+        } else {
+            mount_completion(&server, "正常回复", "stop", 100, 10, None).await;
+        }
+        let req = super::super::build_react_request(&harness.ctx);
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        harness
+            .ctx
+            .client
+            .clone()
+            .stream_function_calls(req, harness.ctx.tools.clone(), tx)
+            .await
+            .unwrap();
+        if protocol == ProviderProtocol::OpenAi {
+            mount_responses(
+                &server,
+                vec![answer("[[SUMMARY]]\n先前结论摘要")],
+                3904,
+                true,
+            )
+            .await;
+        } else {
+            mount_completion(&server, "[[SUMMARY]]\n先前结论摘要", "stop", 100, 10, None).await;
+        }
+        let update = ContextCompressor::new(
+            harness.ctx.session.clone(),
+            harness.ctx.client.clone(),
+            harness.ctx.tools.clone(),
+            harness.ctx.agent_config.reasoning_effort,
+        )
+        .compress(2, 4096)
+        .await
+        .unwrap();
+        assert_eq!(update.summary, "先前结论摘要");
+        assert_eq!(update.summary_up_to, 2);
+        assert_eq!(
+            serde_json::to_vec(&harness.ctx.session).unwrap(),
+            before_session
+        );
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        let before: Value = serde_json::from_slice(&requests[0].body).unwrap();
+        let after: Value = serde_json::from_slice(&requests[1].body).unwrap();
+        assert_eq!(before["model"], after["model"]);
+        assert_eq!(before["tools"], after["tools"]);
+        assert_eq!(after["tool_choice"], "none");
+        let field = if protocol == ProviderProtocol::OpenAi {
+            assert_eq!(before["instructions"], after["instructions"]);
+            assert_eq!(before["reasoning"], after["reasoning"]);
+            assert_eq!(before["prompt_cache_key"], after["prompt_cache_key"]);
+            assert_eq!(after["max_output_tokens"], 4096);
+            "input"
+        } else {
+            assert_eq!(before["thinking"], after["thinking"]);
+            assert_eq!(before["reasoning_effort"], after["reasoning_effort"]);
+            assert_eq!(after["max_tokens"], 4096);
+            "messages"
+        };
+        let old = before[field].as_array().unwrap();
+        let new = after[field].as_array().unwrap();
+        assert_eq!(new.len(), old.len() + 1);
+        assert_eq!(&new[..old.len()], old.as_slice());
+        assert!(new.last().unwrap().to_string().contains("先前结论"));
+        assert!(new.last().unwrap().to_string().contains("不要调用工具"));
+    }
+}
+
+#[tokio::test]
+async fn compression_rejects_unexpected_tool_calls() {
+    let server = MockServer::builder().start().await;
+    let harness = TestHarness::new_with_protocol(
+        &server,
+        ProviderProtocol::OpenAi,
+        vec![tool_spec("cache_probe")],
+        HashMap::new(),
+        Vec::new(),
+    );
+    mount_responses(
+        &server,
+        vec![
+            answer("[[SUMMARY]]\n不能提交的摘要"),
+            call("unexpected", 0, false, false),
+        ],
+        0,
+        true,
+    )
+    .await;
+    let result = crate::context::compressor::ContextCompressor::new(
+        harness.ctx.session.clone(),
+        harness.ctx.client.clone(),
+        harness.ctx.tools.clone(),
+        crate::model::ReasoningEffort::High,
+    )
+    .compress(1, 4096)
+    .await;
+    let error = result.unwrap_err();
+    assert!(error.message.contains("返回了工具调用"));
+    assert!(error.usage.total_tokens > 0);
+    assert!(harness.ctx.session.context_summary.is_none());
+}
+
+#[tokio::test]
+async fn compression_empty_output_keeps_usage_and_original_session() {
+    let server = MockServer::builder().start().await;
+    let harness = TestHarness::new(&server, vec![tool_spec("read_file")], HashMap::new());
+    mount_completion(&server, "", "length", 100, 4096, None).await;
+    let before = serde_json::to_vec(&harness.ctx.session).unwrap();
+    let result = crate::context::compressor::ContextCompressor::new(
+        harness.ctx.session.clone(),
+        harness.ctx.client.clone(),
+        harness.ctx.tools.clone(),
+        crate::model::ReasoningEffort::High,
+    )
+    .compress(1, 4096)
+    .await;
+    let error = result.unwrap_err();
+    assert!(error.message.contains("最大 token 限制"));
+    assert_eq!(error.usage.completion_tokens, 4096);
+    assert_eq!(serde_json::to_vec(&harness.ctx.session).unwrap(), before);
+}
+
 fn assert_request_prefix(previous: &Value, current: &Value) {
     for field in [
         "model",

--- a/crates/tiangong-core/src/react/execute_tests.rs
+++ b/crates/tiangong-core/src/react/execute_tests.rs
@@ -647,7 +647,7 @@ async fn forced_compression_folds_older_history_and_keeps_latest_tool_batch() {
     let compression_body = String::from_utf8_lossy(&requests[1].body);
     let retry_body = String::from_utf8_lossy(&requests[2].body);
     assert!(first_body.contains("recent-tool-output"));
-    assert!(!compression_body.contains("recent-tool-output"));
+    assert!(compression_body.contains("recent-tool-output"));
     assert!(compression_body.contains("较早回答"));
     assert!(retry_body.contains("recent-tool-output"));
 }

--- a/crates/tiangong-llm/src/provider_client.rs
+++ b/crates/tiangong-llm/src/provider_client.rs
@@ -348,7 +348,7 @@ impl SingleProviderClient {
             tools: functions.to_vec(),
             tool_choice: tool_choice
                 .or_else(|| (!functions.is_empty()).then_some(LlmToolChoice::Auto)),
-            max_tokens,
+            max_tokens: req.max_output_tokens.unwrap_or(max_tokens),
             temperature: configured_temperature_f32(),
             top_p: None,
             stop_sequences: Vec::new(),
@@ -366,6 +366,16 @@ impl SingleProviderClient {
     }
     /// 可取消的非流式主模型调用。调用方丢弃 future 时底层 HTTP 请求随之终止。
     pub async fn complete_async(&self, req: &ModelRequest) -> Result<ModelResponse> {
+        self.complete_async_with_tools(req, &[], None).await
+    }
+
+    /// 保留工具定义的非流式调用；返回原始终态和用量，由调用方校验摘要等输出。
+    pub async fn complete_async_with_tools(
+        &self,
+        req: &ModelRequest,
+        tools: &[ToolSpec],
+        tool_choice: Option<ToolChoice>,
+    ) -> Result<ModelResponse> {
         let timeout_ms = self.cfg.timeout_ms;
         let model = self.cfg.model.trim();
         if model.is_empty() {
@@ -373,15 +383,24 @@ impl SingleProviderClient {
         }
         let provider = self.build_provider_dispatch(timeout_ms, req.session_id.as_deref())?;
         let max_tokens = req.max_output_tokens.unwrap_or(MAX_TOKENS_MAIN);
-        let request = self.build_provider_request(req, model, max_tokens, &[], None)?;
+        let request = self.build_provider_request(req, model, max_tokens, tools, tool_choice)?;
         let response = provider.complete(request).await.map_err(map_llm_error)?;
+        let tool_calls = response
+            .assistant_message
+            .content
+            .iter()
+            .filter_map(|content| match content {
+                LlmMessageContent::ToolCall(call) => Some(call.clone()),
+                _ => None,
+            })
+            .collect();
         Ok(ModelResponse {
             text: collect_provider_text(&response).trim().to_string(),
             reasoning_content: response.reasoning_content.unwrap_or_default(),
             reasoning_signature: None,
             stop_reason: response.stop_reason,
             usage: response.usage.unwrap_or_default().into(),
-            tool_calls: Vec::new(),
+            tool_calls,
             invalid_tool_calls: Vec::new(),
         })
     }

--- a/crates/tiangong-llm/src/session_tests.rs
+++ b/crates/tiangong-llm/src/session_tests.rs
@@ -76,8 +76,10 @@ async fn session_headers_reach_streaming_and_non_streaming_openai_requests() {
             let payload: Value = serde_json::from_slice(&request.body).unwrap();
             if protocol == ProviderProtocol::OpenAi {
                 assert_eq!(payload["prompt_cache_key"], session_id);
+                assert_eq!(payload["max_output_tokens"], 256);
             } else {
                 assert!(payload.get("prompt_cache_key").is_none());
+                assert_eq!(payload["max_tokens"], 256);
             }
             assert!(payload.get("session_id").is_none());
         }


### PR DESCRIPTION
此前摘要请求只发送待折叠的历史片段，清空 tools 并关闭思考，无法保持与普通对话相同的请求前缀。现在沿用完整 Session 上下文、模型、工具定义、思考设置及会话缓存标识，只追加摘要要求，通过 tool_choice=none 禁止实际调用工具。

摘要要求明确待替换的历史边界，保留区仅作参考。边界说明追加在请求末尾，不向已有消息插入标记，也不重复大段工具输出。成功后继续原子保存 context_summary、summary_up_to 及重建的 system_prompt_message；错误、截断、空摘要及意外工具调用不会替换历史，已收到的用量保留。

新增保留工具定义的非流式完成接口，避免通用工具响应校验提前丢失空摘要的终态和用量。统一请求构造尊重 ModelRequest.max_output_tokens，未指定时仍使用原有默认值；本次不新增模型输出能力配置或调整全局默认 32K。

验证：

- Core 104 项、LLM 109 项测试通过，真实接口测试默认 ignored。
- Responses 与 Chat Completions 实际 HTTP 请求对比：摘要只在完整历史末尾增加一条要求，系统提示、tools、思考配置与会话缓存标识保持一致，摘要输出预算正确传递。
- 验证摘要落盘、重新加载及追加用户消息后系统提示逐字节一致。
- 验证意外工具调用、空截断输出保留用量且不覆盖旧会话；已有取消和持久化失败回归通过。
- Core 与 LLM 全目标严格 Clippy、格式检查通过。

生成摘要时具备缓存前缀复用条件，不承诺上游一定命中。应用摘要后因历史被替换，首次请求仍需重建缓存。应在输入超过模型实际窗口之前触发压缩，完整历史已经超限时不能依靠此方式绕过上游限制。
