### PR TITLE
fix(attachment): 直接按图片路径分析，保持引导消息生命周期

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10971,6 +10971,7 @@ dependencies = [
  "reqwest 0.13.4",
  "scru128",
  "serde",
+ "serde_json",
  "tiangong-types",
  "tracing",
 ]
@@ -11021,7 +11022,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-analyze-attachment-protocol"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -11029,7 +11030,7 @@ dependencies = [
 
 [[package]]
 name = "tiangong-plugin-analyze-attachment-sidecar"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/tiangong-core/src/react/command.rs
+++ b/crates/tiangong-core/src/react/command.rs
@@ -43,6 +43,15 @@ pub(super) fn save_user_message_and_restart(
         session_id = %ctx.session.id,
         "运行中注入用户消息：中断当前执行并追加新消息"
     );
+    // 注入即新意图开始：重播 turn 开始钩子，让缓存会话快照的插件
+    // （如附件分析按 message_id 精确定位附件）看到刚追加的消息。
+    // ALR-108 的"物理 turn 一次"约束针对常规生命周期；不重播时插件
+    // 快照停留在 turn 开始时刻，注入消息中的附件资源永远找不到。
+    if let Some(turn_start_idx) = ctx.session.latest_user_message_index() {
+        for plugin in &ctx.plugins {
+            plugin.on_turn_started(&mut ctx.session, turn_start_idx);
+        }
+    }
     state.reset_tool_history();
     Ok(())
 }

--- a/crates/tiangong-core/src/react/command.rs
+++ b/crates/tiangong-core/src/react/command.rs
@@ -43,15 +43,6 @@ pub(super) fn save_user_message_and_restart(
         session_id = %ctx.session.id,
         "运行中注入用户消息：中断当前执行并追加新消息"
     );
-    // 注入即新意图开始：重播 turn 开始钩子，让缓存会话快照的插件
-    // （如附件分析按 message_id 精确定位附件）看到刚追加的消息。
-    // ALR-108 的"物理 turn 一次"约束针对常规生命周期；不重播时插件
-    // 快照停留在 turn 开始时刻，注入消息中的附件资源永远找不到。
-    if let Some(turn_start_idx) = ctx.session.latest_user_message_index() {
-        for plugin in &ctx.plugins {
-            plugin.on_turn_started(&mut ctx.session, turn_start_idx);
-        }
-    }
     state.reset_tool_history();
     Ok(())
 }

--- a/crates/tiangong-core/src/react/execute_tests.rs
+++ b/crates/tiangong-core/src/react/execute_tests.rs
@@ -1312,50 +1312,21 @@ async fn inject_user_message_interrupts_tools_and_restarts() {
     assert!(call_closed, "被中断的工具调用应有失败结果（ALR-110）");
 }
 
-/// 记录每次 on_turn_started 时会话用户消息 ID 列表的插件，用于验证
-/// 注入重播后插件快照包含注入的新消息。
-struct SnapshotRecordingPlugin {
-    snapshots: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
-}
-
-impl ToolOverrideHandler for SnapshotRecordingPlugin {}
-impl ToolSpecProvider for SnapshotRecordingPlugin {}
-impl PromptSectionProvider for SnapshotRecordingPlugin {}
-impl MentionCandidateProvider for SnapshotRecordingPlugin {}
-
-impl Plugin for SnapshotRecordingPlugin {
-    fn id(&self) -> &str {
-        "snapshot-recorder"
-    }
-    fn on_turn_started(&self, session: &mut Session, _: usize) {
-        let ids = session
-            .messages
-            .iter()
-            .filter(|m| m.role == MessageRole::User)
-            .map(|m| m.id.clone())
-            .collect();
-        self.snapshots.lock().unwrap().push(ids);
-    }
-}
-
-/// 运行中注入用户消息后重播 turn 开始钩子：依赖会话快照的插件
-/// （如附件分析按 message_id 定位附件）必须看到注入的消息。
+/// 引导消息仍属于当前轮次：新图片路径进入模型上下文，但不重复触发开始钩子。
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn inject_user_message_replays_on_turn_started_with_new_message() {
+async fn injected_image_guidance_keeps_lifecycle_hooks_once() {
     use super::super::turn::run_turn;
 
     let server = MockServer::builder().start().await;
     let started = Arc::new(Notify::new());
-    let release = Arc::new(Notify::new());
     let mut overrides: HashMap<String, Arc<dyn ToolOverrideHandler>> = HashMap::new();
     overrides.insert(
         "paused_probe".to_string(),
         Arc::new(PausedTool {
             started: started.clone(),
-            release: release.clone(),
+            release: Arc::new(Notify::new()),
         }),
     );
-    // 1) 首轮：工具调用阻塞，制造"工具等待中"。
     mount_sse(
         &server,
         vec![
@@ -1364,54 +1335,74 @@ async fn inject_user_message_replays_on_turn_started_with_new_message() {
         ],
     )
     .await;
-    // 2) 注入后新意图：直接文本回答。
     mount_sse(
         &server,
         vec![text_delta_chunk("好的。"), usage_chunk(20, 4)],
     )
     .await;
-
-    let snapshots = Arc::new(std::sync::Mutex::new(Vec::<Vec<String>>::new()));
-    let plugin = Arc::new(SnapshotRecordingPlugin {
-        snapshots: snapshots.clone(),
+    let hook_started = Arc::new(AtomicU32::new(0));
+    let hook_finished = Arc::new(AtomicU32::new(0));
+    let plugin = Arc::new(LifecycleCountingPlugin {
+        started: hook_started.clone(),
+        finished: hook_finished.clone(),
     });
-    let harness = TestHarness::new_with_plugins(
-        &server,
-        vec![tool_spec("paused_probe")],
-        overrides,
-        vec![plugin],
-    );
     let TestHarness {
         ctx,
         cmd_tx,
         mut cmd_rx,
         ..
-    } = harness;
+    } = TestHarness::new_with_plugins(
+        &server,
+        vec![tool_spec("paused_probe")],
+        overrides,
+        vec![plugin],
+    );
     let inject_tx = cmd_tx.clone();
-    let started_wait = started.clone();
     tokio::spawn(async move {
-        tokio::time::timeout(Duration::from_secs(2), started_wait.notified())
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
             .await
             .expect("工具应已启动");
+        let path = "/tmp/guidance-image.png";
         inject_tx
             .send(Command::InjectUserMessage {
-                message_id: "injected-with-attachment".to_string(),
-                content: vec![tiangong_types::ContentBlock::text("看这张新截图")],
+                message_id: scru128::new().to_string(),
+                content: vec![
+                    tiangong_types::ContentBlock::text("看这张新截图"),
+                    tiangong_types::ContentBlock::AssetReference {
+                        asset: tiangong_types::StoredAsset {
+                            asset_id: scru128::new().to_string(),
+                            local_path: path.into(),
+                            original_name: "guidance-image.png".into(),
+                            mime_type: "image/png".into(),
+                            size: 0,
+                            kind: tiangong_types::MediaKind::Image,
+                        },
+                    },
+                    tiangong_types::ContentBlock::ModelInstruction {
+                        text: format!("请通过 images={} 分析新截图", serde_json::json!([path])),
+                    },
+                ],
             })
             .unwrap();
     });
     run_turn(ctx, &mut cmd_rx).await;
-
-    let snapshots = snapshots.lock().unwrap();
-    assert!(
-        snapshots.len() >= 2,
-        "注入后应重播 on_turn_started（turn 开始 + 注入），实际 {} 次",
-        snapshots.len()
+    assert_eq!(
+        hook_started.load(Ordering::SeqCst),
+        1,
+        "引导消息不触发 on_turn_started"
     );
-    let last = snapshots.last().unwrap();
+    wait_for_counter(&hook_finished, 1);
+    assert_eq!(hook_finished.load(Ordering::SeqCst), 1);
     assert!(
-        last.iter().any(|id| id == "injected-with-attachment"),
-        "重播快照应包含注入的消息，实际: {last:?}"
+        server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .any(|request| {
+                String::from_utf8_lossy(&request.body).contains("guidance-image.png")
+            }),
+        "新图片路径必须进入引导后的模型上下文"
     );
 }
 

--- a/crates/tiangong-core/src/react/execute_tests.rs
+++ b/crates/tiangong-core/src/react/execute_tests.rs
@@ -1312,6 +1312,109 @@ async fn inject_user_message_interrupts_tools_and_restarts() {
     assert!(call_closed, "被中断的工具调用应有失败结果（ALR-110）");
 }
 
+/// 记录每次 on_turn_started 时会话用户消息 ID 列表的插件，用于验证
+/// 注入重播后插件快照包含注入的新消息。
+struct SnapshotRecordingPlugin {
+    snapshots: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+}
+
+impl ToolOverrideHandler for SnapshotRecordingPlugin {}
+impl ToolSpecProvider for SnapshotRecordingPlugin {}
+impl PromptSectionProvider for SnapshotRecordingPlugin {}
+impl MentionCandidateProvider for SnapshotRecordingPlugin {}
+
+impl Plugin for SnapshotRecordingPlugin {
+    fn id(&self) -> &str {
+        "snapshot-recorder"
+    }
+    fn on_turn_started(&self, session: &mut Session, _: usize) {
+        let ids = session
+            .messages
+            .iter()
+            .filter(|m| m.role == MessageRole::User)
+            .map(|m| m.id.clone())
+            .collect();
+        self.snapshots.lock().unwrap().push(ids);
+    }
+}
+
+/// 运行中注入用户消息后重播 turn 开始钩子：依赖会话快照的插件
+/// （如附件分析按 message_id 定位附件）必须看到注入的消息。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inject_user_message_replays_on_turn_started_with_new_message() {
+    use super::super::turn::run_turn;
+
+    let server = MockServer::builder().start().await;
+    let started = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let mut overrides: HashMap<String, Arc<dyn ToolOverrideHandler>> = HashMap::new();
+    overrides.insert(
+        "paused_probe".to_string(),
+        Arc::new(PausedTool {
+            started: started.clone(),
+            release: release.clone(),
+        }),
+    );
+    // 1) 首轮：工具调用阻塞，制造"工具等待中"。
+    mount_sse(
+        &server,
+        vec![
+            tool_call_chunk("call_1", "paused_probe", "{}"),
+            usage_chunk(15, 3),
+        ],
+    )
+    .await;
+    // 2) 注入后新意图：直接文本回答。
+    mount_sse(
+        &server,
+        vec![text_delta_chunk("好的。"), usage_chunk(20, 4)],
+    )
+    .await;
+
+    let snapshots = Arc::new(std::sync::Mutex::new(Vec::<Vec<String>>::new()));
+    let plugin = Arc::new(SnapshotRecordingPlugin {
+        snapshots: snapshots.clone(),
+    });
+    let harness = TestHarness::new_with_plugins(
+        &server,
+        vec![tool_spec("paused_probe")],
+        overrides,
+        vec![plugin],
+    );
+    let TestHarness {
+        ctx,
+        cmd_tx,
+        mut cmd_rx,
+        ..
+    } = harness;
+    let inject_tx = cmd_tx.clone();
+    let started_wait = started.clone();
+    tokio::spawn(async move {
+        tokio::time::timeout(Duration::from_secs(2), started_wait.notified())
+            .await
+            .expect("工具应已启动");
+        inject_tx
+            .send(Command::InjectUserMessage {
+                message_id: "injected-with-attachment".to_string(),
+                content: vec![tiangong_types::ContentBlock::text("看这张新截图")],
+            })
+            .unwrap();
+    });
+    run_turn(ctx, &mut cmd_rx).await;
+
+    let snapshots = snapshots.lock().unwrap();
+    assert!(
+        snapshots.len() >= 2,
+        "注入后应重播 on_turn_started（turn 开始 + 注入），实际 {} 次",
+        snapshots.len()
+    );
+    let last = snapshots.last().unwrap();
+    assert!(
+        last.iter().any(|id| id == "injected-with-attachment"),
+        "重播快照应包含注入的消息，实际: {last:?}"
+    );
+}
+
 /// ALR-107（多消息）：注入引导消息后，最终 turn_status 写入最新（注入的）
 /// 用户消息，原始消息不被覆盖；磁盘重载后一致。
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/tiangong-media-archive/Cargo.toml
+++ b/crates/tiangong-media-archive/Cargo.toml
@@ -9,6 +9,7 @@ tiangong-types = { workspace = true }
 base64 = { workspace = true }
 scru128 = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = [
     "blocking",

--- a/crates/tiangong-media-archive/src/attachment.rs
+++ b/crates/tiangong-media-archive/src/attachment.rs
@@ -386,7 +386,8 @@ fn asset_notice_item(index: usize, asset: &StoredAsset) -> String {
 
 fn analyze_attachment_instruction(message_id: &str, index: usize, asset: &StoredAsset) -> String {
     format!(
-        "本条用户消息包含需要附件分析插件处理的附件。需要查看内容时，请调用 analyze_attachment 工具，必须使用 message_id={message_id}，并指定 attachment_index={index}。\n- {}",
+        "本条用户消息包含需要附件分析插件处理的图片。需要查看内容时，请调用 analyze_attachment 工具，将本地图片路径原样传入 images={}，并用 instruction 说明分析要求。消息编号仅用于标识来源，不作为图片参数。\n来源：message_id={message_id} attachment_index={index}\n- {}",
+        serde_json::json!([asset.local_path]),
         asset_notice_item(index, asset)
     )
 }
@@ -1050,7 +1051,7 @@ mod tests {
     }
 
     #[test]
-    fn planner_builds_analyzer_reference_with_exact_message_and_index() {
+    fn planner_builds_analyzer_reference_with_explicit_image_paths() {
         let root = TestRoot::new();
         let mut analyze = root
             .store()
@@ -1082,6 +1083,8 @@ mod tests {
                 if text.contains("analyze_attachment")
                     && text.contains("message_id=message-analyze")
                     && text.contains("attachment_index=1")
+                    && text.contains(&format!("images={}", serde_json::json!([analyze.assets()[1].local_path])))
+                    && !text.contains("必须使用 message_id")
                     && text.contains("name=analyze.png")
                     && text.contains("path=")
         ));

--- a/crates/tiangong-types/src/message.rs
+++ b/crates/tiangong-types/src/message.rs
@@ -538,7 +538,7 @@ fn legacy_resource_instruction(
         ));
     }
     ContentBlock::model_instruction(format!(
-        "本条用户消息包含一个已保存资源。需要读取内容时，请使用当前可用的资源处理能力，并使用 message_id={message_id}、attachment_index={index}。\n- asset_id={} kind={:?} name={} mime_type={} size={} path={}",
+        "本条用户消息包含一个已保存资源。需要读取内容时，请使用当前可用的资源处理能力，直接传入下列本地 path。来源：message_id={message_id}、attachment_index={index}。\n- asset_id={} kind={:?} name={} mime_type={} size={} path={}",
         asset.asset_id,
         asset.kind,
         asset.original_name,

--- a/plugins/tiangong-plugin-analyze-attachment/plugin.json
+++ b/plugins/tiangong-plugin-analyze-attachment/plugin.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "analyze-attachment",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "wasm": {
     "binary": "tiangong_plugin_analyze_attachment_wasm.wasm"
   },

--- a/plugins/tiangong-plugin-analyze-attachment/protocol/Cargo.toml
+++ b/plugins/tiangong-plugin-analyze-attachment/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-analyze-attachment-protocol"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/tiangong-plugin-analyze-attachment/protocol/src/lib.rs
+++ b/plugins/tiangong-plugin-analyze-attachment/protocol/src/lib.rs
@@ -30,7 +30,7 @@ pub struct Empty {}
 
 /// 附件分析请求。
 ///
-/// 图片数据由 wasm 从会话消息提取后，以本地路径传给 sidecar；
+/// 图片路径由工具调用参数直接传入，wasm 原样转交给 sidecar；
 /// sidecar 读取图片文件 → 构造多模态请求 → 调模型。
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AnalyzeRequest {

--- a/plugins/tiangong-plugin-analyze-attachment/sidecar/Cargo.toml
+++ b/plugins/tiangong-plugin-analyze-attachment/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiangong-plugin-analyze-attachment-sidecar"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "Apache-2.0"
 description = "Analyze-Attachment 独立 sidecar（读取模型配置、构造多模态请求、调用 LLM）"

--- a/plugins/tiangong-plugin-analyze-attachment/sidecar/src/service.rs
+++ b/plugins/tiangong-plugin-analyze-attachment/sidecar/src/service.rs
@@ -161,9 +161,12 @@ fn asset_from_path(path: &str) -> Result<StoredAsset> {
         anyhow::bail!("图片路径为空");
     }
     let mime_type = infer_image_mime(path_trimmed);
-    let size = std::fs::metadata(path_trimmed)
-        .map(|m| m.len())
-        .unwrap_or(0);
+    let metadata = std::fs::metadata(path_trimmed)
+        .with_context(|| format!("无法读取图片文件：{path_trimmed}"))?;
+    if !metadata.is_file() {
+        anyhow::bail!("图片路径不是文件：{path_trimmed}");
+    }
+    let size = metadata.len();
     let original_name = std::path::Path::new(path_trimmed)
         .file_name()
         .and_then(|n| n.to_str())

--- a/plugins/tiangong-plugin-analyze-attachment/wasm/src/lib.rs
+++ b/plugins/tiangong-plugin-analyze-attachment/wasm/src/lib.rs
@@ -1,7 +1,6 @@
 //! Analyze-Attachment 插件的 WASM 桥接组件。
 //!
-//! 缓存 session JSON（生命周期钩子），handle_tool 时从消息提取图片路径，
-//! 转发到 sidecar 做多模态分析。
+//! handle_tool 直接接收图片本地路径并转发到 sidecar 做多模态分析。
 
 mod bindings;
 mod sidecar_client;
@@ -28,9 +27,7 @@ fn plugin_err(message: impl Into<String>) -> PluginError {
     PluginError::Message(message.into())
 }
 
-// 缓存的会话消息（thread-local，生命周期钩子注入）。
 thread_local! {
-    static SESSION_MESSAGES: std::cell::RefCell<Vec<Value>> = const { std::cell::RefCell::new(Vec::new()) };
     // 主 Chat 模型是否多模态（on_config_updated 注入）。
     static CHAT_MULTIMODAL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
@@ -57,8 +54,8 @@ impl Guest for Component {
         }
         Ok(vec![ToolSpec {
             name: TOOL_ANALYZE_ATTACHMENT.to_string(),
-            description: "按需调用多模态模型解析用户上传的图片附件。只有当用户问题确实需要查看图片内容时才调用；文档和其他文件应使用对应文件工具。重要：message_id 必须使用用户消息中提示文字所标注的 ID，不要使用其他消息的 ID。".to_string(),
-            input_schema: r#"{"type":"object","properties":{"instruction":{"type":"string","description":"希望多模态模型如何解析附件，例如提取文字、描述画面、识别表格、回答与附件有关的问题"},"message_id":{"type":"string","description":"包含附件的用户消息 ID。省略时使用最近一条包含附件的用户消息"},"attachment_index":{"type":"integer","description":"附件序号，从 0 开始。省略时解析该消息中的全部附件"}},"required":["instruction"]}"#
+            description: "按需调用多模态模型解析图片。只有当用户问题确实需要查看图片内容时才调用；images 必须是消息中明确给出的图片本地路径，不要传消息编号或自行猜测路径。文档和其他文件应使用对应文件工具。".to_string(),
+            input_schema: r#"{"type":"object","properties":{"instruction":{"type":"string","minLength":1,"description":"希望如何解析图片，例如提取文字、描述画面或回答与图片有关的问题"},"images":{"type":"array","minItems":1,"items":{"type":"string","minLength":1},"description":"待分析图片的本地完整路径列表，原样使用用户消息中的 path；多张图片按希望分析的顺序传入"}},"required":["instruction","images"]}"#
                 .to_string(),
         }])
     }
@@ -70,7 +67,7 @@ impl Guest for Component {
         Ok(vec![format!(
             "## 附件分析工具\n\
              当用户消息明确列出需要分析的图片资源，且回答确实需要查看图片内容时，可调用 `{TOOL_ANALYZE_ATTACHMENT}`。\n\
-             调用时必须使用该用户消息标注的 `message_id`；`attachment_index` 从 0 开始，对应消息中的资源顺序。\n\
+             调用时将要分析的图片本地 `path` 原样传入 `images` 数组，并用 `instruction` 说明问题；不要用消息编号代替图片路径。\n\
              文档和其他文件应使用对应文件工具；普通文本对话、无需查看图片内容或消息未提供可分析图片时，不要调用此工具。"
         )])
     }
@@ -112,13 +109,11 @@ impl Guest for Component {
         Ok(())
     }
 
-    fn on_session_ready(session_json: String) -> Result<(), PluginError> {
-        cache_session(&session_json);
+    fn on_session_ready(_session_json: String) -> Result<(), PluginError> {
         Ok(())
     }
 
-    fn on_turn_started(session_json: String, _turn_start_idx: u32) -> Result<(), PluginError> {
-        cache_session(&session_json);
+    fn on_turn_started(_session_json: String, _turn_start_idx: u32) -> Result<(), PluginError> {
         Ok(())
     }
 
@@ -127,62 +122,27 @@ impl Guest for Component {
     }
 
     fn on_session_ended(_session_json: String) -> Result<(), PluginError> {
-        SESSION_MESSAGES.with(|m| m.borrow_mut().clear());
         Ok(())
     }
 }
 
-/// 缓存 session JSON 中的消息列表。
-fn cache_session(session_json: &str) {
-    let session: Value = serde_json::from_str(session_json).unwrap_or(Value::Null);
-    let messages = session
-        .get("messages")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    SESSION_MESSAGES.with(|m| {
-        *m.borrow_mut() = messages;
-    });
+fn parse_analyze_request(arguments: &str) -> Result<AnalyzeRequest, PluginError> {
+    let request: AnalyzeRequest = serde_json::from_str(arguments).map_err(|error| {
+        plugin_err(format!(
+            "附件参数无效，请提供 instruction 和 images 图片路径列表：{error}"
+        ))
+    })?;
+    if request.instruction.trim().is_empty() {
+        return Err(plugin_err("instruction 不能为空"));
+    }
+    if request.images.is_empty() || request.images.iter().any(|path| path.trim().is_empty()) {
+        return Err(plugin_err("images 必须包含非空的图片本地路径"));
+    }
+    Ok(request)
 }
 
 fn handle_analyze(call: &ToolCall) -> Result<ToolResult, PluginError> {
-    let args: Value = serde_json::from_str(&call.arguments).unwrap_or(Value::Null);
-    let instruction = args
-        .get("instruction")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
-    let message_id = args
-        .get("message_id")
-        .and_then(Value::as_str)
-        .map(String::from);
-    let attachment_index = args
-        .get("attachment_index")
-        .and_then(Value::as_u64)
-        .map(|v| v as usize);
-
-    // 从缓存的 session 消息中定位包含附件的用户消息。
-    let (user_text, images) = SESSION_MESSAGES.with(|m| {
-        let messages = m.borrow();
-        find_attachment_source(&messages, message_id.as_deref(), attachment_index)
-    });
-
-    if images.is_empty() {
-        return Ok(ToolResult {
-            ok: false,
-            summary: "未找到可解析的图片附件".to_string(),
-            stdout: String::new(),
-            stderr: "no image attachment found".to_string(),
-            exit_code: 1,
-            execution: None,
-        });
-    }
-
-    let request = AnalyzeRequest {
-        instruction,
-        user_message_text: user_text,
-        images,
-    };
+    let request = parse_analyze_request(&call.arguments)?;
     let response: AnalyzeResponse = sidecar_client::invoke::<Analyze>(&request)
         .map_err(|e| plugin_err(format!("附件分析失败: {e}")))?;
 
@@ -194,85 +154,6 @@ fn handle_analyze(call: &ToolCall) -> Result<ToolResult, PluginError> {
         exit_code: 0,
         execution: None,
     })
-}
-
-/// 从缓存消息中定位附件源消息，提取图片路径。
-///
-/// 返回 (用户消息文本, 图片本地路径列表)。
-fn find_attachment_source(
-    messages: &[Value],
-    message_id: Option<&str>,
-    attachment_index: Option<usize>,
-) -> (String, Vec<String>) {
-    // 定位消息：明确提供 message_id 时严格精确匹配——ID 不存在或该消息
-    // 没有图片都视为定位失败并报错，绝不回退到其他消息（避免误用历史图片
-    // 生成看似正常但内容错误的分析）。仅省略 ID 时取最近一条带图用户消息。
-    let source = match message_id {
-        Some(id) => messages
-            .iter()
-            .find(|msg| msg.get("id").and_then(Value::as_str) == Some(id)),
-        None => messages
-            .iter()
-            .rev()
-            .find(|msg| is_user_message_with_image(msg)),
-    };
-
-    let Some(source) = source else {
-        return (String::new(), Vec::new());
-    };
-
-    // 提取文本内容：用户文本在 content 数组的 text 块中。
-    let user_text = source
-        .get("content")
-        .and_then(Value::as_array)
-        .map(|blocks| {
-            blocks
-                .iter()
-                .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
-                .filter_map(|block| block.get("text").and_then(Value::as_str))
-                .collect::<Vec<_>>()
-                .join("\n")
-        })
-        .unwrap_or_default();
-
-    // 按序号筛选或返回全部。
-    let all_images = message_image_paths(source);
-    let images = match attachment_index {
-        Some(index) => all_images
-            .get(index)
-            .cloned()
-            .map(|p| vec![p])
-            .unwrap_or_default(),
-        None => all_images,
-    };
-
-    (user_text, images)
-}
-
-/// 消息是否为带图片附件的用户消息。
-fn is_user_message_with_image(msg: &Value) -> bool {
-    msg.get("role").and_then(Value::as_str) == Some("user") && !message_image_paths(msg).is_empty()
-}
-
-/// 从消息 content blocks 提取图片本地路径。
-fn message_image_paths(msg: &Value) -> Vec<String> {
-    msg.get("content")
-        .and_then(Value::as_array)
-        .map(|blocks| {
-            blocks
-                .iter()
-                // ContentBlock::Image { asset: { local_path } }
-                .filter_map(|block| {
-                    block
-                        .get("asset")
-                        .or_else(|| block.get("AssetReference").and_then(|a| a.get("asset")))
-                        .and_then(|asset| asset.get("local_path").and_then(Value::as_str))
-                        .filter(|path| !path.is_empty())
-                        .map(String::from)
-                })
-                .collect()
-        })
-        .unwrap_or_default()
 }
 
 impl UiGuest for Component {
@@ -301,59 +182,33 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn user_message_with_image(id: &str, text: &str, path: &str) -> Value {
-        json!({
-            "id": id,
-            "role": "user",
-            "content": [
-                { "type": "text", "text": text },
-                { "type": "image", "asset": { "local_path": path } }
-            ]
-        })
+    #[test]
+    fn 图片路径直接来自本次工具参数() {
+        let paths = vec!["/tmp/旧图.png", "/tmp/新图 \"带引号\".png"];
+        let request = parse_analyze_request(
+            &json!({
+                "instruction": "对比两张图片",
+                "images": paths,
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert_eq!(request.images, paths);
+        assert_eq!(request.instruction, "对比两张图片");
+        assert!(request.user_message_text.is_empty());
     }
 
     #[test]
-    fn message_id_命中时提取文本与图片路径() {
-        let messages = vec![user_message_with_image("msg-1", "看这张图", "/tmp/a.png")];
-        let (text, images) = find_attachment_source(&messages, Some("msg-1"), Some(0));
-        assert_eq!(text, "看这张图");
-        assert_eq!(images, vec!["/tmp/a.png".to_string()]);
-    }
-
-    #[test]
-    fn message_id_未命中时返回空() {
-        let messages = vec![
-            user_message_with_image("msg-1", "第一张", "/tmp/a.png"),
-            json!({ "id": "msg-2", "role": "assistant", "content": [{ "type": "text", "text": "收到" }] }),
-        ];
-        // 模型编造的 ID 在会话中不存在：严格失败，不回退到历史图片。
-        let (text, images) = find_attachment_source(&messages, Some("made-up-id"), Some(0));
-        assert_eq!(text, "");
-        assert!(images.is_empty());
-    }
-
-    #[test]
-    fn 省略_message_id_时取最近带图用户消息() {
-        let messages = vec![
-            user_message_with_image("msg-1", "第一张", "/tmp/a.png"),
-            user_message_with_image("msg-2", "第二张", "/tmp/b.png"),
-        ];
-        let (text, images) = find_attachment_source(&messages, None, None);
-        assert_eq!(text, "第二张");
-        assert_eq!(images, vec!["/tmp/b.png".to_string()]);
-    }
-
-    #[test]
-    fn message_id_命中但无图时图片为空() {
-        let messages = vec![json!({
-            "id": "msg-1",
-            "role": "user",
-            "content": [{ "type": "text", "text": "纯文本" }]
-        })];
-        // 严格匹配：消息找得到（文本正常提取），但没有图片可解析。
-        let (text, images) = find_attachment_source(&messages, Some("msg-1"), Some(0));
-        assert_eq!(text, "纯文本");
-        assert!(images.is_empty());
+    fn 缺少或无效路径明确失败而不回退旧消息() {
+        for args in [
+            json!({"instruction":"看图", "message_id":"old-message", "attachment_index":0}),
+            json!({"instruction":"看图", "images":[]}),
+            json!({"instruction":"看图", "images":[" "]}),
+            json!({"instruction":"看图", "images":"/tmp/image.png"}),
+            json!({"instruction":" ", "images":["/tmp/image.png"]}),
+        ] {
+            assert!(parse_analyze_request(&args.to_string()).is_err(), "{args}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 问题与结果

运行中追加的是引导消息，仍属于当前物理轮次，不应再次触发 on_turn_started。附件分析失败源于插件根据 message_id/attachment_index 查询生命周期钩子缓存的旧消息，无法取得引导消息里的新图片。

本 PR 改为直接传递图片本地路径。普通消息和引导消息使用相同的图片参数通路，不新增或重播生命周期通知。

## 改动

- 撤回引导消息重播开始钩子的代码；Core 的生产调度代码与 main 一致，新增检查保证开始和结束通知各一次，并确认引导中的新图片路径进入模型上下文。
- analyze_attachment 工具要求 instruction 和 images 路径数组；WASM 直接解析并转发给现有 sidecar AnalyzeRequest，删除会话消息缓存及按消息编号查找图片的逻辑。相关会话/轮次钩子为空实现。
- 宿主附件提示提供可直接传入 images 的路径数组，正确转义路径；消息编号和附件序号仅保留为来源信息。旧格式资源迁移提示同样引导直接使用本地路径。
- 缺少路径、空数组、空路径或错误参数类型明确失败，不回退历史图片；sidecar 对不存在的文件和目录路径明确报错。
- 附件分析插件准备为 0.1.6。私有 sidecar 请求原本就接收 images，业务协议结构和版本保持不变。

## 验证

完整提交检查及受影响模块的编译、严格 Clippy、nextest 均通过；已推送提交 8fb3e9f5，线上 CI 另行运行。

- Core 引导消息检查通过：新图片路径进入后续模型上下文，on_turn_started/on_turn_finished 均只执行一次。
- WASM 原生检查 5 项、附件归档 25 项、消息类型 37 项通过；宿主端严格 Clippy、WASM 目标严格 Clippy、实际 WASM/sidecar 构建及插件结构校验通过。
- 使用实际 WASM、真实沙箱中的实际 sidecar 和本地模拟识别服务运行完整调用链：不调用任何会话/轮次钩子即可分析指定图片；先提供旧会话后传入新路径，服务仍收到新图片；多图顺序与图片字节逐一核对一致。
- 路径包含中文、空格和引号的情况通过；旧消息编号参数、空数组、缺失文件及目录路径均失败，没有回退旧图片，也没有额外请求识别服务。
- 未调用真实付费模型、未改写用户会话记录、未发布或替换已安装插件。

## 应用衔接

工具参数由消息编号改为明确路径，发布时需配套更新宿主提示与附件分析插件。已有会话若仍保存旧工具声明，应使用新会话或按现有声明重整流程更新；不为兼容旧声明重播钩子或自动改写历史。
