### PR TITLE
feat(app): SVG 附件消息内联渲染——本地按图片显示、发模型走文件引用

### DIFF
--- a/crates/tiangong-media-archive/src/attachment.rs
+++ b/crates/tiangong-media-archive/src/attachment.rs
@@ -296,6 +296,16 @@ impl AttachmentTransaction {
             };
 
             match stored.kind {
+                // SVG 矢量图不 inline 发送：主流模型 API 仅接受 png/jpeg/webp/gif，
+                // 直发 base64 会被拒收导致整轮消息失败，统一走文件引用路径
+                MediaKind::Image if stored.mime_type == "image/svg+xml" => {
+                    content.push(ContentBlock::AssetReference {
+                        asset: asset.clone(),
+                    });
+                    content.push(ContentBlock::ModelInstruction {
+                        text: file_attachment_instruction(index, &asset),
+                    });
+                }
                 MediaKind::Image if capabilities.chat_multimodal => {
                     let bytes = fs::read(&stored.local_path)
                         .map_err(|error| format!("读取内联图片失败：{error}"))?;
@@ -1000,6 +1010,49 @@ mod tests {
             &stable[2],
             ContentBlock::ModelInstruction { text } if text.contains("path=")
         ));
+    }
+
+    #[test]
+    fn svg_image_uses_file_reference_even_with_multimodal() {
+        let root = TestRoot::new();
+        let mut transaction = root
+            .store()
+            .store_batch(vec![data_attachment(
+                MediaKind::Image,
+                "diagram.svg",
+                "image/svg+xml",
+                b"<svg xmlns=\"http://www.w3.org/2000/svg\"/>",
+            )])
+            .unwrap();
+        let message = transaction
+            .prepare_message(
+                "message-svg",
+                "look",
+                AttachmentCapabilitySnapshot {
+                    chat_multimodal: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert_eq!(transaction.assets().len(), 1);
+        assert_eq!(transaction.assets()[0].mime_type, "image/svg+xml");
+        assert_eq!(message.len(), 3);
+        match &message[1] {
+            ContentBlock::AssetReference { asset } => {
+                assert_eq!(asset, &transaction.assets()[0]);
+            }
+            other => panic!("SVG 应走文件引用，实际：{other:?}"),
+        }
+        assert!(matches!(
+            &message[2],
+            ContentBlock::ModelInstruction { text } if text.contains("path=")
+        ));
+        assert!(
+            !message
+                .iter()
+                .any(|block| matches!(block, ContentBlock::Image { .. }))
+        );
     }
 
     #[test]

--- a/frontend/src/__tests__/resolveMarkdownImages.test.ts
+++ b/frontend/src/__tests__/resolveMarkdownImages.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  convertFileSrc: (path: string) => `asset://mocked/${path}`,
+}));
+
+import { resolveMarkdownImages } from '@/components/message/utils';
+
+const converted = (path: string) => `asset://mocked/${path}`;
+
+describe('resolveMarkdownImages', () => {
+  it('本地 SVG 文件链接改写为内联图片并转换资源地址', () => {
+    expect(
+      resolveMarkdownImages('已生成 [图](file:///Users/test/pelican.svg) 请查收'),
+    ).toBe(`已生成 ![图](${converted('/Users/test/pelican.svg')}) 请查收`);
+  });
+
+  it('POSIX 裸路径与 Windows 盘符的 SVG 链接同样内联', () => {
+    expect(resolveMarkdownImages('[a](/tmp/diagram.svg)')).toBe(
+      `![a](${converted('/tmp/diagram.svg')})`,
+    );
+    expect(resolveMarkdownImages('[a](C:\\Users\\test\\diagram.svg)')).toBe(
+      `![a](${converted('C:\\Users\\test\\diagram.svg')})`,
+    );
+  });
+
+  it('已是图片语法的 SVG 只做路径转换，不重复加感叹号', () => {
+    expect(resolveMarkdownImages('![icon](file:///tmp/icon.svg)')).toBe(
+      `![icon](${converted('/tmp/icon.svg')})`,
+    );
+  });
+
+  it('远程 SVG 链接与非 SVG 链接保持原样', () => {
+    expect(resolveMarkdownImages('[logo](https://example.com/logo.svg)')).toBe(
+      '[logo](https://example.com/logo.svg)',
+    );
+    expect(resolveMarkdownImages('[文档](file:///tmp/readme.md)')).toBe(
+      '[文档](file:///tmp/readme.md)',
+    );
+  });
+
+  it('扩展名大小写不敏感', () => {
+    expect(resolveMarkdownImages('[a](file:///tmp/A.SVG)')).toBe(
+      `![a](${converted('/tmp/A.SVG')})`,
+    );
+  });
+
+  it('既有位图图片路径仍转换资源地址', () => {
+    expect(resolveMarkdownImages('![photo](/Users/test/p.png)')).toBe(
+      `![photo](${converted('/Users/test/p.png')})`,
+    );
+  });
+});

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -753,7 +753,7 @@ export function MessageInput({
           {
             name: '图片、音视频和文件',
             extensions: [
-              'png', 'jpg', 'jpeg', 'webp', 'gif',
+              'png', 'jpg', 'jpeg', 'webp', 'gif', 'svg',
               'mp3', 'wav', 'm4a', 'ogg', 'flac',
               'mp4', 'mov', 'webm', 'mkv',
               'pdf', 'docx', 'xlsx', 'pptx', 'txt', 'md', 'json', 'csv',

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -696,7 +696,7 @@ export function MessageList() {
           {
             name: '图片、音视频和文件',
             extensions: [
-              'png', 'jpg', 'jpeg', 'webp', 'gif',
+              'png', 'jpg', 'jpeg', 'webp', 'gif', 'svg',
               'mp3', 'wav', 'm4a', 'ogg', 'flac',
               'mp4', 'mov', 'webm', 'mkv',
               'pdf', 'docx', 'xlsx', 'pptx', 'txt', 'md', 'json', 'csv',

--- a/frontend/src/components/message/ContentMedia.tsx
+++ b/frontend/src/components/message/ContentMedia.tsx
@@ -35,7 +35,11 @@ export function ContentMedia({ message }: { message: MessageItem }) {
           return <div key={`${message.id}-media-${index}`} className="text-sm text-muted-foreground">旧附件无法安全恢复，请重新上传。</div>;
         }
         const src = resolveAssetUrl(asset.url);
-        if (asset.kind === "image") {
+        // 历史消息里 SVG 曾按 file 归档，按 mime 或扩展名兜底回图片渲染
+        const rendersAsImage = asset.kind === "image"
+          || (asset.kind === "file"
+            && (asset.mime_type === "image/svg+xml" || asset.url.toLowerCase().endsWith(".svg")));
+        if (rendersAsImage) {
           return <img key={`${message.id}-media-${index}`} src={src} alt={asset.title || "生成的图片"} className="max-w-full max-h-96 rounded-md cursor-pointer hover:opacity-90 transition-opacity" loading="lazy" />;
         }
         if (asset.kind === "video") {

--- a/frontend/src/components/message/utils.ts
+++ b/frontend/src/components/message/utils.ts
@@ -103,8 +103,31 @@ export function resolveAssetUrl(url: string): string {
   return resolveAttachmentUrl(url);
 }
 
-export function resolveMarkdownImages(md: string): string {
+/** 判断链接目标是否本地路径形态（file://、POSIX 绝对路径、Windows 盘符或 UNC）。 */
+function isLocalFileUrl(url: string): boolean {
+  return url.startsWith('file:')
+    || url.startsWith('/')
+    || /^[A-Za-z]:[\\/]/.test(url)
+    || url.startsWith('\\\\');
+}
+
+/** 把指向本地 SVG 文件的链接改写为图片语法。模型常用 [名称](file:///…/x.svg)
+ *  引用生成的矢量图，按链接渲染只是一行文本；改写后经下方图片路径解析内联显示
+ *  （img 上下文中的 SVG 不执行脚本）。远程地址不改写，保留链接点击行为。 */
+function inlineLocalSvgLinks(md: string): string {
   return md.replace(
+    /(?<!!)\[([^\]]*)\]\(([^\s)]+)\)/g,
+    (match, alt: string, url: string) => {
+      const path = url.split(/[?#]/)[0];
+      return path.toLowerCase().endsWith('.svg') && isLocalFileUrl(url)
+        ? `![${alt}](${url})`
+        : match;
+    },
+  );
+}
+
+export function resolveMarkdownImages(md: string): string {
+  return inlineLocalSvgLinks(md).replace(
     /(!\[[^\]]*\]\()([^\s)]+)(\))/g,
     (_, prefix, path, suffix) => prefix + resolveAssetUrl(path) + suffix,
   );

--- a/frontend/src/utils/attachments.ts
+++ b/frontend/src/utils/attachments.ts
@@ -11,6 +11,7 @@ export function imageMimeType(path: string): string | undefined {
   if (lower.endsWith('.webp')) return 'image/webp';
   if (lower.endsWith('.gif')) return 'image/gif';
   if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.svg')) return 'image/svg+xml';
   return undefined;
 }
 
@@ -55,6 +56,7 @@ export function imageExtFromMime(mimeType: string): string {
   if (mimeType === 'image/jpeg' || mimeType === 'image/jpg') return 'jpg';
   if (mimeType === 'image/webp') return 'webp';
   if (mimeType === 'image/gif') return 'gif';
+  if (mimeType === 'image/svg+xml') return 'svg';
   return 'png';
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -117,6 +117,7 @@ fn mime_type_from_path(path: &std::path::Path) -> String {
         "png" => "image/png",
         "webp" => "image/webp",
         "gif" => "image/gif",
+        "svg" => "image/svg+xml",
         "pdf" => "application/pdf",
         "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",


### PR DESCRIPTION
## 改动内容

SVG 文件现在可以在消息里像图片一样内联显示，覆盖两条链路：

1. **用户上传 SVG 附件**：之前无法通过附件按钮选中，拖拽进来的被当成普通文件显示成一行链接。
2. **回复正文里的 SVG 文件链接**：模型生成 SVG 文件后常用 `[名称](file:///…/x.svg)` 链接引用，之前渲染成文本链接，现在直接显示为图片（远程地址不改写，保留链接行为）。

### 界面侧
- 附件选择对话框（输入框与消息编辑两处）白名单加入 svg。
- 类型识别补齐：`.svg` → `image/svg+xml`（影响拖拽、路径粘贴、粘贴落盘扩展名）。
- 历史消息里已按文件归档的 SVG（mime 为 `image/svg+xml` 或路径以 `.svg` 结尾）也按图片渲染；正文链接改写发生在渲染时，历史会话无需迁移即生效。
- 链接改写覆盖流式输出、正式回复、worker 回复三处 markdown 入口（共用 `resolveMarkdownImages`）。

### 模型侧（关键取舍）
- SVG 发送给模型时**不走内联图片**，统一走文件引用路径（同 PDF）：模型收到本地路径与文件说明，用工具按需读取源文件。
- 原因：主流模型 API（OpenAI/Anthropic 等）只接受 png/jpeg/webp/gif，直发 SVG base64 会被拒收，导致整轮消息发送失败。
- 因此历史轮重放也不会把 SVG 发给 API。

### 安全
- 渲染只经 `<img>` 元素加载（该上下文不执行 SVG 脚本），与插件图标的既有实践一致；不内联 SVG 文档节点。

## 测试情况

- `cargo clippy -p tiangong-media-archive --all-targets`、`cargo clippy -p tiangong-app`：无告警。
- `cargo test -p tiangong-media-archive -- --test-threads=1`：26 项全过，含新增用例 `svg_image_uses_file_reference_even_with_multimodal`（验证多模态开启时 SVG 产出 AssetReference 而非内联 Image 块）。
- `yarn build` 通过；`yarn test` 262 项全过，含新增 `resolveMarkdownImages.test.ts` 6 项（file:///裸路径/盘符链接改写、已是图片语法不重复、远程与非 SVG 不动、大小写、位图回归）。
- 已用真实会话数据核对：模型输出的 `[pelican_bicycle.svg](file:///Users/…/tiangong_agent/pelican_bicycle.svg)` 属普通正文链接（不在代码块内），路径落在 asset 协议 scope（`$HOME/Documents/**`）内，改写后可正常加载。

## 已知限制（本次不处理）

- 附件分析插件对 SVG 推断 mime 为 png（插件侧问题，按范围纪律未动）。
- 极旧会话中通过粘贴产生的内联 SVG 图片块，重放时仍会以 svg mime 发送（存量边缘 case，非本次引入）。
- 模型无法直接看到 SVG 视觉内容，需读源文件（本方案明确取舍；如需模型直接看图，后续可评估转 PNG 方案）。
- markdown 预处理不跳过代码块（与既有图片路径改写同等精度）：代码块内的 SVG 链接字面量会被改写但代码块内不渲染图片，仅显示文本变化。
