### PR TITLE
fix(message): 修复本地图片资源渲染

### DIFF
--- a/frontend/src/__tests__/resolveAttachmentUrl.test.ts
+++ b/frontend/src/__tests__/resolveAttachmentUrl.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  convertFileSrc: (path: string) => `asset://mocked/${path}`,
+}));
+
+import {
+  clipboardImagePaths,
+  fileUrlToLocalPath,
+  resolveAttachmentUrl,
+} from '@/utils/attachments';
+
+const converted = (path: string) => `asset://mocked/${path}`;
+
+describe('fileUrlToLocalPath', () => {
+  it('还原 Unix 本地路径', () => {
+    expect(fileUrlToLocalPath('file:///Users/test/image.png')).toBe('/Users/test/image.png');
+  });
+
+  it('还原 Windows 盘符路径（剥离盘符前导斜杠）', () => {
+    expect(fileUrlToLocalPath('file:///C:/Users/test/image.png')).toBe('C:/Users/test/image.png');
+  });
+
+  it('还原 UNC 路径（主机名按服务器处理）', () => {
+    expect(fileUrlToLocalPath('file://server/share/image.png')).toBe(
+      '\\\\server/share/image.png',
+    );
+  });
+
+  it('localhost 主机视为本机路径', () => {
+    expect(fileUrlToLocalPath('file://localhost/Users/test/image.png')).toBe(
+      '/Users/test/image.png',
+    );
+    expect(fileUrlToLocalPath('file://localhost/C:/Users/test/image.png')).toBe(
+      'C:/Users/test/image.png',
+    );
+  });
+
+  it('文件名中的 # 与 ? 不丢失（不被当作 fragment/query 切断）', () => {
+    expect(fileUrlToLocalPath('file:///tmp/report#1.png')).toBe('/tmp/report#1.png');
+    expect(fileUrlToLocalPath('file:///tmp/report?draft.png')).toBe('/tmp/report?draft.png');
+  });
+
+  it('scheme 大小写不敏感', () => {
+    expect(fileUrlToLocalPath('FILE:///Users/test/image.png')).toBe('/Users/test/image.png');
+    expect(fileUrlToLocalPath('File:///Users/test/image.png')).toBe('/Users/test/image.png');
+  });
+
+  it('解码百分号编码，非法序列保留原样', () => {
+    expect(fileUrlToLocalPath('file:///tmp/report%20draft.png')).toBe('/tmp/report draft.png');
+    expect(fileUrlToLocalPath('file:///C:/docs/%E6%8A%A5%E8%A1%A8.pdf')).toBe('C:/docs/报表.pdf');
+    expect(fileUrlToLocalPath('file:///tmp/100%.png')).toBe('/tmp/100%.png');
+  });
+
+  it('file://C:/x 误写的主机位盘符', () => {
+    expect(fileUrlToLocalPath('file://C:/Users/test/image.png')).toBe('C:/Users/test/image.png');
+  });
+
+  it('非 file 协议返回 null', () => {
+    expect(fileUrlToLocalPath('https://example.com/a.png')).toBeNull();
+    expect(fileUrlToLocalPath('/Users/test/image.png')).toBeNull();
+    expect(fileUrlToLocalPath('C:\\Users\\test\\image.png')).toBeNull();
+  });
+});
+
+describe('resolveAttachmentUrl', () => {
+  it('file:// URL 先还原为本地路径再转资源地址', () => {
+    expect(resolveAttachmentUrl('file:///Users/test/image.png')).toBe(
+      converted('/Users/test/image.png'),
+    );
+    expect(resolveAttachmentUrl('file:///C:/Users/test/image.png')).toBe(
+      converted('C:/Users/test/image.png'),
+    );
+    expect(resolveAttachmentUrl('file://server/share/image.png')).toBe(
+      converted('\\\\server/share/image.png'),
+    );
+    expect(resolveAttachmentUrl('file://localhost/Users/test/image.png')).toBe(
+      converted('/Users/test/image.png'),
+    );
+  });
+
+  it('带 # 与 ? 的文件名转换后仍指向原文件', () => {
+    expect(resolveAttachmentUrl('file:///tmp/report#1.png')).toBe(converted('/tmp/report#1.png'));
+    expect(resolveAttachmentUrl('file:///tmp/report?draft.png')).toBe(
+      converted('/tmp/report?draft.png'),
+    );
+  });
+
+  it('大小写不敏感的 FILE:// 同样进入转换', () => {
+    expect(resolveAttachmentUrl('FILE:///Users/test/image.png')).toBe(
+      converted('/Users/test/image.png'),
+    );
+  });
+
+  it('裸本地路径直接转换，远程与资源地址原样返回', () => {
+    expect(resolveAttachmentUrl('/Users/test/image.png')).toBe(converted('/Users/test/image.png'));
+    expect(resolveAttachmentUrl('C:\\Users\\test\\image.png')).toBe(
+      converted('C:\\Users\\test\\image.png'),
+    );
+    expect(resolveAttachmentUrl('\\\\server\\share\\image.png')).toBe(
+      converted('\\\\server\\share\\image.png'),
+    );
+    expect(resolveAttachmentUrl('https://example.com/a.png')).toBe('https://example.com/a.png');
+    expect(resolveAttachmentUrl('http://example.com/a.png')).toBe('http://example.com/a.png');
+    expect(resolveAttachmentUrl('asset://localhost/x.png')).toBe('asset://localhost/x.png');
+    expect(resolveAttachmentUrl('about:blank')).toBe('about:blank');
+  });
+});
+
+describe('clipboardImagePaths', () => {
+  it('从剪贴板文本提取图片路径（file:// URL 与裸路径混排）', () => {
+    expect(
+      clipboardImagePaths('file:///tmp/截图 1.png\n/Users/me/b.jpg\nhttps://x/page\nhello'),
+    ).toEqual(['/tmp/截图 1.png', '/Users/me/b.jpg']);
+  });
+
+  it('Windows 盘符 file URL 不丢盘符，# 文件名不截断', () => {
+    expect(clipboardImagePaths('file:///C:/Users/test/pic#2.png')).toEqual([
+      'C:/Users/test/pic#2.png',
+    ]);
+  });
+
+  it('去除首尾引号', () => {
+    expect(clipboardImagePaths('"/tmp/a.png"')).toEqual(['/tmp/a.png']);
+  });
+});

--- a/frontend/src/components/message/utils.ts
+++ b/frontend/src/components/message/utils.ts
@@ -1,5 +1,5 @@
 import { textContent } from "@/api/tauri";
-import { convertFileSrc } from "@tauri-apps/api/core";
+import { resolveAttachmentUrl } from "@/utils/attachments";
 import {
   Brain,
   Plug,
@@ -100,19 +100,12 @@ export function displayTextContent(message: MessageItem): string {
 }
 
 export function resolveAssetUrl(url: string): string {
-  if (!url) return "";
-  if (url.startsWith("http://") || url.startsWith("https://") || url.startsWith("asset://")) {
-    return url;
-  }
-  if (url.startsWith("/")) {
-    return convertFileSrc(url);
-  }
-  return url;
+  return resolveAttachmentUrl(url);
 }
 
 export function resolveMarkdownImages(md: string): string {
   return md.replace(
-    /(!\[[^\]]*\]\()(\/[^\s)]+)(\))/g,
+    /(!\[[^\]]*\]\()([^\s)]+)(\))/g,
     (_, prefix, path, suffix) => prefix + resolveAssetUrl(path) + suffix,
   );
 }

--- a/frontend/src/utils/attachments.ts
+++ b/frontend/src/utils/attachments.ts
@@ -58,20 +58,44 @@ export function imageExtFromMime(mimeType: string): string {
   return 'png';
 }
 
+/** file:// URL 还原为本地路径；非 file 协议返回 null。
+ *  手动切分而非 new URL：文件名中的 # 与 ? 会被 URL 当作 fragment/query
+ *  切掉导致路径丢失（如 report#1.png）；scheme 与主机名按大小写不敏感
+ *  处理，localhost 主机视为本机路径。 */
+export function fileUrlToLocalPath(url: string): string | null {
+  if (!/^file:/i.test(url)) return null;
+  let rest = url.replace(/^file:/i, '');
+  const hasAuthority = rest.startsWith('//');
+  if (hasAuthority) rest = rest.slice(2);
+
+  let path = rest;
+  if (hasAuthority && !rest.startsWith('/')) {
+    const slash = rest.indexOf('/');
+    const authority = slash === -1 ? rest : rest.slice(0, slash);
+    path = slash === -1 ? '' : rest.slice(slash);
+    if (/^[A-Za-z]:$/.test(authority)) {
+      // file://C:/x 误写：主机位实为盘符
+      path = `${authority}${path}`;
+    } else if (!/^localhost$/i.test(authority)) {
+      // 其余主机名按 UNC 服务器处理；localhost 指本机，路径原样
+      path = `\\\\${authority}${path}`;
+    }
+  }
+  try {
+    path = decodeURIComponent(path);
+  } catch {
+    // 路径含未编码的 % 等非法序列时保留原样
+  }
+  return path.replace(/^\/([A-Za-z]:)/, '$1');
+}
+
 export function resolveAttachmentUrl(url: string): string {
   if (!url) return '';
   // 历史消息或剪贴板可能保存为 file:// URL；先还原为本地路径，
   // 再交给 Tauri 的资源协议转换，避免 Windows WebView 将其当网页地址解析。
-  if (url.startsWith('file://')) {
-    try {
-      const parsed = new URL(url);
-      if (parsed.protocol === 'file:') {
-        const path = decodeURIComponent(parsed.pathname).replace(/^\/[A-Za-z]:/, match => match.slice(1));
-        return convertFileSrc(parsed.hostname ? `\\\\${parsed.hostname}${path}` : path);
-      }
-    } catch {
-      // 保留原值，让调用方按普通 URL 处理。
-    }
+  const localPath = fileUrlToLocalPath(url);
+  if (localPath !== null) {
+    return convertFileSrc(localPath);
   }
   if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('asset://')) {
     return url;
@@ -87,14 +111,7 @@ export function clipboardImagePaths(text: string): string[] {
     .split(/\r?\n/)
     .map(part => part.trim())
     .map(part => part.replace(/^["']|["']$/g, ''))
-    .map(part => {
-      if (!part.startsWith('file://')) return part;
-      try {
-        return decodeURIComponent(part.replace(/^file:\/\//, ''));
-      } catch {
-        return part.replace(/^file:\/\//, '');
-      }
-    })
+    .map(part => fileUrlToLocalPath(part) ?? part)
     .filter(part => !!part && !!imageMimeType(part));
 }
 

--- a/frontend/src/utils/attachments.ts
+++ b/frontend/src/utils/attachments.ts
@@ -60,6 +60,19 @@ export function imageExtFromMime(mimeType: string): string {
 
 export function resolveAttachmentUrl(url: string): string {
   if (!url) return '';
+  // 历史消息或剪贴板可能保存为 file:// URL；先还原为本地路径，
+  // 再交给 Tauri 的资源协议转换，避免 Windows WebView 将其当网页地址解析。
+  if (url.startsWith('file://')) {
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol === 'file:') {
+        const path = decodeURIComponent(parsed.pathname).replace(/^\/[A-Za-z]:/, match => match.slice(1));
+        return convertFileSrc(parsed.hostname ? `\\\\${parsed.hostname}${path}` : path);
+      }
+    } catch {
+      // 保留原值，让调用方按普通 URL 处理。
+    }
+  }
   if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('asset://')) {
     return url;
   }


### PR DESCRIPTION
## 变更内容

- 修复消息列表中的本地图片渲染。
- 增加跨 Windows、Linux、macOS 的本地文件协议处理。
- 支持 `file:///`、本地绝对路径、UNC 路径及历史 `asset://localhost/` 地址。
- HTML 文件写入会话目录后加载，支持相对图片、CSS、JS、JSON 和字体资源。
- Windows 使用稳定的本地协议地址，避免 WebView2 直接加载本地路径失败。
- 保留用户可见地址为 `file:///...`，避免界面显示内部协议地址。

## 验证

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check -p tiangong-app --locked`
- `yarn build`

Rust 检查中的 `crates/tiangong-server/src/daemon.rs` unreachable warning 为项目原有警告。
