### PR TITLE
fix(llm): 修复 GLM/Anthropic 缓存用量与完整输入统计

### DIFF
--- a/crates/tiangong-anthropic/src/types.rs
+++ b/crates/tiangong-anthropic/src/types.rs
@@ -10,6 +10,12 @@ pub struct Usage {
     pub input_tokens: Option<u64>,
     #[serde(default)]
     pub output_tokens: Option<u64>,
+    /// 从缓存读取的输入，不包含在 input_tokens 中。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u64>,
+    /// 写入缓存的输入，不包含在 input_tokens 中。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/tiangong-core/src/core/integration_tests.rs
+++ b/crates/tiangong-core/src/core/integration_tests.rs
@@ -16,6 +16,154 @@ use crate::permission::TrustMode;
 use crate::session::MessageRole;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anthropic_continuations_failure_compression_and_reload_keep_usage_balanced() {
+    use crate::core_config::{CoreConfig, CoreConfigProvider};
+    use crate::session::Session;
+    use serde_json::{Value, json};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tiangong_llm::ProviderProtocol;
+    use tiangong_types::TokenUsage;
+    use wiremock::{Mock, ResponseTemplate, matchers::method};
+
+    let (env, sid) = TestEnv::new("anthropic-usage");
+    let server = MockServer::start().await;
+    let step = AtomicUsize::new(0);
+    Mock::given(method("POST")).respond_with(move |request: &wiremock::Request| {
+        let index = step.fetch_add(1, Ordering::SeqCst);
+        let body: Value = serde_json::from_slice(&request.body).unwrap();
+        let (uncached, read, created, output) = [
+            (10000,0,0,20), (20,10000,0,30), (10,10020,20,10),
+            (5,10050,0,3), (15,10050,0,25),
+        ][index];
+        let usage = json!({"input_tokens":uncached,"cache_read_input_tokens":read,"cache_creation_input_tokens":created,"output_tokens":output});
+        if body["stream"] != true {
+            assert_eq!(index,4);
+            return ResponseTemplate::new(200).set_body_json(json!({"id":"summary","type":"message","role":"assistant","model":"glm-5.3-flash","content":[{"type":"text","text":"[[SUMMARY]]\n已完成前两轮，第三轮请求失败。"}],"stop_reason":"end_turn","usage":usage}));
+        }
+        let block = if index==0 { json!({"type":"tool_use","id":"probe-call","name":"probe","input":{}}) } else { json!({"type":"text","text":"完成"}) };
+        let mut events = vec![
+            json!({"type":"message_start","message":{"id":format!("m{index}"),"model":"glm-5.3-flash","role":"assistant","content":[],"usage":{"input_tokens":0,"output_tokens":0}}}),
+            json!({"type":"content_block_start","index":0,"content_block":block}),
+            json!({"type":"content_block_stop","index":0}),
+            json!({"type":"message_delta","delta":{},"usage":usage}),
+        ];
+        if index == 0 {
+            events.insert(2, json!({"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}));
+        }
+        if index==3 {
+            events.push(json!({"type":"error","error":{"type":"api_error","message":"测试请求中断"}}));
+        } else {
+            events.push(json!({"type":"message_delta","delta":{"stop_reason":if index==0 {"tool_use"} else {"end_turn"}},"usage":usage}));
+            events.push(json!({"type":"message_stop"}));
+        }
+        ResponseTemplate::new(200).insert_header("content-type","text/event-stream")
+            .set_body_string(events.iter().map(|e|format!("event: {}\ndata: {e}\n\n",e["type"].as_str().unwrap())).collect::<String>())
+    }).expect(5).mount(&server).await;
+
+    let mut session = Session::new("GLM 用量验证");
+    session.id = sid.clone();
+    session.bind_storage_root(&env.root);
+    // 旧累计可能包含已经没有明细的调用，不能因重新加载而抹掉。
+    session.token_usage = TokenUsage {
+        prompt_tokens: 17,
+        completion_tokens: 5,
+        total_tokens: 22,
+        ..Default::default()
+    };
+    session.try_persist_to_disk().unwrap();
+    let tool = RecordingTool::succeed("probe");
+    let build = || {
+        let mut config = CoreConfig::builder()
+            .with_chat(&server.uri(), "test", "glm-5.3-flash")
+            .with_trust_mode(TrustMode::FullTrust)
+            .build();
+        config.llm.chat.protocol = ProviderProtocol::Anthropic;
+        let (tx, _rx) = std::sync::mpsc::channel();
+        super::TiangongCore::builder()
+            .session_id(sid.clone())
+            .storage_root(env.root.clone())
+            .workspace_dir(env.root.to_string_lossy())
+            .trust_mode(TrustMode::FullTrust)
+            .config(CoreConfigProvider::new(config))
+            .stream_tx(tx)
+            .plugins(vec![Arc::new(ToolPlugin {
+                id: "usage-probe",
+                tool: tool.clone(),
+            })])
+            .build()
+    };
+    let assert_totals = |expected_inputs: &[usize], expected_outputs: &[usize]| {
+        let restored = env.load_session(&sid);
+        let calls: Vec<_> = restored
+            .messages
+            .iter()
+            .filter_map(|m| m.usage.as_ref())
+            .collect();
+        assert_eq!(
+            calls
+                .iter()
+                .map(|u| u.tokens.prompt_tokens)
+                .collect::<Vec<_>>(),
+            expected_inputs
+        );
+        assert_eq!(
+            calls
+                .iter()
+                .map(|u| u.tokens.completion_tokens)
+                .collect::<Vec<_>>(),
+            expected_outputs
+        );
+        let mut total = TokenUsage::default();
+        for call in calls {
+            assert!(call.tokens.cache_hit_rate().is_some());
+            total.accumulate(&call.tokens);
+        }
+        assert_eq!(restored.token_usage.prompt_tokens, 17 + total.prompt_tokens);
+        assert_eq!(
+            restored.token_usage.completion_tokens,
+            5 + total.completion_tokens
+        );
+        assert_eq!(restored.token_usage.total_tokens, 22 + total.total_tokens);
+    };
+    let core = build();
+    send_message(&core, "usage-first", "查询数据");
+    assert_eq!(
+        wait_turn_status(&env, &sid, "usage-first").await,
+        TurnStatus::Success
+    );
+    core.shutdown_join().unwrap();
+    assert_eq!(tool.count(), 1);
+    assert_totals(&[10000, 10020], &[20, 30]);
+    let core = build();
+    send_message(&core, "usage-second", "继续");
+    assert_eq!(
+        wait_turn_status(&env, &sid, "usage-second").await,
+        TurnStatus::Success
+    );
+    wait_idle(&sid).await;
+    assert_totals(&[10000, 10020, 10050], &[20, 30, 10]);
+    assert_eq!(env.load_session(&sid).current_tokens, 10060);
+    send_message(&core, "usage-failed", "再次继续");
+    assert_eq!(
+        wait_turn_status(&env, &sid, "usage-failed").await,
+        TurnStatus::Failed
+    );
+    wait_idle(&sid).await;
+    assert_totals(&[10000, 10020, 10050, 10055], &[20, 30, 10, 3]);
+    core.deliver(AgentInputKind::compress_context()).unwrap();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while env.load_session(&sid).context_summary.is_none() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    core.shutdown_join().unwrap();
+    assert_totals(&[10000, 10020, 10050, 10055, 10065], &[20, 30, 10, 3, 25]);
+    assert_eq!(env.load_session(&sid).current_tokens, 25);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn plugin_and_tool_order_survives_core_recreation_and_followup_turns() {
     use crate::core::plugin::Plugin;
     use crate::core_config::{CoreConfig, CoreConfigProvider};

--- a/crates/tiangong-llm/src/providers/anthropic/mapping.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/mapping.rs
@@ -239,15 +239,48 @@ fn map_stop_reason(reason: &str) -> StopReason {
 }
 
 fn map_usage(usage: Usage) -> TokenUsageData {
-    TokenUsageData::new(
-        usage.input_tokens.unwrap_or(0) as usize,
+    let uncached = usage.input_tokens.unwrap_or(0) as usize;
+    let read = usage.cache_read_input_tokens.map(|value| value as usize);
+    let created = usage
+        .cache_creation_input_tokens
+        .map(|value| value as usize);
+    let miss = uncached + created.unwrap_or(0);
+    let mut mapped = TokenUsageData::new(
+        miss + read.unwrap_or(0),
         usage.output_tokens.unwrap_or(0) as usize,
-    )
+    );
+    mapped.prompt_cache_hit_tokens = read;
+    // GLM 可只返回 cache_read；完全不提供缓存字段的旧响应仍保持未知。
+    if usage.input_tokens.is_some() && (read.is_some() || created.is_some()) {
+        mapped.prompt_cache_miss_tokens = Some(miss);
+    }
+    mapped
 }
 
 #[derive(Default)]
 pub(super) struct AnthropicStreamState {
     tool_calls: BTreeMap<usize, ToolCallAccumulator>,
+    usage: Usage,
+}
+
+impl AnthropicStreamState {
+    fn merge_usage(&mut self, next: Usage) -> TokenUsageData {
+        // message_delta 通常只包含累计输出；缺失字段沿用 message_start。
+        // 必须先合并原始字段，再计算完整输入，不能把各帧的输入总量相加。
+        if next.input_tokens.is_some() {
+            self.usage.input_tokens = next.input_tokens;
+        }
+        if next.output_tokens.is_some() {
+            self.usage.output_tokens = next.output_tokens;
+        }
+        if next.cache_read_input_tokens.is_some() {
+            self.usage.cache_read_input_tokens = next.cache_read_input_tokens;
+        }
+        if next.cache_creation_input_tokens.is_some() {
+            self.usage.cache_creation_input_tokens = next.cache_creation_input_tokens;
+        }
+        map_usage(self.usage.clone())
+    }
 }
 
 #[derive(Default)]
@@ -263,7 +296,7 @@ pub(super) fn map_stream_event(
         StreamEvent::MessageStart { message } => {
             let mut events = vec![ProviderStreamEvent::MessageStart];
             if let Some(usage) = message.usage {
-                events.push(ProviderStreamEvent::Usage(map_usage(usage)));
+                events.push(ProviderStreamEvent::Usage(state.merge_usage(usage)));
             }
             Ok(events)
         }
@@ -337,7 +370,7 @@ pub(super) fn map_stream_event(
         StreamEvent::MessageDelta { delta, usage } => {
             let mut events = Vec::new();
             if let Some(usage) = usage {
-                events.push(ProviderStreamEvent::Usage(map_usage(usage)));
+                events.push(ProviderStreamEvent::Usage(state.merge_usage(usage)));
             }
             if let Some(reason) = delta.stop_reason {
                 events.push(ProviderStreamEvent::MessageEnd {

--- a/crates/tiangong-llm/src/providers/anthropic/tests.rs
+++ b/crates/tiangong-llm/src/providers/anthropic/tests.rs
@@ -161,6 +161,7 @@ fn test_tool_and_thinking_mapping_back_to_message_content() {
         usage: Some(Usage {
             input_tokens: Some(12),
             output_tokens: Some(7),
+            ..Default::default()
         }),
     };
 
@@ -195,6 +196,7 @@ async fn test_provider_complete_and_stream_behavior() {
         usage: Some(Usage {
             input_tokens: Some(10),
             output_tokens: Some(4),
+            ..Default::default()
         }),
     };
 
@@ -210,6 +212,7 @@ async fn test_provider_complete_and_stream_behavior() {
                 usage: Some(Usage {
                     input_tokens: Some(10),
                     output_tokens: Some(0),
+                    ..Default::default()
                 }),
             },
         }),

--- a/crates/tiangong-llm/src/session_tests.rs
+++ b/crates/tiangong-llm/src/session_tests.rs
@@ -2,6 +2,97 @@ use super::*;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+#[tokio::test]
+async fn anthropic_usage_keeps_cache_fields_across_partial_and_repeated_frames() {
+    let cases = [
+        // Anthropic: 输入与缓存先返回，后续帧只带累计输出。
+        (
+            json!({"input_tokens":55,"output_tokens":0,"cache_read_input_tokens":2496,"cache_creation_input_tokens":128}),
+            json!({"output_tokens":3}),
+            json!({"input_tokens":55,"output_tokens":3,"cache_read_input_tokens":2496,"cache_creation_input_tokens":128}),
+            2679,
+            Some(2496),
+            Some(183),
+        ),
+        // GLM: 开始帧都是零，结束帧一次性返回用量。
+        (
+            json!({"input_tokens":0,"output_tokens":0}),
+            json!({"input_tokens":55,"output_tokens":3,"cache_read_input_tokens":2496}),
+            json!({"input_tokens":55,"output_tokens":3,"cache_read_input_tokens":2496}),
+            2551,
+            Some(2496),
+            Some(55),
+        ),
+        // 缓存读取量晚到，不能丢掉之前收到的未缓存输入与写入量。
+        (
+            json!({"input_tokens":55,"output_tokens":0,"cache_creation_input_tokens":128}),
+            json!({"output_tokens":3,"cache_read_input_tokens":2496}),
+            json!({"input_tokens":55,"output_tokens":3,"cache_read_input_tokens":2496,"cache_creation_input_tokens":128}),
+            2679,
+            Some(2496),
+            Some(183),
+        ),
+        (
+            json!({"input_tokens":20,"cache_read_input_tokens":0}),
+            json!({"output_tokens":3}),
+            json!({"input_tokens":20,"output_tokens":3,"cache_read_input_tokens":0}),
+            20,
+            Some(0),
+            Some(20),
+        ),
+        (
+            json!({"input_tokens":20}),
+            json!({"output_tokens":3}),
+            json!({"input_tokens":20,"output_tokens":3}),
+            20,
+            None,
+            None,
+        ),
+    ];
+    for (start, delta, full, input, hit, miss) in cases {
+        let server = MockServer::start().await;
+        Mock::given(method("POST")).respond_with(move |req: &wiremock::Request| {
+            let body: Value = serde_json::from_slice(&req.body).unwrap();
+            let message = json!({"id":"usage-probe","type":"message","role":"assistant","model":"glm-5.3-flash","content":[{"type":"text","text":"OK"}],"stop_reason":"end_turn","usage":full});
+            if body["stream"] != true { return ResponseTemplate::new(200).set_body_json(message); }
+            let events = [
+                json!({"type":"message_start","message":{"id":"usage-probe","model":"glm-5.3-flash","role":"assistant","content":[],"usage":start}}),
+                json!({"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}),
+                json!({"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}}),
+                json!({"type":"message_delta","delta":{},"usage":delta}),
+                json!({"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":delta}),
+                json!({"type":"message_stop"}),
+            ];
+            ResponseTemplate::new(200).insert_header("content-type","text/event-stream")
+                .set_body_string(events.iter().map(|e| format!("event: {}\ndata: {e}\n\n",e["type"].as_str().unwrap())).collect::<String>())
+        }).expect(2).mount(&server).await;
+        let client = SingleProviderClient::new(ModelEndpoint {
+            base_url: server.uri(),
+            api_key: "test".into(),
+            model: "glm-5.3-flash".into(),
+            protocol: ProviderProtocol::Anthropic,
+            ..Default::default()
+        });
+        let req = request("cache-usage");
+        let ordinary = client.complete_async(&req).await.unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let streamed = client.stream_async(req, tx).await.unwrap();
+        let mut snapshots = TokenUsage::default();
+        while let Some(chunk) = rx.recv().await {
+            if let Some(usage) = chunk.usage {
+                snapshots.merge_snapshot(&usage.into());
+            }
+        }
+        for usage in [ordinary.usage, streamed.usage, snapshots] {
+            assert_eq!(usage.prompt_tokens, input);
+            assert_eq!(usage.completion_tokens, 3);
+            assert_eq!(usage.total_tokens, input + 3);
+            assert_eq!(usage.prompt_cache_hit_tokens, hit);
+            assert_eq!(usage.prompt_cache_miss_tokens, miss);
+        }
+    }
+}
+
 fn request(session_id: &str) -> ModelRequest {
     ModelRequest {
         session_id: Some(session_id.to_string()),
@@ -43,10 +134,10 @@ async fn unified_sync_async_and_stream_requests_preserve_parameters_and_usage() 
                 return ResponseTemplate::new(200).set_body_json(reply(protocol));
             }
             if payload["stream"] != true {
-                return ResponseTemplate::new(200).set_body_json(json!({"id":"m","type":"message","role":"assistant","model":"test-model","content":[{"type":"text","text":"OK"}],"stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":2,"cache_read_input_tokens":80}}));
+                return ResponseTemplate::new(200).set_body_json(json!({"id":"m","type":"message","role":"assistant","model":"test-model","content":[{"type":"text","text":"OK"}],"stop_reason":"end_turn","usage":{"input_tokens":20,"output_tokens":2,"cache_read_input_tokens":80}}));
             }
             let events = [
-                json!({"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"test-model","content":[],"usage":{"input_tokens":100,"output_tokens":0,"cache_read_input_tokens":80}}}),
+                json!({"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"test-model","content":[],"usage":{"input_tokens":20,"output_tokens":0,"cache_read_input_tokens":80}}}),
                 json!({"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}),
                 json!({"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}}),
                 json!({"type":"content_block_stop","index":0}),


### PR DESCRIPTION
GLM 的 Anthropic 兼容接口将未缓存输入、缓存读取和缓存写入分别返回。此前 SDK 丢弃缓存字段，LLM 把未缓存输入当成完整输入，导致缓存命中显示未知、连续调用输入骤降，并低估上下文占用。

本 PR 补齐 SDK 的缓存读取和写入字段，在 LLM 层计算完整输入；流式先合并原始累计字段再换算，保留后续帧省略的缓存数据，并区分明确零命中与缺失统计。输出保持接口累计值，不重复相加。

验证：

- 三个受影响 crate 的 244 项自动测试通过，严格 Clippy 和格式检查通过。
- 覆盖 Anthropic 开始帧携带缓存、GLM 结束帧携带缓存、缓存字段晚到、重复累计帧、缓存写入、零命中和未知。
- 真实 Core 验证工具调用后续聊、重建后续聊、流式失败和手动压缩：调用明细与新增会话累计完全一致，完整输入用于上下文占用。
- 使用修复后的客户端实际请求 GLM 5.3 Flash，连续输入与缓存字段正常返回；本次短对话探测返回明确零命中。此前捕获的正命中响应（未缓存 55、缓存读取 2496）在自动测试中验证为完整输入 2551。

旧会话中未保存的缓存字段或历史调用明细无法据此恢复。本 PR 不改写已有会话文件，也不因明细不全而清减历史累计。
