### PR TITLE
fix(server): 调整插件页面上下文与服务端运行环境

### DIFF
--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -337,7 +337,10 @@ impl ServerCoreManager {
             let mut plugins: Vec<std::sync::Arc<dyn tiangong_core::core::Plugin>> = Vec::new();
             plugins.extend(tiangong_plugin_runtime::registry::load_installed_plugins(
                 &storage_root,
-                tiangong_plugin_runtime::registry::RuntimeKind::Server,
+                // 嵌入 server 跑在桌面进程内，共享桌面端运行时——插件
+                // 集合与桌面一致（含 generate-image 等原生 sidecar 能力），
+                // subagent 专属会话由此获得与主会话相同的工具集。
+                tiangong_plugin_runtime::registry::RuntimeKind::Desktop,
             ));
             // web_fetch 由 runtime 按 plugin.json 自动加载 fetch WASM 插件（issue #326）。
             // skill/analyze-attachment 等 WASM 插件由 load_installed_plugins 自动加载。

--- a/frontend/src/components/PluginIframe.tsx
+++ b/frontend/src/components/PluginIframe.tsx
@@ -58,6 +58,21 @@ export function PluginIframe({
     );
   }, [channel, instanceId, sessionId, theme, visible, workspace]);
 
+  // 插件页面用 ES 模块脚本（延迟执行），iframe onLoad 时其 message
+  // 监听器可能尚未建立——上下文消息会丢失、桥接永远等不到通道。
+  // 短间隔重发直到桥接消费（SDK 收到即设 channel，后续消息被忽略）。
+  const sendHostContextUntilReceived = useCallback(() => {
+    if (!iframeRef.current?.contentWindow) return;
+    let attempts = 0;
+    const timer = window.setInterval(() => {
+      attempts += 1;
+      sendHostContext();
+      if (attempts >= 10) window.clearInterval(timer);
+    }, 200);
+    // 组件卸载时清理
+    return () => window.clearInterval(timer);
+  }, [sendHostContext]);
+
   useEffect(() => {
     sendHostContext();
   }, [sendHostContext]);
@@ -156,7 +171,10 @@ export function PluginIframe({
         srcDoc={html}
         className={`block min-h-0 min-w-0 w-full flex-1 border-0 ${maskColor ? 'relative z-[91]' : ''}`}
         sandbox="allow-scripts"
-        onLoad={sendHostContext}
+        onLoad={() => {
+          sendHostContext();
+          sendHostContextUntilReceived();
+        }}
       />
     </div>
   );

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5171,16 +5171,27 @@ pub async fn bridge_call(
     let authoritative_workspace = if method.starts_with("sidecar.") {
         match session_id.filter(|id| !id.trim().is_empty()) {
             Some(session_id) => {
-                let session = state
-                    .inner()
-                    .core_manager
-                    .load_session(&session_id)
-                    .map_err(|error| format!("加载 sidecar 调用所属会话失败: {error}"))?;
-                let cwd = session.cwd.trim();
-                if cwd.is_empty() {
-                    return Err(format!("会话 {session_id} 未配置工作区"));
+                // 新对话在首次发消息前会话文件尚未落盘——不阻断 sidecar
+                // 调用（成员列表等全局查询与会话无关），按无工作区处理；
+                // 预加载（resident）插件的连接本就不使用会话工作区。
+                match state.inner().core_manager.load_session(&session_id) {
+                    Ok(session) => {
+                        let cwd = session.cwd.trim();
+                        if cwd.is_empty() {
+                            None
+                        } else {
+                            Some(PathBuf::from(cwd))
+                        }
+                    }
+                    Err(error) => {
+                        tracing::debug!(
+                            session_id,
+                            %error,
+                            "sidecar 调用所属会话未落盘（新对话），按无工作区处理"
+                        );
+                        None
+                    }
                 }
-                Some(PathBuf::from(cwd))
             }
             None => None,
         }


### PR DESCRIPTION
## 范围与依赖

本 PR 已改为直接基于 main，仅包含三个业务提交。此前收进本分支的 Runtime 连接换代改动（wasm 宿主状态引用刷新与端到端验证）统一在 #505 审查，不再出现在本 PR 差异中。

## 当前改动

- PluginIframe 加载后按短间隔重发宿主上下文，降低页面监听尚未就绪时丢失上下文的概率。
- 桌面桥接在会话尚未落盘或没有工作区时，按无工作区处理 sidecar 调用。
- ServerCoreManager 的插件加载选择改为 Desktop 运行环境；独立 Server 与嵌入 Server 的入口行为仍需分别核对。

## 验证与审查边界

基于 main 提取后本地已完成：cargo check（tiangong-server、tiangong-app）与前端 yarn build 均通过，diff 与原相对 #505 的净差异逐行一致；CI 另跑完整检查。未合并或发布。