### PR TITLE
fix(frontend): 修复切换会话卡顿与滚动定位——撤销强制滚底、阅读位置记忆与渲染优化

### DIFF
--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -381,12 +381,11 @@ export function MessageList() {
     const sessionSwitched = prevActiveSessionRef.current !== undefined
       && activeSessionId !== prevActiveSessionRef.current;
     if (sessionSwitched) {
-      // 切换会话视为重新进入：重置滚动基准并直接定位到底部，不依赖
-      // 消息数量/流式标识的变化检测（避免旧会话残留的流式状态被误判
-      // 为"回复完成"，或变化检测落空导致停在旧位置）
+      // 切换会话时仅重置流式基准，避免旧会话残留的流式状态被误判为
+      // "回复完成"；滚动与否交给通用的变化检测（新会话消息更多且
+      // 在底部时才跟随到底），不做强制定位
       prevStreamingIdRef.current = null;
       prevRunStatusRef.current = 'idle';
-      prevMessagesLengthRef.current = messages.length;
     }
 
     const newMessageArrived = messages.length > prevMessagesLengthRef.current;
@@ -409,8 +408,7 @@ export function MessageList() {
     // 用户离开底部时，新消息/流式 id 变化不强制拉回；用户主动发送始终
     // 跟随；回复完成时保持当前位置不动
     const shouldScroll =
-      sessionSwitched
-      || isUserSelfSent
+      isUserSelfSent
       || (!streamingFinished && (newMessageArrived || streamingIdChanged) && isAtBottomRef.current);
 
     if (shouldScroll) {

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -37,6 +37,15 @@ import {
 } from "./message";
 import { type MentionEditorHandle } from "./MentionEditor";
 
+/** 每个会话的阅读位置锚点：视口顶部对齐的分组索引 + 离开时是否贴底。
+ * 切换会话时按锚点恢复阅读位置（贴底则回到底部保持跟随语义）；
+ * 无记录（首次进入）才定位到底部。 */
+interface SessionScrollAnchor {
+  index: number;
+  atBottom: boolean;
+}
+const sessionScrollAnchors = new Map<string, SessionScrollAnchor>();
+
 /** 取路径最后 1-2 级目录用于简短展示，例如 /a/b/tiangong -> b/tiangong */
 function shortDir(path: string): string {
   if (!path) return '';
@@ -164,33 +173,16 @@ export function MessageList() {
     };
   }, []);
 
-  // 切换会话时关闭搜索
+  // 切换会话时关闭搜索；贴底状态由切换恢复逻辑按锚点位置判定，
+  // 不再无条件视为在底部
   useEffect(() => {
     useSearchStore.getState().closeSearch();
-    // 切换会话视为重新进入，默认在底部
-    isAtBottomRef.current = true;
   }, [activeSessionId]);
 
   // 卸载时清理刻度尺预览卡片的隐藏定时器
   useEffect(() => () => {
     if (railPreviewHideTimerRef.current) window.clearTimeout(railPreviewHideTimerRef.current);
   }, []);
-
-  // 监听滚动位置，维护 isAtBottom 状态
-  useEffect(() => {
-    const el = viewportRef.current;
-    if (!el) return;
-    const handleScroll = () => {
-      const threshold = 80;
-      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-      const next = distance < threshold;
-      if (next !== isAtBottomRef.current) {
-        isAtBottomRef.current = next;
-      }
-    };
-    el.addEventListener('scroll', handleScroll, { passive: true });
-    return () => el.removeEventListener('scroll', handleScroll);
-  }, [activeSessionId]);
 
   // Cmd/Ctrl+F 全局快捷键
   useEffect(() => {
@@ -329,6 +321,31 @@ export function MessageList() {
     overscan: 5,
   });
 
+  // 监听滚动位置，维护 isAtBottom 状态与当前会话的阅读位置锚点。
+  // 置于 virtualizer 声明之后（handleScroll 需要按像素偏移取顶部组索引）
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+    const handleScroll = () => {
+      const threshold = 80;
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      const next = distance < threshold;
+      if (next !== isAtBottomRef.current) {
+        isAtBottomRef.current = next;
+      }
+      // 滚动瞬间记录锚点，保证切走会话时的位置始终是最新的
+      // （新对话态 activeSessionId 为空，无会话内容可记）
+      if (activeSessionId) {
+        const topItem = virtualizer.getVirtualItemForOffset(el.scrollTop);
+        if (topItem) {
+          sessionScrollAnchors.set(activeSessionId, { index: topItem.index, atBottom: next });
+        }
+      }
+    };
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, [activeSessionId, virtualizer]);
+
   // 搜索导航：通过 store subscription 监听 searchQuery 和 currentMatchIndex 变化
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
@@ -380,12 +397,40 @@ export function MessageList() {
     let cancelled = false;
     const sessionSwitched = prevActiveSessionRef.current !== undefined
       && activeSessionId !== prevActiveSessionRef.current;
-    if (sessionSwitched) {
-      // 切换会话时仅重置流式基准，避免旧会话残留的流式状态被误判为
-      // "回复完成"；滚动与否交给通用的变化检测（新会话消息更多且
-      // 在底部时才跟随到底），不做强制定位
+    if (sessionSwitched && activeSessionId) {
+      // 切换会话：重置流式与消息数基准（避免旧会话残留的流式状态被
+      // 误判为"回复完成"、跨会话长度比较误触发跟随），本次定位完全
+      // 由阅读位置锚点接管，不走通用滚动判定
       prevStreamingIdRef.current = null;
       prevRunStatusRef.current = 'idle';
+      prevMessagesLengthRef.current = messages.length;
+      requestAnimationFrame(() => {
+        if (cancelled) return;
+        const lastIndex = completedGroups.length - 1;
+        const anchor = sessionScrollAnchors.get(activeSessionId);
+        // 有记录则恢复到离开时的阅读位置（贴底的回到底部保持跟随）；
+        // 首次进入（或记录越界，如消息被删除/压缩）定位到底部看最新内容
+        if (anchor && anchor.index <= lastIndex) {
+          if (anchor.atBottom) {
+            isAtBottomRef.current = true;
+            if (streamingGroup && scrollRef.current) {
+              scrollRef.current.scrollIntoView({ behavior: 'auto', block: 'end' });
+            } else if (lastIndex >= 0) {
+              virtualizer.scrollToIndex(lastIndex, { behavior: 'auto', align: 'end' });
+            }
+          } else {
+            virtualizer.scrollToIndex(anchor.index, { behavior: 'auto', align: 'start' });
+          }
+        } else if (streamingGroup && scrollRef.current) {
+          scrollRef.current.scrollIntoView({ behavior: 'auto', block: 'end' });
+        } else if (lastIndex >= 0) {
+          virtualizer.scrollToIndex(lastIndex, { behavior: 'auto', align: 'end' });
+        }
+      });
+      prevStreamingIdRef.current = streamingMessageId;
+      prevRunStatusRef.current = runStatus;
+      prevActiveSessionRef.current = activeSessionId;
+      return () => { cancelled = true; };
     }
 
     const newMessageArrived = messages.length > prevMessagesLengthRef.current;

--- a/frontend/src/components/message/AgentTurn.tsx
+++ b/frontend/src/components/message/AgentTurn.tsx
@@ -1,5 +1,4 @@
-import { memo, useEffect, useState } from "react";
-import { MdPreview } from "md-editor-rt";
+import { memo, useEffect, useMemo, useState } from "react";
 import { FileText, ChevronRight, ChevronDown } from "lucide-react";
 import { useSearchStore } from "@/store/useSearchStore";
 import { useStore } from "@/store/useStore";
@@ -27,6 +26,7 @@ import {
 } from "./utils";
 import type { MessageItem } from "./types";
 import { useExpansionState } from "./useExpansionState";
+import { LazyMdPreview } from "./LazyMdPreview";
 import { StreamingMessage } from "./StreamingMessage";
 import { MessageActions } from "./MessageActions";
 import { ContentMedia } from "./ContentMedia";
@@ -74,32 +74,6 @@ function AgentTurnView({
     setShowProcess(isActive);
   }, [isActive]);
 
-  // 工具调用参数配对：assistant 消息携带 tool_calls（含参数），
-  // role:'tool' 结果消息按 tool_call_id 反查参数，用于派生单行摘要与展开内容。
-  const toolCallArgs = new Map<string, { id: string; name: string; arguments?: unknown }>();
-  const settledToolCallIds = new Set<string>();
-  for (const msg of messages) {
-    for (const call of msg.tool_calls ?? []) toolCallArgs.set(call.id, call);
-    if (msg.role === "tool" && msg.tool_call_id) settledToolCallIds.add(msg.tool_call_id);
-  }
-  const argsOfToolMessage = (msg: MessageItem): unknown =>
-    msg.tool_call_id ? toolCallArgs.get(msg.tool_call_id)?.arguments : undefined;
-  // 执行中的调用：tool_calls 已发出但结果未到达，仅活跃轮次渲染为运行行。
-  // 携带发起时刻（store 记录），运行行据此实时跳秒。
-  const runningToolCalls = isActive
-    ? [...toolCallArgs.values()]
-        .filter((call) => !settledToolCallIds.has(call.id))
-        .map((call) => ({ ...call, startedAt: toolCallStartedAt[call.id] }))
-    : [];
-
-  const renderWithHighlight = (msgId: string, text: string) => {
-    if (!searchQuery) return text;
-    const occurrences = findTextOccurrences(text, searchQuery, caseSensitive);
-    if (occurrences.length === 0) return text;
-    const isCurrent = msgId === currentMessageId;
-    return <HighlightText text={text} matches={occurrences} currentMatchStart={isCurrent ? currentMatchStart : null} />;
-  };
-
   type Fragment =
     | { type: "explanation"; text: string; time?: string }
     | { type: "thinking"; content: string; time?: string; elapsedMs?: number | null }
@@ -113,139 +87,206 @@ function AgentTurnView({
     | { type: "subagent_report"; agentName: string; status: string; content: string; time: string; msgId: string }
     | { type: "other_system"; msg: MessageItem };
 
-  const fragments: Fragment[] = [];
-  const shownReasonings = new Set<string>();
-  let pendingTools: MessageItem[] = [];
+  // 消息分类/合并/分桶全量计算装进 useMemo：依赖仅 messages 引用、流式
+  // 消息 id 与 agents——流式正文高频更新、父级重渲、搜索高亮变化都不再
+  // 触发重算（长轮次上百条消息的分类是毫秒级同步计算，重算会在切换
+  // 会话挂载可见组时叠加成可感知的卡顿）
+  const {
+    toolCallArgs,
+    settledToolCallIds,
+    userFrag,
+    mergedFragments,
+    summaryFrags,
+    processFrags,
+    errorFrags,
+    usageAnchorId,
+    lastToolGroupIndex,
+  } = useMemo(() => {
+    // 工具调用参数配对：assistant 消息携带 tool_calls（含参数），
+    // role:'tool' 结果消息按 tool_call_id 反查参数，用于派生单行摘要与展开内容。
+    const toolCallArgs = new Map<string, { id: string; name: string; arguments?: unknown }>();
+    const settledToolCallIds = new Set<string>();
+    for (const msg of messages) {
+      for (const call of msg.tool_calls ?? []) toolCallArgs.set(call.id, call);
+      if (msg.role === "tool" && msg.tool_call_id) settledToolCallIds.add(msg.tool_call_id);
+    }
 
-  const flushTools = () => {
-    if (pendingTools.length === 0) return;
-    fragments.push({ type: "tool_group", key: pendingTools[0].id, tools: [...pendingTools] });
-    pendingTools = [];
-  };
+    const fragments: Fragment[] = [];
+    const shownReasonings = new Set<string>();
+    let pendingTools: MessageItem[] = [];
 
-  for (const msg of messages) {
-    if (msg.role === "notice" && msg.usage) continue;
-    if (msg.role === "user" && textContent(msg).startsWith("[Subagent·")) {
-      flushTools();
-      const raw = textContent(msg);
-      const match = raw.match(/^\[Subagent·([^\]]+)\]\s*(.*)$/s);
-      if (match) {
-        const [, name, body] = match;
-        const statusMatch = body.match(/^(任务完成|执行失败|运行阻塞|等待审批)：?\s*/);
-        const status = statusMatch ? statusMatch[1] : "消息";
-        const content = statusMatch ? body.slice(statusMatch[0].length) : body;
-        fragments.push({ type: "subagent_report", agentName: name.trim(), status, content: content.trim(), time: msg.created_at, msgId: msg.id });
-      } else {
-        fragments.push({ type: "user", msg });
+    // 同一消息在分类链上会被多次取文本（前缀判断 + 正文提取），
+    // 全量拼接按消息缓存一份，避免长轮次（上百条消息）重复分配
+    const textCache = new Map<MessageItem, string>();
+    const textOf = (msg: MessageItem): string => {
+      let text = textCache.get(msg);
+      if (text === undefined) {
+        text = textContent(msg);
+        textCache.set(msg, text);
       }
-    } else if (msg.role === "user") {
-      flushTools();
-      fragments.push({ type: "user", msg });
-    } else if (msg.role === "system" && textContent(msg).startsWith("[记忆检索] 策略:")) {
-      pendingTools.push(msg);
-    } else if (msg.role === "system" && textContent(msg).startsWith("[记忆检索]")) {
-      pendingTools.push(msg);
-    } else if (msg.role === "system" && textContent(msg).startsWith("LLM 输出")) {
-      const reasoning = msgReasoning(msg);
-      const explanation = extractLlmExplanation(textContent(msg));
-      if (!reasoning && !explanation && llmOutputHasToolCalls(textContent(msg))) continue;
-      flushTools();
-      if (reasoning && !shownReasonings.has(reasoning)) {
-        shownReasonings.add(reasoning);
-        fragments.push({ type: "thinking", content: reasoning, time: msg.created_at });
-      }
-      if (explanation) fragments.push({ type: "explanation", text: explanation, time: msg.created_at });
-    } else if (msg.role === "system" && (textContent(msg).includes("tool_name:") || textContent(msg).includes("exit_code") || textContent(msg).startsWith("工具执行 ["))) {
-      pendingTools.push(msg);
-    } else if (msg.role === "tool") {
-      pendingTools.push(msg);
-      continue;
-    } else if (msg.role === "assistant") {
-      const isStreaming = msg.id === streamingMessageId;
-      const assistantReasoning = msgReasoning(msg);
-      const hasVisibleAssistantContent = isStreaming || textContent(msg).trim().length > 0 || assistantReasoning.length > 0 || !!msg.media?.length || hasMediaBlocks(msg);
-      if (!hasVisibleAssistantContent) continue;
-      flushTools();
-      const prevFrag = fragments[fragments.length - 1];
-      if (prevFrag?.type === "explanation" && prevFrag.text === textContent(msg).trim() && !isStreaming) fragments.pop();
-      if (!isStreaming && assistantReasoning && !shownReasonings.has(assistantReasoning)) {
-        shownReasonings.add(assistantReasoning);
-        fragments.push({ type: "thinking", content: assistantReasoning, time: msg.created_at, elapsedMs: msg.reasoning_elapsed_ms });
-      }
-      // 总结阶段判定"任务未完成、需重入 Loop"的回复（[NEED_MORE_WORK] 标头）：
-      // 前端作为思考过程展示，剥除标头，不作为最终回复正文。
-      if (isNeedMoreWorkMessage(msg)) {
-        const needMoreWorkBody = stripSummaryStatusMarker(textContent(msg)).trim();
-        if (needMoreWorkBody || isStreaming) {
-          fragments.push({ type: "thinking", content: needMoreWorkBody, time: msg.created_at, elapsedMs: msg.text_elapsed_ms });
+      return text;
+    };
+
+    const flushTools = () => {
+      if (pendingTools.length === 0) return;
+      fragments.push({ type: "tool_group", key: pendingTools[0].id, tools: [...pendingTools] });
+      pendingTools = [];
+    };
+
+    for (const msg of messages) {
+      if (msg.role === "notice" && msg.usage) continue;
+      if (msg.role === "user" && textOf(msg).startsWith("[Subagent·")) {
+        flushTools();
+        const raw = textOf(msg);
+        const match = raw.match(/^\[Subagent·([^\]]+)\]\s*(.*)$/s);
+        if (match) {
+          const [, name, body] = match;
+          const statusMatch = body.match(/^(任务完成|执行失败|运行阻塞|等待审批)：?\s*/);
+          const status = statusMatch ? statusMatch[1] : "消息";
+          const content = statusMatch ? body.slice(statusMatch[0].length) : body;
+          fragments.push({ type: "subagent_report", agentName: name.trim(), status, content: content.trim(), time: msg.created_at, msgId: msg.id });
+        } else {
+          fragments.push({ type: "user", msg });
         }
+      } else if (msg.role === "user") {
+        flushTools();
+        fragments.push({ type: "user", msg });
+      } else if (msg.role === "system" && textOf(msg).startsWith("[记忆检索] 策略:")) {
+        pendingTools.push(msg);
+      } else if (msg.role === "system" && textOf(msg).startsWith("[记忆检索]")) {
+        pendingTools.push(msg);
+      } else if (msg.role === "system" && textOf(msg).startsWith("LLM 输出")) {
+        const reasoning = msgReasoning(msg);
+        const explanation = extractLlmExplanation(textOf(msg));
+        if (!reasoning && !explanation && llmOutputHasToolCalls(textOf(msg))) continue;
+        flushTools();
+        if (reasoning && !shownReasonings.has(reasoning)) {
+          shownReasonings.add(reasoning);
+          fragments.push({ type: "thinking", content: reasoning, time: msg.created_at });
+        }
+        if (explanation) fragments.push({ type: "explanation", text: explanation, time: msg.created_at });
+      } else if (msg.role === "system" && (textOf(msg).includes("tool_name:") || textOf(msg).includes("exit_code") || textOf(msg).startsWith("工具执行 ["))) {
+        pendingTools.push(msg);
+      } else if (msg.role === "tool") {
+        pendingTools.push(msg);
+        continue;
+      } else if (msg.role === "assistant") {
+        const isStreaming = msg.id === streamingMessageId;
+        const assistantReasoning = msgReasoning(msg);
+        const hasVisibleAssistantContent = isStreaming || textOf(msg).trim().length > 0 || assistantReasoning.length > 0 || !!msg.media?.length || hasMediaBlocks(msg);
+        if (!hasVisibleAssistantContent) continue;
+        flushTools();
+        const prevFrag = fragments[fragments.length - 1];
+        if (prevFrag?.type === "explanation" && prevFrag.text === textOf(msg).trim() && !isStreaming) fragments.pop();
+        if (!isStreaming && assistantReasoning && !shownReasonings.has(assistantReasoning)) {
+          shownReasonings.add(assistantReasoning);
+          fragments.push({ type: "thinking", content: assistantReasoning, time: msg.created_at, elapsedMs: msg.reasoning_elapsed_ms });
+        }
+        // 总结阶段判定"任务未完成、需重入 Loop"的回复（[NEED_MORE_WORK] 标头）：
+        // 前端作为思考过程展示，剥除标头，不作为最终回复正文。
+        if (isNeedMoreWorkMessage(msg)) {
+          const needMoreWorkBody = stripSummaryStatusMarker(textOf(msg)).trim();
+          if (needMoreWorkBody || isStreaming) {
+            fragments.push({ type: "thinking", content: needMoreWorkBody, time: msg.created_at, elapsedMs: msg.text_elapsed_ms });
+          }
+          continue;
+        }
+        fragments.push({ type: "assistant", msg, isStreaming });
+      } else if ((msg.role === "notice" || msg.role === "system") && textOf(msg).startsWith("[错误]")) {
+        flushTools();
+        fragments.push({ type: "error_system", msg });
+      } else if (msg.role === "system" && textOf(msg).startsWith("[重试]")) {
+        flushTools();
+        fragments.push({ type: "retry_system", msg });
+      } else if (msg.role === "system" && textOf(msg).startsWith("[上下文管理]")) {
+        if (textOf(msg).includes("正在压缩")) continue;
+        flushTools();
+        fragments.push({ type: "context_management", msg });
+      } else if (msg.role === "system" && (textOf(msg).startsWith("[Agent]") || textOf(msg).startsWith("[文件锁]"))) {
+        flushTools();
+        const category = textOf(msg).startsWith("[文件锁]") ? "lock" : "info";
+        fragments.push({ type: "agent_event", category, content: textOf(msg), agentRoles: extractAgentRoles(textOf(msg), agents) });
+      } else if (msg.role === "system" || msg.role === "notice") {
+        flushTools();
+        fragments.push({ type: "other_system", msg });
+      }
+    }
+    flushTools();
+
+    const mergedFragments: Fragment[] = [];
+    for (const frag of fragments) {
+      const previous = mergedFragments[mergedFragments.length - 1];
+      if (frag.type === "tool_group" && previous?.type === "tool_group") {
+        previous.tools.push(...frag.tools);
         continue;
       }
-      fragments.push({ type: "assistant", msg, isStreaming });
-    } else if ((msg.role === "notice" || msg.role === "system") && textContent(msg).startsWith("[错误]")) {
-      flushTools();
-      fragments.push({ type: "error_system", msg });
-    } else if (msg.role === "system" && textContent(msg).startsWith("[重试]")) {
-      flushTools();
-      fragments.push({ type: "retry_system", msg });
-    } else if (msg.role === "system" && textContent(msg).startsWith("[上下文管理]")) {
-      if (textContent(msg).includes("正在压缩")) continue;
-      flushTools();
-      fragments.push({ type: "context_management", msg });
-    } else if (msg.role === "system" && (textContent(msg).startsWith("[Agent]") || textContent(msg).startsWith("[文件锁]"))) {
-      flushTools();
-      const category = textContent(msg).startsWith("[文件锁]") ? "lock" : "info";
-      fragments.push({ type: "agent_event", category, content: textContent(msg), agentRoles: extractAgentRoles(textContent(msg), agents) });
-    } else if (msg.role === "system" || msg.role === "notice") {
-      flushTools();
-      fragments.push({ type: "other_system", msg });
+      mergedFragments.push(frag);
     }
-  }
-  flushTools();
 
-  const mergedFragments: Fragment[] = [];
-  for (const frag of fragments) {
-    const previous = mergedFragments[mergedFragments.length - 1];
-    if (frag.type === "tool_group" && previous?.type === "tool_group") {
-      previous.tools.push(...frag.tools);
-      continue;
+    // 分组：用户消息（锚点）/ 过程片段（思考、解释、工具、ReAct 文本等）/ 总结回复。
+    // 已完成轮次默认折叠「过程」仅保留总结可见；活跃轮次全部展示。
+    // summaryFrags 收集同一轮次内全部非 react 的助手回复（含总结阶段产出），
+    // 全部渲染而非仅取最后一条，避免遗漏或互相覆盖。
+    const summaryFrags: Fragment[] = [];
+    const processFrags: Fragment[] = [];
+    // 错误通知不随过程折叠：失败轮次往往没有其他可见输出，错误原因必须始终可见。
+    const errorFrags: Fragment[] = [];
+    let userFrag: Fragment | null = null;
+    for (const frag of mergedFragments) {
+      if (frag.type === "user") {
+        userFrag = frag;
+      } else if (frag.type === "error_system") {
+        errorFrags.push(frag);
+      } else if (frag.type === "assistant" && frag.msg.phase !== "react") {
+        summaryFrags.push(frag);
+      } else {
+        processFrags.push(frag);
+      }
     }
-    mergedFragments.push(frag);
-  }
 
-  // 分组：用户消息（锚点）/ 过程片段（思考、解释、工具、ReAct 文本等）/ 总结回复。
-  // 已完成轮次默认折叠「过程」仅保留总结可见；活跃轮次全部展示。
-  // summaryFrags 收集同一轮次内全部非 react 的助手回复（含总结阶段产出），
-  // 全部渲染而非仅取最后一条，避免遗漏或互相覆盖。
-  let userFrag: Fragment | null = null;
-  const summaryFrags: Fragment[] = [];
-  const processFrags: Fragment[] = [];
-  // 错误通知不随过程折叠：失败轮次往往没有其他可见输出，错误原因必须始终可见。
-  const errorFrags: Fragment[] = [];
-  for (const frag of mergedFragments) {
-    if (frag.type === "user") {
-      userFrag = frag;
-    } else if (frag.type === "error_system") {
-      errorFrags.push(frag);
-    } else if (frag.type === "assistant" && frag.msg.phase !== "react") {
-      summaryFrags.push(frag);
-    } else {
-      processFrags.push(frag);
-    }
-  }
+    // 同一轮的合计只挂在最后一个带操作栏的回复上。
+    const usageAnchor = [...summaryFrags].reverse().find((frag) =>
+      frag.type === "assistant" && !frag.isStreaming && displayTextContent(frag.msg) && !parseAgentReply(displayTextContent(frag.msg))
+    );
+    const usageAnchorId = usageAnchor?.type === "assistant" ? usageAnchor.msg.id : null;
+    // 运行行挂在最后一个工具组：执行中的调用总是出现在过程尾部。
+    const lastToolGroupIndex = (() => {
+      for (let i = mergedFragments.length - 1; i >= 0; i--) {
+        if (mergedFragments[i].type === "tool_group") return i;
+      }
+      return -1;
+    })();
 
-  // 同一轮的合计只挂在最后一个带操作栏的回复上。
-  const usageAnchor = [...summaryFrags].reverse().find((frag) =>
-    frag.type === "assistant" && !frag.isStreaming && displayTextContent(frag.msg) && !parseAgentReply(displayTextContent(frag.msg))
-  );
-  const usageAnchorId = usageAnchor?.type === "assistant" ? usageAnchor.msg.id : null;
-  // 运行行挂在最后一个工具组：执行中的调用总是出现在过程尾部。
-  const lastToolGroupIndex = (() => {
-    for (let i = mergedFragments.length - 1; i >= 0; i--) {
-      if (mergedFragments[i].type === "tool_group") return i;
-    }
-    return -1;
-  })();
+    return {
+      toolCallArgs,
+      settledToolCallIds,
+      userFrag,
+      mergedFragments,
+      summaryFrags,
+      processFrags,
+      errorFrags,
+      usageAnchorId,
+      lastToolGroupIndex,
+    };
+  }, [messages, streamingMessageId, agents]);
+
+  const argsOfToolMessage = (msg: MessageItem): unknown =>
+    msg.tool_call_id ? toolCallArgs.get(msg.tool_call_id)?.arguments : undefined;
+
+  const renderWithHighlight = (msgId: string, text: string) => {
+    if (!searchQuery) return text;
+    const occurrences = findTextOccurrences(text, searchQuery, caseSensitive);
+    if (occurrences.length === 0) return text;
+    const isCurrent = msgId === currentMessageId;
+    return <HighlightText text={text} matches={occurrences} currentMatchStart={isCurrent ? currentMatchStart : null} />;
+  };
+  // 执行中的调用：tool_calls 已发出但结果未到达，仅活跃轮次渲染为运行行。
+  // 携带发起时刻（store 记录），运行行据此实时跳秒。
+  const runningToolCalls = isActive
+    ? [...toolCallArgs.values()]
+        .filter((call) => !settledToolCallIds.has(call.id))
+        .map((call) => ({ ...call, startedAt: toolCallStartedAt[call.id] }))
+    : [];
 
   const renderFragment = (frag: Fragment, i: number) => {
     if (frag.type === "thinking") {
@@ -337,7 +378,7 @@ function AgentTurnView({
                   <ContentMedia message={msg} />
                   {searchQuery && findTextOccurrences(visibleText, searchQuery, caseSensitive).length > 0
                     ? <div className="text-sm whitespace-pre-wrap break-words">{renderWithHighlight(msg.id, visibleText)}</div>
-                    : <MdPreview modelValue={resolveMarkdownImages(visibleText)} theme={resolvedTheme} previewTheme="github" />}
+                    : <LazyMdPreview modelValue={resolveMarkdownImages(visibleText)} theme={resolvedTheme} />}
                 </div>
               ) : null}
               {!isStreaming && msg.content && visibleText && (

--- a/frontend/src/components/message/LazyMdPreview.tsx
+++ b/frontend/src/components/message/LazyMdPreview.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from "react";
+import { MdPreview } from "md-editor-rt";
+
+/**
+ * 懒挂载的 Markdown 预览。
+ *
+ * MdPreview（md-editor-rt）单次挂载是数十毫秒级的重组件（组件初始化
+ * 远贵于正文解析本身），切换会话一次性挂载可见窗口内的多轮回复会把
+ * 这份成本叠加成可感知的卡顿。此处先用按文本长度估高的占位元素撑住
+ * 布局，等元素滚动到视口附近（提前 600px）才真正挂载 MdPreview；
+ * 已挂载的实例保持不变。
+ *
+ * 环境不支持 IntersectionObserver（测试/旧内核）时直接渲染，行为退
+ * 化为立即挂载。
+ */
+export function LazyMdPreview({ modelValue, theme }: {
+  modelValue: string;
+  theme: "light" | "dark";
+}) {
+  const placeholderRef = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (mounted) return;
+    const el = placeholderRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setMounted(true);
+          observer.disconnect();
+        }
+      },
+      // 提前一段距离开始挂载，滚动经过时正文已就绪，肉眼无感
+      { rootMargin: "600px 0px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [mounted]);
+
+  if (mounted || typeof IntersectionObserver === "undefined") {
+    return <MdPreview modelValue={modelValue} theme={theme} previewTheme="github" />;
+  }
+
+  // 占位高度与虚拟列表 estimateSize 的量级保持一致，避免挂载后大幅跳动
+  const estimatedHeight = Math.min(Math.max(Math.ceil(modelValue.length / 48) * 22, 60), 460);
+  return (
+    <div
+      ref={placeholderRef}
+      style={{ minHeight: estimatedHeight }}
+      className="text-sm text-muted-foreground/40"
+      aria-busy="true"
+    />
+  );
+}


### PR DESCRIPTION
## 背景

用户反馈切换会话明显变慢，尤其切到长对话；切到 Core 已就绪、数据已缓存的会话同样慢。逐步定位出三层原因：

1. **#516 的切会话强制定位**：切会话无条件 `scrollToIndex` 到末项，虚拟列表按估算高度定位后需逐组实测修正，长对话累计偏差大、修正链长；撤销后仍有旧的跨会话长度比较路径把位置拉到底部。
2. **阅读位置无记忆**：切回已看过的会话无法回到原阅读位置。
3. **渲染成本被放大**：实测 MdPreview（md-editor-rt）单次挂载约 55ms（同样文本裸 markdown-it 解析仅 2ms），切换时可见窗口一次挂载 5~6 个；AgentTurn 的消息分类/合并/分桶（长轮次上百条消息约 30ms）在 render 体内每次全量重算，流式期间同样反复触发。

## 变更

- **a98a8112** 撤销 #516 的切会话强制定位到底部；保留「回复完成不再拉底」判定与切换时流式基准重置（防旧会话残留流式状态误判）。
- **89cb7ad6** 会话阅读位置记忆：滚动时记录视口顶部对齐的分组索引与是否贴底（模块级 `sessionScrollAnchors`），切回按锚点恢复——贴底回底部保持跟随、中间位置对齐到离开时的分组、首次进入（或锚点越界）才到底部；切换当次不走通用滚动判定，贴底状态不再无条件置 true。
- **3cbd38f2** 渲染性能：AgentTurn 分类/合并/分桶整体移入 `useMemo`（依赖 messages 引用、流式消息 id、agents），分类链取文本按消息缓存；新增 `LazyMdPreview`——视口外按估高占位、滚动到视口附近（提前 600px）才真正挂载 MdPreview，环境不支持 IntersectionObserver 时退化为立即挂载。

## 兼容性说明

- #516 修复的两个问题均保留：回复完成（含出错/取消）不强制拉底；旧会话残留流式状态不会误判。
- 滚动定位对齐到分组顶部（丢失组内像素偏移），属可接受的近似。

## 测试

- `yarn build`（tsc + vite）通过
- `yarn test`：239 项全部通过
- 组件级基准（真实 4.4MB 会话数据）：MdPreview 单挂 55.3ms / 裸解析 2ms，懒挂载后切换仅承担视口内 1~2 个实例
- GUI 实测（切换流畅度、滚动经历史正文、流式跟随、位置恢复）由用户验收