### PR TITLE
fix(mcp): 配置文件加载失败时拒绝写回，防止默认空配置覆盖现有配置

### DIFF
--- a/plugins/tiangong-plugin-mcp/sidecar/src/service.rs
+++ b/plugins/tiangong-plugin-mcp/sidecar/src/service.rs
@@ -42,6 +42,8 @@ pub struct McpService {
     capability: McpCapabilityIndex,
     capability_cache_path: PathBuf,
     mcp_config_path: PathBuf,
+    /// 启动时配置文件加载失败的原因；存在期间拒绝任何写回，防止默认空配置覆盖磁盘上的真实配置。
+    config_load_error: RwLock<Option<String>>,
     /// 当前会话工作目录（由 reconfigure 注入，stdio MCP 子进程用）。
     workspace: RwLock<Option<PathBuf>>,
 }
@@ -56,7 +58,7 @@ impl McpService {
     }
 
     pub fn with_paths(mcp_config_path: PathBuf, capability_cache_path: PathBuf) -> Result<Self> {
-        let mcp_config = load_mcp_config_from_path(&mcp_config_path);
+        let (mcp_config, config_load_error) = load_mcp_config_from_path(&mcp_config_path);
         let capability = McpCapabilityIndex::new();
         let _ = capability.load_cache(&capability_cache_path);
         Ok(Self {
@@ -65,6 +67,7 @@ impl McpService {
             capability,
             capability_cache_path,
             mcp_config_path,
+            config_load_error: RwLock::new(config_load_error),
             workspace: RwLock::new(None),
         })
     }
@@ -307,11 +310,29 @@ impl McpService {
     }
 
     fn apply_config(&self, next: McpConfig, affected_server: Option<&str>) -> Result<()> {
+        // 启动时配置加载失败（文件损坏/不可读）且文件仍在磁盘上：内存里是
+        // 兜底默认配置，一旦写回会把磁盘上的真实配置整体抹掉，必须拒绝。
+        if let Some(error) = self
+            .config_load_error
+            .read()
+            .ok()
+            .and_then(|guard| guard.clone())
+            && self.mcp_config_path.exists()
+        {
+            return Err(anyhow!(
+                "MCP 配置文件加载失败，拒绝写回以防覆盖现有配置：{}（{error}）",
+                self.mcp_config_path.display()
+            ));
+        }
         write_mcp_config_to_path(&self.mcp_config_path, &next)?;
         if let Ok(mut guard) = self.mcp_config.write() {
             *guard = next.clone();
         } else {
             return Err(anyhow!("MCP 配置锁中毒"));
+        }
+        // 写回内容来自内存快照序列化，必然可解析，清除加载失败状态。
+        if let Ok(mut guard) = self.config_load_error.write() {
+            *guard = None;
         }
         self.capability.configure_scheduler(
             next.clone(),
@@ -501,28 +522,34 @@ impl McpService {
     }
 }
 
-/// 从指定路径加载 MCP 配置；文件不存在或解析失败时返回默认配置。
-fn load_mcp_config_from_path(path: &std::path::Path) -> McpConfig {
+/// 从指定路径加载 MCP 配置；返回（配置, 加载失败原因）。
+///
+/// 文件不存在是首装常态，返回默认配置且无错误；文件存在但读取/解析失败时
+/// 同样返回默认配置供只读展示，但记录错误原因——`apply_config` 依赖它拒绝
+/// 写回，避免默认空配置覆盖磁盘上的真实配置。
+fn load_mcp_config_from_path(path: &std::path::Path) -> (McpConfig, Option<String>) {
     if !path.exists() {
-        return McpConfig::default();
+        return (McpConfig::default(), None);
     }
     match std::fs::read_to_string(path) {
         Ok(content) => match serde_json::from_str::<McpConfig>(&content) {
-            Ok(config) => config,
+            Ok(config) => (config, None),
             Err(err) => {
+                let reason = format!("解析失败：{err}");
                 tracing::warn!(
-                    "MCP 配置解析失败，回退为默认配置：path={} error={err}",
+                    "MCP 配置解析失败，回退为默认配置（写回已禁止）：path={} error={err}",
                     path.display()
                 );
-                McpConfig::default()
+                (McpConfig::default(), Some(reason))
             }
         },
         Err(err) => {
+            let reason = format!("读取失败：{err}");
             tracing::warn!(
-                "MCP 配置读取失败，回退为默认配置：path={} error={err}",
+                "MCP 配置读取失败，回退为默认配置（写回已禁止）：path={} error={err}",
                 path.display()
             );
-            McpConfig::default()
+            (McpConfig::default(), Some(reason))
         }
     }
 }
@@ -633,5 +660,83 @@ impl tiangong_plugin_sidecar::SidecarService for McpService {
         request: tiangong_plugin_runtime::protocol::Request,
     ) -> tiangong_plugin_runtime::protocol::Response {
         McpService::dispatch(self, request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn register_request(name: &str) -> RegisterMcpServerRequest {
+        RegisterMcpServerRequest {
+            name: name.to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            tags: vec![],
+            enabled: true,
+            options: Default::default(),
+        }
+    }
+
+    #[test]
+    fn register_rejected_when_config_file_corrupted() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("mcp.json");
+        std::fs::write(&config_path, "{ 损坏的配置").unwrap();
+        let service =
+            McpService::with_paths(config_path.clone(), dir.path().join("cache.json")).unwrap();
+        let error = service
+            .register_server(register_request("new-server"))
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("拒绝写回"),
+            "损坏配置下注册应拒绝写回，实际：{error}"
+        );
+        // 磁盘文件保持原样，未被默认空配置覆盖。
+        assert_eq!(
+            std::fs::read_to_string(&config_path).unwrap(),
+            "{ 损坏的配置"
+        );
+    }
+
+    #[test]
+    fn register_succeeds_when_config_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let service =
+            McpService::with_paths(dir.path().join("mcp.json"), dir.path().join("cache.json"))
+                .unwrap();
+        let message = service
+            .register_server(register_request("first-server"))
+            .unwrap();
+        assert!(message.contains("first-server"));
+    }
+
+    #[test]
+    fn register_appends_to_valid_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("mcp.json");
+        let existing = serde_json::to_string_pretty(&McpConfig {
+            servers: vec![McpServerConfig {
+                name: "existing".to_string(),
+                transport: Default::default(),
+                command: "echo".to_string(),
+                args: vec![],
+                endpoint: String::new(),
+                auth_header: String::new(),
+                headers: BTreeMap::new(),
+                env: BTreeMap::new(),
+                enabled: true,
+                tags: vec![],
+            }],
+            ..Default::default()
+        })
+        .unwrap();
+        std::fs::write(&config_path, existing).unwrap();
+        let service =
+            McpService::with_paths(config_path.clone(), dir.path().join("cache.json")).unwrap();
+        service.register_server(register_request("added")).unwrap();
+        let content = std::fs::read_to_string(&config_path).unwrap();
+        assert!(content.contains("\"existing\""));
+        assert!(content.contains("\"added\""));
     }
 }

--- a/plugins/tiangong-plugin-mcp/sidecar/src/service.rs
+++ b/plugins/tiangong-plugin-mcp/sidecar/src/service.rs
@@ -310,19 +310,31 @@ impl McpService {
     }
 
     fn apply_config(&self, next: McpConfig, affected_server: Option<&str>) -> Result<()> {
-        // 启动时配置加载失败（文件损坏/不可读）且文件仍在磁盘上：内存里是
-        // 兜底默认配置，一旦写回会把磁盘上的真实配置整体抹掉，必须拒绝。
+        // 启动时配置加载失败（文件损坏/不可读）：内存里是兜底默认配置，一旦
+        // 写回会把磁盘上的真实配置整体抹掉，必须拒绝。只有明确确认文件已
+        // 不在磁盘上（NotFound，用户删除后重建）才放行；状态无法确认时同样
+        // 保守拒绝——`exists()` 在权限不足时也会返回 false，不能作放行依据。
         if let Some(error) = self
             .config_load_error
             .read()
             .ok()
             .and_then(|guard| guard.clone())
-            && self.mcp_config_path.exists()
         {
-            return Err(anyhow!(
-                "MCP 配置文件加载失败，拒绝写回以防覆盖现有配置：{}（{error}）",
-                self.mcp_config_path.display()
-            ));
+            match std::fs::metadata(&self.mcp_config_path) {
+                Ok(_) => {
+                    return Err(anyhow!(
+                        "MCP 配置文件加载失败，拒绝写回以防覆盖现有配置：{}（{error}）",
+                        self.mcp_config_path.display()
+                    ));
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(anyhow!(
+                        "MCP 配置文件状态无法确认，拒绝写回以防覆盖现有配置：{}（{error}；{err}）",
+                        self.mcp_config_path.display()
+                    ));
+                }
+            }
         }
         write_mcp_config_to_path(&self.mcp_config_path, &next)?;
         if let Ok(mut guard) = self.mcp_config.write() {
@@ -479,11 +491,16 @@ impl McpService {
     }
 
     fn merge_with_disk(&self) -> Result<()> {
-        if !self.mcp_config_path.exists() {
-            return Ok(());
-        }
-        let disk_content = std::fs::read_to_string(&self.mcp_config_path)
-            .with_context(|| format!("读取 mcp 配置失败：{}", self.mcp_config_path.display()))?;
+        let disk_content = match std::fs::read_to_string(&self.mcp_config_path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => {
+                return Err(anyhow!(
+                    "读取 mcp 配置失败：{}（{err}）",
+                    self.mcp_config_path.display()
+                ));
+            }
+        };
         let disk_mcp: McpConfig = serde_json::from_str(&disk_content)
             .with_context(|| format!("解析 mcp 配置失败：{}", self.mcp_config_path.display()))?;
         let mut next = self.config_snapshot();
@@ -524,29 +541,32 @@ impl McpService {
 
 /// 从指定路径加载 MCP 配置；返回（配置, 加载失败原因）。
 ///
-/// 文件不存在是首装常态，返回默认配置且无错误；文件存在但读取/解析失败时
-/// 同样返回默认配置供只读展示，但记录错误原因——`apply_config` 依赖它拒绝
-/// 写回，避免默认空配置覆盖磁盘上的真实配置。
+/// 只有明确的 NotFound 才是首装常态（返回默认配置且无错误）；读取或解析
+/// 失败（含权限不足等一切非 NotFound 错误）时同样返回默认配置供只读展示，
+/// 但记录错误原因——`apply_config` 依赖它拒绝写回，避免默认空配置覆盖
+/// 磁盘上的真实配置。不能用 `exists()` 预判：无权限 stat 的路径同样返回
+/// false，会被误判成首装。
 fn load_mcp_config_from_path(path: &std::path::Path) -> (McpConfig, Option<String>) {
-    if !path.exists() {
-        return (McpConfig::default(), None);
-    }
-    match std::fs::read_to_string(path) {
-        Ok(content) => match serde_json::from_str::<McpConfig>(&content) {
-            Ok(config) => (config, None),
-            Err(err) => {
-                let reason = format!("解析失败：{err}");
-                tracing::warn!(
-                    "MCP 配置解析失败，回退为默认配置（写回已禁止）：path={} error={err}",
-                    path.display()
-                );
-                (McpConfig::default(), Some(reason))
-            }
-        },
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return (McpConfig::default(), None);
+        }
         Err(err) => {
             let reason = format!("读取失败：{err}");
             tracing::warn!(
                 "MCP 配置读取失败，回退为默认配置（写回已禁止）：path={} error={err}",
+                path.display()
+            );
+            return (McpConfig::default(), Some(reason));
+        }
+    };
+    match serde_json::from_str::<McpConfig>(&content) {
+        Ok(config) => (config, None),
+        Err(err) => {
+            let reason = format!("解析失败：{err}");
+            tracing::warn!(
+                "MCP 配置解析失败，回退为默认配置（写回已禁止）：path={} error={err}",
                 path.display()
             );
             (McpConfig::default(), Some(reason))
@@ -697,6 +717,37 @@ mod tests {
             std::fs::read_to_string(&config_path).unwrap(),
             "{ 损坏的配置"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn register_rejected_when_config_file_inaccessible() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("mcp.json");
+        let existing = serde_json::to_string_pretty(&McpConfig::default()).unwrap();
+        std::fs::write(&config_path, &existing).unwrap();
+
+        // 目录去掉执行权限后 stat 会失败，exists() 会把"无法访问"误报成
+        // "不存在"；加载必须按读取失败记录并保持写回保护，而不是当作首装。
+        let original = std::fs::metadata(dir.path()).unwrap().permissions();
+        let mut restricted = original.clone();
+        restricted.set_mode(0o600);
+        std::fs::set_permissions(dir.path(), restricted).unwrap();
+        let service = McpService::with_paths(config_path.clone(), dir.path().join("cache.json"));
+        // 先恢复权限再断言，保证 tempdir 清理不受断言失败影响。
+        std::fs::set_permissions(dir.path(), original).unwrap();
+
+        let service = service.unwrap();
+        let error = service
+            .register_server(register_request("new-server"))
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("拒绝写回"),
+            "目录不可访问时注册应拒绝写回，实际：{error}"
+        );
+        // 原文件仍在且未被默认空配置覆盖。
+        assert_eq!(std::fs::read_to_string(&config_path).unwrap(), existing);
     }
 
     #[test]


### PR DESCRIPTION
## 背景

MCP 配置保存失败问题排查（沙箱 Launcher 验签窗口 + mcp.json 沙箱读写豁免链）过程中实证的数据丢失风险，独立成 PR。

## 故障

MCP sidecar 启动时若 mcp.json 损坏或不可读（或沙箱读禁导致读到空配置），会静默回退默认空配置；此后任何新增/编辑/启停/删除操作都会把"空配置+本次变更"整体写回，磁盘上的全部既有 server 被抹掉。

## 修复

- 加载失败原因被记录；存在加载失败且磁盘文件仍在时，写回一律拒绝并报出具体原因
- 文件不存在（首装）不受影响；写回成功后清除失败状态

## 验证

- cargo test -p tiangong-plugin-mcp-sidecar：5 项全过（损坏配置拒绝写回且文件保持原样 / 无文件正常注册 / 合法配置正常追加）