### PR TITLE
refactor(llm): 统一请求入口、响应元数据和重试行为

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10883,7 +10883,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-deepseek"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "eventsource-stream",
@@ -11021,7 +11021,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-analyze-attachment-protocol"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -11029,7 +11029,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-analyze-attachment-sidecar"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11453,7 +11453,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -11461,7 +11461,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tiangong-core/src/context/compressor.rs
+++ b/crates/tiangong-core/src/context/compressor.rs
@@ -142,6 +142,7 @@ impl ContextCompressor {
             context,
             reasoning_effort: crate::model::ReasoningEffort::None,
             max_output_tokens: Some(max_output_tokens),
+            ..Default::default()
         }
     }
 

--- a/crates/tiangong-core/src/react/execute.rs
+++ b/crates/tiangong-core/src/react/execute.rs
@@ -543,6 +543,7 @@ fn build_react_request(ctx: &TurnContext) -> ModelRequest {
         context: ctx.session.context(),
         reasoning_effort: ctx.agent_config.reasoning_effort,
         max_output_tokens: None,
+        ..Default::default()
     }
 }
 
@@ -564,7 +565,7 @@ fn start_llm_request(
     let tools = ctx.tools.clone();
     let task = tokio::spawn(async move {
         client
-            .stream_function_calls_with_tool_choice(request, tools, tool_choice, chunk_tx)
+            .stream_async(request.with_tools(tools, tool_choice), chunk_tx)
             .await
     });
 

--- a/crates/tiangong-deepseek/Cargo.toml
+++ b/crates/tiangong-deepseek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-deepseek"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "Apache-2.0"
 description = "An asynchronous Rust client for the DeepSeek API, supporting chat completions (with SSE streaming), responses, files, model listing, and balance queries."

--- a/crates/tiangong-deepseek/README.md
+++ b/crates/tiangong-deepseek/README.md
@@ -8,6 +8,7 @@ An asynchronous Rust client for the [DeepSeek API](https://api-docs.deepseek.com
 - **Thinking Mode** — `thinking`（enabled/disabled）+ `reasoning_effort`（low/high/max）分档控制，`reasoning_content` 思考内容解析
 - **Text Protocol Fallback** — 内置工具调用文本协议兜底（原生 + DSML），SDK 自动从 `content` 文本中识别并解析
 - **Streaming Robustness** — 单 chunk 多事件收集、空 delta 容错
+- **Finish Reason** — 普通响应与流式事件均原样保留服务端结束原因，支持完整 JSON 回退和未知值
 - **Responses API** — OpenAI Responses 兼容格式（适配 Codex 场景），非流式 + 流式，支持图片输入（`image_url` / `file_id`）、function / web_search 工具、reasoning effort
 - **Files API** — 图片文件上传（multipart，支持有效期）、列出、查询、删除，`file_id` 可在对话中引用
 - **Model Listing** — list available models
@@ -19,8 +20,10 @@ An asynchronous Rust client for the [DeepSeek API](https://api-docs.deepseek.com
 
 ```toml
 [dependencies]
-tiangong-deepseek = "0.1.2"
+tiangong-deepseek = "0.1.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+futures-util = "0.3"
+serde_json = "1"
 ```
 
 ```rust
@@ -41,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }],
         ..Default::default()
     }).await?;
-    println!("{}", response.choices[0].message.content.unwrap_or_default());
+    println!("{}", response.choices[0].message.content.as_deref().unwrap_or_default());
 
     // Streaming with thinking mode + usage
     let stream = client.chat().create_stream(ChatCompletionRequest {
@@ -71,7 +74,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let hit = usage.prompt_cache_hit_tokens.unwrap_or(0);
                 println!("\n[kv cache 命中 {hit} tokens]");
             }
-            StreamEvent::Done => println!(),
+            StreamEvent::FinishReason(reason) => eprintln!("\n[结束原因] {reason}"),
+            StreamEvent::Done => {
+                println!();
+                break;
+            }
             _ => {}
         }
     }
@@ -83,6 +90,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 > `ChatMessage` fields like `name`, `tool_calls`, `tool_call_id`, and `prefix` default to `None`/`false` via `#[serde(default)]`. You can use `..Default::default()` to omit them.
 >
 > 当前模型为 `deepseek-v4-pro`（满配）与 `deepseek-v4-flash`（轻量），两者均支持思考模式与工具调用。
+
+## Chat 结束原因（0.1.4）
+
+`finish_reason` 是 [DeepSeek Chat Completions 接口](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion/) 返回的原始字段。
+
+- 普通响应从 `response.choices[index].finish_reason` 读取。
+- 流式响应通过 `StreamEvent::FinishReason(String)` 提供；中间块的 `null` 不产生此事件。
+- 标准 SSE、漏标内容类型的 SSE、网关返回完整 JSON，以及工具文本缓冲路径都保留该值。
+- `StreamEvent::Done` 表示流结束，不能代替结束原因；未知值同样原样透传。
+
+| 服务端值 | 含义 |
+| --- | --- |
+| `stop` | 自然结束或命中停止字符串 |
+| `length` | 达到输出或上下文长度限制，内容可能截断 |
+| `tool_calls` | 请求调用工具 |
+| `content_filter` | 内容被过滤 |
+| `insufficient_system_resource` | 推理资源不足，生成中断 |
+
+SDK 不替调用方判断结果是否完整、是否接受或重试。升级到 0.1.4 时，若原有代码对 `StreamEvent` 使用穷尽匹配，需要增加 `FinishReason` 分支。相关测试覆盖 48 组响应格式、结束原因和工具缓冲组合。
 
 ## Responses API
 

--- a/crates/tiangong-deepseek/src/chat.rs
+++ b/crates/tiangong-deepseek/src/chat.rs
@@ -45,6 +45,7 @@ fn complete_response_events(response: ChatCompletionResponse) -> Vec<StreamEvent
         }
     }
     events.push(StreamEvent::Usage(response.usage));
+    events.push(StreamEvent::FinishReason(choice.finish_reason));
     events.push(StreamEvent::Done);
     events
 }
@@ -402,6 +403,9 @@ pub(crate) fn parse_stream_chunk(data: &str) -> Vec<Result<StreamEvent, DeepSeek
                     }));
                 }
             }
+        }
+        if let Some(reason) = choice.finish_reason {
+            events.push(Ok(StreamEvent::FinishReason(reason)));
         }
     }
 

--- a/crates/tiangong-deepseek/src/tests.rs
+++ b/crates/tiangong-deepseek/src/tests.rs
@@ -389,13 +389,15 @@ fn stream_chunk_emits_multiple_events() {
 }
 
 #[test]
-fn stream_empty_delta_is_skipped_not_error() {
+fn stream_empty_delta_preserves_finish_reason() {
     // OpenAI 兼容协议：role 首片和 finish_reason 结束片 delta 全空，是正常 chunk。
     let role_chunk = r#"{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}"#;
     assert!(parse_stream_chunk(role_chunk).is_empty());
 
     let finish_chunk = r#"{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
-    assert!(parse_stream_chunk(finish_chunk).is_empty());
+    assert!(
+        matches!(parse_stream_chunk(finish_chunk).as_slice(), [Ok(StreamEvent::FinishReason(reason))] if reason == "stop")
+    );
 }
 
 #[test]
@@ -1267,6 +1269,80 @@ async fn chat_stream_accepts_server_ignoring_stream_flag() {
     }
     assert_eq!(text, "一次性完整回复");
     assert!(done, "应收到终止事件");
+}
+
+#[tokio::test]
+async fn finish_reason_survives_all_chat_response_paths() {
+    use futures_util::StreamExt;
+
+    for reason in [
+        "stop",
+        "length",
+        "content_filter",
+        "tool_calls",
+        "insufficient_system_resource",
+        "future_vendor_reason",
+    ] {
+        for (content_type, streaming) in [
+            ("application/json", false),
+            ("application/json", true),
+            ("text/event-stream", true),
+            ("application/octet-stream", true),
+        ] {
+            // 覆盖启用工具文本缓冲与普通对话两条事件转发路径。
+            for with_tools in [false, true] {
+                let usage = json!({"prompt_tokens":3,"completion_tokens":5,"total_tokens":8});
+                let body = if content_type == "application/json" {
+                    json!({"id":"finish","object":"chat.completion","created":0,"model":"deepseek-v4-flash",
+                        "choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":reason}],
+                        "usage":usage}).to_string()
+                } else {
+                    // 中间片明确为 null；结束片没有文本，但必须透传原因和用量。
+                    let first = json!({"id":"finish","object":"chat.completion.chunk","created":0,"model":"deepseek-v4-flash",
+                        "choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]});
+                    let last = json!({"id":"finish","object":"chat.completion.chunk","created":0,"model":"deepseek-v4-flash",
+                        "choices":[{"index":0,"delta":{},"finish_reason":reason}],"usage":usage});
+                    format!("data: {first}\n\ndata: {last}\n\ndata: [DONE]\n\n")
+                };
+                let server =
+                    MockServer::start(vec![http_response("200 OK", content_type, body.as_bytes())]);
+                let client = mock_client(&server.addr);
+                let request: ChatCompletionRequest = serde_json::from_value(json!({
+                    "model":"deepseek-v4-flash", "messages":[{"role":"user","content":"测试"}],
+                    "stream":streaming,
+                    "tools": if with_tools { json!([{"type":"function","function":{"name":"probe","parameters":{"type":"object"}}}]) } else { json!(null) }
+                })).unwrap();
+                if !streaming {
+                    let response = client.chat().create(request).await.unwrap();
+                    assert_eq!(response.choices[0].finish_reason, reason);
+                    assert_eq!(response.usage.total_tokens, 8);
+                    continue;
+                }
+                let events = client
+                    .chat()
+                    .create_stream(request)
+                    .await
+                    .unwrap()
+                    .collect::<Vec<_>>()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap();
+                let reasons: Vec<_> = events
+                    .iter()
+                    .filter_map(|event| match event {
+                        StreamEvent::FinishReason(reason) => Some(reason.as_str()),
+                        _ => None,
+                    })
+                    .collect();
+                assert_eq!(reasons, vec![reason], "{content_type}, tools={with_tools}");
+                assert!(matches!(events.last(), Some(StreamEvent::Done)));
+                assert!(events.iter().any(
+                    |event| matches!(event, StreamEvent::Usage(usage) if usage.total_tokens == 8)
+                ));
+            }
+        }
+    }
 }
 
 #[tokio::test]

--- a/crates/tiangong-deepseek/src/types/chat.rs
+++ b/crates/tiangong-deepseek/src/types/chat.rs
@@ -136,6 +136,7 @@ pub struct ChatCompletionResponse {
 pub struct Choice {
     pub index: u32,
     pub message: ChoiceMessage,
+    /// DeepSeek 原始结束原因；保留未知值，含义由上层解释。
     pub finish_reason: String,
     #[serde(default)]
     pub logprobs: Option<Value>,
@@ -248,6 +249,9 @@ pub enum StreamEvent {
         arguments: String,
     },
     Usage(Usage),
+    /// 原样透传 choices[].finish_reason；中间块的 null 不产生此事件。
+    /// Done 只表示流结束，不能代替服务端提供的结束原因。
+    FinishReason(String),
     Done,
     Error(String),
 }

--- a/crates/tiangong-llm/src/provider_client.rs
+++ b/crates/tiangong-llm/src/provider_client.rs
@@ -105,7 +105,7 @@ fn append_stream_tool_call_arguments(raw_args: &mut String, partial_json: &str) 
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ModelRequest {
     pub user_input: String,
     pub context: Vec<Message>,
@@ -119,9 +119,23 @@ pub struct ModelRequest {
     /// 应显式设置：按 `context_limit - 预估 prompt_tokens` 计算，留出足够
     /// 摘要输出空间，避免 provider 因 `prompt + max_tokens > limit` 报错。
     pub max_output_tokens: Option<u32>,
+    /// 完整工具定义及顺序；普通对话和摘要均从这里传递。
+    pub tools: Vec<ToolSpec>,
+    /// 未指定时，有工具则允许自动调用；Some(None) 明确禁止调用但保留声明。
+    pub tool_choice: Option<ToolChoice>,
+    /// 未指定时沿用现有全局温度配置。
+    pub temperature: Option<f32>,
+    /// 显式请求超时优先于环境变量及端点配置。
+    pub timeout_ms: Option<u64>,
 }
 
 impl ModelRequest {
+    pub fn with_tools(mut self, tools: Vec<ToolSpec>, tool_choice: Option<ToolChoice>) -> Self {
+        self.tools = tools;
+        self.tool_choice = tool_choice;
+        self
+    }
+
     pub fn with_max_output_tokens(mut self, max_tokens: u32) -> Self {
         self.max_output_tokens = Some(max_tokens);
         self
@@ -251,60 +265,12 @@ pub trait ModelClient {
     fn api_timeout_ms(&self) -> u64;
     fn api_model(&self) -> &str;
     fn complete(&self, req: &ModelRequest) -> Result<ModelResponse>;
-    /// 流式调用，通过 on_delta 实时回调每个 chunk（thinking + content）
+    /// 流式调用，通过 on_delta 实时回调内容和用量。
     fn complete_stream(
         &self,
         req: &ModelRequest,
         on_delta: &mut dyn FnMut(&ModelStreamChunk),
-    ) -> Result<ModelResponse> {
-        let resp = self.complete(req)?;
-        if !resp.reasoning_content.is_empty() {
-            on_delta(&ModelStreamChunk {
-                content: String::new(),
-                reasoning_content: resp.reasoning_content.clone(),
-                usage: None,
-            });
-        }
-        if !resp.text.is_empty() {
-            on_delta(&ModelStreamChunk {
-                content: resp.text.clone(),
-                reasoning_content: String::new(),
-                usage: None,
-            });
-        }
-        Ok(resp)
-    }
-    fn complete_with_functions(
-        &self,
-        req: &ModelRequest,
-        _functions: &[ToolSpec],
-    ) -> Result<ModelFunctionResponse> {
-        self.complete(req)
-    }
-    /// 流式函数调用，通过 on_delta 实时回调 thinking chunk
-    fn complete_with_functions_stream(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        on_delta: &mut dyn FnMut(&ModelStreamChunk),
-    ) -> Result<ModelFunctionResponse> {
-        let resp = self.complete_with_functions(req, functions)?;
-        if !resp.reasoning_content.is_empty() {
-            on_delta(&ModelStreamChunk {
-                content: String::new(),
-                reasoning_content: resp.reasoning_content.clone(),
-                usage: None,
-            });
-        }
-        if !resp.text.is_empty() {
-            on_delta(&ModelStreamChunk {
-                content: resp.text.clone(),
-                reasoning_content: String::new(),
-                usage: None,
-            });
-        }
-        Ok(resp)
-    }
+    ) -> Result<ModelResponse>;
 }
 
 /// 重试回调类型：(attempt, max_attempts, delay_ms, error_text)
@@ -328,14 +294,11 @@ impl std::fmt::Debug for SingleProviderClient {
 }
 
 impl SingleProviderClient {
-    fn build_provider_request(
-        &self,
-        req: &ModelRequest,
-        model: &str,
-        max_tokens: u32,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-    ) -> Result<ProviderRequest> {
+    fn build_provider_request(&self, req: &ModelRequest) -> Result<ProviderRequest> {
+        let model = self.cfg.model.trim();
+        if model.is_empty() {
+            return Err(anyhow!("API_MODEL 不能为空，无法发起模型请求"));
+        }
         let (system, messages) = build_provider_messages(req)?;
         Ok(ProviderRequest {
             session_id: req
@@ -345,16 +308,28 @@ impl SingleProviderClient {
             model: model.to_string(),
             system: (!system.trim().is_empty()).then_some(system),
             messages,
-            tools: functions.to_vec(),
-            tool_choice: tool_choice
-                .or_else(|| (!functions.is_empty()).then_some(LlmToolChoice::Auto)),
-            max_tokens,
-            temperature: configured_temperature_f32(),
+            tools: req.tools.clone(),
+            tool_choice: req
+                .tool_choice
+                .clone()
+                .or_else(|| (!req.tools.is_empty()).then_some(LlmToolChoice::Auto)),
+            max_tokens: req.max_output_tokens.unwrap_or(MAX_TOKENS_MAIN),
+            temperature: req.temperature.or_else(configured_temperature_f32),
             top_p: None,
             stop_sequences: Vec::new(),
             metadata: None,
             reasoning_effort: req.reasoning_effort,
         })
+    }
+
+    fn prepare_request(&self, req: &ModelRequest) -> Result<(ProviderDispatch, ProviderRequest)> {
+        let request = self.build_provider_request(req)?;
+        let timeout_ms = req
+            .timeout_ms
+            .unwrap_or_else(|| function_timeout_ms(self.cfg.timeout_ms));
+        let provider =
+            self.build_provider_dispatch(timeout_ms, req.session_id.as_deref(), MAX_RETRIES)?;
+        Ok((provider, request))
     }
 
     pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
@@ -364,26 +339,38 @@ impl SingleProviderClient {
     pub fn model_name(&self) -> &str {
         self.cfg.model.trim()
     }
-    /// 可取消的非流式主模型调用。调用方丢弃 future 时底层 HTTP 请求随之终止。
+    /// 可取消的非流式调用；完整保留终态和用量，由业务调用方判断内容是否有效。
     pub async fn complete_async(&self, req: &ModelRequest) -> Result<ModelResponse> {
-        let timeout_ms = self.cfg.timeout_ms;
-        let model = self.cfg.model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("API_MODEL 不能为空，无法发起模型请求"));
-        }
-        let provider = self.build_provider_dispatch(timeout_ms, req.session_id.as_deref())?;
-        let max_tokens = req.max_output_tokens.unwrap_or(MAX_TOKENS_MAIN);
-        let request = self.build_provider_request(req, model, max_tokens, &[], None)?;
+        let (provider, request) = self.prepare_request(req)?;
         let response = provider.complete(request).await.map_err(map_llm_error)?;
-        Ok(ModelResponse {
-            text: collect_provider_text(&response).trim().to_string(),
-            reasoning_content: response.reasoning_content.unwrap_or_default(),
-            reasoning_signature: None,
-            stop_reason: response.stop_reason,
-            usage: response.usage.unwrap_or_default().into(),
-            tool_calls: Vec::new(),
-            invalid_tool_calls: Vec::new(),
-        })
+        filter_invalid_openai_tool_calls(
+            self.protocol(),
+            &req.tools,
+            convert_provider_response(response),
+        )
+    }
+
+    /// 流式与非流式消费同一请求，取消 future 时关闭底层 HTTP 流。
+    pub async fn stream_async(
+        self,
+        req: ModelRequest,
+        chunk_tx: tokio::sync::mpsc::UnboundedSender<ModelStreamChunk>,
+    ) -> Result<ModelResponse> {
+        let (provider, request) = self.prepare_request(&req)?;
+        let preserve_tool_call_order = matches!(
+            self.protocol(),
+            ProviderProtocol::OpenAi | ProviderProtocol::OpenAiChatCompletions
+        );
+        let stream = provider.stream(request).await.map_err(map_llm_error)?;
+        let response = consume_provider_stream_events_async(
+            stream,
+            &mut |chunk: &ModelStreamChunk| {
+                let _ = chunk_tx.send(chunk.clone());
+            },
+            preserve_tool_call_order,
+        )
+        .await?;
+        filter_invalid_openai_tool_calls(self.protocol(), &req.tools, response)
     }
 
     pub fn new(cfg: ModelEndpoint) -> Self {
@@ -413,6 +400,7 @@ impl SingleProviderClient {
                 timeout_ms,
                 None,
                 &scru128::new().to_string(),
+                MAX_RETRIES,
             )?;
             provider
                 .list_models()
@@ -425,6 +413,7 @@ impl SingleProviderClient {
                 timeout_ms,
                 None,
                 &scru128::new().to_string(),
+                MAX_RETRIES,
             )?;
             provider
                 .list_models()
@@ -437,6 +426,7 @@ impl SingleProviderClient {
                 timeout_ms,
                 None,
                 &scru128::new().to_string(),
+                MAX_RETRIES,
             )?;
             provider
                 .list_models()
@@ -462,6 +452,7 @@ impl SingleProviderClient {
                 timeout_ms,
                 None,
                 &scru128::new().to_string(),
+                MAX_RETRIES,
             )?;
             let runtime = TokioRuntimeBuilder::new_current_thread()
                 .enable_all()
@@ -481,6 +472,7 @@ impl SingleProviderClient {
                 timeout_ms,
                 None,
                 &scru128::new().to_string(),
+                MAX_RETRIES,
             )?;
             let runtime = TokioRuntimeBuilder::new_current_thread()
                 .enable_all()
@@ -494,8 +486,13 @@ impl SingleProviderClient {
             models.dedup();
             return Ok(models);
         }
-        let provider =
-            build_openai_provider_from_config(cfg, timeout_ms, None, &scru128::new().to_string())?;
+        let provider = build_openai_provider_from_config(
+            cfg,
+            timeout_ms,
+            None,
+            &scru128::new().to_string(),
+            MAX_RETRIES,
+        )?;
         let runtime = TokioRuntimeBuilder::new_current_thread()
             .enable_all()
             .build()
@@ -513,19 +510,11 @@ impl SingleProviderClient {
         self.cfg.protocol
     }
 
-    fn build_anthropic_provider(&self, timeout_ms: u64) -> Result<AnthropicProvider> {
-        build_anthropic_provider_from_config(
-            &self.cfg,
-            timeout_ms,
-            self.on_retry.clone(),
-            &self.session_id,
-        )
-    }
-
-    fn build_provider_dispatch(
+    pub(crate) fn build_provider_dispatch(
         &self,
         timeout_ms: u64,
         session_id: Option<&str>,
+        max_retries: u32,
     ) -> Result<ProviderDispatch> {
         let session_id = session_id.unwrap_or(&self.session_id);
         match self.protocol() {
@@ -535,6 +524,7 @@ impl SingleProviderClient {
                     timeout_ms,
                     self.on_retry.clone(),
                     session_id,
+                    max_retries,
                 )?,
             ))),
             ProviderProtocol::OpenAi => Ok(ProviderDispatch::OpenAiResponses(Box::new(
@@ -543,6 +533,7 @@ impl SingleProviderClient {
                     timeout_ms,
                     self.on_retry.clone(),
                     session_id,
+                    max_retries,
                 )?,
             ))),
             ProviderProtocol::OpenAiChatCompletions => Ok(ProviderDispatch::OpenAiChat(Box::new(
@@ -551,29 +542,24 @@ impl SingleProviderClient {
                     timeout_ms,
                     self.on_retry.clone(),
                     session_id,
+                    max_retries,
                 )?,
             ))),
-            ProviderProtocol::DeepSeek => {
-                let mut config = DeepSeekConfig::new(self.cfg.api_key.trim().to_string());
-                config.base_url = if self.cfg.base_url.trim().is_empty() {
-                    None
-                } else {
-                    Some(self.cfg.base_url.clone())
-                };
-                config.timeout = Duration::from_millis(timeout_ms);
-                config.max_retries = MAX_RETRIES;
-                config.retry_notifier = self.on_retry.clone();
-                config.headers = crate::headers::resolve_headers(&self.cfg.headers, session_id)?;
-                Ok(ProviderDispatch::DeepSeek(Box::new(
-                    DeepSeekProvider::from_config(config)?,
-                )))
-            }
+            ProviderProtocol::DeepSeek => Ok(ProviderDispatch::DeepSeek(Box::new(
+                build_deepseek_provider_from_config(
+                    &self.cfg,
+                    timeout_ms,
+                    self.on_retry.clone(),
+                    session_id,
+                    max_retries,
+                )?,
+            ))),
         }
     }
 
     fn block_on_llm<F, T>(&self, future: F) -> Result<T>
     where
-        F: std::future::Future<Output = std::result::Result<T, crate::error::LlmError>> + Send,
+        F: std::future::Future<Output = Result<T>> + Send,
         T: Send,
     {
         if tokio::runtime::Handle::try_current().is_ok() {
@@ -583,7 +569,7 @@ impl SingleProviderClient {
                         .enable_all()
                         .build()
                         .context("初始化异步运行时失败")?;
-                    runtime.block_on(future).map_err(map_llm_error)
+                    runtime.block_on(future)
                 });
                 handle.join().map_err(|_| anyhow!("LLM 请求线程 panic"))?
             });
@@ -593,435 +579,45 @@ impl SingleProviderClient {
             .enable_all()
             .build()
             .context("初始化异步运行时失败")?;
-        runtime.block_on(future).map_err(map_llm_error)
+        runtime.block_on(future)
     }
 
-    fn complete_lite_anthropic(&self, prompt: &str) -> Result<String> {
-        let timeout_ms = 120_000u64;
-        let model = self.cfg.model.trim();
-        if model.is_empty() {
-            return Err(anyhow!(
-                "API_MODEL 不能为空，无法发起 Anthropic 轻量模型请求"
-            ));
-        }
-
-        let provider = self.build_anthropic_provider(timeout_ms)?;
-        let request = ProviderRequest {
-            session_id: Some(self.session_id.clone()),
-            model: model.to_string(),
-            system: Some(
-                "你是会话标题生成助手。根据用户输入生成简洁的标题，要求：\
-1. 标题不超过10个汉字\
-2. 直接返回标题，不要任何解释或额外文字\
-3. 标题要概括性强，简洁明了"
-                    .to_string(),
-            ),
-            messages: vec![ChatMessage::text(LlmMessageRole::User, prompt)],
-            tools: Vec::new(),
-            tool_choice: None,
-            max_tokens: MAX_TOKENS_LITE,
-            temperature: Some(0.3),
-            top_p: None,
-            stop_sequences: Vec::new(),
-            metadata: None,
-            reasoning_effort: ReasoningEffort::None,
-        };
-        let response = self.block_on_llm(provider.complete(request))?;
-        let text = strip_think_tags(&collect_provider_text(&response))
-            .trim()
-            .to_string();
-        Ok(text)
-    }
-
-    pub fn complete_stream_with_callback<F>(
-        &self,
-        req: &ModelRequest,
-        mut on_delta: F,
-    ) -> Result<ModelResponse>
-    where
-        F: FnMut(&ModelStreamChunk),
-    {
-        let timeout_ms = function_timeout_ms(self.cfg.timeout_ms);
-        let model = self.cfg.model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("API_MODEL 不能为空，无法发起流式模型请求"));
-        }
-        let request = self.build_provider_request(req, model, MAX_TOKENS_MAIN, &[], None)?;
-        let provider = self.build_provider_dispatch(timeout_ms, req.session_id.as_deref())?;
-        consume_provider_stream(provider, request, &mut on_delta)
-    }
-
-    /// 流式函数调用：实时输出 thinking，同时累积 tool_calls
-    pub fn complete_with_functions_stream_impl(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        on_delta: &mut dyn FnMut(&ModelStreamChunk),
-    ) -> Result<ModelFunctionResponse> {
-        self.complete_with_functions_stream_impl_with_tool_choice(req, functions, None, on_delta)
-    }
-
-    pub fn complete_with_functions_stream_impl_with_tool_choice(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-        on_delta: &mut dyn FnMut(&ModelStreamChunk),
-    ) -> Result<ModelFunctionResponse> {
-        let response =
-            self.complete_with_functions_stream_once(req, functions, tool_choice, on_delta)?;
-        filter_invalid_openai_tool_calls(self.protocol(), functions, response)
-    }
-
-    fn complete_with_functions_stream_once(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-        on_delta: &mut dyn FnMut(&ModelStreamChunk),
-    ) -> Result<ModelFunctionResponse> {
-        let timeout_ms = function_timeout_ms(self.cfg.timeout_ms);
-        let model = self.cfg.model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("API_MODEL 不能为空，无法发起流式工具模型请求"));
-        }
-        let request =
-            self.build_provider_request(req, model, MAX_TOKENS_MAIN, functions, tool_choice)?;
-        let provider = self.build_provider_dispatch(timeout_ms, req.session_id.as_deref())?;
-        convert_stream_to_function_response(provider, request, on_delta)
-    }
-
-    /// 使用轻量级模型完成简单任务（如会话名称生成）
-    ///
-    /// lite 模型由调用方构造独立的 [`SingleProviderClient`]（持有 lite 端点的 `model`），
-    /// 此处直接使用 `self.cfg.model`。
-    /// 该方法使用更短的超时时间和较低温度以获得更确定的结果。
+    /// 标题生成仅提供任务参数，复用统一非流式请求。
     pub fn complete_lite(&self, prompt: &str) -> Result<String> {
-        if self.protocol() == ProviderProtocol::Anthropic {
-            return self.complete_lite_anthropic(prompt);
-        }
-        let timeout_ms = 120_000u64;
-        let model = self.cfg.model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("API_MODEL 不能为空，无法发起轻量级模型请求"));
-        }
-        let provider = self.build_provider_dispatch(timeout_ms, None)?;
-        let request = ProviderRequest {
-            session_id: Some(self.session_id.clone()),
-            model: model.to_string(),
-            system: Some(
-                "你是会话标题生成助手。根据用户输入生成简洁的标题，要求：\
-                    1. 标题不超过10个汉字\
-                    2. 直接返回标题，不要任何解释或额外文字\
-                    3. 标题要概括性强，简洁明了"
-                    .to_string(),
-            ),
-            messages: vec![ChatMessage::text(LlmMessageRole::User, prompt)],
-            tools: Vec::new(),
-            tool_choice: None,
-            max_tokens: MAX_TOKENS_LITE,
-            temperature: Some(0.3),
-            top_p: None,
-            stop_sequences: Vec::new(),
-            metadata: None,
-            reasoning_effort: ReasoningEffort::None,
-        };
-        let response = self.block_on_llm(provider.complete(request))?;
-        Ok(collect_provider_text(&response).trim().to_string())
+        self.complete_lite_request(
+            "你是会话标题生成助手。根据用户输入生成简洁的标题，要求：1. 标题不超过10个汉字2. 直接返回标题，不要任何解释或额外文字3. 标题要概括性强，简洁明了",
+            prompt,
+            0.3,
+        )
     }
 
-    /// 使用自定义 system prompt 的轻量级模型调用
-    ///
-    /// 适用于检索策略判断、意图分析等简单分类任务。
     pub fn complete_lite_with_system(&self, system: &str, prompt: &str) -> Result<String> {
-        let timeout_ms = 120_000u64;
-        let model = self.cfg.model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("API_MODEL 不能为空，无法发起轻量级模型请求"));
-        }
-        let request = ProviderRequest {
-            session_id: Some(self.session_id.clone()),
-            model: model.to_string(),
-            system: Some(system.to_string()),
-            messages: vec![ChatMessage::text(LlmMessageRole::User, prompt)],
-            tools: Vec::new(),
-            tool_choice: None,
-            max_tokens: MAX_TOKENS_LITE,
-            temperature: Some(0.1),
-            top_p: None,
-            stop_sequences: Vec::new(),
-            metadata: None,
+        self.complete_lite_request(system, prompt, 0.1)
+    }
+
+    fn complete_lite_request(
+        &self,
+        system: &str,
+        prompt: &str,
+        temperature: f32,
+    ) -> Result<String> {
+        let request = ModelRequest {
+            context: vec![
+                Message::new(MessageRole::System, system),
+                Message::new(MessageRole::User, prompt),
+            ],
+            max_output_tokens: Some(MAX_TOKENS_LITE),
             reasoning_effort: ReasoningEffort::None,
+            temperature: Some(temperature),
+            timeout_ms: Some(120_000),
+            ..Default::default()
         };
-        if self.protocol() == ProviderProtocol::Anthropic {
-            let provider = self.build_anthropic_provider(timeout_ms)?;
-            let response = self.block_on_llm(provider.complete(request))?;
-            return Ok(strip_think_tags(&collect_provider_text(&response))
-                .trim()
-                .to_string());
-        }
-        let provider = self.build_provider_dispatch(timeout_ms, None)?;
-        let response = self.block_on_llm(provider.complete(request))?;
-        Ok(collect_provider_text(&response).trim().to_string())
-    }
-
-    /// 真正的 async 流式函数调用。
-    ///
-    /// 通过 `chunk_tx` 实时发送每个 token chunk，完成后返回 `ModelFunctionResponse`。
-    /// 该方法持有 `self`（owned），可直接在 `tokio::spawn` 里使用，future 是 `Send + 'static`。
-    /// 取消 JoinHandle 后 HTTP 流会随 future drop 而断开。
-    pub async fn stream_function_calls(
-        self,
-        req: ModelRequest,
-        functions: Vec<ToolSpec>,
-        chunk_tx: tokio::sync::mpsc::UnboundedSender<ModelStreamChunk>,
-    ) -> Result<ModelFunctionResponse> {
-        self.stream_function_calls_with_tool_choice(req, functions, None, chunk_tx)
-            .await
-    }
-
-    pub async fn stream_function_calls_with_tool_choice(
-        self,
-        req: ModelRequest,
-        functions: Vec<ToolSpec>,
-        tool_choice: Option<ToolChoice>,
-        chunk_tx: tokio::sync::mpsc::UnboundedSender<ModelStreamChunk>,
-    ) -> Result<ModelFunctionResponse> {
-        // 流式失败直接失败，不回退非流式：中途断开时已推送内容会与非流式
-        // 完整响应拼接重复，且非流式整包等待更容易超时。不支持流式的服务不再兼容。
-        let response = self
-            .stream_function_calls_streaming(&req, &functions, tool_choice, &chunk_tx)
-            .await?;
-        filter_invalid_openai_tool_calls(self.protocol(), &functions, response)
-    }
-
-    async fn stream_function_calls_streaming(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-        chunk_tx: &tokio::sync::mpsc::UnboundedSender<ModelStreamChunk>,
-    ) -> Result<ModelFunctionResponse> {
-        let timeout_ms = function_timeout_ms(self.cfg.timeout_ms);
-        let model = self.cfg.model.trim().to_string();
-        if model.is_empty() {
-            return Err(anyhow!(
-                "API_MODEL 不能为空，无法发起 async 流式工具模型请求"
-            ));
-        }
-        let request =
-            self.build_provider_request(req, &model, MAX_TOKENS_MAIN, functions, tool_choice)?;
-        let preserve_tool_call_order = matches!(
-            self.protocol(),
-            ProviderProtocol::OpenAi | ProviderProtocol::OpenAiChatCompletions
-        );
-        let provider = self.build_provider_dispatch(timeout_ms, req.session_id.as_deref())?;
-
-        let mut text = String::new();
-        let mut reasoning_content = String::new();
-        let mut reasoning_signature: Option<String> = None;
-        let mut usage = TokenUsageData::default();
-        let mut stop_reason = None;
-        let mut tool_calls: std::collections::BTreeMap<String, (String, String)> =
-            std::collections::BTreeMap::new();
-        let mut tool_call_order: Vec<String> = Vec::new();
-
-        let mut stream = provider.stream(request).await.map_err(map_llm_error)?;
-        while let Some(event) = stream.next().await {
-            match event.map_err(map_llm_error)? {
-                ProviderStreamEvent::ReasoningDelta(delta) => {
-                    if !delta.is_empty() {
-                        reasoning_content.push_str(&delta);
-                        let _ = chunk_tx.send(ModelStreamChunk {
-                            content: String::new(),
-                            reasoning_content: delta,
-                            usage: None,
-                        });
-                    }
-                }
-                ProviderStreamEvent::ReasoningSignatureDelta(signature) => {
-                    if !signature.trim().is_empty() {
-                        reasoning_signature = Some(signature);
-                    }
-                }
-                ProviderStreamEvent::TextDelta(delta) => {
-                    if !delta.is_empty() {
-                        text.push_str(&delta);
-                        let _ = chunk_tx.send(ModelStreamChunk {
-                            content: delta,
-                            reasoning_content: String::new(),
-                            usage: None,
-                        });
-                    }
-                }
-                ProviderStreamEvent::ToolCallStart(call) => {
-                    let args = if call.arguments.is_null() || call.arguments == json!({}) {
-                        String::new()
-                    } else {
-                        call.arguments.to_string()
-                    };
-                    tool_call_order.push(call.id.clone());
-                    tool_calls.insert(call.id.clone(), (call.name, args));
-                }
-                ProviderStreamEvent::ToolCallDelta {
-                    call_id,
-                    partial_json,
-                } => {
-                    let actual_id = if tool_calls.contains_key(&call_id) {
-                        call_id
-                    } else if let Ok(idx) = call_id.parse::<usize>() {
-                        tool_call_order.get(idx).cloned().unwrap_or_default()
-                    } else {
-                        call_id
-                    };
-                    let entry = tool_calls
-                        .entry(actual_id)
-                        .or_insert_with(|| (String::new(), String::new()));
-                    // 某些 provider 会在 ToolCallStart 里直接给出完整 arguments，
-                    // 也可能在 delta 中再发送一遍；这里尽量避免重复拼接导致 JSON 无法解析。
-                    append_stream_tool_call_arguments(&mut entry.1, &partial_json);
-                }
-                ProviderStreamEvent::Usage(stream_usage) => {
-                    merge_stream_usage(&mut usage, stream_usage);
-                    let _ = chunk_tx.send(ModelStreamChunk {
-                        content: String::new(),
-                        reasoning_content: String::new(),
-                        usage: Some(usage.clone()),
-                    });
-                }
-                ProviderStreamEvent::Error(message) => return Err(anyhow!(message)),
-                ProviderStreamEvent::MessageEnd {
-                    stop_reason: stream_stop_reason,
-                } => stop_reason = stream_stop_reason,
-                ProviderStreamEvent::MessageStart | ProviderStreamEvent::ToolCallEnd { .. } => {}
-            }
-        }
-
-        let tool_calls_vec = if preserve_tool_call_order {
-            collect_openai_stream_tool_calls(tool_calls, tool_call_order)
+        let response = self.complete(&request)?;
+        Ok(if self.protocol() == ProviderProtocol::Anthropic {
+            strip_think_tags(&response.text).trim().to_string()
         } else {
-            tool_calls
-                .into_iter()
-                .filter(|(_, (name, _))| !name.is_empty())
-                .map(|(id, (name, raw_args))| ToolCall {
-                    arguments: parse_tool_arguments_or_error(&name, &id, &raw_args),
-                    id,
-                    name,
-                })
-                .collect()
-        };
-
-        if text.trim().is_empty()
-            && reasoning_content.trim().is_empty()
-            && tool_calls_vec.is_empty()
-        {
-            return Err(anyhow!("async 流式响应缺少文本、思考内容和工具调用"));
-        }
-
-        Ok(ModelFunctionResponse {
-            text: text.trim().to_string(),
-            reasoning_content,
-            reasoning_signature: reasoning_signature.filter(|value| !value.trim().is_empty()),
-            stop_reason,
-            usage: usage.into(),
-            tool_calls: tool_calls_vec,
-            invalid_tool_calls: Vec::new(),
+            response.text
         })
-    }
-
-    pub fn complete_with_functions_with_tool_choice(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-    ) -> Result<ModelFunctionResponse> {
-        let response =
-            self.complete_with_functions_with_tool_choice_once(req, functions, tool_choice)?;
-        filter_invalid_openai_tool_calls(self.protocol(), functions, response)
-    }
-
-    fn complete_with_functions_with_tool_choice_once(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-    ) -> Result<ModelFunctionResponse> {
-        let timeout_ms = function_timeout_ms(self.cfg.timeout_ms);
-        let model = self.cfg.model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("API_MODEL 不能为空，无法发起工具模型请求"));
-        }
-        let provider = self.build_provider_dispatch(timeout_ms, req.session_id.as_deref())?;
-        let request =
-            self.build_provider_request(req, model, MAX_TOKENS_MAIN, functions, tool_choice)?;
-        let response = self.block_on_llm(provider.complete(request))?;
-        convert_provider_response_to_function_response(response)
-    }
-
-    pub async fn complete_with_functions_with_tool_choice_async(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-    ) -> Result<ModelFunctionResponse> {
-        let response = self
-            .complete_with_functions_with_tool_choice_async_once(req, functions, tool_choice)
-            .await?;
-        filter_invalid_openai_tool_calls(self.protocol(), functions, response)
-    }
-
-    async fn complete_with_functions_with_tool_choice_async_once(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-    ) -> Result<ModelFunctionResponse> {
-        let timeout_ms = function_timeout_ms(self.cfg.timeout_ms);
-        let model = self.cfg.model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("API_MODEL 不能为空，无法发起工具模型请求"));
-        }
-        let provider = self.build_provider_dispatch(timeout_ms, req.session_id.as_deref())?;
-        let request =
-            self.build_provider_request(req, model, MAX_TOKENS_MAIN, functions, tool_choice)?;
-        let response = provider.complete(request).await.map_err(map_llm_error)?;
-        convert_provider_response_to_function_response(response)
-    }
-
-    pub fn complete_with_functions_stream_with_tool_choice(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        tool_choice: Option<ToolChoice>,
-        on_delta: &mut dyn FnMut(&ModelStreamChunk),
-    ) -> Result<ModelFunctionResponse> {
-        if use_stream_mode() {
-            // 流式失败直接失败，不回退非流式（同 async 路径）。
-            self.complete_with_functions_stream_impl_with_tool_choice(
-                req,
-                functions,
-                tool_choice,
-                on_delta,
-            )
-        } else {
-            let resp =
-                self.complete_with_functions_with_tool_choice(req, functions, tool_choice)?;
-            if !resp.reasoning_content.is_empty() {
-                on_delta(&ModelStreamChunk {
-                    content: String::new(),
-                    reasoning_content: resp.reasoning_content.clone(),
-                    usage: None,
-                });
-            }
-            if !resp.text.is_empty() {
-                on_delta(&ModelStreamChunk {
-                    content: resp.text.clone(),
-                    reasoning_content: String::new(),
-                    usage: None,
-                });
-            }
-            Ok(resp)
-        }
     }
 }
 
@@ -1043,47 +639,13 @@ impl ModelClient for SingleProviderClient {
         req: &ModelRequest,
         on_delta: &mut dyn FnMut(&ModelStreamChunk),
     ) -> Result<ModelResponse> {
-        self.complete_stream_with_callback(req, on_delta)
+        let (provider, request) = self.prepare_request(req)?;
+        let response = block_on_provider_stream(provider, request, on_delta)?;
+        filter_invalid_openai_tool_calls(self.protocol(), &req.tools, response)
     }
 
     fn complete(&self, req: &ModelRequest) -> Result<ModelResponse> {
-        let timeout_ms = self.cfg.timeout_ms;
-        let model = self.cfg.model.trim();
-        if model.is_empty() {
-            return Err(anyhow!("API_MODEL 不能为空，无法发起模型请求"));
-        }
-        let provider = self.build_provider_dispatch(timeout_ms, req.session_id.as_deref())?;
-        let max_tokens = req.max_output_tokens.unwrap_or(MAX_TOKENS_MAIN);
-        let request = self.build_provider_request(req, model, max_tokens, &[], None)?;
-        let response = self.block_on_llm(provider.complete(request))?;
-        Ok(ModelResponse {
-            text: collect_provider_text(&response).trim().to_string(),
-            reasoning_content: response.reasoning_content.unwrap_or_default(),
-            reasoning_signature: None,
-            stop_reason: response.stop_reason,
-            usage: response.usage.unwrap_or_default().into(),
-            tool_calls: Vec::new(),
-            invalid_tool_calls: Vec::new(),
-        })
-    }
-
-    fn complete_with_functions(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-    ) -> Result<ModelFunctionResponse> {
-        SingleProviderClient::complete_with_functions_with_tool_choice(self, req, functions, None)
-    }
-
-    fn complete_with_functions_stream(
-        &self,
-        req: &ModelRequest,
-        functions: &[ToolSpec],
-        on_delta: &mut dyn FnMut(&ModelStreamChunk),
-    ) -> Result<ModelFunctionResponse> {
-        SingleProviderClient::complete_with_functions_stream_with_tool_choice(
-            self, req, functions, None, on_delta,
-        )
+        self.block_on_llm(self.complete_async(req))
     }
 }
 
@@ -1104,6 +666,7 @@ fn build_anthropic_provider_from_config(
     timeout_ms: u64,
     on_retry: Option<OnRetryCallback>,
     session_id: &str,
+    max_retries: u32,
 ) -> Result<AnthropicProvider> {
     let token = cfg.api_key.trim();
     if token.is_empty() {
@@ -1111,9 +674,9 @@ fn build_anthropic_provider_from_config(
     }
 
     let mut config = AnthropicConfig::new(token.to_string());
-    config.base_url = Some(cfg.base_url.clone());
+    config.base_url = (!cfg.base_url.trim().is_empty()).then(|| cfg.base_url.clone());
     config.timeout = Duration::from_millis(timeout_ms);
-    config.max_retries = MAX_RETRIES;
+    config.max_retries = max_retries;
     config.retry_notifier = on_retry;
     config.headers = crate::headers::resolve_headers(&cfg.headers, session_id)?;
     AnthropicProvider::from_config(config).map_err(map_llm_error)
@@ -1124,6 +687,7 @@ fn build_openai_responses_provider_from_config(
     timeout_ms: u64,
     on_retry: Option<OnRetryCallback>,
     session_id: &str,
+    max_retries: u32,
 ) -> Result<OpenAiResponsesProvider> {
     let token = cfg.api_key.trim();
     if token.is_empty() {
@@ -1133,7 +697,7 @@ fn build_openai_responses_provider_from_config(
     }
     let mut config = OpenAiResponsesConfig::new(token.to_string(), cfg.base_url.clone());
     config.timeout = Duration::from_millis(timeout_ms);
-    config.max_retries = MAX_RETRIES;
+    config.max_retries = max_retries;
     config.retry_notifier = on_retry;
     config.headers = crate::headers::resolve_headers(&cfg.headers, session_id)?;
     Ok(OpenAiResponsesProvider::new(config))
@@ -1144,6 +708,7 @@ fn build_openai_provider_from_config(
     timeout_ms: u64,
     on_retry: Option<OnRetryCallback>,
     session_id: &str,
+    max_retries: u32,
 ) -> Result<OpenAiChatCompletionsProvider> {
     let token = cfg.api_key.trim();
     if token.is_empty() {
@@ -1151,7 +716,7 @@ fn build_openai_provider_from_config(
     }
     let mut config = OpenAiChatConfig::new(token.to_string(), cfg.base_url.clone());
     config.timeout = Duration::from_millis(timeout_ms);
-    config.max_retries = MAX_RETRIES;
+    config.max_retries = max_retries;
     config.retry_notifier = on_retry;
     config.headers = crate::headers::resolve_headers(&cfg.headers, session_id)?;
     Ok(OpenAiChatCompletionsProvider::new(config))
@@ -1162,6 +727,7 @@ fn build_deepseek_provider_from_config(
     timeout_ms: u64,
     on_retry: Option<OnRetryCallback>,
     session_id: &str,
+    max_retries: u32,
 ) -> Result<DeepSeekProvider> {
     let token = cfg.api_key.trim();
     if token.is_empty() {
@@ -1174,7 +740,7 @@ fn build_deepseek_provider_from_config(
         Some(cfg.base_url.clone())
     };
     config.timeout = Duration::from_millis(timeout_ms);
-    config.max_retries = MAX_RETRIES;
+    config.max_retries = max_retries;
     config.retry_notifier = on_retry;
     config.headers = crate::headers::resolve_headers(&cfg.headers, session_id)?;
     DeepSeekProvider::from_config(config).map_err(|err| anyhow!("{err}"))
@@ -1506,113 +1072,24 @@ fn is_empty_provider_message(message: &ChatMessage) -> bool {
     })
 }
 
-fn convert_provider_response_to_function_response(
-    response: ProviderResponse,
-) -> Result<ModelFunctionResponse> {
-    let text = collect_provider_text(&response);
-    let reasoning_content = response.reasoning_content.clone().unwrap_or_default();
-    let tool_calls = response
-        .assistant_message
-        .content
-        .iter()
-        .filter_map(|content| match content {
-            LlmMessageContent::ToolCall(LlmToolCall {
-                id,
-                name,
-                arguments,
-            }) if !name.is_empty() => Some(ToolCall {
-                id: id.clone(),
-                name: name.clone(),
-                arguments: arguments.clone(),
-            }),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-
-    if text.trim().is_empty() && reasoning_content.trim().is_empty() && tool_calls.is_empty() {
-        return Err(anyhow!(
-            "Anthropic 响应缺少文本和工具调用（{}）",
-            empty_provider_response_diagnostic(&response)
-        ));
-    }
-
-    Ok(ModelFunctionResponse {
-        text: text.trim().to_string(),
-        reasoning_content,
+fn convert_provider_response(response: ProviderResponse) -> ModelResponse {
+    ModelResponse {
+        text: collect_provider_text(&response).trim().to_string(),
+        reasoning_content: response.reasoning_content.clone().unwrap_or_default(),
         reasoning_signature: collect_provider_reasoning_signature(&response),
         stop_reason: response.stop_reason,
         usage: response.usage.unwrap_or_default().into(),
-        tool_calls,
+        tool_calls: response
+            .assistant_message
+            .content
+            .iter()
+            .filter_map(|content| match content {
+                LlmMessageContent::ToolCall(call) => Some(call.clone()),
+                _ => None,
+            })
+            .collect(),
         invalid_tool_calls: Vec::new(),
-    })
-}
-
-fn empty_provider_response_diagnostic(response: &ProviderResponse) -> String {
-    let mut parts = Vec::new();
-    if let Some(model) = response.model.as_deref().filter(|model| !model.is_empty()) {
-        parts.push(format!("model={model}"));
     }
-    if let Some(id) = response.id.as_deref().filter(|id| !id.is_empty()) {
-        parts.push(format!("id={id}"));
-    }
-    if let Some(stop_reason) = &response.stop_reason {
-        parts.push(format!("stop_reason={}", display_stop_reason(stop_reason)));
-    }
-    parts.push(format!(
-        "content_blocks={}",
-        response.assistant_message.content.len()
-    ));
-    if let Some(raw) = response.raw.as_ref()
-        && let Some(raw_summary) = summarize_provider_raw_response(raw)
-    {
-        parts.push(raw_summary);
-    }
-    parts.join(", ")
-}
-
-fn display_stop_reason(reason: &StopReason) -> String {
-    match reason {
-        StopReason::EndTurn => "end_turn".to_string(),
-        StopReason::ToolUse => "tool_use".to_string(),
-        StopReason::MaxTokens => "max_tokens".to_string(),
-        StopReason::StopSequence => "stop_sequence".to_string(),
-        StopReason::Other(value) => value.clone(),
-    }
-}
-
-fn summarize_provider_raw_response(raw: &Value) -> Option<String> {
-    let content = raw.get("content")?.as_array()?;
-    if content.is_empty() {
-        return Some("raw_content=[]".to_string());
-    }
-    let blocks = content
-        .iter()
-        .take(8)
-        .enumerate()
-        .map(|(index, block)| {
-            let block_type = block
-                .get("type")
-                .and_then(Value::as_str)
-                .unwrap_or("unknown");
-            let keys = block
-                .as_object()
-                .map(|object| {
-                    object
-                        .keys()
-                        .map(String::as_str)
-                        .collect::<Vec<_>>()
-                        .join("|")
-                })
-                .unwrap_or_default();
-            if keys.is_empty() {
-                format!("{index}:{block_type}")
-            } else {
-                format!("{index}:{block_type}[{keys}]")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(";");
-    Some(format!("raw_content={blocks}"))
 }
 
 fn parse_tool_arguments_or_error(tool_name: &str, call_id: &str, raw_args: &str) -> Value {
@@ -1669,11 +1146,11 @@ fn collect_provider_reasoning_signature(response: &ProviderResponse) -> Option<S
         })
 }
 
-async fn consume_provider_stream_events_async(
+async fn consume_provider_stream_events_async<F: FnMut(&ModelStreamChunk) + ?Sized>(
     mut stream: ProviderStream,
-    on_delta: &mut dyn FnMut(&ModelStreamChunk),
+    on_delta: &mut F,
     preserve_tool_call_order: bool,
-) -> Result<ModelFunctionResponse> {
+) -> Result<ModelResponse> {
     let mut text = String::new();
     let mut reasoning_content = String::new();
     let mut reasoning_signature: Option<String> = None;
@@ -1736,12 +1213,21 @@ async fn consume_provider_stream_events_async(
                 append_stream_tool_call_arguments(&mut entry.1, &partial_json);
             }
             ProviderStreamEvent::Usage(stream_usage) => {
-                merge_stream_usage(&mut usage, stream_usage)
+                merge_stream_usage(&mut usage, stream_usage);
+                on_delta(&ModelStreamChunk {
+                    content: String::new(),
+                    reasoning_content: String::new(),
+                    usage: Some(usage.clone()),
+                });
             }
             ProviderStreamEvent::Error(message) => return Err(anyhow!(message)),
             ProviderStreamEvent::MessageEnd {
                 stop_reason: stream_stop_reason,
-            } => stop_reason = stream_stop_reason,
+            } => {
+                if stream_stop_reason.is_some() {
+                    stop_reason = stream_stop_reason;
+                }
+            }
             ProviderStreamEvent::MessageStart | ProviderStreamEvent::ToolCallEnd { .. } => {}
         }
     }
@@ -1760,13 +1246,9 @@ async fn consume_provider_stream_events_async(
             .collect()
     };
 
-    if text.trim().is_empty() && reasoning_content.trim().is_empty() && tool_calls.is_empty() {
-        return Err(anyhow!("Anthropic 流式响应缺少文本、思考内容和工具调用"));
-    }
-
     Ok(ModelFunctionResponse {
         text: text.trim().to_string(),
-        reasoning_content: reasoning_content.trim().to_string(),
+        reasoning_content,
         reasoning_signature: reasoning_signature.filter(|value| !value.trim().is_empty()),
         stop_reason,
         usage: usage.into(),
@@ -1775,7 +1257,7 @@ async fn consume_provider_stream_events_async(
     })
 }
 
-enum ProviderDispatch {
+pub(crate) enum ProviderDispatch {
     Anthropic(Box<AnthropicProvider>),
     OpenAiResponses(Box<OpenAiResponsesProvider>),
     OpenAiChat(Box<OpenAiChatCompletionsProvider>),
@@ -1783,7 +1265,7 @@ enum ProviderDispatch {
 }
 
 impl ProviderDispatch {
-    async fn complete(
+    pub(crate) async fn complete(
         self,
         request: ProviderRequest,
     ) -> std::result::Result<ProviderResponse, crate::error::LlmError> {
@@ -1806,31 +1288,6 @@ impl ProviderDispatch {
             ProviderDispatch::DeepSeek(provider) => provider.stream(request).await,
         }
     }
-}
-
-fn consume_provider_stream(
-    provider: ProviderDispatch,
-    request: ProviderRequest,
-    on_delta: &mut dyn FnMut(&ModelStreamChunk),
-) -> Result<ModelResponse> {
-    let response = block_on_provider_stream(provider, request, on_delta)?;
-    Ok(ModelResponse {
-        text: response.text,
-        reasoning_content: response.reasoning_content,
-        reasoning_signature: response.reasoning_signature,
-        stop_reason: response.stop_reason,
-        usage: response.usage,
-        tool_calls: response.tool_calls,
-        invalid_tool_calls: response.invalid_tool_calls,
-    })
-}
-
-fn convert_stream_to_function_response(
-    provider: ProviderDispatch,
-    request: ProviderRequest,
-    on_delta: &mut dyn FnMut(&ModelStreamChunk),
-) -> Result<ModelFunctionResponse> {
-    block_on_provider_stream(provider, request, on_delta)
 }
 
 fn block_on_provider_stream(
@@ -1867,7 +1324,7 @@ fn block_on_provider_stream(
                         let response =
                             runtime.block_on(run_stream(provider, request, &mut |chunk| {
                                 chunks.push(chunk.clone())
-                            }))?;
+                            }));
                         Ok::<_, anyhow::Error>((response, chunks))
                     })
                     .join()
@@ -1876,7 +1333,7 @@ fn block_on_provider_stream(
             for chunk in chunks {
                 on_delta(&chunk);
             }
-            Ok(response)
+            response
         }
         Err(_) => {
             let runtime = TokioRuntimeBuilder::new_current_thread()
@@ -1933,20 +1390,6 @@ fn configured_temperature_f32() -> Option<f32> {
         .map(|value| value as f32)
 }
 
-fn use_stream_mode() -> bool {
-    match std::env::var("API_STREAM") {
-        Ok(raw) => {
-            let normalized = raw.trim().to_ascii_lowercase();
-            !matches!(normalized.as_str(), "0" | "false" | "off" | "no")
-        }
-        Err(_) => true,
-    }
-}
-
-/// 工具调用阶段使用的超时时间。
-///
-/// - 若设置了 `API_FUNCTION_TIMEOUT_MS` 环境变量，直接采用（必须 > 0）；
-/// - 否则使用模型供应商配置的超时时间，不再附加更短的隐藏上限。
 fn function_timeout_ms(base_timeout_ms: u64) -> u64 {
     let custom_timeout_ms = std::env::var("API_FUNCTION_TIMEOUT_MS")
         .ok()
@@ -2077,6 +1520,7 @@ mod tests {
             context: vec![user_msg],
             reasoning_effort: ReasoningEffort::None,
             max_output_tokens: None,
+            ..Default::default()
         };
 
         let err = build_provider_messages(&req).unwrap_err();
@@ -2340,12 +1784,13 @@ mod tests {
             context: vec![Message::new(MessageRole::System, "system")],
             reasoning_effort: ReasoningEffort::None,
             max_output_tokens: None,
+            ..Default::default()
         };
         let functions: Vec<ToolSpec> = Vec::new();
         let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let response = client
-            .stream_function_calls(request, functions, chunk_tx)
+            .stream_async(request.with_tools(functions, None), chunk_tx)
             .await
             .unwrap();
 
@@ -2411,12 +1856,13 @@ mod tests {
             context: vec![Message::new(MessageRole::System, "system")],
             reasoning_effort: ReasoningEffort::None,
             max_output_tokens: None,
+            ..Default::default()
         };
         let functions = vec![schema_tool("read_file"), schema_tool("other_tool")];
         let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let response = client
-            .stream_function_calls(request, functions, chunk_tx)
+            .stream_async(request.with_tools(functions, None), chunk_tx)
             .await
             .unwrap();
 
@@ -2489,12 +1935,13 @@ mod tests {
             context: vec![Message::new(MessageRole::System, "system")],
             reasoning_effort: ReasoningEffort::None,
             max_output_tokens: None,
+            ..Default::default()
         };
         let functions = vec![schema_tool("read_file"), schema_tool("other_tool")];
         let (chunk_tx, _chunk_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let response = client
-            .stream_function_calls(request, functions, chunk_tx)
+            .stream_async(request.with_tools(functions, None), chunk_tx)
             .await
             .unwrap();
 
@@ -2873,6 +2320,7 @@ mod tests {
             context: vec![system_msg, user_msg],
             reasoning_effort: ReasoningEffort::None,
             max_output_tokens: None,
+            ..Default::default()
         };
 
         let (system, messages) = build_provider_messages(&req).unwrap();

--- a/crates/tiangong-llm/src/providers/anthropic/mapping.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/mapping.rs
@@ -334,12 +334,17 @@ pub(super) fn map_stream_event(
                 Ok(Vec::new())
             }
         }
-        StreamEvent::MessageDelta { usage, .. } => {
+        StreamEvent::MessageDelta { delta, usage } => {
+            let mut events = Vec::new();
             if let Some(usage) = usage {
-                Ok(vec![ProviderStreamEvent::Usage(map_usage(usage))])
-            } else {
-                Ok(Vec::new())
+                events.push(ProviderStreamEvent::Usage(map_usage(usage)));
             }
+            if let Some(reason) = delta.stop_reason {
+                events.push(ProviderStreamEvent::MessageEnd {
+                    stop_reason: Some(map_stop_reason(&reason)),
+                });
+            }
+            Ok(events)
         }
         StreamEvent::MessageStop => Ok(vec![ProviderStreamEvent::MessageEnd { stop_reason: None }]),
         StreamEvent::Error { message } => Ok(vec![ProviderStreamEvent::Error(message)]),

--- a/crates/tiangong-llm/src/providers/deepseek/mapping.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/mapping.rs
@@ -423,7 +423,7 @@ pub fn parse_stream_usage(usage: &tiangong_deepseek::types::Usage) -> TokenUsage
     parse_usage(usage)
 }
 
-fn map_stop_reason(reason: &str) -> StopReason {
+pub(super) fn map_stop_reason(reason: &str) -> StopReason {
     match reason {
         "stop" => StopReason::EndTurn,
         "tool_calls" => StopReason::ToolUse,

--- a/crates/tiangong-llm/src/providers/deepseek/stream.rs
+++ b/crates/tiangong-llm/src/providers/deepseek/stream.rs
@@ -62,6 +62,9 @@ fn map_event(
             ]
         }
         E::Usage(usage) => vec![Ok(ProviderStreamEvent::Usage(parse_stream_usage(&usage)))],
+        E::FinishReason(reason) => vec![Ok(ProviderStreamEvent::MessageEnd {
+            stop_reason: Some(super::mapping::map_stop_reason(&reason)),
+        })],
         E::Done => vec![Ok(ProviderStreamEvent::MessageEnd { stop_reason: None })],
         E::Error(message) => vec![Err(LlmError::Provider {
             provider: "deepseek",

--- a/crates/tiangong-llm/src/providers/openai/client.rs
+++ b/crates/tiangong-llm/src/providers/openai/client.rs
@@ -33,12 +33,23 @@ impl ResponsesClient {
     }
 
     pub async fn complete(&self, model: &str, payload: Value) -> Result<Value, LlmError> {
-        let client = self.build_client()?;
-        let responses = client.responses();
+        use crate::providers::openai_chatcompletions::client::{parse_complete_body, send_request};
+        let base = normalize_api_base(&self.config.base_url)
+            .map_err(|error| LlmError::Configuration(error.to_string()))?;
+        let url = format!("{base}/responses");
         timeout(
             self.config.timeout,
-            self.with_retry("openai_complete", model, false, || {
-                responses.create_byot::<_, Value>(payload.clone())
+            self.with_retry("openai_complete", model, false, || async {
+                let response = send_request(
+                    &url,
+                    &self.config.api_key,
+                    &self.config.headers,
+                    &payload,
+                    self.config.timeout,
+                    false,
+                )
+                .await?;
+                parse_complete_body(&response.bytes().await?)
             }),
         )
         .await
@@ -64,39 +75,17 @@ impl ResponsesClient {
             let headers = headers.clone();
             async move {
                 use crate::providers::openai_chatcompletions::client::{
-                    StreamBody, resolve_stream_body, stream_timeout_error,
+                    StreamBody, resolve_stream_body,
                 };
-                // 建连、等待响应头与一次性响应体的读取均受用户配置的请求
-                // 超时约束。SSE 流本身允许长时间增量生成，建流成功后不再
-                // 受总时限限制。
-                let client = reqwest::Client::builder()
-                    .default_headers(headers)
-                    .build()?;
-                let mut request = client
-                    .post(&url)
-                    .header(reqwest::header::ACCEPT, "text/event-stream")
-                    .json(&payload);
-                if !api_key.trim().is_empty() {
-                    request = request.bearer_auth(&api_key);
-                }
-                let response = tokio::time::timeout(request_timeout, request.send())
-                    .await
-                    .map_err(|_| stream_timeout_error(request_timeout))??;
-                let status = response.status();
-                if !status.is_success() {
-                    let body = response.text().await.unwrap_or_default();
-                    return Err(async_openai::error::OpenAIError::ApiError(
-                        async_openai::error::ApiErrorResponse {
-                            status_code: status,
-                            api_error: async_openai::error::ApiError {
-                                message: format!("{status}: {body}"),
-                                r#type: None,
-                                param: None,
-                                code: None,
-                            },
-                        },
-                    ));
-                }
+                let response = crate::providers::openai_chatcompletions::client::send_request(
+                    &url,
+                    &api_key,
+                    &headers,
+                    &payload,
+                    request_timeout,
+                    true,
+                )
+                .await?;
                 match resolve_stream_body(response, request_timeout).await? {
                     StreamBody::Sse(stream) => Ok(ResponsesStreamResponse::Sse(stream)),
                     StreamBody::Complete(value) => {
@@ -126,23 +115,6 @@ impl ResponsesClient {
             &self.config.headers,
         )
         .await
-    }
-
-    fn build_client(
-        &self,
-    ) -> Result<async_openai::Client<async_openai::config::OpenAIConfig>, LlmError> {
-        let mut config = async_openai::config::OpenAIConfig::new()
-            .with_api_key(self.config.api_key.clone())
-            .with_api_base(
-                normalize_api_base(&self.config.base_url)
-                    .unwrap_or_else(|_| self.config.base_url.clone()),
-            );
-        for (name, value) in &self.config.headers {
-            config = config
-                .with_header(name.clone(), value.as_bytes())
-                .map_err(|_| LlmError::Configuration(format!("请求头 {name} 的值无效")))?;
-        }
-        Ok(async_openai::Client::with_config(config))
     }
 
     async fn with_retry<F, Fut, T>(

--- a/crates/tiangong-llm/src/providers/openai_chatcompletions/client.rs
+++ b/crates/tiangong-llm/src/providers/openai_chatcompletions/client.rs
@@ -158,7 +158,7 @@ async fn read_complete_body_with_prefix(
     parse_complete_body(&bytes)
 }
 
-fn parse_complete_body(bytes: &[u8]) -> Result<Value, async_openai::error::OpenAIError> {
+pub(crate) fn parse_complete_body(bytes: &[u8]) -> Result<Value, async_openai::error::OpenAIError> {
     serde_json::from_slice(bytes).map_err(|err| {
         async_openai::error::OpenAIError::JSONDeserialize(
             err,
@@ -167,7 +167,57 @@ fn parse_complete_body(bytes: &[u8]) -> Result<Value, async_openai::error::OpenA
     })
 }
 
-const MAX_RETRIES: u32 = 3;
+/// 流式和非流式共用单次发送；重试由调用方统一控制，避免 SDK 再次重试。
+pub(crate) async fn send_request(
+    url: &str,
+    api_key: &str,
+    headers: &reqwest::header::HeaderMap,
+    payload: &Value,
+    request_timeout: Duration,
+    stream: bool,
+) -> Result<reqwest::Response, async_openai::error::OpenAIError> {
+    let client = reqwest::Client::builder()
+        .default_headers(headers.clone())
+        .retry(reqwest::retry::never())
+        .build()?;
+    let mut request = client
+        .post(url)
+        .header(
+            reqwest::header::ACCEPT,
+            if stream {
+                "text/event-stream"
+            } else {
+                "application/json"
+            },
+        )
+        .json(payload);
+    if !api_key.trim().is_empty() {
+        request = request.bearer_auth(api_key);
+    }
+    let response = timeout(request_timeout, request.send())
+        .await
+        .map_err(|_| stream_timeout_error(request_timeout))??;
+    let status = response.status();
+    if !status.is_success() {
+        let body = timeout(request_timeout, response.text())
+            .await
+            .map_err(|_| stream_timeout_error(request_timeout))?
+            .unwrap_or_default();
+        return Err(async_openai::error::OpenAIError::ApiError(
+            async_openai::error::ApiErrorResponse {
+                status_code: status,
+                api_error: async_openai::error::ApiError {
+                    message: format!("{status}: {body}"),
+                    r#type: None,
+                    param: None,
+                    code: None,
+                },
+            },
+        ));
+    }
+    Ok(response)
+}
+
 const INITIAL_RETRY_DELAY_MS: u64 = 1000;
 
 #[derive(Clone)]
@@ -181,12 +231,22 @@ impl OpenAiClient {
     }
 
     pub async fn complete(&self, model: &str, payload: Value) -> Result<Value, LlmError> {
-        let client = self.build_client()?;
-        let chat = client.chat();
+        let base = normalize_api_base(&self.config.base_url)
+            .map_err(|error| LlmError::Configuration(error.to_string()))?;
+        let url = format!("{base}/chat/completions");
         timeout(
             self.config.timeout,
-            self.with_retry("openai_complete", model, false, || {
-                chat.create_byot::<_, Value>(payload.clone())
+            self.with_retry("openai_complete", model, false, || async {
+                let response = send_request(
+                    &url,
+                    &self.config.api_key,
+                    &self.config.headers,
+                    &payload,
+                    self.config.timeout,
+                    false,
+                )
+                .await?;
+                parse_complete_body(&response.bytes().await?)
             }),
         )
         .await
@@ -211,37 +271,8 @@ impl OpenAiClient {
             let request_timeout = request_timeout;
             let headers = headers.clone();
             async move {
-                // 建连、等待响应头与一次性响应体的读取均受用户配置的请求
-                // 超时约束。SSE 流本身允许长时间增量生成，建流成功后不再
-                // 受总时限限制。
-                let client = reqwest::Client::builder()
-                    .default_headers(headers)
-                    .build()?;
-                let mut request = client
-                    .post(&url)
-                    .header(reqwest::header::ACCEPT, "text/event-stream")
-                    .json(&payload);
-                if !api_key.trim().is_empty() {
-                    request = request.bearer_auth(&api_key);
-                }
-                let response = tokio::time::timeout(request_timeout, request.send())
-                    .await
-                    .map_err(|_| stream_timeout_error(request_timeout))??;
-                let status = response.status();
-                if !status.is_success() {
-                    let body = response.text().await.unwrap_or_default();
-                    return Err(async_openai::error::OpenAIError::ApiError(
-                        async_openai::error::ApiErrorResponse {
-                            status_code: status,
-                            api_error: async_openai::error::ApiError {
-                                message: format!("{status}: {body}"),
-                                r#type: None,
-                                param: None,
-                                code: None,
-                            },
-                        },
-                    ));
-                }
+                let response =
+                    send_request(&url, &api_key, &headers, &payload, request_timeout, true).await?;
                 match resolve_stream_body(response, request_timeout).await? {
                     StreamBody::Sse(stream) => Ok(OpenAiStreamResponse::Sse(stream)),
                     StreamBody::Complete(value) => {
@@ -345,23 +376,6 @@ impl OpenAiClient {
         .await
     }
 
-    fn build_client(
-        &self,
-    ) -> Result<async_openai::Client<async_openai::config::OpenAIConfig>, LlmError> {
-        let mut config = async_openai::config::OpenAIConfig::new()
-            .with_api_key(self.config.api_key.clone())
-            .with_api_base(
-                normalize_api_base(&self.config.base_url)
-                    .unwrap_or_else(|_| self.config.base_url.clone()),
-            );
-        for (name, value) in &self.config.headers {
-            config = config
-                .with_header(name.clone(), value.as_bytes())
-                .map_err(|_| LlmError::Configuration(format!("请求头 {name} 的值无效")))?;
-        }
-        Ok(async_openai::Client::with_config(config))
-    }
-
     async fn with_retry<F, Fut, T>(
         &self,
         operation: &'static str,
@@ -375,7 +389,7 @@ impl OpenAiClient {
     {
         let mut attempt = 0u32;
         let mut delay_ms = INITIAL_RETRY_DELAY_MS;
-        let max_retries = self.config.max_retries.max(MAX_RETRIES);
+        let max_retries = self.config.max_retries;
         loop {
             let start = std::time::Instant::now();
             tracing::info!(

--- a/crates/tiangong-llm/src/session_tests.rs
+++ b/crates/tiangong-llm/src/session_tests.rs
@@ -12,6 +12,7 @@ fn request(session_id: &str) -> ModelRequest {
         ],
         reasoning_effort: ReasoningEffort::None,
         max_output_tokens: Some(256),
+        ..Default::default()
     }
 }
 
@@ -24,6 +25,205 @@ fn reply(protocol: ProviderProtocol) -> Value {
         json!({"id":"chat_test","created":0,"object":"chat.completion","model":"test-model",
             "choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"OK"}}],
             "usage":{"prompt_tokens":100,"completion_tokens":2,"total_tokens":102,"prompt_tokens_details":{"cached_tokens":80}}})
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unified_sync_async_and_stream_requests_preserve_parameters_and_usage() {
+    for protocol in [
+        ProviderProtocol::OpenAi,
+        ProviderProtocol::OpenAiChatCompletions,
+        ProviderProtocol::DeepSeek,
+        ProviderProtocol::Anthropic,
+    ] {
+        let server = MockServer::start().await;
+        Mock::given(method("POST")).respond_with(move |request: &wiremock::Request| {
+            let payload: Value = serde_json::from_slice(&request.body).unwrap();
+            if protocol != ProviderProtocol::Anthropic {
+                return ResponseTemplate::new(200).set_body_json(reply(protocol));
+            }
+            if payload["stream"] != true {
+                return ResponseTemplate::new(200).set_body_json(json!({"id":"m","type":"message","role":"assistant","model":"test-model","content":[{"type":"text","text":"OK"}],"stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":2,"cache_read_input_tokens":80}}));
+            }
+            let events = [
+                json!({"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"test-model","content":[],"usage":{"input_tokens":100,"output_tokens":0,"cache_read_input_tokens":80}}}),
+                json!({"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}),
+                json!({"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}}),
+                json!({"type":"content_block_stop","index":0}),
+                json!({"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}),
+                json!({"type":"message_stop"}),
+            ];
+            ResponseTemplate::new(200).insert_header("content-type", "text/event-stream")
+                .set_body_string(events.iter().map(|event| format!("event: {}\ndata: {event}\n\n", event["type"].as_str().unwrap())).collect::<String>())
+        }).expect(4).mount(&server).await;
+        let client = SingleProviderClient::new(ModelEndpoint {
+            base_url: server.uri(),
+            api_key: "test-key".into(),
+            model: "test-model".into(),
+            protocol,
+            headers: [("x-session".into(), "${session_id}".into())].into(),
+            ..Default::default()
+        });
+        let req = ModelRequest {
+            tools: vec![ToolSpec {
+                name: "probe".into(),
+                description: "固定工具".into(),
+                input_schema: json!({"type":"object","properties":{"path":{"type":"string"}}}),
+            }],
+            tool_choice: Some(ToolChoice::None),
+            temperature: Some(0.2),
+            timeout_ms: Some(5_000),
+            ..request("unified-session")
+        };
+        let first = client.complete_async(&req).await.unwrap();
+        let sync_client = client.clone();
+        let sync_req = req.clone();
+        let second = tokio::task::spawn_blocking(move || sync_client.complete(&sync_req))
+            .await
+            .unwrap()
+            .unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let third = client.clone().stream_async(req.clone(), tx).await.unwrap();
+        let chunks: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert!(chunks.iter().any(|chunk| chunk.usage.is_some()));
+        let (fourth, chunks) = tokio::task::spawn_blocking(move || {
+            let mut chunks = Vec::new();
+            let response = client
+                .complete_stream(&req, &mut |chunk| chunks.push(chunk.clone()))
+                .unwrap();
+            (response, chunks)
+        })
+        .await
+        .unwrap();
+        assert!(chunks.iter().any(|chunk| chunk.usage.is_some()));
+        for response in [second, third, fourth] {
+            assert_eq!(response.text, first.text);
+            assert_eq!(response.stop_reason, first.stop_reason, "{protocol:?}");
+            assert_eq!(
+                serde_json::to_value(response.usage).unwrap(),
+                serde_json::to_value(&first.usage).unwrap()
+            );
+        }
+        let requests = server.received_requests().await.unwrap();
+        let mut previous = None;
+        for request in requests {
+            assert_eq!(request.headers.get("x-session").unwrap(), "unified-session");
+            let mut payload: Value = serde_json::from_slice(&request.body).unwrap();
+            payload.as_object_mut().unwrap().remove("stream");
+            payload.as_object_mut().unwrap().remove("stream_options");
+            if let Some(previous) = previous {
+                assert_eq!(payload, previous);
+            }
+            previous = Some(payload);
+        }
+    }
+}
+
+#[tokio::test]
+async fn empty_truncated_response_preserves_stop_reason_and_usage_in_both_modes() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST")).respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        "id":"empty","choices":[{"index":0,"finish_reason":"length","message":{"role":"assistant","content":""}}],
+        "usage":{"prompt_tokens":100,"completion_tokens":256,"total_tokens":356,"prompt_tokens_details":{"cached_tokens":80}}
+    }))).expect(2).mount(&server).await;
+    let client = SingleProviderClient::new(ModelEndpoint {
+        base_url: server.uri(),
+        api_key: "test".into(),
+        model: "test-model".into(),
+        protocol: ProviderProtocol::OpenAiChatCompletions,
+        ..Default::default()
+    });
+    let req = request("empty-response");
+    let first = client.complete_async(&req).await.unwrap();
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let second = client.stream_async(req, tx).await.unwrap();
+    for response in [first, second] {
+        assert!(response.text.is_empty());
+        assert_eq!(
+            response.stop_reason,
+            Some(crate::response::StopReason::MaxTokens)
+        );
+        assert_eq!(response.usage.total_tokens, 356);
+        assert_eq!(response.usage.prompt_cache_hit_tokens, Some(80));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lite_and_text_helpers_preserve_their_request_options() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(reply(ProviderProtocol::OpenAiChatCompletions)),
+        )
+        .expect(2)
+        .mount(&server)
+        .await;
+    let client = SingleProviderClient::new(ModelEndpoint {
+        base_url: server.uri(),
+        api_key: "test".into(),
+        model: "test-model".into(),
+        protocol: ProviderProtocol::OpenAiChatCompletions,
+        ..Default::default()
+    });
+    assert_eq!(
+        tokio::task::spawn_blocking(move || client.complete_lite("标题输入"))
+            .await
+            .unwrap()
+            .unwrap(),
+        "OK"
+    );
+    let config = crate::text::LlmEndpointConfig {
+        protocol: ProviderProtocol::OpenAiChatCompletions,
+        max_retries: 0,
+        ..crate::text::LlmEndpointConfig::new("test", server.uri(), "test-model")
+    };
+    let (text, usage) = crate::text::complete_text_with_usage(&config, "固定系统", "文本输入", 123)
+        .await
+        .unwrap();
+    assert_eq!(text, "OK");
+    assert_eq!(usage.unwrap().prompt_cache_hit_tokens, Some(80));
+    let requests = server.received_requests().await.unwrap();
+    for (request, limit, temperature) in [(&requests[0], 200, 0.3), (&requests[1], 123, 0.2)] {
+        let body: Value = serde_json::from_slice(&request.body).unwrap();
+        assert_eq!(body["max_tokens"], limit);
+        assert!((body["temperature"].as_f64().unwrap() - temperature).abs() < 0.0001);
+        assert_eq!(body["thinking"]["type"], "disabled");
+    }
+    for protocol in [
+        ProviderProtocol::OpenAiChatCompletions,
+        ProviderProtocol::OpenAi,
+    ] {
+        server.reset().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(2)
+            .mount(&server)
+            .await;
+        let config = crate::text::LlmEndpointConfig {
+            protocol,
+            ..config.clone()
+        };
+        assert!(
+            crate::text::complete_text(&config, "固定系统", "失败输入", 123)
+                .await
+                .is_err()
+        );
+        let client = SingleProviderClient::new(ModelEndpoint {
+            base_url: server.uri(),
+            api_key: "test".into(),
+            model: "test-model".into(),
+            protocol,
+            ..Default::default()
+        });
+        let provider = client.build_provider_dispatch(5_000, None, 0).unwrap();
+        assert!(
+            provider
+                .stream(client.build_provider_request(&request("no-retry")).unwrap())
+                .await
+                .is_err()
+        );
+        server.verify().await;
     }
 }
 
@@ -63,21 +263,16 @@ async fn session_headers_reach_streaming_and_non_streaming_openai_requests() {
         assert_eq!(response.text, "OK");
         assert_eq!(response.usage.prompt_cache_hit_tokens, Some(80));
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        assert_eq!(
-            client
-                .stream_function_calls(req, Vec::new(), tx)
-                .await
-                .unwrap()
-                .text,
-            "OK"
-        );
+        assert_eq!(client.stream_async(req, tx).await.unwrap().text, "OK");
         let requests = server.received_requests().await.unwrap();
         for request in requests {
             let payload: Value = serde_json::from_slice(&request.body).unwrap();
             if protocol == ProviderProtocol::OpenAi {
                 assert_eq!(payload["prompt_cache_key"], session_id);
+                assert_eq!(payload["max_output_tokens"], 256);
             } else {
                 assert!(payload.get("prompt_cache_key").is_none());
+                assert_eq!(payload["max_tokens"], 256);
             }
             assert!(payload.get("session_id").is_none());
         }
@@ -125,13 +320,15 @@ async fn streamed_reasoning_is_replayed_verbatim_after_message_reload() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let response = client
             .clone()
-            .stream_function_calls(
-                req.clone(),
-                vec![ToolSpec {
-                    name: "read_probe".into(),
-                    description: "读取".into(),
-                    input_schema: json!({"type":"object"}),
-                }],
+            .stream_async(
+                req.clone().with_tools(
+                    vec![ToolSpec {
+                        name: "read_probe".into(),
+                        description: "读取".into(),
+                        input_schema: json!({"type":"object"}),
+                    }],
+                    None,
+                ),
                 tx,
             )
             .await
@@ -195,7 +392,7 @@ async fn retry_retains_the_same_session_header() {
     });
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     client
-        .stream_function_calls(request("session_retry"), Vec::new(), tx)
+        .stream_async(request("session_retry"), tx)
         .await
         .unwrap();
     let requests = server.received_requests().await.unwrap();
@@ -322,7 +519,7 @@ async fn live_session_routing_smoke() {
                 Duration::from_secs(100),
                 client
                     .clone()
-                    .stream_function_calls(req.clone(), tools.clone(), tx),
+                    .stream_async(req.clone().with_tools(tools.clone(), None), tx),
             )
             .await
             .unwrap()

--- a/crates/tiangong-llm/src/text.rs
+++ b/crates/tiangong-llm/src/text.rs
@@ -5,14 +5,11 @@
 
 use std::time::Duration;
 
+use crate::endpoint::ModelEndpoint;
 use crate::error::LlmError;
 use crate::message::{ChatMessage, MessageContent, MessageRole};
 use crate::model::ProviderProtocol;
-use crate::provider::LlmProvider;
-use crate::providers::anthropic::{AnthropicConfig, AnthropicProvider};
-use crate::providers::deepseek::{DeepSeekConfig, DeepSeekProvider};
-use crate::providers::openai::{OpenAiResponsesConfig, OpenAiResponsesProvider};
-use crate::providers::openai_chatcompletions::{OpenAiChatCompletionsProvider, OpenAiChatConfig};
+use crate::provider_client::{ProviderDispatch, SingleProviderClient};
 use crate::request::ProviderRequest;
 use crate::request::ReasoningEffort;
 
@@ -89,43 +86,23 @@ pub async fn complete_text_with_usage(
     Ok((message_text(&response.assistant_message), response.usage))
 }
 
-fn build_provider(config: &LlmEndpointConfig) -> Result<Box<dyn LlmProvider>, LlmError> {
-    match config.protocol {
-        ProviderProtocol::OpenAi => {
-            let mut provider_config =
-                OpenAiResponsesConfig::new(config.api_key.clone(), config.base_url.clone());
-            provider_config.timeout = config.timeout;
-            provider_config.max_retries = config.max_retries;
-            Ok(Box::new(OpenAiResponsesProvider::new(provider_config)))
-        }
-        ProviderProtocol::OpenAiChatCompletions => {
-            let mut provider_config =
-                OpenAiChatConfig::new(config.api_key.clone(), config.base_url.clone());
-            provider_config.timeout = config.timeout;
-            provider_config.max_retries = config.max_retries;
-            Ok(Box::new(OpenAiChatCompletionsProvider::new(
-                provider_config,
-            )))
-        }
-        ProviderProtocol::Anthropic => {
-            let mut provider_config = AnthropicConfig::new(config.api_key.clone());
-            if !config.base_url.trim().is_empty() {
-                provider_config.base_url = Some(config.base_url.clone());
-            }
-            provider_config.timeout = config.timeout;
-            provider_config.max_retries = config.max_retries;
-            Ok(Box::new(AnthropicProvider::from_config(provider_config)?))
-        }
-        ProviderProtocol::DeepSeek => {
-            let mut provider_config = DeepSeekConfig::new(config.api_key.clone());
-            if !config.base_url.trim().is_empty() {
-                provider_config.base_url = Some(config.base_url.clone());
-            }
-            provider_config.timeout = config.timeout;
-            provider_config.max_retries = config.max_retries;
-            Ok(Box::new(DeepSeekProvider::from_config(provider_config)?))
-        }
-    }
+fn build_provider(config: &LlmEndpointConfig) -> Result<ProviderDispatch, LlmError> {
+    let timeout_ms = config.timeout.as_millis().min(u64::MAX as u128) as u64;
+    SingleProviderClient::new(ModelEndpoint {
+        api_key: config.api_key.clone(),
+        base_url: config.base_url.clone(),
+        model: config.model.clone(),
+        protocol: config.protocol,
+        timeout_ms,
+        ..Default::default()
+    })
+    .build_provider_dispatch(timeout_ms, None, config.max_retries)
+    .map_err(|error| {
+        error
+            .downcast_ref::<LlmError>()
+            .cloned()
+            .unwrap_or_else(|| LlmError::Configuration(error.to_string()))
+    })
 }
 
 fn message_text(message: &ChatMessage) -> String {

--- a/plugins/tiangong-plugin-analyze-attachment/plugin.json
+++ b/plugins/tiangong-plugin-analyze-attachment/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "analyze-attachment",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "wasm": {
     "binary": "tiangong_plugin_analyze_attachment_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-analyze-attachment/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-analyze-attachment/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-analyze-attachment-protocol"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-analyze-attachment/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-analyze-attachment/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-analyze-attachment-sidecar"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "Apache-2.0"
 description = "Analyze-Attachment 独立 sidecar（读取模型配置、构造多模态请求、调用 LLM）"

--- a/plugins/tiangong-plugin-analyze-attachment/sidecar/src/service.rs
+++ b/plugins/tiangong-plugin-analyze-attachment/sidecar/src/service.rs
@@ -138,6 +138,7 @@ async fn analyze(req: AnalyzeRequest) -> Result<AnalyzeResponse> {
         context,
         reasoning_effort: tiangong_llm::request::ReasoningEffort::None,
         max_output_tokens: None,
+        ..Default::default()
     };
 
     let response = client

--- a/plugins/tiangong-plugin-memory/plugin.json
+++ b/plugins/tiangong-plugin-memory/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "memory",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "wasm": {
     "binary": "tiangong_plugin_memory_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-memory/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-protocol"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-memory/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-memory-sidecar"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "Apache-2.0"
 description = "Memory System 独立 sidecar 进程（承载 SQLite/tantivy/lancedb 原生运行）"


### PR DESCRIPTION
## 问题与结果

普通对话、工具调用和摘要原先使用多套模型调用方法，重复处理请求参数、流式事件和响应。现在 ModelRequest 统一携带工具、调用策略、输出上限、思考设置、温度与超时；主入口仅区分 complete_async 与 stream_async，同步及轻量任务保留薄封装。

- 共用请求构建、流式解析和工具异常校验，保留结束原因、思考签名及用量；内容是否可接受由 Core 判断。
- DeepSeek SDK 完整透传 finish_reason，LLM 统一解释；DeepSeek 和 Anthropic 流式结束原因不再丢失。
- OpenAI 两种协议共用单次 HTTP 发送，消除宿主与 SDK 的重复重试；配置不重试时只发送一次。
- Core 与附件分析插件仅做新接口所需的调用迁移。本 PR 不改变插件声明持久化或摘要上下文策略。

## 验证

- 发布版本：DeepSeek SDK 0.1.4、analyze-attachment 0.1.5、memory 0.1.7。插件清单、protocol 与 sidecar 版本同步，WASM 对外版本由 protocol 提供。
- SDK README 补充结束原因、流事件处理和升级注意事项，依赖示例更新至 0.1.4；示例已实际编译，SDK 打包及包内验证通过。
- 两个受影响插件的 WASM 构建与 sidecar 严格检查通过；附件分析直接调用模型，记忆插件通过共享文本调用接口使用 LLM。

- 基于 main 独立验证：Core 101 项、DeepSeek SDK 76 项、LLM 112 项通过，1 项真实 API 测试按原配置忽略。
- 四种协议的同步/异步、流式/非流式请求参数与用量一致；48 组 SDK 结束原因组合验证通过。
- Core、CoreManager、LLM、DeepSeek、附件分析的严格 Clippy 与格式检查通过；推送执行相关检查。
- 最新提交 97f27478 的 App CI 和 Plugin CI 均通过，包含记忆与附件分析插件的三平台 sidecar 构建。

## 关联

从 #496 提取，独立基于 main。KV cache 优化保留在 #496，并以本分支为基础审查；建议先合并本 PR，再合并 #496。
