### PR TITLE
fix(app): 插件热加载真正重载界面型插件——停旧 sidecar 并重建后台执行壳

### DIFF
--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -1213,9 +1213,32 @@ mod tests {
             "permissions":["tool.provide"],"entrypoints":["desktop"],
             "ui":{"contributions":[{"slot":"extension.tab","id":"app","entry":"app/index.html"}]}});
         std::fs::write(directory.join(MANIFEST_FILE), manifest_value.to_string()).unwrap();
-        let manifest: PluginManifest =
-            serde_json::from_str(&std::fs::read_to_string(directory.join(MANIFEST_FILE)).unwrap())
-                .unwrap();
+        let parse_manifest = || {
+            serde_json::from_str::<PluginManifest>(
+                &std::fs::read_to_string(directory.join(MANIFEST_FILE)).unwrap(),
+            )
+            .unwrap()
+        };
+
+        // 断言失败也清理全局状态，避免污染后续用例。
+        struct GlobalStateGuard {
+            id: String,
+            directory: PathBuf,
+        }
+        impl Drop for GlobalStateGuard {
+            fn drop(&mut self) {
+                if let Ok(mut connections) = sidecar_connections().lock() {
+                    connections.retain(|key, _| key.directory != self.directory);
+                }
+                if let Ok(mut plugins) = loaded_plugins().lock() {
+                    plugins.remove(&self.id);
+                }
+            }
+        }
+        let _guard = GlobalStateGuard {
+            id: id.clone(),
+            directory: directory.clone(),
+        };
 
         let healthy = std::sync::Arc::new(StubSidecarConnection {
             stopped: std::sync::atomic::AtomicBool::new(false),
@@ -1242,17 +1265,44 @@ mod tests {
                 std::sync::Arc::clone(&failing) as std::sync::Arc<dyn SidecarConnection>,
             );
         }
+        // 注册表记录里的旧 sidecar（stop_loaded_sidecar 分支的目标）也种桩。
+        let loaded_stub = std::sync::Arc::new(StubSidecarConnection {
+            stopped: std::sync::atomic::AtomicBool::new(false),
+            fail_stop: false,
+        });
+        loaded_plugins().lock().unwrap().insert(
+            id.clone(),
+            LoadedPlugin {
+                directory: directory.clone(),
+                manifest: parse_manifest(),
+                wasm_bytes: None,
+                component: None,
+                ui_plugin: None,
+                descriptor: None,
+                generation: 0,
+                instances: Vec::new(),
+                ts_instances: Vec::new(),
+                sidecar: Some(
+                    std::sync::Arc::clone(&loaded_stub) as std::sync::Arc<dyn SidecarConnection>
+                ),
+                verified_sidecar: None,
+                load_error: None,
+                runtime_error: None,
+                enabled: true,
+            },
+        );
 
         let installed = InstalledPlugin {
             directory: directory.clone(),
-            manifest,
+            manifest: parse_manifest(),
             enabled: true,
             signed_release: None,
         };
+        // 热加载自身尽力而为：连接清理报错（failing 桩）只告警，重载仍成功。
         reload_plugin_inner(root.path(), &installed).expect("热加载应成功");
 
         // 无条件清理：该目录的连接全部出表；个别 stop 失败不阻断摘表，
-        // 也不阻断其余连接的停止。
+        // 也不阻断其余连接的停止；注册表记录里的旧 sidecar 同样被停。
         let remaining = sidecar_connections()
             .lock()
             .unwrap()
@@ -1262,7 +1312,7 @@ mod tests {
         assert_eq!(remaining, 0, "热加载后连接表不应残留该目录的连接");
         assert!(healthy.stopped.load(Ordering::SeqCst));
         assert!(failing.stopped.load(Ordering::SeqCst));
-        loaded_plugins().lock().unwrap().remove(&id);
+        assert!(loaded_stub.stopped.load(Ordering::SeqCst));
     }
 
     #[test]
@@ -3493,8 +3543,11 @@ pub(crate) fn stop_connection_for_directory(directory: &Path) -> Result<()> {
         .map(|(_, connection)| connection.clone())
         .collect::<Vec<_>>();
     // 先摘表再停进程：任一连接停止失败也不能让连接残留在表中（残留
-    // 会被下次调用直接复用并打到旧二进制），失败仅告警并继续处理其余。
+    // 会被下次调用直接复用并打到旧二进制）。停止失败聚合成首个错误
+    // 照常上报——停用回滚、卸载的 Windows 二进制占用保护等调用方依赖
+    // 失败语义；需要尽力而为语义的调用点（如热加载）自行吞错告警。
     remove_sidecar_connection(directory);
+    let mut first_error = None;
     for connection in connections {
         if let Err(error) = connection.stop() {
             tracing::warn!(
@@ -3502,9 +3555,15 @@ pub(crate) fn stop_connection_for_directory(directory: &Path) -> Result<()> {
                 %error,
                 "停止 sidecar 连接失败（连接已从表中摘除）"
             );
+            if first_error.is_none() {
+                first_error = Some(error);
+            }
         }
     }
-    Ok(())
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
 }
 
 /// 兜底按二进制 image 名清理该插件的所有残留 sidecar 进程。

--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -867,17 +867,26 @@ fn reload_plugin_inner(storage_root: &Path, installed: &InstalledPlugin) -> Resu
     // UI 记录直接替换；存活 Core 中的 TS 适配器原位更新，下一轮立即使用新清单。
     if installed.manifest.wasm_binary().is_none() {
         crate::ts_tools::cancel_plugin_calls(&installed.manifest.id);
-        // 停掉旧 sidecar（连接 + 进程）：热加载的前提是插件目录可能已被
-        // 整体替换，残留的旧进程会让工具继续打到旧二进制。停止后下次
-        // 调用按磁盘最新版本重新拉起；失败仅告警不阻断声明层重载。
-        if installed.manifest.sidecar.is_some()
-            && let Err(error) = stop_loaded_sidecar(&installed.manifest.id)
-                .and_then(|_| stop_connection_for_directory(&installed.directory))
-        {
+        // 停掉旧 sidecar（进程 + 该安装目录的连接缓存）：热加载的前提是
+        // 插件目录可能已被整体替换，残留会让工具继续打到旧二进制；新清
+        // 单即使去掉 sidecar 声明也照清（此时旧连接/旧进程正是要清除的
+        // 残留，Windows 上还会占用目录导致替换失败）。两步独立执行、各
+        // 自告警：停进程失败不能阻断连接清理，否则下次调用会复用表内
+        // 旧连接。桥订阅有意不清——可见标签里的旧页面仍可接应工具调用
+        //（执行走重启后的 sidecar），后台执行壳则由前端收到
+        // plugin_reloaded 后卸载重建。
+        if let Err(error) = stop_loaded_sidecar(&installed.manifest.id) {
             tracing::warn!(
                 plugin_id = %installed.manifest.id,
                 %error,
                 "热加载停止 sidecar 失败，工具调用将沿用旧进程"
+            );
+        }
+        if let Err(error) = stop_connection_for_directory(&installed.directory) {
+            tracing::warn!(
+                plugin_id = %installed.manifest.id,
+                %error,
+                "热加载清理 sidecar 连接缓存失败，下次调用可能复用旧连接"
             );
         }
         let ts_instances = loaded_plugins()
@@ -1162,6 +1171,99 @@ pub fn plugin_install_directory(plugin_id: &str) -> Option<PathBuf> {
 mod tests {
     use super::*;
     use tiangong_core::MentionCandidate;
+
+    /// 记录 stop 调用的桩连接：验证热加载清理连接缓存的行为，
+    /// 可注入 stop 失败验证「先摘表再停」不被个别失败阻断。
+    struct StubSidecarConnection {
+        stopped: std::sync::atomic::AtomicBool,
+        fail_stop: bool,
+    }
+    impl SidecarConnection for StubSidecarConnection {
+        fn invoke(&self, _: &str, _: &str) -> Result<String> {
+            Ok("{}".into())
+        }
+        fn ensure_running(&self) -> Result<()> {
+            Ok(())
+        }
+        fn stop(&self) -> Result<()> {
+            use std::sync::atomic::Ordering;
+            self.stopped.store(true, Ordering::SeqCst);
+            if self.fail_stop {
+                bail!("stub stop failure");
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn reload_clears_stale_connections_even_without_sidecar_declaration() {
+        use std::sync::atomic::Ordering;
+        let root = tempfile::tempdir().unwrap();
+        let config_directory = root.path().join("config");
+        std::fs::create_dir_all(&config_directory).unwrap();
+        tiangong_config::registry::init_from_dir(&config_directory);
+        let id = format!("reload-stale-{}", scru128::new());
+        let directory = root.path().join("plugins").join(&id);
+        std::fs::create_dir_all(directory.join("app")).unwrap();
+        std::fs::write(directory.join("app/index.html"), "ui").unwrap();
+        // 新清单不含 sidecar 声明：目录整体替换后去掉 sidecar 的场景，
+        // 热加载仍必须清掉旧连接缓存（否则旧进程残留、Windows 上目录被占用）。
+        let manifest_value = serde_json::json!({"schema_version":2,"id":id,"version":"0.1.0",
+            "permissions":["tool.provide"],"entrypoints":["desktop"],
+            "ui":{"contributions":[{"slot":"extension.tab","id":"app","entry":"app/index.html"}]}});
+        std::fs::write(directory.join(MANIFEST_FILE), manifest_value.to_string()).unwrap();
+        let manifest: PluginManifest =
+            serde_json::from_str(&std::fs::read_to_string(directory.join(MANIFEST_FILE)).unwrap())
+                .unwrap();
+
+        let healthy = std::sync::Arc::new(StubSidecarConnection {
+            stopped: std::sync::atomic::AtomicBool::new(false),
+            fail_stop: false,
+        });
+        let failing = std::sync::Arc::new(StubSidecarConnection {
+            stopped: std::sync::atomic::AtomicBool::new(false),
+            fail_stop: true,
+        });
+        {
+            let mut connections = sidecar_connections().lock().unwrap();
+            connections.insert(
+                SidecarConnectionKey {
+                    directory: directory.clone(),
+                    workspace: None,
+                },
+                std::sync::Arc::clone(&healthy) as std::sync::Arc<dyn SidecarConnection>,
+            );
+            connections.insert(
+                SidecarConnectionKey {
+                    directory: directory.clone(),
+                    workspace: Some(root.path().to_path_buf()),
+                },
+                std::sync::Arc::clone(&failing) as std::sync::Arc<dyn SidecarConnection>,
+            );
+        }
+
+        let installed = InstalledPlugin {
+            directory: directory.clone(),
+            manifest,
+            enabled: true,
+            signed_release: None,
+        };
+        reload_plugin_inner(root.path(), &installed).expect("热加载应成功");
+
+        // 无条件清理：该目录的连接全部出表；个别 stop 失败不阻断摘表，
+        // 也不阻断其余连接的停止。
+        let remaining = sidecar_connections()
+            .lock()
+            .unwrap()
+            .keys()
+            .filter(|key| key.directory == directory)
+            .count();
+        assert_eq!(remaining, 0, "热加载后连接表不应残留该目录的连接");
+        assert!(healthy.stopped.load(Ordering::SeqCst));
+        assert!(failing.stopped.load(Ordering::SeqCst));
+        loaded_plugins().lock().unwrap().remove(&id);
+    }
 
     #[test]
     #[serial_test::serial]
@@ -3390,10 +3492,18 @@ pub(crate) fn stop_connection_for_directory(directory: &Path) -> Result<()> {
         .filter(|(key, _)| key.directory == directory)
         .map(|(_, connection)| connection.clone())
         .collect::<Vec<_>>();
-    for connection in connections {
-        connection.stop()?;
-    }
+    // 先摘表再停进程：任一连接停止失败也不能让连接残留在表中（残留
+    // 会被下次调用直接复用并打到旧二进制），失败仅告警并继续处理其余。
     remove_sidecar_connection(directory);
+    for connection in connections {
+        if let Err(error) = connection.stop() {
+            tracing::warn!(
+                directory = %directory.display(),
+                %error,
+                "停止 sidecar 连接失败（连接已从表中摘除）"
+            );
+        }
+    }
     Ok(())
 }
 

--- a/crates/tiangong-plugin-runtime/src/registry.rs
+++ b/crates/tiangong-plugin-runtime/src/registry.rs
@@ -867,6 +867,19 @@ fn reload_plugin_inner(storage_root: &Path, installed: &InstalledPlugin) -> Resu
     // UI 记录直接替换；存活 Core 中的 TS 适配器原位更新，下一轮立即使用新清单。
     if installed.manifest.wasm_binary().is_none() {
         crate::ts_tools::cancel_plugin_calls(&installed.manifest.id);
+        // 停掉旧 sidecar（连接 + 进程）：热加载的前提是插件目录可能已被
+        // 整体替换，残留的旧进程会让工具继续打到旧二进制。停止后下次
+        // 调用按磁盘最新版本重新拉起；失败仅告警不阻断声明层重载。
+        if installed.manifest.sidecar.is_some()
+            && let Err(error) = stop_loaded_sidecar(&installed.manifest.id)
+                .and_then(|_| stop_connection_for_directory(&installed.directory))
+        {
+            tracing::warn!(
+                plugin_id = %installed.manifest.id,
+                %error,
+                "热加载停止 sidecar 失败，工具调用将沿用旧进程"
+            );
+        }
         let ts_instances = loaded_plugins()
             .lock()
             .map_err(|_| anyhow::anyhow!("插件注册表已损坏"))?

--- a/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
+++ b/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
@@ -288,8 +288,8 @@ describe('MainApp sessions_updated scheduling contract', () => {
     await advance(120);
 
     expect(getSessionsMock).not.toHaveBeenCalled();
-    // stream + 6 个事件监听 + resize。
-    expect(registeredUnlisteners.length).toBe(8);
+    // stream + 7 个事件监听 + resize。
+    expect(registeredUnlisteners.length).toBe(9);
     for (const unlisten of registeredUnlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }

--- a/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
+++ b/frontend/src/__tests__/mainAppSessionsRefresh.test.tsx
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => {
     getSessions: vi.fn(),
     getReasoningEffort: vi.fn(() => Promise.resolve('medium')),
     getWorkspaceDir: vi.fn(() => Promise.resolve('/workspace')),
+    pluginOpenEntry: vi.fn(() => Promise.resolve('<div>stub-plugin-page</div>')),
     onStreamEvent: vi.fn((callback: (event: unknown) => void) => {
       streamEventHandlers.add(callback);
       return makeRegistration().then((unlisten) => {
@@ -294,6 +295,49 @@ describe('MainApp sessions_updated scheduling contract', () => {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
     expect(mocks.eventHandlers.get('sessions_updated')?.size ?? 0).toBe(0);
+  });
+
+  it('plugin_reloaded 卸载该插件的后台执行壳，下次后台挂载重建', async () => {
+    mocks.api.pluginOpenEntry.mockClear();
+    await mountMainApp();
+    useStore.setState({ activeSessionId: 's1' });
+    const openEntry = vi.mocked(mocks.api.pluginOpenEntry);
+    const emit = (name: string, payload: unknown) => {
+      act(() => {
+        for (const handler of mocks.eventHandlers.get(name) ?? []) {
+          handler({ payload });
+        }
+      });
+    };
+    const openBackground = () => emit('app:open_plugin', {
+      plugin_id: 'terminal',
+      contribution_id: 'app',
+      background: true,
+    });
+
+    openBackground();
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    expect(openEntry).toHaveBeenCalledTimes(1);
+
+    // 同插件同会话再次后台挂载命中判重，不重建实例。
+    openBackground();
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    expect(openEntry).toHaveBeenCalledTimes(1);
+
+    // 热加载事件卸载旧壳后判重不再命中，重新挂载会拉取磁盘最新页面。
+    emit('plugin_reloaded', 'terminal');
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    openBackground();
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    expect(openEntry).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/frontend/src/pages/MainApp.tsx
+++ b/frontend/src/pages/MainApp.tsx
@@ -566,6 +566,16 @@ export function MainApp() {
         void openWorkspacePanel('plugin');
       }));
       guard();
+      // 插件热加载完成：卸载该插件的后台执行壳。壳内可能是目录替换前
+      // 的旧页面（桥订阅已断），保留会让工具调用的"已有实例"判重吞掉
+      // 重新挂载的请求，永远等不到新订阅。卸载后下次调用自动按磁盘
+      // 最新页面重建并接续执行；在途调用已由后端热加载先行取消。
+      track(await listen<string>('plugin_reloaded', (event) => {
+        const pluginId = event.payload;
+        if (!pluginId) return;
+        setBgPluginInstances((prev) => prev.filter((item) => item.pluginId !== pluginId));
+      }));
+      guard();
       // app.close 原语落地：宿主请求关闭插件 App 实例（Agent/插件在必要
       // 时收起对应 tab）。instance_id 精确关一个实例，all 收起全部。
       track(await listen<{

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5142,12 +5142,16 @@ pub async fn reload_plugin(
     let storage_root = state
         .with_state_read(|core_state| Ok(core_state.config.storage_root.clone()))
         .await?;
+    let reloaded_id = plugin_id.clone();
     let status = tauri::async_runtime::spawn_blocking(move || {
         tiangong_plugin_runtime::registry::reload_plugin(&storage_root, &plugin_id)
             .map_err(|error| error.to_string())
     })
     .await
     .map_err(|error| format!("重载插件任务失败: {error}"))??;
+    // 定向通知前端该插件已热加载：前端据此卸载旧的后台执行壳，下次
+    // 工具调用按磁盘最新页面重建，避免旧壳吞掉重新挂载的请求。
+    let _ = app.emit("plugin_reloaded", &reloaded_id);
     notify_plugins_changed(&app);
     Ok(status)
 }


### PR DESCRIPTION
## 问题

插件目录在应用运行期间被整体替换（本地开发部署的常见场景）后，插件管理的「热加载」只更新内存声明：旧 sidecar 进程继续以旧二进制服务工具调用，前端后台执行壳仍是旧页面——工具调用的「已有实例」判重会吞掉重新挂载请求，会话永久卡死，只能重启应用（2026-09-11 实录）。

## 改动

- **插件运行时**（registry）：
  - 热加载对无 WASM 插件停掉旧 sidecar（进程 + 该安装目录的连接缓存），**无条件执行**——新清单去掉 sidecar 声明时同样清理（此时旧连接正是要清除的残留，Windows 上还会占用目录导致替换失败）；
  - 停进程与清连接**独立执行、各自告警**：停进程失败不阻断连接清理，避免下次调用复用表内旧连接打到旧二进制；
  - `stop_connection_for_directory` 改为**先摘表再逐个停止**：个别连接停止失败不再让连接残留表中；
  - 桥订阅**有意不清**（与停用/卸载路径不同）：可见标签里的旧页面仍可接应工具调用（执行走重启后的新 sidecar），后台执行壳由前端重建路径覆盖——意图已写入代码注释。
- **应用命令层**（commands）：热加载成功后定向广播 `plugin_reloaded`（携带插件 id）。
- **前端**（MainApp）：监听 `plugin_reloaded`，卸载该插件的后台执行壳；下次工具调用自动按磁盘最新页面重建并接续执行（在途调用已由热加载先行取消）。

## 行为边界（取舍说明）

- **可见标签不强制关闭**：用户开着的插件标签保留旧页面，旧页面仍可接应工具调用（执行走重启后的 sidecar）；只有旧页面自身失效时才需手动关闭标签，由下次调用重建。
- **无界面 + sidecar 直连类插件**：热加载不触发制品重验证，制品变化后验证记录失效，工具会返回「请重新验证后重试」而非直接可用——本 PR 目标是有界面的插件，不受影响。
- 声明需要预热且验证记录仍有效时，热加载过程内会立即拉起新 sidecar（而非等下次调用）。

## 验证

- `cargo clippy`（受影响 crate）无警告；插件运行时 180 项 lib 测试 + 集成测试全过；前端构建与 256 项测试全过。
- **新增行为测试**：后端——无 sidecar 声明的插件热加载后连接表无该目录残留、个别 stop 失败不阻断摘表与其余连接停止；前端——`plugin_reloaded` 卸载后台壳后判重不再命中、再次后台挂载会重建并重新拉取页面。
- 真实场景（应用运行中替换插件目录 → 热加载 → 会话继续使用工具）需合并后随应用构建实测。