### PR TITLE
fix(terminal): 修复隐藏面板后命令就绪超时

### DIFF
--- a/plugins/tiangong-plugin-terminal/src/terminal-view.ts
+++ b/plugins/tiangong-plugin-terminal/src/terminal-view.ts
@@ -72,6 +72,9 @@ export function createTerminalView(
   terminal.loadAddon(fit);
   terminal.open(host);
   const fitToHost = () => {
+    // 隐藏的保活标签没有布局尺寸，FitAddon 此时可能把百分比宽度
+    // 当成像素，或缩成 2×1；不能将这个尺寸传给仍在运行的 PTY。
+    if (host.clientWidth <= 0 || host.clientHeight <= 0) return false;
     try {
       fit.fit();
       return true;
@@ -93,7 +96,7 @@ export function createTerminalView(
 
   // xterm 尺寸同步到 PTY（rows/cols 不一致会导致换行与全屏应用错乱）
   const syncSize = () => {
-    if (!attached) return;
+    if (!attached || host.clientWidth <= 0 || host.clientHeight <= 0) return;
     const sizeKey = `${attached}:${terminal.cols}x${terminal.rows}`;
     if (sizeKey === lastSyncedSize) return;
     lastSyncedSize = sizeKey;


### PR DESCRIPTION
终端标签或右侧面板隐藏后，FitAddon 将未布局的百分比宽高误算为 11 列、6 行并同步到 PTY。PowerShell 就绪回应被拆散，执行 dir 时误报“等待 Shell 就绪超时”。

面板宽高为零时跳过尺寸拟合及同步，保留之前的有效尺寸；隐藏时首次创建沿用 80×24，展开后恢复正常拟合。

验证：yarn build 通过；12 项现有前端检查通过。真实浏览器对照旧版隐藏后 100×28→11×6，修复版保持 100×28；隐藏时新建和重新展开通过。使用已安装 Terminal 0.3.1 在 D:\tiangong_agent 实测：11×6 稳定复现超时；正常尺寸下 PowerShell/CMD 首次 dir、同一终端连续 echo 和关闭均通过。

仅修改终端前端尺寸同步，不升版。已生成本地签名修复包，尚未导入用户正在运行的应用。
