### PR TITLE
fix(app): sidecar 调用对未落盘会话降级通用可写域

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5194,21 +5194,29 @@ pub async fn bridge_call(
     state: State<'_, TiangongApp>,
 ) -> Result<String, String> {
     // 前端实例只传会话 ID；sidecar 可写域必须由宿主从权威 Session 加载，
-    // 不能采用抢到全局工具事件的界面实例所携带的工作区。
+    // 不能采用抢到全局工具事件的界面实例所携带的工作区。新对话首条消息
+    // 发出前只有前端本地编号（未落盘）或工作区未定：此时按无会话处理，
+    // 走通用可写域——终端等面板在新对话中立即可用，不因会话未就绪被拒。
     let authoritative_workspace = if method.starts_with("sidecar.") {
         match session_id.filter(|id| !id.trim().is_empty()) {
-            Some(session_id) => {
-                let session = state
-                    .inner()
-                    .core_manager
-                    .load_session(&session_id)
-                    .map_err(|error| format!("加载 sidecar 调用所属会话失败: {error}"))?;
-                let cwd = session.cwd.trim();
-                if cwd.is_empty() {
-                    return Err(format!("会话 {session_id} 未配置工作区"));
+            Some(session_id) => match state.inner().core_manager.load_session(&session_id) {
+                Ok(session) => {
+                    let cwd = session.cwd.trim();
+                    if cwd.is_empty() {
+                        None
+                    } else {
+                        Some(PathBuf::from(cwd))
+                    }
                 }
-                Some(PathBuf::from(cwd))
-            }
+                Err(error) => {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        %error,
+                        "sidecar 调用所属会话加载失败，降级为通用可写域"
+                    );
+                    None
+                }
+            },
             None => None,
         }
     } else {


### PR DESCRIPTION
## 问题

新建对话（未发首条消息）里打开终端面板，界面停在「正在连接终端…」无法进入；已有对话的会话里打开正常。

## 根因

新对话在首条消息发出前只有前端本地编号（`newConversationId`，宿主未落盘）。插件页面的 shadow 桥接自动把该编号作为 sessionId 附加到所有 `bridge.call`，宿主 `bridge_call` 对 `sidecar.*` 方法强制 `core_manager.load_session`（纯磁盘加载）——临时编号必然加载失败，调用在入口即被硬拒，终端插件的 terminalFind/terminalSpawn 全部失败。

插件侧无法绕开（sessionId 由宿主前端注入附加），宿主入口是唯一修复位。该强校验自 047ccd01（沙箱集成）即存在，非近期回归，只是此前无人踩到「空对话开面板」场景。

## 修复

`bridge_call` 解析 sidecar 可写域时，会话加载失败或工作区为空不再报错，按无会话语义降级为通用可写域（与全局面板一致），并记 WARN 日志观察降级频次。

影响面说明：
- 常驻（resident/预热型）插件本就强制通用域，行为不变；
- 按需插件的会话隔离可写域在此场景退回通用域（固定目录，非任意路径），与「无会话」时已有的语义一致。

## 测试

- `cargo check` 通过
- `cargo test --lib`（tiangong-app）51 项全部通过
- 本地部署 terminal 0.3.2 插件验证：已有对话会话打开终端正常（问题场景的对照路径）