### PR TITLE
fix(core): 稳定 KV cache 上下文与会话恢复

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,18 @@
 [test-groups]
 memory-integration = { max-threads = 1 }
+plugin-runtime-integration = { max-threads = 1 }
 
 [[profile.default.overrides]]
 filter = 'package(=tiangong-memory)'
 test-group = 'memory-integration'
+
+# 只限制 integration_ 标记的真实安装及 WASM/Launcher 集成测试。
+# 规则、状态处理、文件保存等普通单元测试继续按默认并发运行。
+[[profile.default.overrides]]
+filter = '''
+package(=tiangong-plugin-runtime) & (
+    test(plugin_dev::tests::integration_) |
+    binary(/^(declaration_stability|load_and_call|ephemeral_route|official_catalog_e2e|m0_slot_bridge|v2_manifest_contribution|tool_ui_launcher)$/)
+)
+'''
+test-group = 'plugin-runtime-integration'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,7 +12,7 @@ test-group = 'memory-integration'
 filter = '''
 package(=tiangong-plugin-runtime) & (
     test(plugin_dev::tests::integration_) |
-    binary(/^(declaration_stability|load_and_call|ephemeral_route|official_catalog_e2e|m0_slot_bridge|v2_manifest_contribution|tool_ui_launcher)$/)
+    binary(/^(load_and_call|ephemeral_route|official_catalog_e2e|m0_slot_bridge|v2_manifest_contribution|tool_ui_launcher)$/)
 )
 '''
 test-group = 'plugin-runtime-integration'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,9 @@ jobs:
           cargo build -p tiangong-sandbox --bin tiangong-sandbox \
             -p tiangong-plugin-command-sidecar --bin tiangong-command-sidecar \
             -p tiangong-plugin-sidecar --bin test-stdio-host
+          timeout 120 rustup target add wasm32-wasip2
+          timeout 300 env RUSTFLAGS= cargo build -p tiangong-plugin-mcp-wasm \
+            -p tiangong-plugin-skill-wasm --target wasm32-wasip2
       - name: Test crates
         env:
           MATRIX: ${{ needs.changes.outputs.matrix }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,9 +226,6 @@ jobs:
           cargo build -p tiangong-sandbox --bin tiangong-sandbox \
             -p tiangong-plugin-command-sidecar --bin tiangong-command-sidecar \
             -p tiangong-plugin-sidecar --bin test-stdio-host
-          timeout 120 rustup target add wasm32-wasip2
-          timeout 300 env RUSTFLAGS= cargo build -p tiangong-plugin-mcp-wasm \
-            -p tiangong-plugin-skill-wasm --target wasm32-wasip2
       - name: Test crates
         env:
           MATRIX: ${{ needs.changes.outputs.matrix }}

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -267,12 +267,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust for WASM plugin
+      - name: Setup Rust for plugin protocol
         if: matrix.plugin.rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-          targets: wasm32-wasip2
 
       - name: Setup Rust for native plugin
         if: matrix.plugin.native
@@ -344,18 +343,6 @@ jobs:
         env:
           PROTOCOL: ${{ matrix.plugin.protocol }}
         run: cargo clippy --locked -p "$PROTOCOL" --all-targets -- -D warnings
-
-      - name: Check plugin WASM
-        if: matrix.plugin.rust
-        env:
-          WASM: ${{ matrix.plugin.wasm }}
-        run: cargo check --locked -p "$WASM" --target wasm32-wasip2
-
-      - name: Lint plugin WASM
-        if: matrix.plugin.rust
-        env:
-          WASM: ${{ matrix.plugin.wasm }}
-        run: cargo clippy --locked -p "$WASM" --target wasm32-wasip2 -- -D warnings
 
       - name: Check native plugin formatting
         if: matrix.plugin.native

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11413,7 +11413,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-mcp-protocol"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -11421,7 +11421,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-mcp-sidecar"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11537,6 +11537,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "windows-sys 0.61.2",
+ "wiremock",
  "zstd",
 ]
 
@@ -11640,7 +11641,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-skill-protocol"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -11648,7 +11649,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-skill-sidecar"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11537,7 +11537,6 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "windows-sys 0.61.2",
- "wiremock",
  "zstd",
 ]
 

--- a/crates/tiangong-core/src/context/compressor.rs
+++ b/crates/tiangong-core/src/context/compressor.rs
@@ -155,7 +155,12 @@ impl ContextCompressor {
             session_id: Some(session.id.clone()),
             user_input: String::new(),
             context,
-            reasoning_effort,
+            // 摘要只需整理已有事实，降低强度但不切换思考开关。
+            reasoning_effort: if reasoning_effort.is_thinking_enabled() {
+                ReasoningEffort::Low
+            } else {
+                ReasoningEffort::None
+            },
             max_output_tokens: Some(max_output_tokens),
             ..Default::default()
         }
@@ -187,6 +192,7 @@ impl ContextCompressor {
             "请压缩以上对话历史。{merge_hint}\
              以上完整上下文供你理解任务。摘要截止于最后一条符合以下边界描述的历史消息（包含该消息）：{boundary}。\n\
              边界之后的消息将原样保留，只供参考，不要重复写入摘要。不要调用工具。\n\
+             只整理已有信息，尽量缩短思考，仅做必要的简短核对；不要重新推导、扩展分析或解决任务，把输出预算优先用于完整摘要。\n\
              总输出不得超过 {max_output_tokens} tokens，请在达到预算前主动结束。\n\
              保留关键事实、决策、路径、错误和重要结果，删除重复内容、过程性描述和无效工具输出。\n\
              不要回答用户，严格按以下格式输出：\n\n\
@@ -245,7 +251,7 @@ mod tests {
         let request =
             ContextCompressor::summary_request(&session, 2, 10_000, ReasoningEffort::High);
         assert_eq!(request.session_id.as_deref(), Some(session.id.as_str()));
-        assert_eq!(request.reasoning_effort, ReasoningEffort::High);
+        assert_eq!(request.reasoning_effort, ReasoningEffort::Low);
 
         assert_eq!(request.max_output_tokens, Some(10_000));
         assert_eq!(request.context.len(), 4);
@@ -255,6 +261,34 @@ mod tests {
         let instruction = request.context[3].text_content();
         assert!(instruction.contains("不得超过 10000 tokens"));
         assert!(instruction.contains("[[SUMMARY]]"));
+    }
+
+    #[test]
+    fn summary_lowers_effort_without_rewriting_thinking_history() {
+        let mut session = Session::new("thinking-history");
+        session.system_prompt_message = Some(Message::new(MessageRole::System, "固定系统提示"));
+        let mut reply = assistant("已完成核对");
+        reply.reasoning_content = "  保留原始思考\n及空白  ".into();
+        reply.reasoning_signature = Some("original-signature".into());
+        session.messages = vec![user("核对记录"), reply, user("后续问题")];
+        let original = serde_json::to_value(&session).unwrap();
+        let history = serde_json::to_value(session.context()).unwrap();
+
+        for (effort, expected) in [
+            (ReasoningEffort::None, ReasoningEffort::None),
+            (ReasoningEffort::Low, ReasoningEffort::Low),
+            (ReasoningEffort::Medium, ReasoningEffort::Low),
+            (ReasoningEffort::High, ReasoningEffort::Low),
+            (ReasoningEffort::Max, ReasoningEffort::Low),
+        ] {
+            let request = ContextCompressor::summary_request(&session, 2, 10_000, effort);
+            assert_eq!(request.reasoning_effort, expected);
+            let (instruction, prefix) = request.context.split_last().unwrap();
+            assert_eq!(serde_json::to_value(prefix).unwrap(), history);
+            assert_eq!(instruction.role, MessageRole::User);
+            assert!(instruction.text_content().contains("尽量缩短思考"));
+            assert_eq!(serde_json::to_value(&session).unwrap(), original);
+        }
     }
 
     #[test]

--- a/crates/tiangong-core/src/context/compressor.rs
+++ b/crates/tiangong-core/src/context/compressor.rs
@@ -1,4 +1,7 @@
-use crate::model::{ModelRequest, SingleProviderClient, StopReason, TokenUsage};
+use crate::model::{
+    ModelRequest, ReasoningEffort, SingleProviderClient, StopReason, TokenUsage, ToolChoice,
+    ToolSpec,
+};
 use crate::session::{Message, MessagePhase, MessageRole, Session};
 
 /// 判断消息是否为可压缩的有效消息。
@@ -12,6 +15,8 @@ pub(crate) fn is_compressible(message: &Message) -> bool {
 pub struct ContextCompressor {
     session: Session,
     client: SingleProviderClient,
+    tools: Vec<ToolSpec>,
+    reasoning_effort: ReasoningEffort,
 }
 
 #[derive(Debug, Clone)]
@@ -54,8 +59,18 @@ impl std::fmt::Display for CompressionError {
 impl std::error::Error for CompressionError {}
 
 impl ContextCompressor {
-    pub fn new(session: Session, client: SingleProviderClient) -> Self {
-        Self { session, client }
+    pub fn new(
+        session: Session,
+        client: SingleProviderClient,
+        tools: Vec<ToolSpec>,
+        reasoning_effort: ReasoningEffort,
+    ) -> Self {
+        Self {
+            session,
+            client,
+            tools,
+            reasoning_effort,
+        }
     }
 
     pub fn has_pending_messages(&self) -> bool {
@@ -87,13 +102,24 @@ impl ContextCompressor {
         }
 
         let boundary_message_id = self.session.messages[split_point - 1].id.clone();
-        let request = Self::summary_request(&self.session, split_point, max_output_tokens);
+        let request = Self::summary_request(
+            &self.session,
+            split_point,
+            max_output_tokens,
+            self.reasoning_effort,
+        );
         let response = self
             .client
-            .complete_async(&request)
+            .complete_async(&request.with_tools(self.tools.clone(), Some(ToolChoice::None)))
             .await
             .map_err(|error| CompressionError::new(error.to_string()))?;
         let usage = response.usage.clone();
+        if !response.tool_calls.is_empty() || !response.invalid_tool_calls.is_empty() {
+            return Err(CompressionError::with_usage(
+                "上下文压缩返回了工具调用，拒绝提交摘要",
+                usage,
+            ));
+        }
         if response.stop_reason == Some(StopReason::MaxTokens) {
             return Err(CompressionError::with_usage(
                 "上下文压缩输出达到最大 token 限制，拒绝提交截断摘要",
@@ -116,37 +142,30 @@ impl ContextCompressor {
         session: &Session,
         split_point: usize,
         max_output_tokens: u32,
+        reasoning_effort: ReasoningEffort,
     ) -> ModelRequest {
         let split_point = split_point.min(session.messages.len());
-        let start = session.summary_up_to.min(split_point);
-        let mut context = Vec::with_capacity((split_point - start) + 2);
-        if let Some(system) = session.system_prompt_message.as_ref() {
-            context.push(system.clone());
-        }
-        context.extend(
-            session.messages[start..split_point]
-                .iter()
-                .filter(|message| {
-                    is_compressible(message) || message.phase == MessagePhase::CompressedResume
-                })
-                .cloned(),
-        );
+        let mut context = session.context();
         context.push(Message::new(
             MessageRole::User,
-            Self::compress_instruction(session, max_output_tokens),
+            Self::compress_instruction(session, split_point, max_output_tokens),
         ));
 
         ModelRequest {
             session_id: Some(session.id.clone()),
             user_input: String::new(),
             context,
-            reasoning_effort: crate::model::ReasoningEffort::None,
+            reasoning_effort,
             max_output_tokens: Some(max_output_tokens),
             ..Default::default()
         }
     }
 
-    fn compress_instruction(session: &Session, max_output_tokens: u32) -> String {
+    fn compress_instruction(
+        session: &Session,
+        split_point: usize,
+        max_output_tokens: u32,
+    ) -> String {
         let existing_summary = session
             .context_summary
             .as_deref()
@@ -157,8 +176,17 @@ impl ContextCompressor {
         } else {
             ""
         };
+        // 边界说明仅追加在请求末尾，不向原历史插入标记或重复整段工具输出。
+        let boundary = session.messages[..split_point].iter().rev().find(|message| {
+            message.role != MessageRole::System && message.role != MessageRole::Notice
+        }).map(|message| {
+            let tail: String = message.text_content().chars().rev().take(512).collect::<Vec<_>>().into_iter().rev().collect();
+            serde_json::json!({"role":message.role,"tool_call_id":message.tool_call_id,"tool_call_ids":message.tool_calls.iter().map(|call|&call.id).collect::<Vec<_>>(),"text_end":tail})
+        }).unwrap_or(serde_json::Value::Null);
         format!(
             "请压缩以上对话历史。{merge_hint}\
+             以上完整上下文供你理解任务。摘要截止于最后一条符合以下边界描述的历史消息（包含该消息）：{boundary}。\n\
+             边界之后的消息将原样保留，只供参考，不要重复写入摘要。不要调用工具。\n\
              总输出不得超过 {max_output_tokens} tokens，请在达到预算前主动结束。\n\
              保留关键事实、决策、路径、错误和重要结果，删除重复内容、过程性描述和无效工具输出。\n\
              不要回答用户，严格按以下格式输出：\n\n\
@@ -214,8 +242,10 @@ mod tests {
         session.system_prompt_message = Some(Message::new(MessageRole::System, "系统提示"));
         session.messages = vec![user("你好"), assistant("你好，有什么可以帮你？")];
 
-        let request = ContextCompressor::summary_request(&session, 2, 10_000);
+        let request =
+            ContextCompressor::summary_request(&session, 2, 10_000, ReasoningEffort::High);
         assert_eq!(request.session_id.as_deref(), Some(session.id.as_str()));
+        assert_eq!(request.reasoning_effort, ReasoningEffort::High);
 
         assert_eq!(request.max_output_tokens, Some(10_000));
         assert_eq!(request.context.len(), 4);
@@ -232,7 +262,7 @@ mod tests {
         let mut session = Session::new("test");
         session.context_summary = Some("不应重复出现的旧摘要正文".to_string());
 
-        let instruction = ContextCompressor::compress_instruction(&session, 50_000);
+        let instruction = ContextCompressor::compress_instruction(&session, 0, 50_000);
 
         assert!(instruction.contains("系统提示中已经包含此前对话摘要"));
         assert!(!instruction.contains("不应重复出现的旧摘要正文"));
@@ -248,7 +278,8 @@ mod tests {
         resume.phase = MessagePhase::CompressedResume;
         session.messages = vec![resume, assistant("后续交互")];
 
-        let request = ContextCompressor::summary_request(&session, 2, 10_000);
+        let request =
+            ContextCompressor::summary_request(&session, 2, 10_000, ReasoningEffort::None);
 
         assert_eq!(request.context[1].role, MessageRole::User);
         assert_eq!(request.context[1].phase, MessagePhase::CompressedResume);

--- a/crates/tiangong-core/src/core/integration_tests.rs
+++ b/crates/tiangong-core/src/core/integration_tests.rs
@@ -28,6 +28,7 @@ async fn plugin_and_tool_order_survives_core_recreation_and_followup_turns() {
         id: &'static str,
         names: [&'static str; 2],
         calls: AtomicUsize,
+        prompt_reads: AtomicUsize,
     }
     impl Plugin for OrderedPlugin {
         fn id(&self) -> &str {
@@ -38,6 +39,7 @@ async fn plugin_and_tool_order_survives_core_recreation_and_followup_turns() {
     impl ToolOverrideHandler for OrderedPlugin {}
     impl PromptSectionProvider for OrderedPlugin {
         fn prompt_sections(&self) -> Vec<String> {
+            self.prompt_reads.fetch_add(1, Ordering::SeqCst);
             vec![format!("插件提示:{}", self.id)]
         }
     }
@@ -87,6 +89,7 @@ async fn plugin_and_tool_order_survives_core_recreation_and_followup_turns() {
     .into_iter()
     .enumerate()
     {
+        let mut instances = Vec::new();
         let plugins: Vec<Arc<dyn Plugin>> = order
             .into_iter()
             .map(|index| {
@@ -95,11 +98,14 @@ async fn plugin_and_tool_order_survives_core_recreation_and_followup_turns() {
                     ("prompt", ["identity_b", "identity_a"]),
                     ("alpha", ["z_first", "y_first"]),
                 ][index];
-                Arc::new(OrderedPlugin {
+                let plugin = Arc::new(OrderedPlugin {
                     id,
                     names,
                     calls: AtomicUsize::new(generation),
-                }) as Arc<dyn Plugin>
+                    prompt_reads: AtomicUsize::new(0),
+                });
+                instances.push(plugin.clone());
+                plugin as Arc<dyn Plugin>
             })
             .collect();
         let (event_tx, event_rx) = std::sync::mpsc::channel();
@@ -165,6 +171,11 @@ async fn plugin_and_tool_order_survives_core_recreation_and_followup_turns() {
             }
             system_id = Some(current_id);
         }
+        for plugin in instances {
+            let reads = usize::from(generation == 0);
+            assert_eq!(plugin.calls.load(Ordering::SeqCst), generation + reads);
+            assert_eq!(plugin.prompt_reads.load(Ordering::SeqCst), reads);
+        }
         core.shutdown_join().unwrap();
     }
 }
@@ -206,6 +217,66 @@ async fn plain_question_completes_with_done_event() {
     assert!(request.role_message_contains("user", "解释一下贪心算法"));
     routes["plain-answer"].assert_hits(1);
     core.shutdown_join().expect("关闭失败");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn legacy_prompt_is_preserved_until_reset_and_failed_reset_keeps_history() {
+    let (env, sid) = TestEnv::new("legacy-declarations");
+    let server = MockServer::builder().start().await;
+    mount_prompt_router(
+        &server,
+        vec![PromptRoute::new(
+            "answer",
+            |_| true,
+            MockReply::sse(stream_text_chunks(&["完成"])),
+        )],
+    )
+    .await;
+    let (core, _) = core_for(&env, &sid, &server.uri());
+    let mut legacy = env.load_session(&sid);
+    legacy.system_prompt_message = Some(crate::session::Message::new(
+        MessageRole::System,
+        "旧系统提示，必须原样保留",
+    ));
+    legacy.context_summary = Some("旧摘要".into());
+    legacy.try_persist_to_disk().unwrap();
+    send_message(&core, "legacy-first", "继续");
+    assert_eq!(
+        wait_turn_status(&env, &sid, "legacy-first").await,
+        TurnStatus::Success
+    );
+    wait_idle(&sid).await;
+    let before = env.load_session(&sid);
+    assert_eq!(
+        serde_json::to_value(&before.system_prompt_message).unwrap(),
+        serde_json::to_value(&legacy.system_prompt_message).unwrap()
+    );
+    assert_eq!(before.plugin_declarations.as_deref().unwrap().len(), 1);
+    assert!(
+        before.plugin_declarations.as_ref().unwrap()[0]
+            .plugin_id
+            .is_empty()
+    );
+    fail_all_persistence_for_session(&sid);
+    assert!(core.deliver(AgentInputKind::reset_context()).is_err());
+    assert_eq!(
+        serde_json::to_value(env.load_session(&sid)).unwrap(),
+        serde_json::to_value(&before).unwrap()
+    );
+    // 解除故障后再次清理，必须同时移除旧摘要并重建系统提示。
+    clear_persistent_persistence_failure(&sid);
+    core.deliver(AgentInputKind::reset_context()).unwrap();
+    let reset = env.load_session(&sid);
+    assert!(reset.context_summary.is_none());
+    assert_eq!(reset.summary_up_to, reset.messages.len());
+    assert!(
+        !reset
+            .system_prompt_message
+            .unwrap()
+            .text_content()
+            .contains("旧系统提示")
+    );
+    core.shutdown_join().unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -482,8 +553,12 @@ async fn high_pressure_triggers_pre_request_compression() {
 
     let compression = chat_request_at(&server, 1).await;
     assert!(compression.any_message_contains("AUTO-COMPRESS-FIRST"));
-    assert!(!compression.any_message_contains("AUTO-COMPRESS-SECOND"));
-    assert!(compression.defined_tools().is_empty());
+    assert!(compression.any_message_contains("AUTO-COMPRESS-SECOND"));
+    assert_eq!(
+        compression.defined_tools(),
+        chat_request_at(&server, 0).await.defined_tools()
+    );
+    assert!(!compression.allows_tool_calls());
     assert!(
         !compression.is_stream(),
         "压缩沿生产接口使用非流式 completion"

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -65,7 +65,8 @@ pub struct TiangongCore {
     /// 事件输出通道(会话级,跨 turn;clone 给每个 turn task 的 forwarder)。
     stream_tx: Sender<StreamEvent>,
     /// 进程内插件(会话级,跨 turn)。
-    plugins: Vec<Arc<dyn Plugin>>,
+    #[builder(setter(transform = |plugins: Vec<Arc<dyn Plugin>>| Arc::new(std::sync::Mutex::new(crate::core::plugin::PreparedPlugins { plugins, ..Default::default() }))))]
+    plugins: Arc<std::sync::Mutex<crate::core::plugin::PreparedPlugins>>,
     /// on_session_ready 是否已对本 Core 实例执行过（会话级一次性状态，不落盘）。
     /// 首次 turn 置为 true，此后复用同一 Core 的轮次只触发 on_turn_started。
     #[builder(default)]
@@ -83,9 +84,15 @@ impl TiangongCore {
 
     /// 替换该 Core 的独立配置。
     ///
-    /// 配置在下一次 turn 构建 engine 时自动生效（每 turn 现建 engine 会读取最新
-    /// generation），无需显式通知 worker。
+    /// 运行配置在后续 turn 生效；工具及提示声明仅在压缩成功或清理上下文时重新采集。
     pub fn replace_config(&self, config: CoreConfig) -> Result<(), CoreError> {
+        let changed = serde_json::to_value(&*self.config.snapshot()).ok()
+            != serde_json::to_value(&config).ok();
+        if changed && self.session_ready.load(Ordering::Acquire) {
+            for plugin in self.plugin_instances() {
+                plugin.on_config_updated(&config);
+            }
+        }
         self.config.replace(config);
         Ok(())
     }
@@ -106,7 +113,7 @@ impl TiangongCore {
     pub fn set_trust_mode(&self, mode: crate::permission::TrustMode) {
         // Core 和插件立即使用新值；Session 字段由活跃 turn 或下一轮统一写入。
         *self.trust_mode.lock().unwrap_or_else(|p| p.into_inner()) = mode;
-        for plugin in &self.plugins {
+        for plugin in self.plugin_instances() {
             plugin.set_trust_mode(mode);
         }
         if self.is_busy() {
@@ -136,7 +143,7 @@ impl TiangongCore {
     /// 同一 trait。宿主（src-tauri 的 `get_mention_candidates` 命令）经 CoreManager
     /// 调用本方法，不再硬编码 skill/mcp。
     pub fn get_mentions(&self) -> Vec<crate::MentionCandidate> {
-        self.plugins
+        self.plugin_instances()
             .iter()
             .flat_map(|plugin| plugin.mention_candidates())
             .collect()
@@ -233,7 +240,6 @@ impl TiangongCore {
 
         let config = self.config.snapshot();
         let stream_tx = self.stream_tx.clone();
-        let plugins = self.plugins.clone();
         let retry_tx = stream_tx.clone();
         let on_retry: crate::model::OnRetryCallback =
             Arc::new(move |attempt, max_attempts, _delay_ms, error_text| {
@@ -259,17 +265,19 @@ impl TiangongCore {
             SingleProviderClient::new(config.llm.chat.clone()).with_on_retry(on_retry.clone());
         #[cfg(not(test))]
         let lite_client = config.llm.lite.clone().map(SingleProviderClient::new);
-        let prepared_plugins =
-            crate::core::plugin::prepare_plugins(&plugins, &config, trust_mode, &session);
-        // 工具规格与 prompt 段落全部来自 Plugin trait（含声明式插件适配器）。
-        let turn_tools = prepared_plugins.tools;
+        let prepared = self
+            .plugins
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone();
 
         Ok(TurnContext::builder()
             .client(client)
             .lite_client(lite_client)
             .session(session)
             .stream_tx(stream_tx)
-            .plugins(prepared_plugins.plugins)
+            .plugins(prepared.plugins)
+            .prompt_sections(prepared.prompt_sections)
             .context_limit(config.context_limit)
             .agent_config(crate::agent_config::AgentConfig {
                 trust_mode,
@@ -279,9 +287,59 @@ impl TiangongCore {
             })
             .trust_mode(trust_mode)
             .observer(crate::observe::Observer::new(self.storage_root.clone()))
-            .tool_overrides(prepared_plugins.tool_overrides)
-            .tools(turn_tools)
+            .tool_overrides(prepared.tool_overrides)
+            .tools(prepared.tools)
             .build())
+    }
+
+    fn plugin_instances(&self) -> Vec<Arc<dyn Plugin>> {
+        self.plugins
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .plugins
+            .clone()
+    }
+
+    fn initialize_plugins(&self, ctx: &mut TurnContext) -> Result<(), CoreError> {
+        let initializing = !self.session_ready.load(Ordering::Acquire);
+        let needs_persist = initializing || ctx.session.system_prompt_message.is_none();
+        let mut prepared = self
+            .plugins
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if initializing {
+            let initialized = crate::core::plugin::prepare_plugins(
+                &prepared.plugins,
+                &self.config.snapshot(),
+                ctx.trust_mode,
+                &mut ctx.session,
+            );
+            *prepared = initialized;
+        } else if let Some(declarations) = &ctx.session.plugin_declarations {
+            *prepared = crate::core::plugin::PreparedPlugins::restore(
+                prepared.plugins.clone(),
+                declarations,
+            );
+        }
+        ctx.plugins = prepared.plugins.clone();
+        ctx.tools = prepared.tools.clone();
+        ctx.tool_overrides = prepared.tool_overrides.clone();
+        ctx.prompt_sections = prepared.prompt_sections.clone();
+        drop(prepared);
+        if ctx.session.system_prompt_message.is_none() {
+            crate::react::context::rebuild_system_prompt_for_session(
+                &mut ctx.session,
+                &ctx.prompt_sections,
+            );
+        }
+        if needs_persist {
+            ctx.session.try_persist_to_disk().map_err(|error| {
+                tracing::error!(%error, "保存会话插件声明失败");
+                CoreError::WorkerStopped
+            })?;
+        }
+        self.session_ready.store(true, Ordering::Release);
+        Ok(())
     }
 
     /// 空闲起轮：构建上下文 → 校验并保存用户消息（成功才确认）→ spawn turn task。
@@ -307,28 +365,9 @@ impl TiangongCore {
             content_blocks: tiangong_types::stable_content_blocks(&content),
             media: Vec::new(),
         });
-        let session_ready = self.session_ready.clone();
         let core = self.clone();
         crate::shared_runtime::spawn_turn(ctx, move |mut ctx, cmd_rx| {
-            if session_ready
-                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
-            {
-                for plugin in &ctx.plugins {
-                    plugin.on_session_ready(&mut ctx.session);
-                }
-            }
-            let prompt_sections = ctx
-                .plugins
-                .iter()
-                .flat_map(|plugin| plugin.prompt_sections())
-                .collect();
-            ctx.session.rebuild_system_prompt(
-                &crate::prompt::SystemPromptConfig::from_plugin_sections(prompt_sections),
-            );
-            if let Err(error) = ctx.session.try_persist_to_disk() {
-                tracing::warn!(%error, "持久化本轮系统提示失败");
-            }
+            core.initialize_plugins(&mut ctx)?;
             let mut cmd_rx = cmd_rx;
             Ok(async move {
                 run_turn(ctx, &mut cmd_rx).await;
@@ -418,14 +457,7 @@ impl TiangongCore {
         crate::shared_runtime::spawn_turn(ctx, move |mut ctx, mut cmd_rx| {
             // 防御性重建 system prompt：压缩请求需要它承载旧摘要（裸 session 直接
             // 手动压缩时可能缺失）。
-            let prompt_sections = ctx
-                .plugins
-                .iter()
-                .flat_map(|plugin| plugin.prompt_sections())
-                .collect();
-            ctx.session.rebuild_system_prompt(
-                &crate::prompt::SystemPromptConfig::from_plugin_sections(prompt_sections),
-            );
+            core.initialize_plugins(&mut ctx)?;
             Ok(async move {
                 if let Some(crate::react::compression::CompressionInterrupt::Command(command)) =
                     crate::react::compression::run_manual_context_compression(ctx, &mut cmd_rx)
@@ -474,7 +506,9 @@ impl TiangongCore {
         if self.is_busy() {
             return Err(CoreError::Busy);
         }
-        let mut session = self.load_session()?;
+        let mut ctx = self.build_turn_context()?;
+        self.initialize_plugins(&mut ctx)?;
+        let mut session = ctx.session.clone();
         let total = session.messages.len();
         session.summary_up_to = total;
         crate::context::compressor::mark_compact_boundary(&mut session.messages, total);
@@ -482,10 +516,26 @@ impl TiangongCore {
         session.current_tokens = 0;
         session.active_agent_current_tokens = 0;
         session.agent_current_tokens.clear();
+        session.plugin_declarations = Some(crate::core::plugin::collect_declarations(
+            &ctx.plugins,
+            session.plugin_declarations.as_deref().unwrap_or_default(),
+        ));
+        let prepared = crate::core::plugin::PreparedPlugins::restore(
+            ctx.plugins,
+            session.plugin_declarations.as_deref().unwrap(),
+        );
+        crate::react::context::rebuild_system_prompt_for_session(
+            &mut session,
+            &prepared.prompt_sections,
+        );
         session.try_persist_to_disk().map_err(|error| {
             tracing::warn!(%error, session_id = %self.session_id, "清空上下文落盘失败");
             CoreError::WorkerStopped
         })?;
+        *self
+            .plugins
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()) = prepared;
         crate::react::compression::notify_cleared(&self.stream_tx, &session);
         Ok(())
     }
@@ -517,7 +567,7 @@ impl TiangongCore {
     /// 通知型钩子：后台线程投递、不等待完成——关闭会话/退出应用不被任何插件
     /// 无限阻塞（issue #404）。钩子收到只读快照，收尾成败与产出由插件自行负责。
     fn finalize_plugins(&self, session: &Session) {
-        crate::core::plugin::notify_session_ended(&self.plugins, session);
+        crate::core::plugin::notify_session_ended(&self.plugin_instances(), session);
     }
 }
 

--- a/crates/tiangong-core/src/core/plugin/mod.rs
+++ b/crates/tiangong-core/src/core/plugin/mod.rs
@@ -36,4 +36,5 @@ pub use trait_def::Plugin;
 
 pub(crate) use injection::injection_tool_spec;
 pub(crate) use notify::{notify_session_ended, notify_turn_finished};
-pub(crate) use registry::prepare_plugins;
+pub use registry::PreparedPlugins;
+pub(crate) use registry::{collect_declarations, prepare_plugins};

--- a/crates/tiangong-core/src/core/plugin/registry.rs
+++ b/crates/tiangong-core/src/core/plugin/registry.rs
@@ -4,22 +4,24 @@ use std::sync::Arc;
 use crate::core_config::CoreConfig;
 use crate::model::ToolSpec;
 use crate::permission::TrustMode;
-use crate::session::Session;
+use crate::session::{PluginDeclaration, Session};
 use crate::tool_override::ToolOverrideHandler;
 
 use super::{Plugin, injection_tool_spec};
 
-pub(crate) struct PreparedPlugins {
+#[derive(Clone, Default)]
+pub struct PreparedPlugins {
     pub plugins: Vec<Arc<dyn Plugin>>,
     pub tools: Vec<ToolSpec>,
     pub tool_overrides: HashMap<String, Arc<dyn ToolOverrideHandler>>,
+    pub prompt_sections: Vec<String>,
 }
 
 pub(crate) fn prepare_plugins(
     plugins: &[Arc<dyn Plugin>],
     config: &CoreConfig,
     trust_mode: TrustMode,
-    session: &Session,
+    session: &mut Session,
 ) -> PreparedPlugins {
     // 提示与工具共用固定顺序，避免加载顺序变化改写请求前缀。
     let mut sorted: Vec<Arc<dyn Plugin>> = plugins.to_vec();
@@ -49,30 +51,91 @@ pub(crate) fn prepare_plugins(
         plugin.set_workspace(workspace);
         plugin.set_trust_mode(trust_mode);
     }
-
-    let mut tools = vec![injection_tool_spec()];
-    let mut tool_overrides: HashMap<String, Arc<dyn ToolOverrideHandler>> = HashMap::new();
-    let mut seen_tool_names = HashSet::new();
     for plugin in plugins {
-        let mut plugin_tools = plugin.tool_specs();
-        plugin_tools.sort_by(|left, right| left.name.cmp(&right.name));
-        for spec in plugin_tools {
-            if seen_tool_names.insert(spec.name.clone()) {
-                tool_overrides.insert(spec.name.clone(), plugin.clone());
-                tools.push(spec);
-            } else {
-                tracing::debug!(
-                    tool = %spec.name,
-                    plugin = %plugin.id(),
-                    "跳过与其他插件重名的工具规格（保留先注册者）"
-                );
+        plugin.on_session_ready(session);
+    }
+    if session.plugin_declarations.is_none() {
+        session.plugin_declarations = Some(collect_declarations(plugins, &[]));
+    }
+    PreparedPlugins::restore(sorted, session.plugin_declarations.as_deref().unwrap())
+}
+
+pub(crate) fn collect_declarations(
+    plugins: &[Arc<dyn Plugin>],
+    previous: &[PluginDeclaration],
+) -> Vec<PluginDeclaration> {
+    // Core 自带的反馈工具也保存完整定义，避免升级后恢复时悄悄改写 tools。
+    let mut declarations = vec![PluginDeclaration {
+        plugin_id: String::new(),
+        tools: vec![injection_tool_spec()],
+        prompt_sections: Vec::new(),
+    }];
+    for plugin in plugins {
+        let result = plugin.try_tool_specs().and_then(|tools| {
+            plugin
+                .try_prompt_sections()
+                .map(|prompt_sections| PluginDeclaration {
+                    plugin_id: plugin.id().to_string(),
+                    tools,
+                    prompt_sections,
+                })
+        });
+        let mut declaration = match result {
+            Ok(declaration) => declaration,
+            Err(error) => {
+                let Some(previous) = previous.iter().find(|item| item.plugin_id == plugin.id())
+                else {
+                    tracing::warn!(plugin_id = plugin.id(), %error, "声明读取失败且没有历史定义，暂不加入该插件声明");
+                    continue;
+                };
+                tracing::warn!(plugin_id = plugin.id(), %error, "声明读取失败，保留会话原声明");
+                previous.clone()
+            }
+        };
+        declaration
+            .tools
+            .sort_by(|left, right| left.name.cmp(&right.name));
+        declarations.push(declaration);
+    }
+    declarations
+}
+
+impl PreparedPlugins {
+    pub(crate) fn restore(
+        plugins: Vec<Arc<dyn Plugin>>,
+        declarations: &[PluginDeclaration],
+    ) -> Self {
+        let mut tools = Vec::new();
+        let mut tool_overrides: HashMap<String, Arc<dyn ToolOverrideHandler>> = HashMap::new();
+        let mut seen_tool_names = HashSet::new();
+        let mut prompt_sections = Vec::new();
+        for declaration in declarations {
+            prompt_sections.extend(declaration.prompt_sections.clone());
+            let plugin = plugins
+                .iter()
+                .find(|plugin| plugin.id() == declaration.plugin_id);
+            let plugin_tools = declaration.tools.clone();
+            for spec in plugin_tools {
+                if seen_tool_names.insert(spec.name.clone()) {
+                    if let Some(plugin) = plugin {
+                        tool_overrides.insert(spec.name.clone(), plugin.clone());
+                    }
+                    tools.push(spec);
+                } else {
+                    tracing::debug!(
+                        tool = %spec.name,
+                        plugin = %declaration.plugin_id,
+                        "跳过与其他插件重名的工具规格（保留先注册者）"
+                    );
+                }
             }
         }
-    }
 
-    PreparedPlugins {
-        plugins: sorted,
-        tools,
-        tool_overrides,
+        PreparedPlugins {
+            plugins,
+            tools,
+            tool_overrides,
+            prompt_sections,
+        }
     }
 }

--- a/crates/tiangong-core/src/react/compression.rs
+++ b/crates/tiangong-core/src/react/compression.rs
@@ -89,7 +89,12 @@ impl ContextCompression {
         notify_started(ctx);
         Self {
             task: start_task(
-                ContextCompressor::new(ctx.session.clone(), ctx.client.clone()),
+                ContextCompressor::new(
+                    ctx.session.clone(),
+                    ctx.client.clone(),
+                    ctx.tools.clone(),
+                    ctx.agent_config.reasoning_effort,
+                ),
                 organizer,
                 observed_tokens,
                 compression_split_point(&ctx.session),
@@ -233,7 +238,12 @@ pub(crate) async fn run_manual_context_compression(
     let observed_tokens = ctx.session.current_tokens;
     let organizer = ContextOrganizer::new(ctx.context_limit);
 
-    let compressor = ContextCompressor::new(ctx.session.clone(), ctx.client.clone());
+    let compressor = ContextCompressor::new(
+        ctx.session.clone(),
+        ctx.client.clone(),
+        ctx.tools.clone(),
+        ctx.agent_config.reasoning_effort,
+    );
     if !compressor.has_pending_messages() {
         notify_result(&ctx, ContextCompressAction::Noop);
         return None;
@@ -415,11 +425,22 @@ fn apply_compression(
     }
     let current_tokens = update.usage.completion_tokens;
     candidate.current_tokens = current_tokens;
-    rebuild_system_prompt_for_session(&mut candidate, &ctx.plugins);
+    candidate.plugin_declarations = Some(crate::core::plugin::collect_declarations(
+        &ctx.plugins,
+        candidate.plugin_declarations.as_deref().unwrap_or_default(),
+    ));
+    let prepared = crate::core::plugin::PreparedPlugins::restore(
+        ctx.plugins.clone(),
+        candidate.plugin_declarations.as_deref().unwrap(),
+    );
+    rebuild_system_prompt_for_session(&mut candidate, &prepared.prompt_sections);
     candidate
         .try_persist_to_disk()
         .map_err(anyhow::Error::msg)?;
     ctx.session = candidate;
+    ctx.tools = prepared.tools;
+    ctx.tool_overrides = prepared.tool_overrides;
+    ctx.prompt_sections = prepared.prompt_sections;
     Ok(current_tokens)
 }
 
@@ -650,7 +671,7 @@ mod tests {
             session.append_message(MessageRole::User, format!("{round}问题"));
             session.append_message(MessageRole::Assistant, format!("{round}回答"));
         }
-        let (mut ctx, _root) = test_context(session);
+        let (mut ctx, root) = test_context(session);
 
         // 模拟压缩分割点：保留第三轮（最近交互），折叠前两轮。
         let update = update_for(&ctx.session, 0, "前两轮摘要", 4);
@@ -658,6 +679,22 @@ mod tests {
 
         assert_eq!(ctx.session.context_summary.as_deref(), Some("前两轮摘要"));
         assert_eq!(ctx.session.summary_up_to, 4);
+        let saved_prompt = serde_json::to_vec(&ctx.session.system_prompt_message).unwrap();
+        let mut restored = Session::load_from_storage(root.path(), &ctx.session.id).unwrap();
+        assert_eq!(restored.context_summary, ctx.session.context_summary);
+        assert_eq!(restored.summary_up_to, ctx.session.summary_up_to);
+        for question in ["继续", "再核对一次"] {
+            restored.append_message(MessageRole::User, question);
+            let prepared = crate::core::plugin::PreparedPlugins::restore(
+                Vec::new(),
+                restored.plugin_declarations.as_deref().unwrap(),
+            );
+            rebuild_system_prompt_for_session(&mut restored, &prepared.prompt_sections);
+            assert_eq!(
+                serde_json::to_vec(&restored.system_prompt_message).unwrap(),
+                saved_prompt
+            );
+        }
         let context = ctx.session.context();
         assert_eq!(context[0].role, MessageRole::System);
         assert_eq!(context[1].text_content(), "第三轮问题");
@@ -669,6 +706,107 @@ mod tests {
                 .all(|message| message.phase != MessagePhase::CompressedResume),
             "压缩不注入合成续接消息"
         );
+    }
+
+    #[test]
+    fn compression_refreshes_declarations_atomically_and_keeps_unreadable_ones() {
+        use crate::core::plugin::{Plugin, PreparedPlugins};
+        use crate::session::PluginDeclaration;
+        use crate::tool_override::{
+            MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
+        };
+
+        struct ChangingPlugin {
+            fail: bool,
+        }
+        impl Plugin for ChangingPlugin {
+            fn id(&self) -> &str {
+                "changing"
+            }
+        }
+        impl MentionCandidateProvider for ChangingPlugin {}
+        impl ToolOverrideHandler for ChangingPlugin {}
+        impl ToolSpecProvider for ChangingPlugin {
+            fn try_tool_specs(&self) -> std::result::Result<Vec<crate::model::ToolSpec>, String> {
+                if self.fail {
+                    return Err("offline".into());
+                }
+                Ok(vec![crate::model::ToolSpec {
+                    name: "new_tool".into(),
+                    description: "new".into(),
+                    input_schema: serde_json::json!({"type":"object"}),
+                }])
+            }
+        }
+        impl PromptSectionProvider for ChangingPlugin {
+            fn prompt_sections(&self) -> Vec<String> {
+                vec!["new prompt".into()]
+            }
+        }
+
+        for (unreadable, fail_save) in [(false, false), (true, false), (false, true)] {
+            let mut session = Session::new("整理声明");
+            session.append_message(MessageRole::User, "历史问题");
+            session.append_message(MessageRole::Assistant, "历史回答");
+            session.append_message(MessageRole::User, "当前问题");
+            session.plugin_declarations = Some(vec![PluginDeclaration {
+                plugin_id: "changing".into(),
+                tools: vec![crate::model::ToolSpec {
+                    name: "old_tool".into(),
+                    description: "old".into(),
+                    input_schema: serde_json::json!({"type":"object"}),
+                }],
+                prompt_sections: vec!["old prompt".into()],
+            }]);
+            let (mut ctx, root) = test_context(session);
+            ctx.plugins = vec![std::sync::Arc::new(ChangingPlugin { fail: unreadable })];
+            let prepared = PreparedPlugins::restore(
+                ctx.plugins.clone(),
+                ctx.session.plugin_declarations.as_deref().unwrap(),
+            );
+            ctx.tools = prepared.tools;
+            ctx.prompt_sections = prepared.prompt_sections;
+            rebuild_system_prompt_for_session(&mut ctx.session, &ctx.prompt_sections);
+            ctx.session.try_persist_to_disk().unwrap();
+            let old_session = serde_json::to_value(&ctx.session).unwrap();
+            let old_tools = serde_json::to_value(&ctx.tools).unwrap();
+            if fail_save {
+                crate::core::test_support::fail_next_persistence_for_session(&ctx.session.id);
+            }
+            let update = update_for(&ctx.session, 0, "新的摘要", 2);
+            let result = apply_compression(&mut ctx, &update, false);
+            let restored = Session::load_from_storage(root.path(), &ctx.session.id).unwrap();
+            if fail_save {
+                assert!(result.is_err());
+                assert_eq!(serde_json::to_value(&ctx.session).unwrap(), old_session);
+                assert_eq!(serde_json::to_value(&restored).unwrap(), old_session);
+                assert_eq!(serde_json::to_value(&ctx.tools).unwrap(), old_tools);
+            } else {
+                result.unwrap();
+                assert_eq!(restored.context_summary.as_deref(), Some("新的摘要"));
+                let prepared = PreparedPlugins::restore(
+                    Vec::new(),
+                    restored.plugin_declarations.as_deref().unwrap(),
+                );
+                assert_eq!(
+                    serde_json::to_value(prepared.tools).unwrap(),
+                    serde_json::to_value(&ctx.tools).unwrap()
+                );
+                assert_eq!(prepared.prompt_sections, ctx.prompt_sections);
+                assert_eq!(
+                    ctx.prompt_sections,
+                    vec![if unreadable {
+                        "old prompt"
+                    } else {
+                        "new prompt"
+                    }]
+                );
+                assert_eq!(
+                    serde_json::to_value(restored.system_prompt_message).unwrap(),
+                    serde_json::to_value(&ctx.session.system_prompt_message).unwrap()
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/tiangong-core/src/react/context.rs
+++ b/crates/tiangong-core/src/react/context.rs
@@ -47,19 +47,12 @@ pub(super) fn record_call_usage(
     crate::react::message::emit_session_message_upsert(ctx, message_id);
 }
 
-/// 从本轮插件快照收集段落并重建 session 的 system prompt。
+/// 从 Core 已固定的提示段落与会话摘要重建 system prompt，不调用插件。
 ///
 /// 产品身份 / 通用规则 / 自定义指令外围等文案由各插件经 `PromptSectionProvider`
 /// 注入（产品基础文案见 `tiangong-plugin-prompt`），core 不再持有产品文案。
-pub(crate) fn rebuild_system_prompt_for_session(
-    session: &mut Session,
-    plugins: &[std::sync::Arc<dyn crate::core::plugin::Plugin>],
-) {
-    let plugin_sections = plugins
-        .iter()
-        .flat_map(|plugin| plugin.prompt_sections())
-        .collect();
-    let config = SystemPromptConfig::from_plugin_sections(plugin_sections);
+pub(crate) fn rebuild_system_prompt_for_session(session: &mut Session, plugin_sections: &[String]) {
+    let config = SystemPromptConfig::from_plugin_sections(plugin_sections.to_vec());
     session.rebuild_system_prompt(&config);
 }
 

--- a/crates/tiangong-core/src/react/context_cache_tests.rs
+++ b/crates/tiangong-core/src/react/context_cache_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use serde_json::{Value, json};
 
 #[tokio::test]
-async fn compression_request_preserves_full_prefix_tools_and_reasoning() {
+async fn compression_request_preserves_full_prefix_and_tools_with_lower_effort() {
     use crate::context::compressor::ContextCompressor;
     for protocol in [
         ProviderProtocol::OpenAi,
@@ -64,6 +64,10 @@ async fn compression_request_preserves_full_prefix_tools_and_reasoning() {
         assert_eq!(update.summary, "先前结论摘要");
         assert_eq!(update.summary_up_to, 2);
         assert_eq!(
+            harness.ctx.agent_config.reasoning_effort,
+            crate::model::ReasoningEffort::High
+        );
+        assert_eq!(
             serde_json::to_vec(&harness.ctx.session).unwrap(),
             before_session
         );
@@ -76,13 +80,19 @@ async fn compression_request_preserves_full_prefix_tools_and_reasoning() {
         assert_eq!(after["tool_choice"], "none");
         let field = if protocol == ProviderProtocol::OpenAi {
             assert_eq!(before["instructions"], after["instructions"]);
-            assert_eq!(before["reasoning"], after["reasoning"]);
+            assert_eq!(before["reasoning"]["effort"], "high");
+            assert_eq!(after["reasoning"]["effort"], "low");
+            assert_eq!(
+                before["reasoning"]["summary"],
+                after["reasoning"]["summary"]
+            );
             assert_eq!(before["prompt_cache_key"], after["prompt_cache_key"]);
             assert_eq!(after["max_output_tokens"], 4096);
             "input"
         } else {
             assert_eq!(before["thinking"], after["thinking"]);
-            assert_eq!(before["reasoning_effort"], after["reasoning_effort"]);
+            assert_eq!(before["reasoning_effort"], "high");
+            assert_eq!(after["reasoning_effort"], "low");
             assert_eq!(after["max_tokens"], 4096);
             "messages"
         };
@@ -92,6 +102,7 @@ async fn compression_request_preserves_full_prefix_tools_and_reasoning() {
         assert_eq!(&new[..old.len()], old.as_slice());
         assert!(new.last().unwrap().to_string().contains("先前结论"));
         assert!(new.last().unwrap().to_string().contains("不要调用工具"));
+        assert!(new.last().unwrap().to_string().contains("尽量缩短思考"));
     }
 }
 

--- a/crates/tiangong-core/src/react/context_cache_tests.rs
+++ b/crates/tiangong-core/src/react/context_cache_tests.rs
@@ -1,6 +1,154 @@
 use super::*;
 use serde_json::{Value, json};
 
+#[tokio::test]
+async fn compression_request_preserves_full_prefix_tools_and_reasoning() {
+    use crate::context::compressor::ContextCompressor;
+    for protocol in [
+        ProviderProtocol::OpenAi,
+        ProviderProtocol::OpenAiChatCompletions,
+    ] {
+        let server = MockServer::builder().start().await;
+        let mut harness = TestHarness::new_with_protocol(
+            &server,
+            protocol,
+            vec![tool_spec("read_file")],
+            HashMap::new(),
+            Vec::new(),
+        );
+        harness.ctx.agent_config.reasoning_effort = crate::model::ReasoningEffort::High;
+        harness.ctx.session.messages.push(Message::with_reasoning(
+            MessageRole::Assistant,
+            "先前结论",
+            "保留这段历史思考",
+        ));
+        harness
+            .ctx
+            .session
+            .append_message(MessageRole::User, "最新问题仍需原样保留");
+        let before_session = serde_json::to_vec(&harness.ctx.session).unwrap();
+        if protocol == ProviderProtocol::OpenAi {
+            mount_responses(&server, vec![answer("正常回复")], 0, true).await;
+        } else {
+            mount_completion(&server, "正常回复", "stop", 100, 10, None).await;
+        }
+        let req = super::super::build_react_request(&harness.ctx);
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        harness
+            .ctx
+            .client
+            .clone()
+            .stream_async(req.with_tools(harness.ctx.tools.clone(), None), tx)
+            .await
+            .unwrap();
+        if protocol == ProviderProtocol::OpenAi {
+            mount_responses(
+                &server,
+                vec![answer("[[SUMMARY]]\n先前结论摘要")],
+                3904,
+                true,
+            )
+            .await;
+        } else {
+            mount_completion(&server, "[[SUMMARY]]\n先前结论摘要", "stop", 100, 10, None).await;
+        }
+        let update = ContextCompressor::new(
+            harness.ctx.session.clone(),
+            harness.ctx.client.clone(),
+            harness.ctx.tools.clone(),
+            harness.ctx.agent_config.reasoning_effort,
+        )
+        .compress(2, 4096)
+        .await
+        .unwrap();
+        assert_eq!(update.summary, "先前结论摘要");
+        assert_eq!(update.summary_up_to, 2);
+        assert_eq!(
+            serde_json::to_vec(&harness.ctx.session).unwrap(),
+            before_session
+        );
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        let before: Value = serde_json::from_slice(&requests[0].body).unwrap();
+        let after: Value = serde_json::from_slice(&requests[1].body).unwrap();
+        assert_eq!(before["model"], after["model"]);
+        assert_eq!(before["tools"], after["tools"]);
+        assert_eq!(after["tool_choice"], "none");
+        let field = if protocol == ProviderProtocol::OpenAi {
+            assert_eq!(before["instructions"], after["instructions"]);
+            assert_eq!(before["reasoning"], after["reasoning"]);
+            assert_eq!(before["prompt_cache_key"], after["prompt_cache_key"]);
+            assert_eq!(after["max_output_tokens"], 4096);
+            "input"
+        } else {
+            assert_eq!(before["thinking"], after["thinking"]);
+            assert_eq!(before["reasoning_effort"], after["reasoning_effort"]);
+            assert_eq!(after["max_tokens"], 4096);
+            "messages"
+        };
+        let old = before[field].as_array().unwrap();
+        let new = after[field].as_array().unwrap();
+        assert_eq!(new.len(), old.len() + 1);
+        assert_eq!(&new[..old.len()], old.as_slice());
+        assert!(new.last().unwrap().to_string().contains("先前结论"));
+        assert!(new.last().unwrap().to_string().contains("不要调用工具"));
+    }
+}
+
+#[tokio::test]
+async fn compression_rejects_unexpected_tool_calls() {
+    let server = MockServer::builder().start().await;
+    let harness = TestHarness::new_with_protocol(
+        &server,
+        ProviderProtocol::OpenAi,
+        vec![tool_spec("cache_probe")],
+        HashMap::new(),
+        Vec::new(),
+    );
+    mount_responses(
+        &server,
+        vec![
+            answer("[[SUMMARY]]\n不能提交的摘要"),
+            call("unexpected", 0, false, false),
+        ],
+        0,
+        true,
+    )
+    .await;
+    let result = crate::context::compressor::ContextCompressor::new(
+        harness.ctx.session.clone(),
+        harness.ctx.client.clone(),
+        harness.ctx.tools.clone(),
+        crate::model::ReasoningEffort::High,
+    )
+    .compress(1, 4096)
+    .await;
+    let error = result.unwrap_err();
+    assert!(error.message.contains("返回了工具调用"));
+    assert!(error.usage.total_tokens > 0);
+    assert!(harness.ctx.session.context_summary.is_none());
+}
+
+#[tokio::test]
+async fn compression_empty_output_keeps_usage_and_original_session() {
+    let server = MockServer::builder().start().await;
+    let harness = TestHarness::new(&server, vec![tool_spec("read_file")], HashMap::new());
+    mount_completion(&server, "", "length", 100, 4096, None).await;
+    let before = serde_json::to_vec(&harness.ctx.session).unwrap();
+    let result = crate::context::compressor::ContextCompressor::new(
+        harness.ctx.session.clone(),
+        harness.ctx.client.clone(),
+        harness.ctx.tools.clone(),
+        crate::model::ReasoningEffort::High,
+    )
+    .compress(1, 4096)
+    .await;
+    let error = result.unwrap_err();
+    assert!(error.message.contains("最大 token 限制"));
+    assert_eq!(error.usage.completion_tokens, 4096);
+    assert_eq!(serde_json::to_vec(&harness.ctx.session).unwrap(), before);
+}
+
 fn assert_request_prefix(previous: &Value, current: &Value) {
     for field in [
         "model",

--- a/crates/tiangong-core/src/react/execute_tests.rs
+++ b/crates/tiangong-core/src/react/execute_tests.rs
@@ -647,7 +647,7 @@ async fn forced_compression_folds_older_history_and_keeps_latest_tool_batch() {
     let compression_body = String::from_utf8_lossy(&requests[1].body);
     let retry_body = String::from_utf8_lossy(&requests[2].body);
     assert!(first_body.contains("recent-tool-output"));
-    assert!(!compression_body.contains("recent-tool-output"));
+    assert!(compression_body.contains("recent-tool-output"));
     assert!(compression_body.contains("较早回答"));
     assert!(retry_body.contains("recent-tool-output"));
 }

--- a/crates/tiangong-core/src/session.rs
+++ b/crates/tiangong-core/src/session.rs
@@ -119,6 +119,9 @@ pub struct Session {
     /// `context()` 返回时会将其置于消息列表头部，由 `build_provider_messages()` 提取。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_prompt_message: Option<Message>,
+    /// 当前整理周期内固定的插件声明；None 表示尚未迁移的旧会话。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin_declarations: Option<Vec<PluginDeclaration>>,
     pub created_at: String,
     pub updated_at: String,
     /// 父会话 ID（Worker 子会话标注所属的父会话）
@@ -130,6 +133,14 @@ pub struct Session {
     /// 当前 Session 独立的持久化根，仅用于运行时，不写入会话 JSON。
     #[serde(skip)]
     storage_root: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginDeclaration {
+    /// 空 ID 表示 Core 自带的反馈工具，不绑定外部插件。
+    pub plugin_id: String,
+    pub tools: Vec<crate::model::ToolSpec>,
+    pub prompt_sections: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -273,6 +284,7 @@ impl Session {
             context_summary: None,
             summary_up_to: 0,
             system_prompt_message: None,
+            plugin_declarations: None,
             created_at: now.clone(),
             updated_at: now,
             parent_session_id: None,
@@ -309,6 +321,7 @@ impl Session {
             context_summary: None,
             summary_up_to: 0,
             system_prompt_message: None,
+            plugin_declarations: None,
             created_at: now.clone(),
             updated_at: now,
             parent_session_id: None,

--- a/crates/tiangong-core/src/tool_override.rs
+++ b/crates/tiangong-core/src/tool_override.rs
@@ -31,6 +31,10 @@ pub trait ToolOverrideHandler: Send + Sync + 'static {
 /// Plugin 通过此机制向 Agent 注入新的工具定义（ToolSpec）。
 /// 注册后，新工具会与 core 内置工具合并，统一暴露给 LLM。
 pub trait ToolSpecProvider: Send + Sync + 'static {
+    /// 整理会话时保留读取错误，避免把暂时不可用当成删除全部工具。
+    fn try_tool_specs(&self) -> Result<Vec<ToolSpec>, String> {
+        Ok(self.tool_specs())
+    }
     /// 返回该 plugin 暴露的所有工具规格。默认返回空，不暴露新工具的插件无需覆写。
     fn tool_specs(&self) -> Vec<ToolSpec> {
         Vec::new()
@@ -44,6 +48,9 @@ pub trait ToolSpecProvider: Send + Sync + 'static {
 /// 相同配置下必须保持稳定，不应包含当前时间、轮次、自动提取的记忆或成员状态。
 /// 动态信息应经工具结果或追加消息进入上下文，避免改写已发送的请求前缀。
 pub trait PromptSectionProvider: Send + Sync + 'static {
+    fn try_prompt_sections(&self) -> Result<Vec<String>, String> {
+        Ok(self.prompt_sections())
+    }
     /// 返回该 plugin 暴露的所有 prompt 段落（每段会作为独立块拼接到 system prompt）。
     /// 默认返回空，不注入 prompt 的插件无需覆写。
     fn prompt_sections(&self) -> Vec<String> {

--- a/crates/tiangong-core/src/turn_context.rs
+++ b/crates/tiangong-core/src/turn_context.rs
@@ -44,6 +44,9 @@ pub struct TurnContext {
     pub stream_tx: Sender<StreamEvent>,
     /// 本轮使用的插件及生命周期钩子。
     pub plugins: Vec<Arc<dyn Plugin>>,
+    /// 从会话恢复的固定插件提示；仅在压缩成功或清理上下文时重新采集。
+    #[builder(default)]
+    pub prompt_sections: Vec<String>,
     /// 上下文 token 上限
     pub context_limit: usize,
     /// Agent 配置（reasoning_effort 等）

--- a/crates/tiangong-core/tests/declaration_stability.rs
+++ b/crates/tiangong-core/tests/declaration_stability.rs
@@ -1,3 +1,4 @@
+//! Core 声明稳定性测试：直接模拟 Plugin 接口，不加载 WASM 或启动插件服务。
 use serde_json::{Value, json};
 use std::sync::{
     Arc, Mutex,
@@ -7,20 +8,21 @@ use tiangong_core::{
     agent_input::{AgentInput, AgentInputKind},
     core::{Plugin, TiangongCore},
     core_config::{CoreConfig, CoreConfigProvider},
+    model::{ToolCall, ToolSpec},
     permission::TrustMode,
     session::Session,
-};
-use tiangong_plugin_runtime::{
-    PluginRuntimeConfig, SidecarConnection, WasmPluginAdapter, WasmPluginLoader,
+    tool::ToolResult,
+    tool_override::{
+        MentionCandidateProvider, PromptSectionProvider, ToolOverrideHandler, ToolSpecProvider,
+    },
 };
 use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
-
-struct ToggleSidecar {
+struct PluginState {
     available: AtomicBool,
     revision: AtomicUsize,
     calls: Mutex<Vec<String>>,
 }
-impl ToggleSidecar {
+impl PluginState {
     fn new() -> Self {
         Self {
             available: AtomicBool::new(true),
@@ -28,32 +30,78 @@ impl ToggleSidecar {
             calls: Mutex::new(Vec::new()),
         }
     }
-}
-impl SidecarConnection for ToggleSidecar {
-    fn invoke(&self, operation: &str, _: &str) -> anyhow::Result<String> {
+    fn declaration(&self, operation: &str) -> Result<String, String> {
         self.calls.lock().unwrap().push(operation.into());
-        anyhow::ensure!(self.available.load(Ordering::SeqCst), "工具服务暂时不可用");
-        let description = format!("revision-{}", self.revision.load(Ordering::SeqCst));
-        Ok(match operation {
-            "mcp.list_tools" => json!({"servers":[{"server":"probe","tools":[{"name":"read","description":description,"input_schema":{"type":"object"}}]}]}),
-            "get_skill_summary" => json!({"storage_root":"/tmp/skills","items":[{"id":"probe","name":"Probe","description":description}]}),
-            "mcp.execute_tool" => json!({"ok":true,"summary":"完成","stdout":"OK","stderr":"","exit_code":0,"duration_ms":1,"tool_name":"mcp::probe::read","arguments":[]}),
-            _ => json!({}),
-        }.to_string())
+        if !self.available.load(Ordering::SeqCst) {
+            return Err("插件声明暂时不可用".into());
+        }
+        Ok(format!("revision-{}", self.revision.load(Ordering::SeqCst)))
     }
 }
-
-fn adapter(id: &str, sidecar: Arc<ToggleSidecar>) -> Arc<WasmPluginAdapter> {
-    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
-        "../../target/wasm32-wasip2/debug/tiangong_plugin_{id}_wasm.wasm"
-    ));
-    assert!(path.exists(), "先构建 {id} WASM: {}", path.display());
-    let config = PluginRuntimeConfig::default();
-    let loader = WasmPluginLoader::with_sidecar(&config, Some(sidecar)).unwrap();
-    Arc::new(WasmPluginAdapter::new(
-        loader.load_for_plugin(&path, &config, id).unwrap(),
-        config,
-    ))
+struct MockPlugin {
+    id: String,
+    state: Arc<PluginState>,
+}
+impl Plugin for MockPlugin {
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+impl MentionCandidateProvider for MockPlugin {}
+impl ToolSpecProvider for MockPlugin {
+    fn try_tool_specs(&self) -> Result<Vec<ToolSpec>, String> {
+        let description = if self.id == "dynamic-tools" {
+            self.state.declaration("tools")?
+        } else {
+            "固定工具".into()
+        };
+        Ok(vec![ToolSpec {
+            name: "probe_read".into(),
+            description,
+            input_schema: json!({"type":"object","properties":{"path":{"type":"string"}}}),
+        }])
+    }
+}
+impl PromptSectionProvider for MockPlugin {
+    fn try_prompt_sections(&self) -> Result<Vec<String>, String> {
+        if self.id == "dynamic-prompt" {
+            Ok(vec![self.state.declaration("prompt")?])
+        } else {
+            Ok(vec!["固定插件提示".into()])
+        }
+    }
+}
+impl ToolOverrideHandler for MockPlugin {
+    fn handle(
+        &self,
+        call: &ToolCall,
+        _session: &mut Session,
+        _actor_id: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<ToolResult>> + Send>> {
+        let handled = call.name == "probe_read";
+        let ok = self.state.available.load(Ordering::SeqCst);
+        Box::pin(async move {
+            handled.then(|| ToolResult {
+                ok,
+                summary: if ok {
+                    "完成"
+                } else {
+                    "工具暂时不可用"
+                }
+                .into(),
+                stdout: if ok { "OK" } else { "" }.into(),
+                stderr: if ok { "" } else { "工具暂时不可用" }.into(),
+                exit_code: if ok { 0 } else { 1 },
+                execution: None,
+            })
+        })
+    }
+}
+fn plugin(id: &str, state: Arc<PluginState>) -> Arc<dyn Plugin> {
+    Arc::new(MockPlugin {
+        id: id.into(),
+        state,
+    })
 }
 
 fn core(
@@ -115,7 +163,7 @@ async fn send(
 fn reply(call: Option<usize>) -> ResponseTemplate {
     let (message, finish) = match call {
         Some(index) => (
-            json!({"role":"assistant","tool_calls":[{"id":format!("call-{index}"),"type":"function","function":{"name":"mcp__probe__read","arguments":"{\"path\":\"probe\"}"}}]}),
+            json!({"role":"assistant","tool_calls":[{"id":format!("call-{index}"),"type":"function","function":{"name":"probe_read","arguments":"{\"path\":\"probe\"}"}}]}),
             "tool_calls",
         ),
         None => (json!({"role":"assistant","content":"完成"}), "stop"),
@@ -125,18 +173,18 @@ fn reply(call: Option<usize>) -> ResponseTemplate {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn actual_wasm_declarations_survive_core_recreation_and_refresh_on_reset() {
-    for id in ["mcp", "skill"] {
-        let sidecar = Arc::new(ToggleSidecar::new());
+async fn declarations_survive_core_recreation_and_refresh_on_reset() {
+    for id in ["dynamic-tools", "dynamic-prompt"] {
+        let state = Arc::new(PluginState::new());
         let root = tempfile::tempdir().unwrap();
         let server = MockServer::builder().start().await;
         Mock::given(method("POST"))
             .respond_with(reply(None))
             .mount(&server)
             .await;
-        let (core, config, rx, sid) = core(root.path(), &server, adapter(id, sidecar.clone()));
+        let (core, config, rx, sid) = core(root.path(), &server, plugin(id, state.clone()));
         for (round, available) in [true, false, true].into_iter().enumerate() {
-            sidecar.available.store(available, Ordering::SeqCst);
+            state.available.store(available, Ordering::SeqCst);
             core.replace_config(config.clone()).unwrap();
             send(&core, &rx, &format!("继续 {round}")).await;
         }
@@ -152,13 +200,13 @@ async fn actual_wasm_declarations_survive_core_recreation_and_refresh_on_reset()
                 old.as_slice()
             );
         }
-        let operation = if id == "mcp" {
-            "mcp.list_tools"
+        let operation = if id == "dynamic-tools" {
+            "tools"
         } else {
-            "get_skill_summary"
+            "prompt"
         };
         assert_eq!(
-            sidecar
+            state
                 .calls
                 .lock()
                 .unwrap()
@@ -169,8 +217,8 @@ async fn actual_wasm_declarations_survive_core_recreation_and_refresh_on_reset()
         );
         core.shutdown_join().unwrap();
 
-        sidecar.available.store(false, Ordering::SeqCst);
-        sidecar.revision.store(1, Ordering::SeqCst);
+        state.available.store(false, Ordering::SeqCst);
+        state.revision.store(1, Ordering::SeqCst);
         let (tx, rx) = std::sync::mpsc::channel();
         let restored = TiangongCore::builder()
             .session_id(sid.clone())
@@ -179,11 +227,11 @@ async fn actual_wasm_declarations_survive_core_recreation_and_refresh_on_reset()
             .trust_mode(TrustMode::FullTrust)
             .config(CoreConfigProvider::new(config))
             .stream_tx(tx)
-            .plugins(vec![adapter(id, sidecar.clone()) as Arc<dyn Plugin>])
+            .plugins(vec![plugin(id, state.clone()) as Arc<dyn Plugin>])
             .build();
         send(&restored, &rx, "重启后继续").await;
         assert_eq!(
-            sidecar
+            state
                 .calls
                 .lock()
                 .unwrap()
@@ -204,7 +252,7 @@ async fn actual_wasm_declarations_survive_core_recreation_and_refresh_on_reset()
             serde_json::to_value(&before.plugin_declarations).unwrap(),
             serde_json::to_value(&offline.plugin_declarations).unwrap()
         );
-        sidecar.available.store(true, Ordering::SeqCst);
+        state.available.store(true, Ordering::SeqCst);
         restored.deliver(AgentInputKind::reset_context()).unwrap();
         let refreshed = Session::load_from_storage(root.path(), &sid).unwrap();
         assert_ne!(
@@ -214,7 +262,7 @@ async fn actual_wasm_declarations_survive_core_recreation_and_refresh_on_reset()
         send(&restored, &rx, "整理后继续").await;
         let requests = server.received_requests().await.unwrap();
         let next: Value = serde_json::from_slice(&requests.last().unwrap().body).unwrap();
-        if id == "mcp" {
+        if id == "dynamic-tools" {
             assert_ne!(first["tools"], next["tools"]);
         } else {
             assert_ne!(first["messages"][0], next["messages"][0]);
@@ -225,7 +273,7 @@ async fn actual_wasm_declarations_survive_core_recreation_and_refresh_on_reset()
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn failed_execution_and_retry_do_not_change_declarations_or_invent_feedback() {
-    let sidecar = Arc::new(ToggleSidecar::new());
+    let state = Arc::new(PluginState::new());
     let root = tempfile::tempdir().unwrap();
     let server = MockServer::builder().start().await;
     let step = AtomicUsize::new(0);
@@ -236,11 +284,11 @@ async fn failed_execution_and_retry_do_not_change_declarations_or_invent_feedbac
         })
         .mount(&server)
         .await;
-    let (core, _, rx, id) = core(root.path(), &server, adapter("mcp", sidecar.clone()));
+    let (core, _, rx, id) = core(root.path(), &server, plugin("dynamic-tools", state.clone()));
     send(&core, &rx, "初始化").await;
-    sidecar.available.store(false, Ordering::SeqCst);
+    state.available.store(false, Ordering::SeqCst);
     send(&core, &rx, "调用工具").await;
-    sidecar.available.store(true, Ordering::SeqCst);
+    state.available.store(true, Ordering::SeqCst);
     send(&core, &rx, "重试工具").await;
     let requests = server.received_requests().await.unwrap();
     assert_eq!(requests.len(), 5);
@@ -285,7 +333,7 @@ async fn missing_plugin_after_restart_keeps_tools_and_reports_execution_failure(
     let (core, config, rx, sid) = core(
         root.path(),
         &server,
-        adapter("mcp", Arc::new(ToggleSidecar::new())),
+        plugin("dynamic-tools", Arc::new(PluginState::new())),
     );
     send(&core, &rx, "初始化").await;
     core.shutdown_join().unwrap();
@@ -320,9 +368,9 @@ async fn undiscovered_offline_plugin_does_not_block_chat_and_is_added_on_reset()
         .respond_with(reply(None))
         .mount(&server)
         .await;
-    let sidecar = Arc::new(ToggleSidecar::new());
-    sidecar.available.store(false, Ordering::SeqCst);
-    let (core, _, rx, sid) = core(root.path(), &server, adapter("mcp", sidecar.clone()));
+    let state = Arc::new(PluginState::new());
+    state.available.store(false, Ordering::SeqCst);
+    let (core, _, rx, sid) = core(root.path(), &server, plugin("dynamic-tools", state.clone()));
     send(&core, &rx, "离线开始").await;
     let before = Session::load_from_storage(root.path(), &sid).unwrap();
     assert!(
@@ -330,9 +378,9 @@ async fn undiscovered_offline_plugin_does_not_block_chat_and_is_added_on_reset()
             .plugin_declarations
             .unwrap()
             .iter()
-            .any(|item| item.plugin_id == "mcp")
+            .any(|item| item.plugin_id == "dynamic-tools")
     );
-    sidecar.available.store(true, Ordering::SeqCst);
+    state.available.store(true, Ordering::SeqCst);
     send(&core, &rx, "恢复后普通续聊").await;
     core.deliver(AgentInputKind::reset_context()).unwrap();
     send(&core, &rx, "整理后继续").await;

--- a/crates/tiangong-plugin-runtime/Cargo.toml
+++ b/crates/tiangong-plugin-runtime/Cargo.toml
@@ -48,5 +48,6 @@ windows-sys = { workspace = true, features = [
 ] }
 
 [dev-dependencies]
+wiremock = { workspace = true }
 serial_test = { workspace = true }
 tiangong-plugin-command-protocol = { workspace = true }

--- a/crates/tiangong-plugin-runtime/Cargo.toml
+++ b/crates/tiangong-plugin-runtime/Cargo.toml
@@ -48,6 +48,5 @@ windows-sys = { workspace = true, features = [
 ] }
 
 [dev-dependencies]
-wiremock = { workspace = true }
 serial_test = { workspace = true }
 tiangong-plugin-command-protocol = { workspace = true }

--- a/crates/tiangong-plugin-runtime/src/adapter.rs
+++ b/crates/tiangong-plugin-runtime/src/adapter.rs
@@ -12,7 +12,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use crate::sidecar::SidecarConnection;
-use serde_json::Value;
 use tiangong_core::core::Plugin;
 use tiangong_core::core::plugin::PluginFeedbackTx;
 use tiangong_core::core_config::CoreConfig;
@@ -100,6 +99,21 @@ impl WasmPluginAdapter {
 
     pub(crate) fn set_enabled(&self, enabled: bool) {
         self.enabled.store(enabled, Ordering::Release);
+    }
+
+    pub(crate) fn notify_tools_recovered(&self, names: &[String]) {
+        if !self.is_enabled() {
+            return;
+        }
+        if names.is_empty() {
+            return;
+        }
+        if let Some(feedback) = self.feedback_tx.read().ok().and_then(|value| value.clone()) {
+            feedback.inject_tool(
+                "plugin_availability",
+                serde_json::json!({"plugin_id":self.id,"available":true,"tools":names}),
+            );
+        }
     }
 
     pub(crate) fn is_enabled(&self) -> bool {
@@ -392,23 +406,31 @@ impl WasmPluginAdapter {
 // ToolSpecProvider：返回插件声明的工具规格。
 impl ToolSpecProvider for WasmPluginAdapter {
     fn tool_specs(&self) -> Vec<ToolSpec> {
+        self.try_tool_specs().unwrap_or_else(|error| {
+            tracing::error!(%error, "读取 wasm 插件工具规格失败");
+            Vec::new()
+        })
+    }
+
+    fn try_tool_specs(&self) -> Result<Vec<ToolSpec>, String> {
         if !self.is_enabled() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
-        match self.call_wasm_off_runtime(WasmPlugin::tool_specs) {
-            Ok(specs) => specs
-                .into_iter()
-                .map(|s| ToolSpec {
-                    name: s.name,
-                    description: s.description,
-                    input_schema: serde_json::from_str(&s.input_schema).unwrap_or(Value::Null),
-                })
-                .collect(),
-            Err(e) => {
-                tracing::error!("读取 wasm 插件工具规格失败: {e}");
-                Vec::new()
-            }
-        }
+        self.call_wasm_off_runtime(WasmPlugin::tool_specs)
+            .map_err(|error| error.to_string())
+            .and_then(|specs| {
+                specs
+                    .into_iter()
+                    .map(|s| {
+                        Ok(ToolSpec {
+                            name: s.name,
+                            description: s.description,
+                            input_schema: serde_json::from_str(&s.input_schema)
+                                .map_err(|error| error.to_string())?,
+                        })
+                    })
+                    .collect()
+            })
     }
 }
 
@@ -421,7 +443,8 @@ impl ToolOverrideHandler for WasmPluginAdapter {
         actor_id: &str,
     ) -> Pin<Box<dyn Future<Output = Option<ToolResult>> + Send>> {
         if !self.is_enabled() {
-            return Box::pin(async { None });
+            let message = format!("插件 {} 已停用，工具不可用", self.id);
+            return Box::pin(async move { Some(unavailable_tool_result(message)) });
         }
         let arguments = serde_json::to_string(&call.arguments).unwrap_or_else(|_| "{}".into());
         let wit_call = crate::loader::ToolCall {
@@ -440,7 +463,7 @@ impl ToolOverrideHandler for WasmPluginAdapter {
             &session.id,
             session.cwd.trim(),
             actor_id,
-            feedback,
+            feedback.clone(),
         );
         if let Some(sidecar) = &self.sidecar {
             let sidecar = sidecar.clone();
@@ -450,9 +473,11 @@ impl ToolOverrideHandler for WasmPluginAdapter {
             });
         }
         let Some(inner) = self.current_inner() else {
-            return Box::pin(async { None });
+            let message = format!("插件 {} 当前不可用", self.id);
+            return Box::pin(async move { Some(unavailable_tool_result(message)) });
         };
         let config = self.config.clone();
+        let plugin_id = self.id.clone();
         Box::pin(crate::invocation::dispatch(
             invocation.clone(),
             async move {
@@ -462,8 +487,16 @@ impl ToolOverrideHandler for WasmPluginAdapter {
                     })
                 })
                 .await
-                .ok()?
-                .ok()?;
+                .map_err(anyhow::Error::from)
+                .and_then(|result| result);
+                let result = match result {
+                    Ok(result) => result,
+                    Err(error) => {
+                        return Some(unavailable_tool_result(format!(
+                            "插件 {plugin_id} 工具调用失败：{error}"
+                        )));
+                    }
+                };
                 Some(ToolResult {
                     ok: result.ok,
                     summary: result.summary,
@@ -484,19 +517,21 @@ impl ToolOverrideHandler for WasmPluginAdapter {
     }
 }
 
-// PromptSectionProvider：调 WASM 的 prompt-sections 导出，拉取三级记忆注入。
+// PromptSectionProvider：供首次会话初始化及压缩、清理后的声明整理使用。
 impl PromptSectionProvider for WasmPluginAdapter {
     fn prompt_sections(&self) -> Vec<String> {
+        self.try_prompt_sections().unwrap_or_else(|error| {
+            tracing::warn!(%error, "wasm prompt_sections 失败");
+            Vec::new()
+        })
+    }
+
+    fn try_prompt_sections(&self) -> Result<Vec<String>, String> {
         if !self.is_enabled() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
-        match self.call_wasm_off_runtime(WasmPlugin::prompt_sections) {
-            Ok(sections) => sections,
-            Err(e) => {
-                tracing::warn!("wasm prompt_sections 失败: {e}");
-                Vec::new()
-            }
-        }
+        self.call_wasm_off_runtime(WasmPlugin::prompt_sections)
+            .map_err(|error| error.to_string())
     }
 }
 
@@ -539,6 +574,17 @@ where
             .map_err(|e| anyhow::anyhow!("wasm 插件锁中毒: {e}"))?;
         call(&mut plugin)
     })
+}
+
+fn unavailable_tool_result(message: String) -> ToolResult {
+    ToolResult {
+        ok: false,
+        summary: message.clone(),
+        stdout: String::new(),
+        stderr: message,
+        exit_code: 1,
+        execution: None,
+    }
 }
 
 /// 序列化 CoreConfig 为插件配置载荷，并附加主 Chat 模型的能力声明。

--- a/crates/tiangong-plugin-runtime/src/plugin_dev.rs
+++ b/crates/tiangong-plugin-runtime/src/plugin_dev.rs
@@ -515,6 +515,7 @@ mod tests {
     /// 初始化测试配置并准备测试 Launcher 信任链：sidecar 恒走沙箱
     ///（策略表不接受关闭输入），本组测试以测试密钥签名的真实 Launcher
     /// 覆盖安装/签名/调用契约的完整链路。
+    /// 使用此准备步骤的测试以 integration_ 开头，供 nextest 限制重型测试并发。
     fn init_config_with_launcher(root: &Path) {
         let config_dir = root.join("config");
         std::fs::create_dir_all(&config_dir).unwrap();
@@ -768,7 +769,7 @@ await runSidecar({
     /// 插件写会话工作区成功，写存储根之外的路径被沙箱拒绝。
     #[test]
     #[serial_test::serial]
-    fn 按需sidecar_新版上下文工作区成为沙箱写域() {
+    fn integration_按需sidecar_新版上下文工作区成为沙箱写域() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -875,7 +876,7 @@ await runSidecar({
     /// 记录缺失时重新验证入口恢复、卸载清理记录。
     #[test]
     #[serial_test::serial]
-    fn sidecar验证记录_安装生成_重验恢复_卸载清理() {
+    fn integration_sidecar验证记录_安装生成_重验恢复_卸载清理() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -938,62 +939,7 @@ await runSidecar({
 
     #[test]
     #[serial_test::serial]
-    #[cfg(unix)]
-    fn 验证记录保存失败_插件保留并标记异常() {
-        let Some(_node) = find_node_for_test() else {
-            eprintln!("跳过：PATH 中未找到 node");
-            return;
-        };
-        let root = tempfile::tempdir().unwrap();
-        require_native_sandbox!();
-        init_config_with_launcher(root.path());
-        let id = "verify-save-fail-demo";
-        make_project(root.path(), id);
-        make_node_sidecar_release(root.path(), id);
-        // 预先创建只读验证记录目录：sidecar 运行检查成功但记录保存必然
-        // 失败。运行异常不回滚安装——插件保留、标记异常，用户可重试。
-        let verifications = root.path().join("plugins").join(".verifications");
-        std::fs::create_dir_all(&verifications).unwrap();
-        let mut permissions = std::fs::metadata(&verifications).unwrap().permissions();
-        permissions.set_readonly(true);
-        std::fs::set_permissions(&verifications, permissions).unwrap();
-
-        let result = install(root.path(), id, None).expect("记录保存失败不得回滚安装");
-        assert_eq!(result.plugin_id, id);
-        assert!(
-            root.path().join("plugins").join(id).exists(),
-            "插件目录必须保留"
-        );
-        assert!(
-            crate::registry::loaded_verified_sidecar(id).is_none(),
-            "记录保存失败时不得有内存能力快照"
-        );
-        let runtime_error =
-            crate::registry::loaded_runtime_error(id).expect("运行检查失败应登记插件异常状态");
-        assert!(
-            runtime_error.contains("验证记录"),
-            "异常状态应指向记录保存失败: {runtime_error}"
-        );
-
-        // 恢复可写后重新验证：记录恢复，能力快照立即生效。
-        use std::os::unix::fs::PermissionsExt;
-        let permissions = std::fs::Permissions::from_mode(0o755);
-        std::fs::set_permissions(&verifications, permissions).unwrap();
-        crate::registry::reverify_plugin_sidecar(root.path(), id).expect("重新验证应恢复记录");
-        assert_eq!(
-            crate::registry::loaded_verified_sidecar(id),
-            Some(Vec::new()),
-            "重新验证后内存能力快照应立即可见"
-        );
-        assert!(
-            crate::registry::loaded_runtime_error(id).is_none(),
-            "运行检查重新成功后应清除启动异常状态"
-        );
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn 解释器sidecar_创作链自动签名安装_真实调用与篡改拒绝() {
+    fn integration_解释器sidecar_创作链自动签名安装_真实调用与篡改拒绝() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1055,7 +1001,7 @@ await runSidecar({
     /// 调用方插件为已安装的 node demo 插件（install 本体直调装好）。
     #[test]
     #[serial_test::serial]
-    fn 安装授权_五场景() {
+    fn integration_安装授权_五场景() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1128,7 +1074,7 @@ await runSidecar({
     /// 成功安装消费登记（再次安装需重新构建）。
     #[test]
     #[serial_test::serial]
-    fn 指纹核验_篡改产物拒绝与安装消费() {
+    fn integration_指纹核验_篡改产物拒绝与安装消费() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1202,7 +1148,7 @@ await runSidecar({
     /// 失败构建撤销：note(None) 语义清除旧登记后不可安装。
     #[test]
     #[serial_test::serial]
-    fn 失败构建_撤销登记后不可安装() {
+    fn integration_失败构建_撤销登记后不可安装() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1248,7 +1194,7 @@ await runSidecar({
     /// 的机制基础）。
     #[test]
     #[serial_test::serial]
-    fn sidecar观察者_成功调用触发() {
+    fn integration_sidecar观察者_成功调用触发() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1316,7 +1262,7 @@ await runSidecar({
     /// → sidecar 真实调用 → 移除公钥后失效。
     #[test]
     #[serial_test::serial]
-    fn 三方导入_签名归档安装与移除公钥后失效() {
+    fn integration_三方导入_签名归档安装与移除公钥后失效() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1453,7 +1399,7 @@ await runSidecar({
     /// 两种信任来源同时存在时启动门槛必须拒绝（来源不明确）。
     #[test]
     #[serial_test::serial]
-    fn 解释器sidecar_官方签名与本地信任混用拒绝() {
+    fn integration_解释器sidecar_官方签名与本地信任混用拒绝() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1542,7 +1488,7 @@ await runSidecar({
     /// 产物（release/）由 `yarn package` 生成、不入库：CI 无产物时跳过。
     #[test]
     #[serial_test::serial]
-    fn creator真实产物_安装与devkit_init全链路() {
+    fn integration_creator真实产物_安装与devkit_init全链路() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1594,7 +1540,7 @@ await runSidecar({
     #[test]
     #[ignore = "真实 yarn 构建需数分钟与网络，按需显式运行"]
     #[serial_test::serial]
-    fn 从零创建node_sidecar插件_完整旅程() {
+    fn integration_从零创建node_sidecar插件_完整旅程() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1681,7 +1627,7 @@ await runSidecar({
     /// 修改产物被拒，重新登记（等价重新构建）后放行。
     #[test]
     #[serial_test::serial]
-    fn 纯ui插件_构建指纹核验() {
+    fn integration_纯ui插件_构建指纹核验() {
         let root = tempfile::tempdir().unwrap();
         // 纯 UI 产物无 sidecar：安装不触发沙箱内验证，无需原生沙箱环境。
         init_config_with_launcher(root.path());
@@ -1727,7 +1673,7 @@ await runSidecar({
     /// 工具契约（操作名=工具名、ToolOutcome 形状）经 sidecar 真实往返。
     #[test]
     #[serial_test::serial]
-    fn 无界面纯工具插件_安装与工具契约() {
+    fn integration_无界面纯工具插件_安装与工具契约() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1790,7 +1736,7 @@ await runSidecar({
     /// 字节与 MIME（read 走 loaded_plugins 内存表，install 后可用）。
     #[test]
     #[serial_test::serial]
-    fn 插件图标_安装与读取往返() {
+    fn integration_插件图标_安装与读取往返() {
         let root = tempfile::tempdir().unwrap();
         // 纯 UI 产物无 sidecar：安装不触发沙箱内验证，无需原生沙箱环境。
         init_config_with_launcher(root.path());
@@ -1827,7 +1773,7 @@ await runSidecar({
     #[test]
     #[ignore = "Agent Handler 不再自动超时；仅显式取消终止"]
     #[serial_test::serial]
-    fn 直连工具_超时终止进程() {
+    fn integration_直连工具_超时终止进程() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;
@@ -1931,7 +1877,7 @@ await runSidecar({
     #[test]
     #[ignore = "Agent Handler 不再自动超时；并发取消由显式取消链路覆盖"]
     #[serial_test::serial]
-    fn 直连工具_并发隔离与取消归属() {
+    fn integration_直连工具_并发隔离与取消归属() {
         let Some(_node) = find_node_for_test() else {
             eprintln!("跳过：PATH 中未找到 node");
             return;

--- a/crates/tiangong-plugin-runtime/src/protocol.rs
+++ b/crates/tiangong-plugin-runtime/src/protocol.rs
@@ -12,6 +12,14 @@ pub const PROTOCOL_VERSION: &str = "0.1.0";
 /// 由运行时发起的健康检查操作。
 pub const HANDSHAKE_OPERATION: &str = "runtime.handshake";
 
+/// 检测到工具恢复时通知当前活动 Agent，不修改工具声明。
+pub const TOOLS_RECOVERED_CHANNEL: &str = "runtime.tools_recovered";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolsRecovered {
+    pub tools: Vec<String>,
+}
+
 /// 随工具请求透传的宿主权威调用上下文。
 ///
 /// 字段均由宿主调用边界产生。sidecar 不应从页面状态或工具参数推断会话

--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -1155,6 +1155,116 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
+    fn sidecar_check_failures_keep_installation_and_publish_only_after_save() {
+        use crate::verification::SidecarVerification;
+        use std::cell::RefCell;
+
+        let root = tempfile::tempdir().unwrap();
+        let id = format!("verify-{}", scru128::new());
+        let directory = root.path().join("plugins").join(&id);
+        std::fs::create_dir_all(&directory).unwrap();
+        let manifest: PluginManifest = serde_json::from_value(serde_json::json!({
+            "schema_version":2, "id":id, "version":"0.1.0",
+            "permissions":["sidecar.invoke"],
+            "sidecar":{"runtime":"node","entry":"must-not-run.mjs"}
+        }))
+        .unwrap();
+        let manifest_bytes = serde_json::to_vec(&manifest).unwrap();
+        std::fs::write(directory.join(MANIFEST_FILE), &manifest_bytes).unwrap();
+        loaded_plugins().lock().unwrap().insert(
+            id.clone(),
+            LoadedPlugin {
+                directory: directory.clone(),
+                manifest,
+                wasm_bytes: None,
+                component: None,
+                ui_plugin: None,
+                descriptor: None,
+                generation: 1,
+                instances: Vec::new(),
+                ts_instances: Vec::new(),
+                sidecar: None,
+                verified_sidecar: None,
+                load_error: None,
+                runtime_error: None,
+                enabled: true,
+            },
+        );
+        let record = SidecarVerification {
+            plugin_id: id.clone(),
+            plugin_version: "0.1.0".into(),
+            artifact_digest: crate::verification::artifact_digest(&directory).unwrap(),
+            protocol_version: crate::protocol::PROTOCOL_VERSION.into(),
+            capabilities: vec!["tool:probe".into()],
+            verified_at: chrono::Local::now().naive_local().to_string(),
+        };
+
+        // 连续模拟验证失败、保存失败、恢复成功；整个过程不创建外部进程。
+        for failure in ["verify", "save", "none"] {
+            let operations = RefCell::new(Vec::new());
+            post_install_sidecar_check_with(
+                &id,
+                || {
+                    operations.borrow_mut().push("verify");
+                    if failure == "verify" {
+                        return Err(anyhow::anyhow!("模拟验证失败"))
+                            .context("sidecar 完整验证失败");
+                    }
+                    Ok(record.clone())
+                },
+                |verified| {
+                    operations.borrow_mut().push("save");
+                    assert_eq!(verified.plugin_id, id);
+                    assert_eq!(verified.capabilities, record.capabilities);
+                    assert!(
+                        loaded_verified_sidecar(&id).is_none(),
+                        "保存成功前不能发布能力"
+                    );
+                    if failure == "save" {
+                        return Err(anyhow::anyhow!("模拟磁盘写入失败"))
+                            .context("保存验证记录失败");
+                    }
+                    Ok(())
+                },
+            );
+            assert_eq!(
+                std::fs::read(directory.join(MANIFEST_FILE)).unwrap(),
+                manifest_bytes,
+                "失败不能回滚或删除已安装插件"
+            );
+            assert!(loaded_plugins().lock().unwrap().contains_key(&id));
+            if failure == "none" {
+                assert_eq!(
+                    loaded_verified_sidecar(&id),
+                    Some(record.capabilities.clone())
+                );
+                assert!(loaded_runtime_error(&id).is_none(), "恢复后应清除异常");
+            } else {
+                assert!(loaded_verified_sidecar(&id).is_none());
+                let error = loaded_runtime_error(&id).expect("失败应登记异常");
+                assert!(
+                    error.contains(if failure == "verify" {
+                        "模拟验证失败"
+                    } else {
+                        "模拟磁盘写入失败"
+                    }),
+                    "{error}"
+                );
+            }
+            assert_eq!(
+                *operations.borrow(),
+                if failure == "verify" {
+                    vec!["verify"]
+                } else {
+                    vec!["verify", "save"]
+                }
+            );
+        }
+        loaded_plugins().lock().unwrap().remove(&id);
+    }
+
+    #[test]
     fn group_按kind分组保持顺序() {
         let groups = group_mention_candidates(
             vec![
@@ -1807,6 +1917,38 @@ fn load_core_plugin(plugin_id: &str, runtime: RuntimeKind) -> Option<Arc<dyn Plu
     Some(adapter)
 }
 
+pub(crate) fn dispatch_tools_recovered(plugin_id: &str, payload: &str) {
+    let Ok(event) = serde_json::from_str::<crate::protocol::ToolsRecovered>(payload) else {
+        return;
+    };
+    let (wasm, ts) = {
+        let Ok(plugins) = loaded_plugins().lock() else {
+            return;
+        };
+        let Some(loaded) = plugins.get(plugin_id).filter(|plugin| plugin.enabled) else {
+            return;
+        };
+        (
+            loaded
+                .instances
+                .iter()
+                .filter_map(Weak::upgrade)
+                .collect::<Vec<_>>(),
+            loaded
+                .ts_instances
+                .iter()
+                .filter_map(Weak::upgrade)
+                .collect::<Vec<_>>(),
+        )
+    };
+    for adapter in wasm {
+        adapter.notify_tools_recovered(&event.tools);
+    }
+    for adapter in ts {
+        adapter.notify_tools_recovered(&event.tools);
+    }
+}
+
 /// 编译产物：纯 UI 插件（无 wasm）三项均为 None。
 type CompiledPlugin = (
     Option<Arc<wasmtime::component::Component>>,
@@ -2071,11 +2213,24 @@ fn post_install_sidecar_check(storage_root: &Path, plugin_id: &str) {
     let Ok(installed) = find_installed_plugin(storage_root, plugin_id) else {
         return;
     };
-    let check_result = crate::verification::verify_installed_sidecar(storage_root, &installed)
-        .and_then(|record| {
-            crate::verification::save_verification(&installed.directory, &record)?;
-            Ok(record)
-        });
+    post_install_sidecar_check_with(
+        plugin_id,
+        || crate::verification::verify_installed_sidecar(storage_root, &installed),
+        |record| crate::verification::save_verification(&installed.directory, record),
+    );
+}
+
+// 验证和保存是两个外部操作，状态处理只依赖它们的结果。
+// 单元测试可分别注入失败，无需启动真实 sidecar 或改变目录权限。
+fn post_install_sidecar_check_with(
+    plugin_id: &str,
+    verify: impl FnOnce() -> Result<crate::verification::SidecarVerification>,
+    save: impl FnOnce(&crate::verification::SidecarVerification) -> Result<()>,
+) {
+    let check_result = verify().and_then(|record| {
+        save(&record)?;
+        Ok(record)
+    });
     match check_result {
         Ok(record) => {
             refresh_verified_sidecar(plugin_id, record.capabilities);
@@ -2087,7 +2242,7 @@ fn post_install_sidecar_check(storage_root: &Path, plugin_id: &str) {
                 %error,
                 "安装后 sidecar 运行检查失败：插件保持安装，标记运行异常（可重试验证）"
             );
-            set_runtime_error(plugin_id, error.to_string());
+            set_runtime_error(plugin_id, format!("{error:#}"));
         }
     }
 }

--- a/crates/tiangong-plugin-runtime/src/sidecar.rs
+++ b/crates/tiangong-plugin-runtime/src/sidecar.rs
@@ -1455,6 +1455,9 @@ async fn run_notification_connection(
         }
         match serde_json::from_str::<crate::protocol::IpcFrame>(line.trim_end()) {
             Ok(crate::protocol::IpcFrame::Notification { channel, payload }) => {
+                if channel == crate::protocol::TOOLS_RECOVERED_CHANNEL {
+                    crate::registry::dispatch_tools_recovered(plugin_id, &payload);
+                }
                 if let Some(forwarder) = forwarder {
                     forwarder(plugin_id, &channel, &payload);
                 }

--- a/crates/tiangong-plugin-runtime/src/sidecar/stdio.rs
+++ b/crates/tiangong-plugin-runtime/src/sidecar/stdio.rs
@@ -1543,6 +1543,9 @@ fn spawn_stdio_reader(
                         }
                     }
                     IpcFrame::Notification { channel, payload } => {
+                        if channel == crate::protocol::TOOLS_RECOVERED_CHANNEL {
+                            crate::registry::dispatch_tools_recovered(&plugin_id, &payload);
+                        }
                         if let Some(forwarder) = crate::sidecar::sidecar_notification_forwarder() {
                             forwarder(&plugin_id, &channel, &payload);
                         }

--- a/crates/tiangong-plugin-runtime/src/ts_plugin.rs
+++ b/crates/tiangong-plugin-runtime/src/ts_plugin.rs
@@ -45,6 +45,20 @@ pub struct TsPluginAdapter {
 }
 
 impl TsPluginAdapter {
+    pub(crate) fn notify_tools_recovered(&self, names: &[String]) {
+        if !self.enabled.load(Ordering::Acquire) {
+            return;
+        }
+        if names.is_empty() {
+            return;
+        }
+        if let Some(feedback) = self.feedback_tx.read().ok().and_then(|value| value.clone()) {
+            feedback.inject_tool(
+                "plugin_availability",
+                serde_json::json!({"plugin_id":self.id,"available":true,"tools":names}),
+            );
+        }
+    }
     pub(crate) fn from_manifest(
         manifest: &PluginManifest,
         enabled: bool,
@@ -152,10 +166,13 @@ impl ToolOverrideHandler for TsPluginAdapter {
         actor_id: &str,
     ) -> Pin<Box<dyn Future<Output = Option<ToolResult>> + Send>> {
         if !self.is_enabled() {
-            return Box::pin(async { None });
+            let failure = sidecar_tool_failure(&self.id, "插件已停用，工具不可用");
+            return Box::pin(async move { Some(failure) });
         }
         let Some(tool) = self.tool(&call.name) else {
-            return Box::pin(async { None });
+            let failure =
+                sidecar_tool_failure(&self.id, "当前插件已不提供该工具，请重新加载会话能力");
+            return Box::pin(async move { Some(failure) });
         };
         let plugin_id = self.id.clone();
         let call = call.clone();

--- a/crates/tiangong-plugin-runtime/tests/declaration_stability.rs
+++ b/crates/tiangong-plugin-runtime/tests/declaration_stability.rs
@@ -1,0 +1,349 @@
+use serde_json::{Value, json};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+use tiangong_core::{
+    agent_input::{AgentInput, AgentInputKind},
+    core::{Plugin, TiangongCore},
+    core_config::{CoreConfig, CoreConfigProvider},
+    permission::TrustMode,
+    session::Session,
+};
+use tiangong_plugin_runtime::{
+    PluginRuntimeConfig, SidecarConnection, WasmPluginAdapter, WasmPluginLoader,
+};
+use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+
+struct ToggleSidecar {
+    available: AtomicBool,
+    revision: AtomicUsize,
+    calls: Mutex<Vec<String>>,
+}
+impl ToggleSidecar {
+    fn new() -> Self {
+        Self {
+            available: AtomicBool::new(true),
+            revision: AtomicUsize::new(0),
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+}
+impl SidecarConnection for ToggleSidecar {
+    fn invoke(&self, operation: &str, _: &str) -> anyhow::Result<String> {
+        self.calls.lock().unwrap().push(operation.into());
+        anyhow::ensure!(self.available.load(Ordering::SeqCst), "工具服务暂时不可用");
+        let description = format!("revision-{}", self.revision.load(Ordering::SeqCst));
+        Ok(match operation {
+            "mcp.list_tools" => json!({"servers":[{"server":"probe","tools":[{"name":"read","description":description,"input_schema":{"type":"object"}}]}]}),
+            "get_skill_summary" => json!({"storage_root":"/tmp/skills","items":[{"id":"probe","name":"Probe","description":description}]}),
+            "mcp.execute_tool" => json!({"ok":true,"summary":"完成","stdout":"OK","stderr":"","exit_code":0,"duration_ms":1,"tool_name":"mcp::probe::read","arguments":[]}),
+            _ => json!({}),
+        }.to_string())
+    }
+}
+
+fn adapter(id: &str, sidecar: Arc<ToggleSidecar>) -> Arc<WasmPluginAdapter> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
+        "../../target/wasm32-wasip2/debug/tiangong_plugin_{id}_wasm.wasm"
+    ));
+    assert!(path.exists(), "先构建 {id} WASM: {}", path.display());
+    let config = PluginRuntimeConfig::default();
+    let loader = WasmPluginLoader::with_sidecar(&config, Some(sidecar)).unwrap();
+    Arc::new(WasmPluginAdapter::new(
+        loader.load_for_plugin(&path, &config, id).unwrap(),
+        config,
+    ))
+}
+
+fn core(
+    root: &std::path::Path,
+    server: &MockServer,
+    plugin: Arc<dyn Plugin>,
+) -> (
+    TiangongCore,
+    CoreConfig,
+    std::sync::mpsc::Receiver<tiangong_types::StreamEvent>,
+    String,
+) {
+    let mut session = Session::new("稳定声明验证");
+    session.cwd = root.to_string_lossy().into_owned();
+    session.bind_storage_root(root);
+    session.try_persist_to_disk().unwrap();
+    let config = CoreConfig::builder()
+        .with_chat(&server.uri(), "test", "test-model")
+        .with_trust_mode(TrustMode::FullTrust)
+        .build();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let core = TiangongCore::builder()
+        .session_id(session.id.clone())
+        .storage_root(root.to_path_buf())
+        .workspace_dir(root.to_string_lossy())
+        .trust_mode(TrustMode::FullTrust)
+        .config(CoreConfigProvider::new(config.clone()))
+        .stream_tx(tx)
+        .plugins(vec![plugin])
+        .build();
+    (core, config, rx, session.id)
+}
+
+async fn send(
+    core: &TiangongCore,
+    rx: &std::sync::mpsc::Receiver<tiangong_types::StreamEvent>,
+    text: &str,
+) {
+    core.deliver(AgentInputKind::prepared(vec![
+        tiangong_types::ContentBlock::text(text),
+    ]))
+    .unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(12), async {
+        let mut done = false;
+        loop {
+            done |= rx
+                .try_iter()
+                .any(|event| matches!(event, tiangong_types::StreamEvent::Done { .. }));
+            if done && !core.is_busy() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+fn reply(call: Option<usize>) -> ResponseTemplate {
+    let (message, finish) = match call {
+        Some(index) => (
+            json!({"role":"assistant","tool_calls":[{"id":format!("call-{index}"),"type":"function","function":{"name":"mcp__probe__read","arguments":"{\"path\":\"probe\"}"}}]}),
+            "tool_calls",
+        ),
+        None => (json!({"role":"assistant","content":"完成"}), "stop"),
+    };
+    ResponseTemplate::new(200)
+        .set_body_json(json!({"id":"reply","choices":[{"message":message,"finish_reason":finish}]}))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn actual_wasm_declarations_survive_core_recreation_and_refresh_on_reset() {
+    for id in ["mcp", "skill"] {
+        let sidecar = Arc::new(ToggleSidecar::new());
+        let root = tempfile::tempdir().unwrap();
+        let server = MockServer::builder().start().await;
+        Mock::given(method("POST"))
+            .respond_with(reply(None))
+            .mount(&server)
+            .await;
+        let (core, config, rx, sid) = core(root.path(), &server, adapter(id, sidecar.clone()));
+        for (round, available) in [true, false, true].into_iter().enumerate() {
+            sidecar.available.store(available, Ordering::SeqCst);
+            core.replace_config(config.clone()).unwrap();
+            send(&core, &rx, &format!("继续 {round}")).await;
+        }
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 3);
+        let first: Value = serde_json::from_slice(&requests[0].body).unwrap();
+        for request in &requests[1..] {
+            let next: Value = serde_json::from_slice(&request.body).unwrap();
+            assert_eq!(first["tools"], next["tools"]);
+            let old = first["messages"].as_array().unwrap();
+            assert_eq!(
+                &next["messages"].as_array().unwrap()[..old.len()],
+                old.as_slice()
+            );
+        }
+        let operation = if id == "mcp" {
+            "mcp.list_tools"
+        } else {
+            "get_skill_summary"
+        };
+        assert_eq!(
+            sidecar
+                .calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|call| call.as_str() == operation)
+                .count(),
+            1
+        );
+        core.shutdown_join().unwrap();
+
+        sidecar.available.store(false, Ordering::SeqCst);
+        sidecar.revision.store(1, Ordering::SeqCst);
+        let (tx, rx) = std::sync::mpsc::channel();
+        let restored = TiangongCore::builder()
+            .session_id(sid.clone())
+            .storage_root(root.path().to_path_buf())
+            .workspace_dir(root.path().to_string_lossy())
+            .trust_mode(TrustMode::FullTrust)
+            .config(CoreConfigProvider::new(config))
+            .stream_tx(tx)
+            .plugins(vec![adapter(id, sidecar.clone()) as Arc<dyn Plugin>])
+            .build();
+        send(&restored, &rx, "重启后继续").await;
+        assert_eq!(
+            sidecar
+                .calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|call| call.as_str() == operation)
+                .count(),
+            1
+        );
+        let requests = server.received_requests().await.unwrap();
+        let replay: Value = serde_json::from_slice(&requests.last().unwrap().body).unwrap();
+        assert_eq!(first["tools"], replay["tools"]);
+        assert_eq!(first["messages"][0], replay["messages"][0]);
+
+        let before = Session::load_from_storage(root.path(), &sid).unwrap();
+        restored.deliver(AgentInputKind::reset_context()).unwrap();
+        let offline = Session::load_from_storage(root.path(), &sid).unwrap();
+        assert_eq!(
+            serde_json::to_value(&before.plugin_declarations).unwrap(),
+            serde_json::to_value(&offline.plugin_declarations).unwrap()
+        );
+        sidecar.available.store(true, Ordering::SeqCst);
+        restored.deliver(AgentInputKind::reset_context()).unwrap();
+        let refreshed = Session::load_from_storage(root.path(), &sid).unwrap();
+        assert_ne!(
+            serde_json::to_value(&before.plugin_declarations).unwrap(),
+            serde_json::to_value(&refreshed.plugin_declarations).unwrap()
+        );
+        send(&restored, &rx, "整理后继续").await;
+        let requests = server.received_requests().await.unwrap();
+        let next: Value = serde_json::from_slice(&requests.last().unwrap().body).unwrap();
+        if id == "mcp" {
+            assert_ne!(first["tools"], next["tools"]);
+        } else {
+            assert_ne!(first["messages"][0], next["messages"][0]);
+        }
+        restored.shutdown_join().unwrap();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_execution_and_retry_do_not_change_declarations_or_invent_feedback() {
+    let sidecar = Arc::new(ToggleSidecar::new());
+    let root = tempfile::tempdir().unwrap();
+    let server = MockServer::builder().start().await;
+    let step = AtomicUsize::new(0);
+    Mock::given(method("POST"))
+        .respond_with(move |_: &wiremock::Request| {
+            let step = step.fetch_add(1, Ordering::SeqCst);
+            reply(matches!(step, 1 | 3).then_some(step))
+        })
+        .mount(&server)
+        .await;
+    let (core, _, rx, id) = core(root.path(), &server, adapter("mcp", sidecar.clone()));
+    send(&core, &rx, "初始化").await;
+    sidecar.available.store(false, Ordering::SeqCst);
+    send(&core, &rx, "调用工具").await;
+    sidecar.available.store(true, Ordering::SeqCst);
+    send(&core, &rx, "重试工具").await;
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 5);
+    let first: Value = serde_json::from_slice(&requests[0].body).unwrap();
+    let last: Value = serde_json::from_slice(&requests[4].body).unwrap();
+    for request in &requests[1..] {
+        let next: Value = serde_json::from_slice(&request.body).unwrap();
+        assert_eq!(first["tools"], next["tools"]);
+        assert_eq!(first["messages"][0], next["messages"][0]);
+    }
+    assert!(
+        String::from_utf8_lossy(&requests[2].body).contains("暂时不可用"),
+        "{}",
+        String::from_utf8_lossy(&requests[2].body)
+    );
+    assert!(!last["messages"].to_string().contains("plugin_availability"));
+    let session = Session::load_from_storage(root.path(), &id).unwrap();
+    assert_eq!(
+        session
+            .messages
+            .iter()
+            .flat_map(|message| &message.tool_calls)
+            .filter(|call| call.arguments["source"] == "plugin_availability")
+            .count(),
+        0
+    );
+    core.shutdown_join().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_plugin_after_restart_keeps_tools_and_reports_execution_failure() {
+    let root = tempfile::tempdir().unwrap();
+    let server = MockServer::builder().start().await;
+    let step = AtomicUsize::new(0);
+    Mock::given(method("POST"))
+        .respond_with(move |_: &wiremock::Request| {
+            let step = step.fetch_add(1, Ordering::SeqCst);
+            reply((step == 1).then_some(step))
+        })
+        .mount(&server)
+        .await;
+    let (core, config, rx, sid) = core(
+        root.path(),
+        &server,
+        adapter("mcp", Arc::new(ToggleSidecar::new())),
+    );
+    send(&core, &rx, "初始化").await;
+    core.shutdown_join().unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let restored = TiangongCore::builder()
+        .session_id(sid)
+        .storage_root(root.path().to_path_buf())
+        .workspace_dir(root.path().to_string_lossy())
+        .trust_mode(TrustMode::FullTrust)
+        .config(CoreConfigProvider::new(config))
+        .stream_tx(tx)
+        .plugins(Vec::new())
+        .build();
+    send(&restored, &rx, "调用原工具").await;
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 3);
+    let first: Value = serde_json::from_slice(&requests[0].body).unwrap();
+    for request in &requests[1..] {
+        let next: Value = serde_json::from_slice(&request.body).unwrap();
+        assert_eq!(first["tools"], next["tools"]);
+        assert_eq!(first["messages"][0], next["messages"][0]);
+    }
+    assert!(String::from_utf8_lossy(&requests[2].body).contains("未注册的工具"));
+    restored.shutdown_join().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn undiscovered_offline_plugin_does_not_block_chat_and_is_added_on_reset() {
+    let root = tempfile::tempdir().unwrap();
+    let server = MockServer::builder().start().await;
+    Mock::given(method("POST"))
+        .respond_with(reply(None))
+        .mount(&server)
+        .await;
+    let sidecar = Arc::new(ToggleSidecar::new());
+    sidecar.available.store(false, Ordering::SeqCst);
+    let (core, _, rx, sid) = core(root.path(), &server, adapter("mcp", sidecar.clone()));
+    send(&core, &rx, "离线开始").await;
+    let before = Session::load_from_storage(root.path(), &sid).unwrap();
+    assert!(
+        !before
+            .plugin_declarations
+            .unwrap()
+            .iter()
+            .any(|item| item.plugin_id == "mcp")
+    );
+    sidecar.available.store(true, Ordering::SeqCst);
+    send(&core, &rx, "恢复后普通续聊").await;
+    core.deliver(AgentInputKind::reset_context()).unwrap();
+    send(&core, &rx, "整理后继续").await;
+    let requests = server.received_requests().await.unwrap();
+    let bodies: Vec<Value> = requests
+        .iter()
+        .map(|request| serde_json::from_slice(&request.body).unwrap())
+        .collect();
+    assert_eq!(bodies.len(), 3);
+    assert_eq!(bodies[0]["tools"], bodies[1]["tools"]);
+    assert_eq!(bodies[0]["tools"].as_array().unwrap().len(), 1);
+    assert_eq!(bodies[2]["tools"].as_array().unwrap().len(), 2);
+    core.shutdown_join().unwrap();
+}

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -250,6 +250,10 @@ wit_bindgen::generate!({
 - `open-view`、`get-view-resource`、`handle-view-message`：提供页面和双向消息。
 - `shutdown`：释放 WASM 内部状态。
 
+`tool-specs` 与 `prompt-sections` 首次采集后按插件顺序保存到会话，并由 Core 的 `PreparedPlugins` 使用。普通 turn 和 Core 重建恢复这份声明，不按工具的临时健康状态重新增删。压缩成功或清理上下文时重新采集，与摘要和系统提示一起保存；读取失败沿用该插件的旧声明，不能把错误伪装成空列表。执行权限和可用性仍在调用入口检查。
+
+工具不可用时，`handle-tool` 返回明确的失败结果。sidecar 检测到恢复后，可用现有 Notification 帧发送 `runtime.tools_recovered`，payload 为 `{"tools":["模型可见的工具名"]}`。宿主通过插件反馈通道向相关的活动 Agent 追加 `plugin_availability` 信息，不修改 system prompt/tools，也不唤醒已结束 turn。后台恢复事件应只在不可用到可用的转换时发送，避免重复通知。
+
 宿主导入目前包括：
 
 - `clock.now-millis`：读取真实时间。

--- a/plugins/tiangong-plugin-mcp/plugin.json
+++ b/plugins/tiangong-plugin-mcp/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "wasm": {
     "binary": "tiangong_plugin_mcp_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-mcp/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-mcp/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-mcp-protocol"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-mcp/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-mcp/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-mcp-sidecar"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "MCP 独立 sidecar 进程（承载 rmcp 客户端、capability 探测原生运行）"

--- a/plugins/tiangong-plugin-mcp/sidecar/src/capability.rs
+++ b/plugins/tiangong-plugin-mcp/sidecar/src/capability.rs
@@ -220,6 +220,7 @@ impl McpCapabilityIndex {
                     guard.insert(server.name.clone(), capability);
                 }
             } else {
+                emit_recovery_if_needed(&server.name, guard.get(&server.name), &capability);
                 guard.insert(server.name.clone(), capability);
             }
         }
@@ -266,18 +267,29 @@ impl McpCapabilityIndex {
             .map(|entry| entry.tools.clone())
     }
 
-    /// 读取所有 healthy server 的工具列表（供 tool spec 生成）。
+    /// 工具声明沿用已发现缓存，健康状态仅用于执行及界面显示。
     pub fn cached_active_tools(&self) -> Vec<(String, Vec<McpToolMeta>)> {
         self.index
             .read()
             .map(|guard| {
                 guard
                     .iter()
-                    .filter(|(_, capability)| capability.healthy)
                     .map(|(name, capability)| (name.clone(), capability.tools.clone()))
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default()
+    }
+
+    pub fn record_success(&self, server_name: &str) {
+        if let Ok(mut index) = self.index.write()
+            && let Some(current) = index.get_mut(server_name)
+            && !current.healthy
+        {
+            let previous = current.clone();
+            current.healthy = true;
+            current.last_error = None;
+            emit_recovery_if_needed(server_name, Some(&previous), current);
+        }
     }
 
     /// 所有 server 的健康状态（供前端健康面板）。
@@ -303,6 +315,116 @@ impl McpCapabilityIndex {
 impl Default for McpCapabilityIndex {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn emit_recovery_if_needed(
+    name: &str,
+    previous: Option<&McpServerCapability>,
+    current: &McpServerCapability,
+) {
+    let Some(event) = recovery_event(name, previous, current) else {
+        return;
+    };
+    if let Ok(payload) = serde_json::to_string(&event) {
+        tiangong_plugin_sidecar::server::emit_notification(
+            tiangong_plugin_runtime::protocol::TOOLS_RECOVERED_CHANNEL,
+            payload,
+        );
+    }
+}
+
+fn recovery_event(
+    name: &str,
+    previous: Option<&McpServerCapability>,
+    current: &McpServerCapability,
+) -> Option<tiangong_plugin_runtime::protocol::ToolsRecovered> {
+    if !previous.is_some_and(|previous| !previous.healthy) || !current.healthy {
+        return None;
+    }
+    let tools = current
+        .tools
+        .iter()
+        .map(|tool| crate::execution::resolve_mcp_function_name(name, &tool.name))
+        .collect::<Vec<_>>();
+    if tools.is_empty() {
+        return None;
+    }
+    Some(tiangong_plugin_runtime::protocol::ToolsRecovered { tools })
+}
+
+#[cfg(test)]
+mod declaration_tests {
+    use super::*;
+    #[test]
+    fn unhealthy_tools_remain_declared_after_disk_reload() {
+        let index = McpCapabilityIndex::new();
+        let tools = vec![serde_json::from_value(serde_json::json!({"name":"read","description":"fixed","input_schema":{"type":"object"}})).unwrap()];
+        let healthy = McpServerCapability {
+            tools,
+            healthy: true,
+            ..Default::default()
+        };
+        index
+            .index
+            .write()
+            .unwrap()
+            .insert("probe".into(), healthy.clone());
+        let before = serde_json::to_value(index.cached_active_tools()).unwrap();
+        index
+            .index
+            .write()
+            .unwrap()
+            .get_mut("probe")
+            .unwrap()
+            .healthy = false;
+        assert_eq!(
+            serde_json::to_value(index.cached_active_tools()).unwrap(),
+            before
+        );
+        assert!(!index.health_statuses()[0].healthy);
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("cache.json");
+        index.persist_cache(&path).unwrap();
+        let restored = McpCapabilityIndex::new();
+        restored.load_cache(&path).unwrap();
+        assert_eq!(
+            serde_json::to_value(restored.cached_active_tools()).unwrap(),
+            before
+        );
+        let offline = restored.index.read().unwrap()["probe"].clone();
+        assert!(recovery_event("probe", Some(&healthy), &healthy).is_none());
+        assert!(recovery_event("probe", None, &healthy).is_none());
+        let event = recovery_event("probe", Some(&offline), &healthy).unwrap();
+        assert_eq!(event.tools, vec!["mcp__probe__read"]);
+        restored.record_success("probe");
+        assert_eq!(
+            serde_json::to_value(restored.cached_active_tools()).unwrap(),
+            before
+        );
+        assert!(restored.health_statuses()[0].healthy);
+    }
+
+    #[tokio::test]
+    async fn explicit_disable_still_blocks_declarations_and_execution() {
+        let config: McpConfig = serde_json::from_value(serde_json::json!({"enabled":false,"servers":[{"name":"probe","command":"must-not-run"}]})).unwrap();
+        let declared = vec![(
+            "probe".into(),
+            vec![serde_json::from_value(serde_json::json!({"name":"read"})).unwrap()],
+        )];
+        assert!(
+            crate::execution::list_tools_response(&config, declared)
+                .servers
+                .is_empty()
+        );
+        let target = crate::execution::McpFunctionTarget {
+            server_name: "probe".into(),
+            tool_name: "read".into(),
+        };
+        let error = crate::execution::execute_tool(&target, serde_json::json!({}), &config, None)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("已停用"));
     }
 }
 
@@ -363,6 +485,7 @@ fn refresh_mcp_capabilities(
                 }
                 continue;
             }
+            emit_recovery_if_needed(&name, guard.get(&name), &capability);
             guard.insert(name, capability);
         }
         // 清理已移除或禁用的服务器

--- a/plugins/tiangong-plugin-mcp/sidecar/src/execution.rs
+++ b/plugins/tiangong-plugin-mcp/sidecar/src/execution.rs
@@ -22,7 +22,7 @@ pub struct McpFunctionTarget {
     pub tool_name: String,
 }
 
-/// 构建 sidecar 的 `list_tools` 响应：每个健康 server → 其工具列表。
+/// 构建 sidecar 的声明列表；健康状态不删减声明，显式禁用仍生效。
 pub fn list_tools_response(
     mcp_config: &McpConfig,
     active: Vec<(String, Vec<McpToolMeta>)>,
@@ -121,6 +121,9 @@ pub async fn execute_tool(
     mcp_config: &McpConfig,
     workspace: Option<PathBuf>,
 ) -> Result<ExecuteToolResponse> {
+    if !mcp_config.enabled {
+        return Err(anyhow!("MCP 已停用，拒绝执行工具"));
+    }
     let started = Instant::now();
     let server = find_mcp_server(mcp_config, &target.server_name).ok_or_else(|| {
         anyhow!(

--- a/plugins/tiangong-plugin-mcp/sidecar/src/service.rs
+++ b/plugins/tiangong-plugin-mcp/sidecar/src/service.rs
@@ -293,6 +293,9 @@ impl McpService {
                             exit_code: 1,
                             ..Default::default()
                         });
+                if result.ok {
+                    self.capability.record_success(&target.server_name);
+                }
                 Ok(serde_json::to_value(result)?)
             }
             tiangong_plugin_mcp_protocol::env::ENV_COLLECT_OPERATION => {

--- a/plugins/tiangong-plugin-mcp/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-mcp/wasm/src/lib.rs
@@ -77,12 +77,12 @@ impl Guest for Component {
     }
 
     fn tool_specs() -> Result<Vec<ToolSpec>, PluginError> {
-        // 动态工具：每次从 sidecar 拉取健康 server 的工具列表。
+        // 声明与健康状态分离；通信失败由宿主保留最近一次成功快照。
         let response: ListToolsResponse = match sidecar_client::invoke::<ListTools>(&Empty {}) {
             Ok(response) => response,
             Err(error) => {
                 tracing_like_warn(&format!("MCP tool_specs 拉取失败: {error}"));
-                return Ok(Vec::new());
+                return Err(plugin_err(format!("读取 MCP 工具声明失败: {error}")));
             }
         };
         let specs = response

--- a/plugins/tiangong-plugin-skill/plugin.json
+++ b/plugins/tiangong-plugin-skill/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "id": "skill",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "wasm": {
     "binary": "tiangong_plugin_skill_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-skill/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-skill/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-skill-protocol"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-skill/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-skill/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-skill-sidecar"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Skill 独立 sidecar 进程（承载 skill 注册表扫描、skill.toml 读写与审计日志）"

--- a/plugins/tiangong-plugin-skill/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-skill/wasm/src/lib.rs
@@ -45,11 +45,7 @@ impl Guest for Component {
     }
 
     fn tool_specs() -> Result<Vec<ToolSpec>, PluginError> {
-        // 仅当存在 enabled skill 时才暴露 get_skill_detail 工具。
-        let summary = load_summary().unwrap_or_default();
-        if summary.items.is_empty() {
-            return Ok(Vec::new());
-        }
+        // 工具声明固定；具体 Skill 是否存在或可用，在调用时检查。
         Ok(vec![ToolSpec {
             name: TOOL_GET_SKILL_DETAIL.to_string(),
             description: "获取已安装 Skill 的完整使用说明。".to_string(),
@@ -59,7 +55,7 @@ impl Guest for Component {
     }
 
     fn prompt_sections() -> Result<Vec<String>, PluginError> {
-        Ok(build_prompt_sections())
+        build_prompt_sections()
     }
 
     fn handle_tool(call: ToolCall) -> Result<ToolResult, PluginError> {
@@ -154,11 +150,13 @@ fn handle_get_skill_detail(call: &ToolCall) -> Result<ToolResult, PluginError> {
 // ── prompt 段落组装 ─────────────────────────────────────────────
 
 /// 构造 3 段 system prompt：已安装 skill 摘要、允许文件操作目录、创建规范。
-fn build_prompt_sections() -> Vec<String> {
+fn build_prompt_sections() -> Result<Vec<String>, PluginError> {
     let mut sections = Vec::new();
 
     // 段落 1：已安装 Skills 摘要（条件注入）。
-    if let Some(summary) = load_summary() {
+    let summary = sidecar_client::invoke::<GetSkillSummary>(&Empty {})
+        .map_err(|error| plugin_err(format!("读取 Skill 提示声明失败: {error}")))?;
+    {
         if !summary.items.is_empty() {
             let mut lines = String::from(
                 "已安装的 Skills（如果 Skill 能处理用户请求，优先调用 get_skill_detail 获取完整说明，然后按文档使用 run_command/run_shell 执行对应脚本）：\n",
@@ -181,7 +179,7 @@ fn build_prompt_sections() -> Vec<String> {
         sections.push(skill_creation_guide(&summary.storage_root));
     }
 
-    sections
+    Ok(sections)
 }
 
 /// skill 创建规范模板（对齐原 prompt.rs 的 skill_creation_guide）。

--- a/scripts/pre-commit-affected-crates.sh
+++ b/scripts/pre-commit-affected-crates.sh
@@ -102,6 +102,9 @@ case "$sub" in
       fi
     done
     if [[ "$prepare_runtime_test_binaries" == "true" ]]; then
+      timeout 120 rustup target add wasm32-wasip2
+      timeout 300 cargo build -p tiangong-plugin-mcp-wasm \
+        -p tiangong-plugin-skill-wasm --target wasm32-wasip2
       cargo build -p tiangong-sandbox --bin tiangong-sandbox \
         -p tiangong-plugin-command-sidecar --bin tiangong-command-sidecar \
         -p tiangong-plugin-sidecar --bin test-stdio-host

--- a/scripts/pre-commit-affected-crates.sh
+++ b/scripts/pre-commit-affected-crates.sh
@@ -21,24 +21,21 @@ shift || true
 # 用 if [[ ]] 模式匹配 + sort -u 去重，兼容老版本 bash，避免 case 在命令替换内的解析问题
 crates="$(
   for f in "$@"; do
-    if [[ "$f" == plugins/tiangong-plugin-memory/protocol/* ]]; then
+    # WASM 的真实目标编译由发布流程承担；提交阶段仍执行 rustfmt。
+    if [[ "$f" == plugins/*/wasm/* ]]; then
+      continue
+    elif [[ "$f" == plugins/tiangong-plugin-memory/protocol/* ]]; then
       printf '%s\n' "tiangong-plugin-memory-protocol"
     elif [[ "$f" == plugins/tiangong-plugin-memory/sidecar/* ]]; then
       printf '%s\n' "tiangong-plugin-memory-sidecar"
-    elif [[ "$f" == plugins/tiangong-plugin-memory/wasm/* ]]; then
-      printf '%s\n' "tiangong-plugin-memory-wasm"
     elif [[ "$f" == plugins/tiangong-plugin-mcp/protocol/* ]]; then
       printf '%s\n' "tiangong-plugin-mcp-protocol"
     elif [[ "$f" == plugins/tiangong-plugin-mcp/sidecar/* ]]; then
       printf '%s\n' "tiangong-plugin-mcp-sidecar"
-    elif [[ "$f" == plugins/tiangong-plugin-mcp/wasm/* ]]; then
-      printf '%s\n' "tiangong-plugin-mcp-wasm"
     elif [[ "$f" == plugins/tiangong-plugin-index/protocol/* ]]; then
       printf '%s\n' "tiangong-plugin-index-protocol"
     elif [[ "$f" == plugins/tiangong-plugin-index/sidecar/* ]]; then
       printf '%s\n' "tiangong-plugin-index-sidecar"
-    elif [[ "$f" == plugins/tiangong-plugin-index/wasm/* ]]; then
-      printf '%s\n' "tiangong-plugin-index-wasm"
     elif [[ "$f" == plugins/tiangong-plugin-scheduler/protocol/* ]]; then
       printf '%s\n' "tiangong-plugin-scheduler-protocol"
     elif [[ "$f" == plugins/tiangong-plugin-scheduler/sidecar/* ]]; then
@@ -102,9 +99,6 @@ case "$sub" in
       fi
     done
     if [[ "$prepare_runtime_test_binaries" == "true" ]]; then
-      timeout 120 rustup target add wasm32-wasip2
-      timeout 300 cargo build -p tiangong-plugin-mcp-wasm \
-        -p tiangong-plugin-skill-wasm --target wasm32-wasip2
       cargo build -p tiangong-sandbox --bin tiangong-sandbox \
         -p tiangong-plugin-command-sidecar --bin tiangong-command-sidecar \
         -p tiangong-plugin-sidecar --bin test-stdio-host


### PR DESCRIPTION
## 问题与结果

插件临时状态和每轮重新采集的声明会改变会话请求前缀，Core 重建也无法完整恢复之前的工具列表。本 PR 固定并保存会话使用的插件提示、完整工具定义及顺序，普通续聊与 Core 重建恢复相同内容。

压缩请求沿用原来的完整上下文和工具配置生成摘要；成功后才重新采集插件声明，与摘要和系统提示一起保存。清理上下文也重新整理。读取失败沿用旧声明，保存失败不覆盖原状态。

摘要要求只做必要的简短思考，不重新解决原任务。摘要请求将已开启的思考强度降到 Low，原本关闭时保持 None；普通对话配置与历史思考内容不变。各协议沿用现有映射，Anthropic 当前仍只有开关映射；降低强度和提示词是软约束，不保证思考长度或缓存命中率。

## 主要改动

- Core 使用 PreparedPlugins，提示段落和工具不再每轮从插件重新读取；会话保存恢复所需内容。
- MCP 保留已发现的离线工具，插件读取失败明确返回错误；调用时检查权限、停用和可用性，恢复由插件反馈告知。
- 验证失败、保存失败及恢复状态通过注入结果测试；文件保存及真实安装链独立验证。仅重型集成测试限制并发。
- Core 多轮、压缩和持久化测试；使用内部模拟插件验证故障、恢复、重建和清理后的声明刷新，不依赖真实 WASM 制品。
- 移除 App CI、推送检查为缓存测试新增的 WASM 构建，以及 Plugin CI 的 WASM 编译和 Clippy；格式、协议和其他检查保留，WASM 真实构建由现有发布流程承担。
- 本 PR 将 MCP 和 Skill 的插件发布版本同步升级至 0.2.3；清单、protocol、sidecar 版本一致，WASM 对外版本由 protocol 提供。

## 验证

- 基于 main；#497 已合并，本 PR 仅包含缓存优化，不包含 llm、deepseek crate 或附件分析、记忆插件的重复改动。
- Core 124 项测试全部通过，包含五档思考设置、历史思考与签名保留、普通请求配置不变，以及两种 OpenAI 协议的完整消息前缀和 Low 参数。
- DeepSeek 官方与 OpenCode Go 的四次真实摘要请求均成功，关键事实及未完成状态保留；思考 token 有波动，不据此承诺稳定缩短。格式、编译、严格检查及推送检查通过。
- 四个迁移场景在没有 WASM 制品的工作目录下通过；完整推送检查（Core/Runtime 编译、严格检查、nextest）、工作流 actionlint 和脚本语法检查通过。真实插件加载与跨 WASM 调用不属于这四个模拟场景的覆盖范围。

上游缓存保留时间、路由和模型切换仍会影响实际命中。
