### PR TITLE
fix(server): 修正会话轮次取消语义

### DIFF
--- a/crates/tiangong-core-manager/src/core_manager/ensure.rs
+++ b/crates/tiangong-core-manager/src/core_manager/ensure.rs
@@ -107,7 +107,10 @@ impl CoreManager {
         }
     }
 
-    /// 取消指定会话的执行（向活跃 turn task 投递 Cancel；无活跃 task 则忽略）。
+    /// 取消指定会话的执行。
+    ///
+    /// 返回 true 表示 Cancel 已投递到活跃 turn task，false 表示当时没有可接受
+    /// 取消命令的活跃 task；它不表示 turn 已经完成收尾。
     pub fn cancel_core(&self, session_id: &str) -> bool {
         let registry = self.registry();
         registry

--- a/crates/tiangong-core/src/core/integration_tests.rs
+++ b/crates/tiangong-core/src/core/integration_tests.rs
@@ -601,6 +601,18 @@ async fn cancel_running_turn_ends_cancelled() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_idle_core_is_rejected() {
+    let (env, sid) = TestEnv::new("cancel-idle");
+    let (core, _events) = core_for(&env, &sid, "http://unused.invalid");
+
+    let error = core
+        .deliver(AgentInputKind::cancel())
+        .expect_err("空闲 Core 不应报告取消命令已投递");
+    assert!(matches!(error, crate::core::CoreError::WorkerStopped));
+    core.shutdown_join().expect("关闭失败");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn idle_injection_deferred_into_next_request() {
     let (env, sid) = TestEnv::new("inject");
     let server = MockServer::builder().start().await;

--- a/crates/tiangong-core/src/core/mod.rs
+++ b/crates/tiangong-core/src/core/mod.rs
@@ -555,8 +555,11 @@ impl crate::agent_input::AgentInput for TiangongCore {
             ),
             AgentInputKind::Command(cmd) => match cmd {
                 CommandInput::Cancel => {
-                    let _ = crate::shared_runtime::send_command(&self.session_id, Command::Cancel);
-                    Ok(())
+                    if crate::shared_runtime::send_command(&self.session_id, Command::Cancel) {
+                        Ok(())
+                    } else {
+                        Err(CoreError::WorkerStopped)
+                    }
                 }
                 CommandInput::SetTrustMode(trust_mode) => {
                     self.set_trust_mode(trust_mode);

--- a/crates/tiangong-core/src/shared_runtime.rs
+++ b/crates/tiangong-core/src/shared_runtime.rs
@@ -123,7 +123,7 @@ where
 
 /// 向当前活跃任务发送命令（取消、工具注入和运行配置更新等）。
 ///
-/// 无活跃任务时返回 false(命令被忽略)。
+/// 无活跃任务或命令通道已关闭时返回 false（命令被忽略）。
 pub fn send_command(session_id: &str, cmd: Command) -> bool {
     if let Ok(tasks) = turn_tasks().lock()
         && let Some(task) = tasks.get(session_id)

--- a/crates/tiangong-server/src/api/mod.rs
+++ b/crates/tiangong-server/src/api/mod.rs
@@ -107,6 +107,7 @@ pub fn build_routes(
                 Route::new("<id>")
                     .get(sessions::get_session)
                     .append(Route::new("cost").get(sessions::get_session_cost))
+                    .append(Route::new("cancel").post(sessions::cancel_session_turn))
                     .delete(sessions::delete_session),
             ),
         )
@@ -199,6 +200,11 @@ mod tests {
         }
 
         async fn delete_session(&self, _session_id: &str) -> Result<bool> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Err(anyhow!("not used"))
+        }
+
+        async fn cancel_session_turn(&self, _session_id: &str) -> Result<bool> {
             self.calls.fetch_add(1, Ordering::Relaxed);
             Err(anyhow!("not used"))
         }

--- a/crates/tiangong-server/src/api/sessions.rs
+++ b/crates/tiangong-server/src/api/sessions.rs
@@ -172,8 +172,9 @@ pub async fn delete_session(req: Request) -> Result<Response> {
 /// POST /api/v1/sessions/:id/cancel — 取消会话当前执行中的轮次
 ///
 /// 快速停止：向活跃 turn 投递取消信号，Core 立即终止；该会话全部等待中的
-/// 投递调用立即收到「已取消/执行已取消」错误返回（不排队）。返回 false
-/// 表示没有可取消的活跃执行。
+/// 投递调用立即收到「已取消/执行已取消」错误返回（不排队）。返回 true 表示
+/// 取消命令已投递到活跃执行，false 表示本次没有可接受取消命令的活跃执行；
+/// false 不表示会话资源不存在。
 pub async fn cancel_session_turn(req: Request) -> Result<Response> {
     let token = req.get_state::<AuthToken>()?.clone();
     check_auth(&req, token.0.as_deref())?;

--- a/crates/tiangong-server/src/api/sessions.rs
+++ b/crates/tiangong-server/src/api/sessions.rs
@@ -168,3 +168,33 @@ pub async fn delete_session(req: Request) -> Result<Response> {
         "id": id,
     })))
 }
+
+/// POST /api/v1/sessions/:id/cancel — 取消会话当前执行中的轮次
+///
+/// 快速停止：向活跃 turn 投递取消信号，Core 立即终止；该会话全部等待中的
+/// 投递调用立即收到「已取消/执行已取消」错误返回（不排队）。返回 false
+/// 表示没有可取消的活跃执行。
+pub async fn cancel_session_turn(req: Request) -> Result<Response> {
+    let token = req.get_state::<AuthToken>()?.clone();
+    check_auth(&req, token.0.as_deref())?;
+    let access = extract_remote_access(&req)?;
+    ensure_remote_action(&access, access.role.can_manage_sessions(), "取消会话执行")?;
+
+    let id: String = req.get_path_params("id")?;
+    let app_ctx = req.get_state::<SharedAppContext>()?.clone();
+    let cancelled = app_ctx
+        .core_backend
+        .cancel_session_turn(&id)
+        .await
+        .map_err(|error| {
+            SilentError::business_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("取消会话执行失败：{error}"),
+            )
+        })?;
+
+    Ok(Response::json(&serde_json::json!({
+        "cancelled": cancelled,
+        "id": id,
+    })))
+}

--- a/crates/tiangong-server/src/remote/backend.rs
+++ b/crates/tiangong-server/src/remote/backend.rs
@@ -38,7 +38,8 @@ pub trait ServerCoreBackend: Send + Sync {
     async fn delete_session(&self, session_id: &str) -> Result<bool>;
 
     /// 取消会话当前执行中的轮次（快速停止：等待方立即收到取消错误）。
-    /// 返回 false 表示没有可取消的活跃执行。
+    /// 返回 true 表示取消命令已投递到活跃执行；false 表示当时没有可接受命令的
+    /// 活跃执行，不代表会话资源不存在。
     async fn cancel_session_turn(&self, session_id: &str) -> Result<bool>;
 
     async fn sync_config_from_state(&self) -> Result<()>;

--- a/crates/tiangong-server/src/remote/backend.rs
+++ b/crates/tiangong-server/src/remote/backend.rs
@@ -37,6 +37,10 @@ pub trait ServerCoreBackend: Send + Sync {
 
     async fn delete_session(&self, session_id: &str) -> Result<bool>;
 
+    /// 取消会话当前执行中的轮次（快速停止：等待方立即收到取消错误）。
+    /// 返回 false 表示没有可取消的活跃执行。
+    async fn cancel_session_turn(&self, session_id: &str) -> Result<bool>;
+
     async fn sync_config_from_state(&self) -> Result<()>;
 }
 
@@ -72,6 +76,10 @@ impl ServerCoreBackend for ServerCoreManager {
 
     async fn delete_session(&self, session_id: &str) -> Result<bool> {
         ServerCoreManager::delete_session(self, session_id).await
+    }
+
+    async fn cancel_session_turn(&self, session_id: &str) -> Result<bool> {
+        ServerCoreManager::cancel_session_turn(self, session_id).await
     }
 
     async fn sync_config_from_state(&self) -> Result<()> {

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -56,11 +56,22 @@ impl ServerCoreManager {
 
     /// 取消指定会话当前执行中的轮次：向活跃 turn 投递 Cancel 信号，Core
     /// 立即终止并以「已取消」错误唤醒全部等待方（快速停止，不排队）。
-    /// 返回 false 表示会话没有可取消的活跃执行。
+    /// 返回 true 表示命令已投递到活跃执行，false 表示当时没有可接受命令的活跃
+    /// 执行。首轮未命中时只等待发送准备到消息入队的操作边界，不等待整轮完成。
     pub async fn cancel_session_turn(&self, session_id: &str) -> Result<bool> {
         let session_id = normalize_session_id(session_id)?;
-        let state = self.state.lock().await;
-        Ok(state.core_manager.cancel_core(&session_id))
+        let core_manager = {
+            let state = self.state.lock().await;
+            state.core_manager.clone()
+        };
+        if core_manager.cancel_core(&session_id) {
+            return Ok(true);
+        }
+
+        // 发送流程在消息入队前持有 operation lock；取消不拿 wait lock，避免等待整轮。
+        let operation_lock = self.session_operation_lock(&session_id);
+        let _operation_guard = operation_lock.lock().await;
+        Ok(core_manager.cancel_core(&session_id))
     }
 
     /// 从 App State 刷新全局模板，并按 session 为每个 Core 替换独立配置快照。
@@ -1177,6 +1188,44 @@ mod tests {
 
         cleanup_created_attachment_paths(&created_paths).unwrap();
         assert!(!created_paths[0].exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelling_idle_session_returns_false() {
+        let _storage_guard = STORAGE_TEST_LOCK.lock().await;
+        let root = tempfile::tempdir().unwrap();
+        let _home_guard = TestHomeGuard::new(&root.path().join("home"));
+        let (manager, session, _session_path, _state) = isolated_test_manager(root.path());
+
+        assert!(!manager.cancel_session_turn(&session.id).await.unwrap());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancellation_waits_only_for_operation_boundary() {
+        let _storage_guard = STORAGE_TEST_LOCK.lock().await;
+        let root = tempfile::tempdir().unwrap();
+        let _home_guard = TestHomeGuard::new(&root.path().join("home"));
+        let (manager, session, _session_path, _state) = isolated_test_manager(root.path());
+        let wait_lock = manager.session_wait_lock(&session.id);
+        let _wait_guard = wait_lock.lock().await;
+        let operation_lock = manager.session_operation_lock(&session.id);
+        let operation_guard = operation_lock.lock_owned().await;
+
+        let cancelling = {
+            let manager = manager.clone();
+            let session_id = session.id.clone();
+            tokio::spawn(async move { manager.cancel_session_turn(&session_id).await })
+        };
+        tokio::task::yield_now().await;
+        assert!(!cancelling.is_finished(), "取消应等待发送操作边界");
+
+        drop(operation_guard);
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), cancelling)
+            .await
+            .expect("释放操作锁后取消应立即返回")
+            .expect("取消任务不应 panic")
+            .unwrap();
+        assert!(!result);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/tiangong-server/src/remote/core.rs
+++ b/crates/tiangong-server/src/remote/core.rs
@@ -54,6 +54,15 @@ impl ServerCoreManager {
         }
     }
 
+    /// 取消指定会话当前执行中的轮次：向活跃 turn 投递 Cancel 信号，Core
+    /// 立即终止并以「已取消」错误唤醒全部等待方（快速停止，不排队）。
+    /// 返回 false 表示会话没有可取消的活跃执行。
+    pub async fn cancel_session_turn(&self, session_id: &str) -> Result<bool> {
+        let session_id = normalize_session_id(session_id)?;
+        let state = self.state.lock().await;
+        Ok(state.core_manager.cancel_core(&session_id))
+    }
+
     /// 从 App State 刷新全局模板，并按 session 为每个 Core 替换独立配置快照。
     pub async fn sync_config_from_state(&self) {
         let _config_guard = self.config_update_lock.lock().await;

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -270,6 +270,25 @@ GET /api/v1/sessions/{id}
 GET /api/v1/sessions/{id}/cost
 ```
 
+#### 取消会话当前轮次
+
+```
+POST /api/v1/sessions/{id}/cancel
+```
+
+无需请求体。需要认证，并要求调用方拥有管理会话权限（`can_manage_sessions`）。接口只
+尝试向当前活跃执行投递取消命令，不等待整轮收尾；发送请求正处于准备或入队边界时，
+接口会短暂等待该边界后再重试一次。
+
+**响应**：
+
+```json
+{ "cancelled": true, "id": "会话 ID" }
+```
+
+`cancelled: true` 表示取消命令已投递到活跃执行，`false` 表示本次没有可接受取消命令
+的活跃执行。`false` 不等同于 HTTP 404，也不表示会话资源不存在。
+
 #### 删除会话
 
 ```

--- a/src-tauri/src/embedded_server.rs
+++ b/src-tauri/src/embedded_server.rs
@@ -49,6 +49,11 @@ enum EmbeddedCoreRequest {
         session_id: String,
         reply: oneshot::Sender<HostResult<bool>>,
     },
+    /// 取消会话当前执行中的轮次（快速停止：等待方立即收到取消错误）。
+    CancelTurn {
+        session_id: String,
+        reply: oneshot::Sender<HostResult<bool>>,
+    },
     SyncConfig {
         reply: oneshot::Sender<HostResult<()>>,
     },
@@ -128,6 +133,20 @@ impl ServerCoreBackend for DesktopServerCoreBridge {
         reply_rx
             .await
             .map_err(|_| anyhow!("Desktop 内嵌 Server 未返回删除结果"))?
+            .map_err(anyhow::Error::msg)
+    }
+
+    async fn cancel_session_turn(&self, session_id: &str) -> Result<bool> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.request_tx
+            .send(EmbeddedCoreRequest::CancelTurn {
+                session_id: session_id.to_string(),
+                reply: reply_tx,
+            })
+            .map_err(|_| anyhow!("Desktop 内嵌 Server 桥接已关闭"))?;
+        reply_rx
+            .await
+            .map_err(|_| anyhow!("Desktop 内嵌 Server 未返回取消结果"))?
             .map_err(anyhow::Error::msg)
     }
 
@@ -221,6 +240,20 @@ pub(crate) fn spawn_desktop_server_core_bridge(
                         let state = request_app.state::<TiangongApp>();
                         let result = delete_session(&request_app, state.inner(), &session_id).await;
                         let _ = reply.send(result);
+                    }
+                    EmbeddedCoreRequest::CancelTurn { session_id, reply } => {
+                        let state = request_app.state::<TiangongApp>();
+                        // 只投取消信号：轮次终态由原投递路径的等待器链处理
+                        // （等待方收到「执行已取消」错误并释放远端轮次）。
+                        let cancelled = state
+                            .with_state_read(|core_state| {
+                                Ok::<_, anyhow::Error>(
+                                    core_state.core_manager.cancel_core(&session_id),
+                                )
+                            })
+                            .await
+                            .map_err(|error| error.to_string());
+                        let _ = reply.send(cancelled);
                     }
                     EmbeddedCoreRequest::SyncConfig { reply } => {
                         let state = request_app.state::<TiangongApp>();


### PR DESCRIPTION
## 变更内容

- 修正 `Command::Cancel` 的返回语义：只有取消命令实际投递到活跃 turn task 时才返回成功。
- Server 取消接口首次未命中时，等待发送准备到消息入队之间的短操作边界后重试一次。
- 取消路径不等待整轮执行，避免被长时间模型请求阻塞。
- 补充 Core 空闲取消、Server 空闲返回和操作锁边界回归测试。
- 同步 `docs/server-api.md`，明确权限和 `cancelled` 字段含义。

## 验证

- `cargo fmt --all --check`
- 受影响 crate `cargo check`
- 受影响 crate `cargo clippy --all-targets -- -D warnings`
- Core 单测：114 passed
- Server 单测：15 passed
- Core 活跃/空闲取消测试通过
- Server 取消回归测试通过
- 推送检查中的 cargo check、clippy、nextest 全部通过
